### PR TITLE
fixing workspace_manager and refactoring of `comfy node`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,38 +30,43 @@ system. If you run in a ComfyUI repo that has already been setup. The command
 will simply update the comfy.yaml file to reflect the local setup
 
   * `comfy install --skip-manager`: Install ComfyUI without ComfyUI-Manager.
-  * `comfy install --workspace=<path>`: Install ComfyUI into `<path>/ComfyUI`.
+  * `comfy --workspace=<path> install`: Install ComfyUI into `<path>/ComfyUI`.
+  * For `comfy install`, if no path specification like `--workspace, --recent, or --here` is provided, it will be implicitly installed in `<HOME>/comfy`.
 
+
+### Specifying execution path
+
+* You can specify the path of ComfyUI where the command will be applied through path indicators as follows:
+  * `comfy --workspace=<path>`: Run from the ComfyUI installed in the specified workspace.
+  * `comfy --recent`: Run from the recently executed or installed ComfyUI.
+  * `comfy --here`: Run from the ComfyUI located in the current directory.
+* --workspace, --recent, and --here options cannot be used simultaneously.
+* If there is no path indicator, the following priority applies:
+  * Run from the default ComfyUI at the path specified by `comfy set-default <path>`.
+  * Run from the recently executed or installed ComfyUI.
+  * Run from the ComfyUI located in the current directory.
+
+* Example 1: To run the recently executed ComfyUI:
+  * `comfy --recent launch`
+* Example 2: To install a package on the ComfyUI in the current directory:
+  * `comfy --here node install ComfyUI-Impact-Pack`
+* Example 3: To update the automatically selected path of ComfyUI and custom nodes based on priority:
+  * `comfy node update all`
+
+* You can use the `comfy which` command to check the path of the target workspace.
+  * e.g) `comfy --recent which`, `comfy --here which`, `comfy which`, ...
 
 ### Launch ComfyUI
 
 Comfy provides commands that allow you to easily run the installed ComfyUI.
 
-- To execute specifying the path of the workspace where ComfyUI is installed:
-
-  `comfy launch --workspace <path>`
-
-- To execute commands automatically, prioritize without specifying a path:
-    - 1st: To run ComfyUI from the current directory, if you are inside the ComfyUI repository
-    - 2nd: To run ComfyUI from the default workspace, if you are inside the ComfyUI repository and default workspace is set
-    - 3rd: To execute the ComfyUI that was last run or last installed, if you are outside of the ComfyUI repository
-
   `comfy launch`
-
--  To execute the ComfyUI that was last run or last installed
-    - If the `--workspace` option is provided, the `--recent` option is ignored.):
-  
-   `comfy launch --recent`
 
 - To run with default ComfyUI options:
 
   `comfy launch -- <extra args...>`
 
   `comfy launch -- --cpu --listen 0.0.0.0`
-
-- To set default workspace:
-
-  `comfy set-default <workspace path>`
 
 
 ### Managing Packages [WIP]

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -21,7 +21,8 @@ def execute_cm_cli(ctx: typer.Context, args, channel=None, mode=None):
     _config_manager = ConfigManager()
     _config_manager.write_config()
 
-    comfyui_path = os.path.join(workspace_manager.get_workspace_path(ctx), 'ComfyUI')
+    workspace_path = workspace_manager.get_workspace_path(ctx)
+    comfyui_path = os.path.join(workspace_path, 'ComfyUI')
 
     if not os.path.exists(comfyui_path):
         print(f"\nComfyUI not found: {comfyui_path}\n", file=sys.stderr)
@@ -49,6 +50,7 @@ def execute_cm_cli(ctx: typer.Context, args, channel=None, mode=None):
     print(f"Execute from: {comfyui_path}")
 
     subprocess.run(cmd, env=new_env)
+    workspace_manager.set_recent_workspace(workspace_path)
 
 
 def validate_comfyui_manager(_env_checker):

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -9,29 +9,19 @@ import sys
 from rich import print
 import uuid
 from comfy_cli.config_manager import ConfigManager
+from comfy_cli.workspace_manager import WorkspaceManager
 
 app = typer.Typer()
 manager_app = typer.Typer()
+workspace_manager = WorkspaceManager()
 
 
-def execute_cm_cli(args, channel=None, mode=None, workspace=None, recent=False):
+def execute_cm_cli(ctx: typer.Context, args, channel=None, mode=None):
     _env_checker = EnvChecker()
     _config_manager = ConfigManager()
     _config_manager.write_config()
 
