### PR TITLE
Feat/node dep install

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ will simply update the comfy.yaml file to reflect the local setup
 * You can use the `comfy which` command to check the path of the target workspace.
   * e.g `comfy --recent which`, `comfy --here which`, `comfy which`, ...
 
+
 ### Launch ComfyUI
 
 Comfy provides commands that allow you to easily run the installed ComfyUI.
@@ -85,7 +86,7 @@ comfy provides a convenient way to manage custom nodes for extending ComfyUI's f
 
 - Show custom nodes' information:
  ```
-comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list] 
+comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]
                               ?[--channel <channel name>] 
                               ?[--mode [remote|local|cache]]
 ```
@@ -104,6 +105,18 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
   `comfy node save-snapshot`
 
   `comfy node restore-snapshot <snapshot name>`
+
+
+- Install dependencies:
+
+  `comfy node install-deps --deps=<deps .json file>` 
+
+  `comfy node install-deps --workflow=<workflow .json/.png file>`
+
+
+- Generate deps:
+
+  `comfy node deps-in-workflow --workflow=<workflow .json/.png file>` 
 
 
 ### Managing Models

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -396,6 +396,31 @@ def fix(
     execute_cm_cli(["fix"] + args, channel, mode)
 
 
+@app.command("install-deps")
+@tracking.track_command("node")
+def install_deps(
+    deps_file: str,
+    channel: Annotated[
+        str,
+        "--channel",
+        typer.Option(show_default=False, help="Specify the operation mode"),
+    ] = None,
+    mode: Annotated[
+        str, "--mode", typer.Option(show_default=False, help="[remote|local|cache]")
+    ] = None,
+):
+    valid_modes = ["remote", "local", "cache"]
+    if mode and mode.lower() not in valid_modes:
+        typer.echo(
+            f"Invalid mode: {mode}. Allowed modes are 'remote', 'local', 'cache'.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    deps_file = os.path.abspath(os.path.expanduser(deps_file))
+    execute_cm_cli(["install-deps", deps_file], channel, mode)
+
+
 # TODO: re-enable publish after v0 launch
 # @app.command("publish", help="Publish node to registry")
 # @tracking.track_command("publish")


### PR DESCRIPTION
support `comfy node install-deps` and `comfy node deps-in-workflow` command

- Install dependencies:

  `comfy node install-deps --deps=<deps .json file>` 

  `comfy node install-deps --workflow=<workflow .json/.png file>`


- Generate deps:

  `comfy node deps-in-workflow --workflow=<workflow .json/.png file>` 