### PR TITLE
Fix: Install command with just --workspace flag doesn't work

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -112,14 +112,15 @@ def entry(
             help="Enable tracking",
         ),
     ] = True,
-    version: bool = typer.Option(
-        False,
-        "--version",
-        "-v",
-        help="Print version and exit",
-        is_flag=True,
-        callback=exclusivity_callback,
-    ),
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            show_default=False,
+            is_flag=True,
+            help="Print version and exit",
+            callback=exclusivity_callback,
+        ),
+    ] = None,
 ):
     if version:
         print(ConfigManager().get_cli_version())

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -115,6 +115,8 @@ def entry(
     version: Annotated[
         Optional[bool],
         typer.Option(
+            "--version",
+            "-v",
             show_default=False,
             is_flag=True,
             help="Print version and exit",


### PR DESCRIPTION
**Issue:**
When you try to run following command to install comfy in particular workspace it doesn't works
```bash
comfy --workspace=<workspace path> install
```

It throws following error:

```
Error 
│ Invalid value for '--version' / '-v': option `version` is mutually     │
│ exclusive with option `workspace`                                      │
╰─────────────────────────────────────
```

**Expected:**
The install command should work with just workspace flag provided that we're not adding other mutually exclusive flags like `--here` and `--recent`


**Fix:**
We need to wrap [version](https://github.com/Comfy-Org/comfy-cli/blob/main/comfy_cli/cmdline.py#L115-L122) with `Annotated` and making it Optional to avoid triggering exclusivity_callback on it. 


**Results:**

Before fix:

<img width="1509" alt="Screenshot 2024-07-03 at 11 43 49 AM" src="https://github.com/Comfy-Org/comfy-cli/assets/2155572/0029094c-704e-41d9-8891-7e6aff80417b">

After fix:

<img width="1197" alt="Screenshot 2024-07-03 at 11 43 04 AM" src="https://github.com/Comfy-Org/comfy-cli/assets/2155572/d0e3fbf3-56bd-40ca-81ee-50804eed6694">


Let me know if there is a better way to fix it. I'd be happy to change it