-    if workspace is not None:
-        workspace = os.path.expanduser(workspace)
-        comfyui_path = os.path.join(workspace, 'ComfyUI')
-    elif not recent and _env_checker.comfy_repo is not None:
-        os.chdir(_env_checker.comfy_repo.working_dir)
-        comfyui_path = _env_checker.comfy_repo.working_dir
-    elif not recent and _config_manager.config['DEFAULT'].get('default_workspace') is not None:
-        comfyui_path = os.path.join(_config_manager.config['DEFAULT'].get('default_workspace'), 'ComfyUI')
-    elif _config_manager.config['DEFAULT'].get('recent_path') is not None:
-        comfyui_path = _config_manager.config['DEFAULT'].get('recent_path')
-    else:
-        print(f"\nComfyUI is not available.\n", file=sys.stderr)
-        raise typer.Exit(code=1)
+    comfyui_path = os.path.join(workspace_manager.get_workspace_path(ctx), 'ComfyUI')
 
     if not os.path.exists(comfyui_path):
         print(f"\nComfyUI not found: {comfyui_path}\n", file=sys.stderr)
@@ -78,67 +68,54 @@ def validate_comfyui_manager(_env_checker):
 @app.command('save-snapshot', help="Save a snapshot of the current ComfyUI environment")
 @tracking.track_command("node")
 def save_snapshot(
-        output: Annotated[str, '--output', typer.Option(show_default=False, help="Specify the output file path. (.json/.yaml)")] = None,
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+        ctx: typer.Context,
+        output: Annotated[str, '--output', typer.Option(show_default=False, help="Specify the output file path. (.json/.yaml)")] = None
+):
     if output is None:
-        execute_cm_cli(['save-snapshot'], workspace=workspace, recent=recent)
+        execute_cm_cli(ctx, ['save-snapshot'])
     else:
         output = os.path.abspath(output)  # to compensate chdir
-        execute_cm_cli(['save-snapshot', '--output', output], workspace=workspace, recent=recent)
+        execute_cm_cli(ctx, ['save-snapshot', '--output', output])
 
 
 @app.command('restore-snapshot')
 @tracking.track_command("node")
