### PR TITLE
Fixed: MAC_M_SERIES enum not found

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -275,14 +275,14 @@ def install(
     elif amd:
         gpu = GPU_OPTION.AMD
     elif m_series:
-        gpu = GPU_OPTION.M_SERIES
+        gpu = GPU_OPTION.MAC_M_SERIES
     elif intel_arc:
         gpu = GPU_OPTION.INTEL_ARC
     else:
         if platform == constants.OS.MACOS:
             gpu = ui.prompt_select_enum(
                 "What type of Mac do you have?",
-                [GPU_OPTION.M_SERIES, GPU_OPTION.MAC_INTEL],
+                [GPU_OPTION.MAC_M_SERIES, GPU_OPTION.MAC_INTEL],
             )
         else:
             gpu = ui.prompt_select_enum(
@@ -616,14 +616,14 @@ def standalone(
     elif amd:
         gpu = GPU_OPTION.AMD
     elif m_series:
-        gpu = GPU_OPTION.M_SERIES
+        gpu = GPU_OPTION.MAC_M_SERIES
     elif intel_arc:
         gpu = GPU_OPTION.INTEL_ARC
     else:
         if platform == constants.OS.MACOS:
             gpu = ui.prompt_select_enum(
                 "What type of Mac do you have?",
-                [GPU_OPTION.M_SERIES, GPU_OPTION.MAC_INTEL],
+                [GPU_OPTION.MAC_M_SERIES, GPU_OPTION.MAC_INTEL],
             )
         else:
             gpu = ui.prompt_select_enum(

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -111,7 +111,7 @@ def pip_install_comfyui_dependencies(
             result = subprocess.run([sys.executable, "-m", "pip", "install", "torch-directml"], check=True)
 
         # install torch for Mac M Series
-        if gpu == GPU_OPTION.M_SERIES:
+        if gpu == GPU_OPTION.MAC_M_SERIES:
             result = subprocess.run(
                 [
                     sys.executable,

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -68,7 +68,7 @@ class GPU_OPTION(str, Enum):
     NVIDIA = "nvidia"
     AMD = "amd"
     INTEL_ARC = "intel_arc"
-    M_SERIES = "mac_m_series"
+    MAC_M_SERIES = "mac_m_series"
     MAC_INTEL = "mac_intel"
 
 

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import requests
 
-from comfy_cli.constants import OS, PROC
+from comfy_cli.constants import GPU_OPTION, OS, PROC
 from comfy_cli.typing import PathLike
 from comfy_cli.utils import download_progress, get_os, get_proc
 from comfy_cli.uv import DependencyCompiler
@@ -92,6 +92,8 @@ class StandalonePython:
 
         old_rpath = fpath.parent / old_name
         rpath = fpath.parent / name
+        # clean the expanded destination
+        shutil.rmtree(rpath, ignore_errors=True)
         shutil.move(old_rpath, rpath)
         return StandalonePython(rpath=rpath)
 
@@ -138,25 +140,25 @@ class StandalonePython:
     def install_comfy(self, *args: list[str], gpu_arg: str = "--nvidia"):
         self.run_comfy_cli("--here", "--skip-prompt", "install", "--fast-deps", gpu_arg, *args)
 
-    def compile_comfy_deps(self, comfyDir: PathLike, gpu: str, outDir: Optional[PathLike] = None):
+    def compile_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
         outDir = self.rpath if outDir is None else outDir
 
         self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
         self.dep_comp.compile_comfy_deps()
 
-    def install_comfy_deps(self, comfyDir: PathLike, gpu: str, outDir: Optional[PathLike] = None):
+    def install_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
         outDir = self.rpath if outDir is None else outDir
 
         self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
         self.dep_comp.install_core_plus_ext()
 
-    def precache_comfy_deps(self, comfyDir: PathLike, gpu: str, outDir: Optional[PathLike] = None):
+    def precache_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
         outDir = self.rpath if outDir is None else outDir
 
         self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
         self.dep_comp.precache_comfy_deps()
 
-    def wheel_comfy_deps(self, comfyDir: PathLike, gpu: str, outDir: Optional[PathLike] = None):
+    def wheel_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
         outDir = self.rpath if outDir is None else outDir
 
         self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -265,7 +265,7 @@ class DependencyCompiler:
         return _check_call(cmd, cwd)
 
     @staticmethod
-    def Resolve_Gpu(gpu: Union[GPU_OPTION, str, None]):
+    def Resolve_Gpu(gpu: Union[GPU_OPTION, None]):
         if gpu is None:
             try:
                 tver = metadata.version("torch")
@@ -277,8 +277,6 @@ class DependencyCompiler:
                     return None
             except metadata.PackageNotFoundError:
                 return None
-        elif isinstance(gpu, str):
-            return GPU_OPTION[gpu.upper()]
         else:
             return gpu
 
@@ -286,7 +284,7 @@ class DependencyCompiler:
         self,
         cwd: PathLike = ".",
         executable: PathLike = sys.executable,
-        gpu: Union[GPU_OPTION, str, None] = None,
+        gpu: Union[GPU_OPTION, None] = None,
         outDir: PathLike = ".",
         outName: str = "requirements.compiled",
         reqFilesCore: Optional[list[PathLike]] = None,


### PR DESCRIPTION
Because Resolve_Gpu converts a string to a GPU_Option, we need to use the exact same string as upper and lowercase. `gpu.uppper` converts the previous mac_m_series into `MAC_M_SERIES` which was a non-existent GPU_OPTION.

```
@staticmethod
    def Resolve_Gpu(gpu: Union[GPU_OPTION, str, None]):
        if gpu is None:
            try:
                tver = metadata.version("torch")
                if "+cu" in tver:
                    return GPU_OPTION.NVIDIA
                elif "+rocm" in tver:
                    return GPU_OPTION.AMD
                else:
                    return None
            except metadata.PackageNotFoundError:
                return None
        elif isinstance(gpu, str):
            return GPU_OPTION[gpu.upper()]
        else:
            return gpu
            ```