### PR TITLE
Add `comfy run` command

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -17,6 +17,7 @@ import threading
 
 from comfy_cli import constants, env_checker, logging, tracking, ui, utils
 from comfy_cli.command import custom_nodes
+from comfy_cli.command import run as run_inner
 from comfy_cli.command import install as install_inner
 from comfy_cli.command.models import models as models_command
 from comfy_cli.config_manager import ConfigManager
@@ -341,12 +342,24 @@ def update(
     custom_nodes.command.update_node_id_cache()
 
 
-# @app.command(help="Run workflow file")
-# @tracking.track_command()
-# def run(
-#   workflow_file: Annotated[str, typer.Option(help="Path to the workflow file.")],
-# ):
-#   run_inner.execute(workflow_file)
+@app.command(help="Run API workflow file using the ComfyUI launched by `comfy launch --background`")
+@tracking.track_command()
+def run(
+    workflow: Annotated[str, typer.Option(help="Path to the workflow API json file.")],
+    wait: Annotated[
+        Optional[bool], typer.Option(help="If the command should wait until execution completes.")
+    ] = True,
+    verbose: Annotated[
+        Optional[bool], typer.Option(help="Enables verbose output of the execution process.")
+    ] = False,
+):
+    config = ConfigManager()
+    if not config.background:
+        print(
+            "[bold red]No ComfyUI background process information found. Please ensure you have run `comfy run --background` first.[/bold red]"
+        )
+        raise typer.Exit(code=1)
+    run_inner.execute(workflow, config.background[0], config.background[1], wait, verbose)
 
 
 def validate_comfyui(_env_checker):

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -342,15 +342,19 @@ def update(
     custom_nodes.command.update_node_id_cache()
 
 
-@app.command(help="Run API workflow file using the ComfyUI launched by `comfy launch --background`")
+@app.command(
+    help="Run API workflow file using the ComfyUI launched by `comfy launch --background`"
+)
 @tracking.track_command()
 def run(
     workflow: Annotated[str, typer.Option(help="Path to the workflow API json file.")],
     wait: Annotated[
-        Optional[bool], typer.Option(help="If the command should wait until execution completes.")
+        Optional[bool],
+        typer.Option(help="If the command should wait until execution completes."),
     ] = True,
     verbose: Annotated[
-        Optional[bool], typer.Option(help="Enables verbose output of the execution process.")
+        Optional[bool],
+        typer.Option(help="Enables verbose output of the execution process."),
     ] = False,
 ):
     config = ConfigManager()
@@ -359,7 +363,9 @@ def run(
             "[bold red]No ComfyUI background process information found. Please ensure you have run `comfy run --background` first.[/bold red]"
         )
         raise typer.Exit(code=1)
-    run_inner.execute(workflow, config.background[0], config.background[1], wait, verbose)
+    run_inner.execute(
+        workflow, config.background[0], config.background[1], wait, verbose
+    )
 
 
 def validate_comfyui(_env_checker):

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -362,7 +362,7 @@ def run(
     config = ConfigManager()
     if not config.background:
         print(
-            "[bold red]No ComfyUI background process information found. Please ensure you have run `comfy run --background` first.[/bold red]"
+            "[bold red]No ComfyUI background process information found. Please ensure you have run `comfy launch --background` first.[/bold red]"
         )
         raise typer.Exit(code=1)
     run_inner.execute(

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -1,2 +1,293 @@
-def execute(workflow_name: str):
-    print(f"Executing workflow: {workflow_name}")
+
+import json
+import os
+import time
+import typer
+import uuid
+import urllib.error
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TimeElapsedColumn,
+    Column,
+    Table
+)
+from urllib import request
+from websocket import WebSocket
+from rich import print as pprint
+from comfy_cli.env_checker import check_comfy_server_running
+from comfy_cli.workspace_manager import WorkspaceManager
+from datetime import timedelta
+
+workspace_manager = WorkspaceManager()
+
+
+def load_api_workflow(file: str):
+    with open(file, encoding="utf-8") as f:
+        workflow = json.load(f)
+        # Check for litegraph properties to ensure this isnt a UI workflow file
+        if "nodes" in workflow and "links" in workflow:
+            return None
+
+        # Try validating the first entry to ensure it has a node class property
+        node_id = next(iter(workflow))
+        node = workflow[node_id]
+        if "class_type" not in node:
+            return None
+
+        return workflow
+
+
+def execute(workflow: str, listen, port, wait=True, verbose=False):
+    workflow_name = os.path.abspath(workflow)
+    if not os.path.isfile(workflow):
+        pprint(
+            "[bold red]Specified workflow file not found[/bold red]"
+        )
+        raise typer.Exit(code=1)
+
+    workflow = load_api_workflow(workflow)
+
+    if not workflow:
+        pprint(
+            "[bold red]Specified workflow does not appear to be an API workflow json file[/bold red]"
+        )
+        raise typer.Exit(code=1)
+
+    if not check_comfy_server_running(port):
+        pprint(
+            f"[bold red]ComfyUI not running on specified port ({port})[/bold red]"
+        )
+        raise typer.Exit(code=1)
+
+    progress = None
+    start = time.time()
+    if wait:
+        pprint(f"Executing workflow: {workflow_name}")
+        progress = ExecutionProgress()
+        progress.start()
+    else:
+        print(f"Queuing workflow: {workflow_name}")
+
+    execution = WorkflowExecution(
+        workflow, listen, port, verbose, progress)
+
+    try:
+        if wait:
+            execution.connect()
+        execution.queue()
+        if wait:
+            execution.watch_execution()
+            end = time.time()
+            progress.stop()
+            progress = None
+
+            if len(execution.outputs):
+                pprint("[bold green]\nOutputs:[/bold green]")
+
+                for f in execution.outputs:
+                    pprint(f)
+
+            elapsed = timedelta(seconds=end-start)
+            pprint(
+                f"[bold green]\nWorkflow execution completed ({elapsed})[/bold green]")
+        else:
+            pprint("[bold green]Workflow queued[/bold green]")
+    finally:
+        if progress:
+            progress.stop()
+
+
+class ExecutionProgress(Progress):
+    def get_renderables(self):
+        table_columns = (
+            (
+                Column(no_wrap=True)
+                if isinstance(_column, str)
+                else _column.get_table_column().copy()
+            )
+            for _column in self.columns
+        )
+
+        for task in self.tasks:
+            percent = "[progress.percentage]{task.percentage:>3.0f}%".format(
+                task=task)
+            if task.fields.get("progress_type") == "overall":
+                overall_table = Table.grid(
+                    *table_columns, padding=(0, 1), expand=self.expand)
+                overall_table.add_row(BarColumn().render(
+                    task), percent, TimeElapsedColumn().render(task))
+                yield overall_table
+            else:
+                yield self.make_tasks_table([task])
+
+
+class WorkflowExecution:
+    def __init__(self, workflow, host, port, verbose, progress):
+        self.workflow = workflow
+        self.host = host
+        self.port = port
+        self.verbose = verbose
+        self.client_id = str(uuid.uuid4())
+        self.outputs = []
+        self.progress = progress
+        self.remaining_nodes = set(self.workflow.keys())
+        self.total_nodes = len(self.remaining_nodes)
+        if progress:
+            self.overall_task = self.progress.add_task(
+                "", total=self.total_nodes, progress_type="overall")
+        self.current_node = None
+        self.progress_task = None
+        self.progress_node = None
+        self.prompt_id = None
+
+    def connect(self):
+        self.ws = WebSocket()
+        self.ws.connect(
+            f"ws://{self.host}:{self.port}/ws?clientId={self.client_id}")
+
+    def queue(self):
+        data = {"prompt": self.workflow, "client_id": self.client_id}
+        req = request.Request(
+            f"http://{self.host}:{self.port}/prompt", json.dumps(data).encode("utf-8"))
+        try:
+            resp = request.urlopen(req)
+            body = json.loads(resp.read())
+
+            self.prompt_id = body["prompt_id"]
+        except urllib.error.HTTPError as e:
+            message = "An unknown error occurred"
+            if e.status == 500:
+                # This is normally just the generic internal server error
+                message = e.read().decode()
+            elif e.status == 400:
+                # Bad Request - workflow failed validation on the server
+                body = json.loads(e.read())
+                if body["node_errors"].keys():
+                    message = json.dumps(body["node_errors"], indent=2)
+
+            self.progress.stop()
+            
+            pprint(
+                f"[bold red]Error running workflow\n{message}[/bold red]"
+            )
+            raise typer.Exit(code=1)
+
+    def watch_execution(self):
+        self.ws.settimeout(30)
+        while True:
+            message = self.ws.recv()
+            if isinstance(message, str):
+                message = json.loads(message)
+                if not self.on_message(message):
+                    break
+
+    def update_overall_progress(self):
+        self.progress.update(
+            self.overall_task, completed=self.total_nodes - len(self.remaining_nodes))
+
+    def get_node_title(self, node_id):
+        node = self.workflow[node_id]
+        if "_meta" in node and "title" in node["_meta"]:
+            return node["_meta"]["title"]
+        return node["class_type"]
+
+    def log_node(self, type, node_id):
+        if not self.verbose:
+            return
+
+        node = self.workflow[node_id]
+        class_type = node["class_type"]
+        title = self.get_node_title(node_id)
+
+        if title != class_type:
+            title += f"[bright_black] - {class_type}[/]"
+        title += f"[bright_black] ({node_id})[/]"
+
+        pprint(f"{type} : {title}")
+
+    def format_image_path(self, img):
+        filename = img["filename"]
+        subfolder = img["subfolder"]
+        output_type = img["type"] or "output"
+
+        if subfolder:
+            filename = os.path.join(subfolder, filename)
+
+        filename = os.path.join(workspace_manager.get_workspace_path()[
+                                0], output_type, filename)
+        return filename
+
+    def on_message(self, message):
+        data = message["data"] if "data" in message else {}
+        # Skip any messages that aren't about our prompt
+        if "prompt_id" not in data or data["prompt_id"] != self.prompt_id:
+            return True
+
+        match message["type"]:
+            case "executing":
+                return self.on_executing(data)
+            case "execution_cached":
+                self.on_cached(data)
+            case "progress":
+                self.on_progress(data)
+            case "executed":
+                self.on_executed(data)
+            case "execution_error":
+                self.on_error(data)
+
+        return True
+
+    def on_executing(self, data):
+        if self.progress_task:
+            self.progress.remove_task(self.progress_task)
+            self.progress_task = None
+
+        if data["node"] is None:
+            return False
+        else:
+           if self.current_node:
+               self.remaining_nodes.discard(self.current_node)
+               self.update_overall_progress()
+           self.current_node = data["node"]
+           self.log_node("Executing", data["node"])
+        return True
+
+    def on_cached(self, data):
+        nodes = data["nodes"]
+        for n in nodes:
+            self.remaining_nodes.discard(n)
+            self.log_node("Cached", n)
+        self.update_overall_progress()
+
+    def on_progress(self, data):
+        node = data["node"]
+        if self.progress_node != node:
+            self.progress_node = node
+            if self.progress_task:
+                self.progress.remove_task(self.progress_task)
+
+            self.progress_task = self.progress.add_task(
+                self.get_node_title(node), total=data["max"], progress_type="node")
+        self.progress.update(self.progress_task, completed=data["value"])
+
+    def on_executed(self, data):
+        self.remaining_nodes.discard(data["node"])
+        self.update_overall_progress()
+
+        if "output" not in data:
+            return
+
+        output = data["output"]
+
+        if "images" not in output:
+            return
+
+        for img in output["images"]:
+            self.outputs.append(self.format_image_path(img))
+
+    def on_error(self, data):
+        pprint(
+            f"[bold red]Error running workflow\n{json.dumps(data, indent=2)}[/bold red]"
+        )
+        raise typer.Exit(code=1)

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 import typer
 import uuid
@@ -32,9 +33,9 @@ def load_api_workflow(file: str):
 
 
 def execute(workflow: str, listen, port, wait=True, verbose=False):
-    workflow_name = os.path.abspath(workflow)
+    workflow_name = os.path.abspath(os.path.expanduser(workflow))
     if not os.path.isfile(workflow):
-        pprint("[bold red]Specified workflow file not found[/bold red]")
+        pprint(f"[bold red]Specified workflow file not found: {workflow}[/bold red]", file=sys.stderr)
         raise typer.Exit(code=1)
 
     workflow = load_api_workflow(workflow)

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -224,17 +224,16 @@ class WorkflowExecution:
         if "prompt_id" not in data or data["prompt_id"] != self.prompt_id:
             return True
 
-        match message["type"]:
-            case "executing":
-                return self.on_executing(data)
-            case "execution_cached":
-                self.on_cached(data)
-            case "progress":
-                self.on_progress(data)
-            case "executed":
-                self.on_executed(data)
-            case "execution_error":
-                self.on_error(data)
+        if message["type"] == "executing":
+            return self.on_executing(data)
+        elif message["type"] == "execution_cached":
+            self.on_cached(data)
+        elif message["type"] == "progress":
+            self.on_progress(data)
+        elif message["type"] == "executed":
+            self.on_executed(data)
+        elif message["type"] == "execution_error":
+            self.on_error(data)
 
         return True
 

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -36,7 +36,7 @@ def format_python_version(version_info):
     )
 
 
-def check_comfy_server_running(port=8188):
+def check_comfy_server_running(port=8188, host="localhost"):
     """
     Checks if the Comfy server is running by making a GET request to the /history endpoint.
 
@@ -44,7 +44,7 @@ def check_comfy_server_running(port=8188):
         bool: True if the Comfy server is running, False otherwise.
     """
     try:
-        response = requests.get(f"http://localhost:{port}/history")
+        response = requests.get(f"http://{host}:{port}/history")
         return response.status_code == 200
     except requests.exceptions.RequestException:
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pathspec",
     "httpx",
     "packaging",
+    "websocket-client"
 ]
 
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pathspec
 httpx
 packaging
 charset-normalizer>=3.0.0
+websocket-client


### PR DESCRIPTION
Adds `comfy run --workflow {file}`,  allowing you to run API workflows from the cli using the comfy cli background instance.

Arguments: 
`--workflow` - The workflow API JSON to run
`--[no-]wait` - If the execution should be awaited or just queued and exits, default True
`--verbose` - If additional node execution logs should be output, default False

Outputs list of files that were generated during the run
![image](https://github.com/yoland68/comfy-cli/assets/125205205/4db70ac5-8984-46a6-a01e-ba81907b1d29)


Adds the websocket-client package for handling workflow execution messages.

Tested on Windows & WSL 2 (Ubuntu)