### PR TITLE
Update generate deps command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
 
 - Generate deps:
 
-  `comfy node deps-in-workflow --workflow=<workflow .json/.png file>`
+  `comfy node deps-in-workflow --workflow=<workflow .json/.png file> --output=<output deps .json file>` 
 
 ### Managing Models
 


### PR DESCRIPTION
The current example for generating deps from a workflow json doesn't includes complete command. Updated `deps-in-workflow` command to include `--output=<output deps .json file>`
