### PR TITLE
Disable flaky Window GPU test

### DIFF
--- a/.github/workflows/run-on-gpu.yml
+++ b/.github/workflows/run-on-gpu.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows, linux]
+        # windows test is flaky.
+        os: [linux]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Windows GPU test is flaky. Example run. https://github.com/Comfy-Org/comfy-cli/actions/runs/9976340707/job/27568268156. Disable it until issue resolved.