-def restore_snapshot(
-        path: str,
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
-
+def restore_snapshot(ctx: typer.Context, path: str):
     path = os.path.abspath(path)
-    execute_cm_cli(['restore-snapshot', path], workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['restore-snapshot', path])
 
 
 @app.command('restore-dependencies')
 @tracking.track_command("node")
-def restore_dependencies(
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
-    execute_cm_cli(['restore-dependencies'], workspace=workspace, recent=recent)
+def restore_dependencies(ctx: typer.Context):
+    execute_cm_cli(ctx, ['restore-dependencies'])
 
 
 @manager_app.command('disable-gui')
 @tracking.track_command("node")
-def disable_gui(
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
-    execute_cm_cli(['cli-only-mode', 'enable'], workspace=workspace, recent=recent)
+def disable_gui(ctx: typer.Context):
+    execute_cm_cli(ctx, ['cli-only-mode', 'enable'])
 
 
 @manager_app.command('enable-gui')
 @tracking.track_command("node")
-def enable_gui(
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
-    execute_cm_cli(['cli-only-mode', 'disable'], workspace=workspace, recent=recent)
+def enable_gui(ctx: typer.Context):
+    execute_cm_cli(ctx, ['cli-only-mode', 'disable'])
 
 
 @manager_app.command()
 @tracking.track_command("node")
-def clear(path: str,
-          workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-          recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+def clear(ctx: typer.Context, path: str):
     path = os.path.abspath(path)
-    execute_cm_cli(['clear', path], workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['clear', path])
 
 
 @app.command()
 @tracking.track_command("node")
-def show(args: List[str] = typer.Argument(..., help="[installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]"),
+def show(ctx: typer.Context,
+         args: List[str] = typer.Argument(..., help="[installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]"),
          channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-         mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-         workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-         recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+         mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
 
     valid_commands = ["installed", "enabled", "not-installed", "disabled", "all", "snapshot", "snapshot-list"]
     if not args or len(args) > 1 or args[0] not in valid_commands:
@@ -150,16 +127,15 @@ def show(args: List[str] = typer.Argument(..., help="[installed|enabled|not-inst
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['show'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['show'] + args, channel, mode)
 
 
 @app.command('simple-show')
 @tracking.track_command("node")
-def simple_show(args: List[str] = typer.Argument(..., help="[installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]"),
+def simple_show(ctx: typer.Context,
+                args: List[str] = typer.Argument(..., help="[installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]"),
                 channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-                mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-                workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-                recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+                mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
 
     valid_commands = ["installed", "enabled", "not-installed", "disabled", "all", "snapshot", "snapshot-list"]
     if not args or len(args) > 1 or args[0] not in valid_commands:
@@ -171,17 +147,16 @@ def simple_show(args: List[str] = typer.Argument(..., help="[installed|enabled|n
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['simple-show'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['simple-show'] + args, channel, mode)
 
 
 # install, reinstall, uninstall
 @app.command()
 @tracking.track_command("node")
-def install(args: List[str] = typer.Argument(..., help="install custom nodes"),
+def install(ctx: typer.Context,
+            args: List[str] = typer.Argument(..., help="install custom nodes"),
             channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-            mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-            workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-            recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+            mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     if 'all' in args:
         typer.echo(f"Invalid command: {mode}. `install all` is not allowed", err=True)
         raise typer.Exit(code=1)
@@ -191,16 +166,15 @@ def install(args: List[str] = typer.Argument(..., help="install custom nodes"),
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['install'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['install'] + args, channel, mode)
 
 
 @app.command()
 @tracking.track_command("node")
-def reinstall(args: List[str] = typer.Argument(..., help="reinstall custom nodes"),
+def reinstall(ctx: typer.Context,
+              args: List[str] = typer.Argument(..., help="reinstall custom nodes"),
               channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-              mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-              workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-              recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+              mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     if 'all' in args:
         typer.echo(f"Invalid command: {mode}. `reinstall all` is not allowed", err=True)
         raise typer.Exit(code=1)
@@ -210,16 +184,15 @@ def reinstall(args: List[str] = typer.Argument(..., help="reinstall custom nodes
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['reinstall'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['reinstall'] + args, channel, mode)
 
 
 @app.command()
 @tracking.track_command("node")
-def uninstall(args: List[str] = typer.Argument(..., help="uninstall custom nodes"),
+def uninstall(ctx: typer.Context,
+              args: List[str] = typer.Argument(..., help="uninstall custom nodes"),
               channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-              mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-              workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-              recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+              mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     if 'all' in args:
         typer.echo(f"Invalid command: {mode}. `uninstall all` is not allowed", err=True)
         raise typer.Exit(code=1)
@@ -229,66 +202,62 @@ def uninstall(args: List[str] = typer.Argument(..., help="uninstall custom nodes
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['uninstall'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['uninstall'] + args, channel, mode)
 
 
 # `update, disable, enable, fix` allows `all` param
 
 @app.command()
 @tracking.track_command("node")
-def update(args: List[str] = typer.Argument(..., help="update custom nodes"),
+def update(ctx: typer.Context,
+           args: List[str] = typer.Argument(..., help="update custom nodes"),
            channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-           mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-           workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-           recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+           mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     valid_modes = ["remote", "local", "cache"]
     if mode and mode.lower() not in valid_modes:
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['update'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['update'] + args, channel, mode)
 
 
 @app.command()
 @tracking.track_command("node")
-def disable(args: List[str] = typer.Argument(..., help="disable custom nodes"),
+def disable(ctx: typer.Context,
+            args: List[str] = typer.Argument(..., help="disable custom nodes"),
             channel: Annotated[str, '--channel', typer.Option(show_default=False,help="Specify the operation mode")] = None,
-            mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-            workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-            recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+            mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     valid_modes = ["remote", "local", "cache"]
     if mode and mode.lower() not in valid_modes:
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['disable'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['disable'] + args, channel, mode)
 
 
 @app.command()
 @tracking.track_command("node")
-def enable(args: List[str] = typer.Argument(..., help="enable custom nodes"),
+def enable(ctx: typer.Context,
+           args: List[str] = typer.Argument(..., help="enable custom nodes"),
            channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-           mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-           workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-           recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+           mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     valid_modes = ["remote", "local", "cache"]
     if mode and mode.lower() not in valid_modes:
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['enable'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['enable'] + args, channel, mode)
 
 
 @app.command()
 @tracking.track_command("node")
-def fix(args: List[str] = typer.Argument(..., help="fix dependencies for specified custom nodes"),
+def fix(ctx: typer.Context,
+        args: List[str] = typer.Argument(..., help="fix dependencies for specified custom nodes"),
         channel: Annotated[str, '--channel', typer.Option(show_default=False, help="Specify the operation mode")] = None,
-        mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None,
-        workspace: Annotated[str, typer.Option(show_default=False, help="Path to ComfyUI workspace")] = None,
-        recent: Annotated[bool, typer.Option(help="Use recent path (--workspace is higher)")] = False):
+        mode: Annotated[str, '--mode', typer.Option(show_default=False, help="[remote|local|cache]")] = None):
     valid_modes = ["remote", "local", "cache"]
     if mode and mode.lower() not in valid_modes:
         typer.echo(f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.", err=True)
         raise typer.Exit(code=1)
 
-    execute_cm_cli(['fix'] + args, channel, mode, workspace=workspace, recent=recent)
+    execute_cm_cli(ctx, ['fix'] + args, channel, mode)

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -58,7 +58,7 @@ class ConfigManager(object):
     else:
       table.add_row("Default ComfyUI workspace", "No default ComfyUI workspace")
 
-    if self.config.has_option('DEFAULT', 'recent_path'):
-      table.add_row("Recent ComfyUI", self.config['DEFAULT']['recent_path'])
+    if self.config.has_option('DEFAULT', constants.CONFIG_KEY_RECENT_WORKSPACE):
+      table.add_row("Recent ComfyUI workspace", self.config['DEFAULT'][constants.CONFIG_KEY_RECENT_WORKSPACE])
     else:
-      table.add_row("Recent ComfyUI", "No recent run")
+      table.add_row("Recent ComfyUI workspace", "No recent run")

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -26,6 +26,7 @@ DEFAULT_CONFIG = {
 
 CONTEXT_KEY_WORKSPACE = 'workspace'
 CONTEXT_KEY_RECENT = 'recent'
+CONTEXT_KEY_HERE = 'here'
 
 CONFIG_KEY_DEFAULT_WORKSPACE = 'default_workspace'
 CONFIG_KEY_RECENT_WORKSPACE = 'recent_workspace'

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -43,7 +43,7 @@ class WorkspaceManager:
     """
     Sets the default workspace path in the configuration.
     """
-    self.config_manager.set(constants.CONTEXT_KEY_WORKSPACE, path)
+    self.config_manager.set(constants.CONFIG_KEY_DEFAULT_WORKSPACE, path)
 
   def get_workspace_comfy_path(self, context: typer.Context) -> str:
     """

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -1,11 +1,14 @@
 import os
+import sys
 from typing import Optional
 
 import typer
 
 from comfy_cli import constants
 from comfy_cli.config_manager import ConfigManager
+from comfy_cli.env_checker import EnvChecker
 from comfy_cli.utils import singleton
+from rich import print
 
 
 @singleton
@@ -14,14 +17,21 @@ class WorkspaceManager:
     self.config_manager = ConfigManager()
 
   @staticmethod
-  def update_context(context: typer.Context, workspace: Optional[str], recent: Optional[bool]):
+  def update_context(context: typer.Context, workspace: Optional[str], recent: Optional[bool], here: Optional[bool]):
     """
     Updates the context object with the workspace and recent flags.
     """
+
+    if [workspace is not None, recent, here].count(True) > 1:
+      print(f"--workspace, --recent, and --here options cannot be used together.", file=sys.stderr)
+      raise typer.Exit(code=1)
+
     if workspace:
       context.obj[constants.CONTEXT_KEY_WORKSPACE] = workspace
     if recent:
       context.obj[constants.CONTEXT_KEY_RECENT] = recent
+    if here:
+      context.obj[constants.CONTEXT_KEY_HERE] = here
 
   def set_recent_workspace(self, path: str):
     """
@@ -57,22 +67,44 @@ class WorkspaceManager:
     """
     specified_workspace = context.obj.get(constants.CONTEXT_KEY_WORKSPACE)
     use_recent = context.obj.get(constants.CONTEXT_KEY_RECENT)
+    use_here = context.obj.get(constants.CONTEXT_KEY_HERE)
 
     # Check for explicitly specified workspace first
     if specified_workspace:
       specified_path = os.path.expanduser(specified_workspace)
       if os.path.exists(specified_path):
-        return specified_path
+        if os.path.exists(os.path.join(specified_path, 'ComfyUI')):
+          return specified_path
+        else:
+          print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
+          raise typer.Exit(code=1)
 
     # Check for recent workspace if requested
     if use_recent:
       recent_workspace = self.config_manager.get(constants.CONFIG_KEY_RECENT_WORKSPACE)
       if recent_workspace and os.path.exists(recent_workspace):
-        return recent_workspace
+        if os.path.exists(os.path.join(recent_workspace, 'ComfyUI')):
+          return recent_workspace
+        else:
+          print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
+          raise typer.Exit(code=1)
+
+    # Check for current workspace if requested
+    if use_here:
+      current_directory = os.getcwd()
+      if os.path.exists(os.path.join(current_directory, 'ComfyUI')):
+        return current_directory
+
+      comfy_repo = EnvChecker().comfy_repo
+      if comfy_repo is not None:
+        if os.path.basename(comfy_repo.working_dir) == 'ComfyUI':
+          return os.path.abspath(os.path.join(comfy_repo.working_dir, '..'))
+        else:
+          print(f"[bold red]warn: The path name of the ComfyUI executed through 'comfy-cli' must be 'ComfyUI'. The current ComfyUI is being ignored.[/bold red]")
 
     # Check for user-set default workspace
     default_workspace = self.config_manager.get(constants.CONFIG_KEY_DEFAULT_WORKSPACE)
-    if default_workspace and os.path.exists(default_workspace):
+    if default_workspace and os.path.exists(os.path.join(default_workspace, 'ComfyUI')):
       return default_workspace
 
     # Check the current directory for a ComfyUI setup
@@ -80,10 +112,15 @@ class WorkspaceManager:
     if os.path.exists(os.path.join(current_directory, 'ComfyUI')):
       return current_directory
 
+    # Check the current directory for a ComfyUI repo
+    comfy_repo = EnvChecker().comfy_repo
+    if comfy_repo is not None and os.path.basename(comfy_repo.working_dir) == 'ComfyUI':
+      return os.path.abspath(os.path.join(comfy_repo.working_dir, '..'))
+
     # Fallback to the most recent workspace if it exists
     if not use_recent:
       recent_workspace = self.config_manager.get(constants.CONFIG_KEY_RECENT_WORKSPACE)
-      if recent_workspace and os.path.exists(recent_workspace):
+      if recent_workspace and os.path.exists(os.path.join(recent_workspace, 'ComfyUI')):
         return recent_workspace
 
     # Final fallback to a hardcoded default workspace

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -75,9 +75,9 @@ class WorkspaceManager:
       if os.path.exists(specified_path):
         if os.path.exists(os.path.join(specified_path, 'ComfyUI')):
           return specified_path
-        else:
-          print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
-          raise typer.Exit(code=1)
+
+      print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
+      raise typer.Exit(code=1)
 
     # Check for recent workspace if requested
     if use_recent:
@@ -85,9 +85,9 @@ class WorkspaceManager:
       if recent_workspace and os.path.exists(recent_workspace):
         if os.path.exists(os.path.join(recent_workspace, 'ComfyUI')):
           return recent_workspace
-        else:
-          print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
-          raise typer.Exit(code=1)
+
+      print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
+      raise typer.Exit(code=1)
 
     # Check for current workspace if requested
     if use_here:
@@ -101,6 +101,10 @@ class WorkspaceManager:
           return os.path.abspath(os.path.join(comfy_repo.working_dir, '..'))
         else:
           print(f"[bold red]warn: The path name of the ComfyUI executed through 'comfy-cli' must be 'ComfyUI'. The current ComfyUI is being ignored.[/bold red]")
+          raise typer.Exit(code=1)
+
+      print(f"[bold red]warn: The specified workspace does not contain ComfyUI directory.[/bold red]")  # If a path has been explicitly specified, cancel the command for safety.
+      raise typer.Exit(code=1)
 
     # Check for user-set default workspace
     default_workspace = self.config_manager.get(constants.CONFIG_KEY_DEFAULT_WORKSPACE)


### PR DESCRIPTION
refactor: `comfy node` command uses typer context instead of separated args

improve: `--here` context arg is added

fix: `comfy install` behavior should not depend on get_workspace_path

fix: workspace_manager - Ensure that the workspace always points to where ComfyUI is installed.

feat: `comfy which` - Shows target workspace path

modified: `comfy node` update recent workspace

update README.md