### PR TITLE
Allowing picking of specific branch in `--url`/`--manager-url` options for `comfy install` command

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -140,9 +140,19 @@ def entry(
 @app.command(help="Download and install ComfyUI and ComfyUI-Manager")
 @tracking.track_command()
 def install(
-    url: Annotated[str, typer.Option(show_default=False)] = constants.COMFY_GITHUB_URL,
+    url: Annotated[
+        str,
+        typer.Option(
+            show_default=False,
+            help="url or local path pointing to the ComfyUI core git repo to be installed",
+        ),
+    ] = constants.COMFY_GITHUB_URL,
     manager_url: Annotated[
-        str, typer.Option(show_default=False)
+        str,
+        typer.Option(
+            show_default=False,
+            help="url or local path pointing to the ComfyUI-Manager git repo to be installed. A specific branch can optionally be specified using a setuptools-like syntax, eg https://foo.git@bar",
+        ),
     ] = constants.COMFY_MANAGER_GITHUB_URL,
     restore: Annotated[
         bool,

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -144,7 +144,7 @@ def install(
         str,
         typer.Option(
             show_default=False,
-            help="url or local path pointing to the ComfyUI core git repo to be installed",
+            help="url or local path pointing to the ComfyUI core git repo to be installed. A specific branch can optionally be specified using a setuptools-like syntax, eg https://foo.git@bar",
         ),
     ] = constants.COMFY_GITHUB_URL,
     manager_url: Annotated[

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -189,7 +189,15 @@ def execute(
         os.makedirs(parent_path, exist_ok=True)
 
     if not os.path.exists(repo_dir):
-        subprocess.run(["git", "clone", url, repo_dir], check=True)
+        if "@" in url:
+            # clone specific branch
+            *url_parts, branch = url.split("@")
+            url = "".join(url_parts)
+
+            subprocess.run(["git", "clone", "-b", branch, url, repo_dir], check=True)
+        else:
+            subprocess.run(["git", "clone", url, repo_dir], check=True)
+
     elif not check_comfy_repo(repo_dir)[0]:
         print(
             f"[bold red]'{repo_dir}' already exists. But it is an invalid ComfyUI repository. Remove it and retry.[/bold red]"

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -191,8 +191,7 @@ def execute(
     if not os.path.exists(repo_dir):
         if "@" in url:
             # clone specific branch
-            *url_parts, branch = url.split("@")
-            url = "".join(url_parts)
+            url, branch = url.rsplit("@", 1)
 
             subprocess.run(["git", "clone", "-b", branch, url, repo_dir], check=True)
         else:
@@ -236,8 +235,7 @@ def execute(
 
             if "@" in manager_url:
                 # clone specific branch
-                *manager_url_parts, manager_branch = manager_url.split("@")
-                manager_url = "".join(manager_url_parts)
+                manager_url, manager_branch = manager_url.rsplit("@", 1)
 
                 subprocess.run(["git", "clone", "-b", manager_branch, manager_url, manager_repo_dir], check=True)
             else:

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -1,10 +1,10 @@
+from rich import print
 import os
 import platform
 import subprocess
 import sys
-
 import typer
-from rich import print
+from typing import Optional
 
 from comfy_cli import constants, ui, utils
 from comfy_cli.command.custom_nodes.command import update_node_id_cache
@@ -163,7 +163,7 @@ def execute(
     comfy_path: str,
     restore: bool,
     skip_manager: bool,
-    commit=None,
+    commit: Optional[str] = None,
     gpu: constants.GPU_OPTION = None,
     cuda_version: constants.CUDAVersion = constants.CUDAVersion.v12_1,
     plat: constants.OS = None,

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -226,7 +226,15 @@ def execute(
         else:
             print("\nInstalling ComfyUI-Manager..")
 
-            subprocess.run(["git", "clone", manager_url, manager_repo_dir], check=True)
+            if "@" in manager_url:
+                # clone specific branch
+                *manager_url_parts, manager_branch = manager_url.split("@")
+                manager_url = "".join(manager_url_parts)
+
+                subprocess.run(["git", "clone", "-b", manager_branch, manager_url, manager_repo_dir], check=True)
+            else:
+                subprocess.run(["git", "clone", manager_url, manager_repo_dir], check=True)
+
             install_manager_dependencies(repo_dir)
 
         update_node_id_cache()


### PR DESCRIPTION
Currently, the url options of `comfy install` allow a user to specify a url or local path pointing to a particular git repo that will then be used to install either ComfyUI core or ComfyUI-Manager. This PR allows one to also pick a specific branch of said git repo. Branch can be selected using a syntax similar to that of [pip/setuptools dependency specification](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#direct-url-dependencies). For example:

```
https://myrepo.git@branch
```

This will make it easier to test out dev/feature branches of both core and Manager, eg comfyanonymous/ComfyUI#3897, ltdrdata/ComfyUI-Manager#886