### PR TITLE
Fix `check_comfy_repo`

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -6,6 +6,7 @@ import uuid
 import webbrowser
 from typing import Optional
 
+import git
 import questionary
 import typer
 from rich import print
@@ -27,7 +28,7 @@ from comfy_cli.update import check_for_updates
 from comfy_cli.workspace_manager import (
     WorkspaceManager,
     WorkspaceType,
-    check_comfy_repo,
+    get_comfy_repo,
 )
 
 logging.setup_logging()
@@ -230,8 +231,8 @@ def install(
     if comfy_path is None:
         comfy_path = utils.get_not_user_set_default_workspace()
 
-    is_comfy_path, repo_dir = check_comfy_repo(comfy_path)
-    if is_comfy_path and not restore:
+    comfy_repo: git.Repo = get_comfy_repo(comfy_path)
+    if comfy_repo and not restore:
         print(
             f"[bold red]ComfyUI is already installed at the specified path:[/bold red] {comfy_path}\n"
         )
@@ -240,8 +241,8 @@ def install(
         )
         raise typer.Exit(code=1)
 
-    if repo_dir is not None:
-        comfy_path = str(repo_dir.working_dir)
+    if comfy_repo is not None:
+        comfy_path = str(comfy_repo.working_dir)
 
     if checker.python_version.major < 3 or checker.python_version.minor < 9:
         print(
@@ -707,8 +708,8 @@ def set_default(
         )
         raise typer.Exit(code=1)
 
-    is_comfy_repo, comfy_repo = check_comfy_repo(comfy_path)
-    if not is_comfy_repo:
+    comfy_repo = get_comfy_repo(comfy_path)
+    if not comfy_repo:
         print(
             f"\nSpecified path is not a ComfyUI path: {comfy_path}.\n",
             file=sys.stderr,

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -8,7 +8,7 @@ import typer
 
 from comfy_cli import constants, ui, utils
 from comfy_cli.constants import GPU_OPTION
-from comfy_cli.workspace_manager import WorkspaceManager, check_comfy_repo
+from comfy_cli.workspace_manager import WorkspaceManager, get_comfy_repo
 from comfy_cli.command.custom_nodes.command import update_node_id_cache
 
 workspace_manager = WorkspaceManager()
@@ -190,7 +190,7 @@ def execute(
 
     if not os.path.exists(repo_dir):
         subprocess.run(["git", "clone", url, repo_dir])
-    elif not check_comfy_repo(repo_dir)[0]:
+    elif not get_comfy_repo(repo_dir)[0]:
         print(
             f"[bold red]'{repo_dir}' already exists. But it is an invalid ComfyUI repository. Remove it and retry.[/bold red]"
         )


### PR DESCRIPTION
Currently `check_comfy_repo` is returning `Tuple[bool, Optional[git.Repo]]`, but most call site is treating the return value as a bool, so the check at most callsites just always pass, because the a tuple of 2 items always evals to True.

This PR does following changes:
- Rename `check_comfy_repo` to `get_comfy_repo` as the git.Repo is the most important return value
- Simplify the return value to `Optional[git.Repo]` as the bool can be obtained from nullity of `Optional[git.Repo]`
- Change call site where a tuple of 2 itmes are expected

Note:
This will likely break things. So don't merge it until we have more test coverage.