### PR TITLE
Add `.rehydrate_comfy_deps` method to `StandalonePython`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__/
 
 #COMMON CONFIGs
 .DS_Store
-.ruff_cache
 .src_port
 .webpack_watch.log
 *.swp
@@ -48,7 +47,9 @@ share/python-wheels/
 *.manifest
 *.spec
 
-# temporary files created by tests
+# temporary files created by linting, tests, etc
+.pytest_cache/
+.ruff_cache/
 tests/temp/
 
 venv/

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -610,6 +610,13 @@ def standalone(
             callback=g_gpu_exclusivity.validate,
         ),
     ] = None,
+    rehydrate: Annotated[
+        bool,
+        typer.Option(
+            show_default=False,
+            help="Create standalone Python for CPU",
+        ),
+    ] = False,
 ):
     comfy_path, _ = workspace_manager.get_workspace_path()
 
@@ -652,9 +659,13 @@ def standalone(
                 raise typer.Exit(code=0)
         print("[bold yellow]Installing on Intel ARC is in beta stage.[/bold yellow]")
 
-    sty = StandalonePython.FromDistro(platform=platform, proc=proc)
-    sty.dehydrate_comfy_deps(comfyDir=comfy_path, gpu=gpu, extraSpecs=cli_spec)
-    sty.to_tarball()
+    if rehydrate:
+        sty = StandalonePython.FromTarball(fpath="python")
+        sty.rehydrate_comfy_deps()
+    else:
+        sty = StandalonePython.FromDistro(platform=platform, proc=proc)
+        sty.dehydrate_comfy_deps(comfyDir=comfy_path, gpu=gpu, extraSpecs=cli_spec)
+        sty.to_tarball()
 
 
 app.add_typer(models_command.app, name="model", help="Manage models.")

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -660,7 +660,7 @@ def standalone(
         print("[bold yellow]Installing on Intel ARC is in beta stage.[/bold yellow]")
 
     if rehydrate:
-        sty = StandalonePython.FromTarball(fpath="python")
+        sty = StandalonePython.FromTarball(fpath="python.tgz")
         sty.rehydrate_comfy_deps()
     else:
         sty = StandalonePython.FromDistro(platform=platform, proc=proc)

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -547,6 +547,13 @@ def feedback():
 @app.command(help="Download a standalone Python interpreter and dependencies based on an existing comfyui workspace")
 @tracking.track_command()
 def standalone(
+    cli_spec: Annotated[
+        str,
+        typer.Option(
+            show_default=False,
+            help="setuptools-style requirement specificer pointing to an instance of comfy-cli",
+        ),
+    ] = "comfy-cli",
     platform: Annotated[
         Optional[constants.OS],
         typer.Option(
@@ -646,7 +653,7 @@ def standalone(
         print("[bold yellow]Installing on Intel ARC is in beta stage.[/bold yellow]")
 
     sty = StandalonePython.FromDistro(platform=platform, proc=proc)
-    sty.precache_comfy_deps(comfyDir=comfy_path, gpu=gpu)
+    sty.precache_comfy_deps(comfyDir=comfy_path, gpu=gpu, extraSpecs=cli_spec)
     sty.to_tarball()
 
 

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -653,7 +653,7 @@ def standalone(
         print("[bold yellow]Installing on Intel ARC is in beta stage.[/bold yellow]")
 
     sty = StandalonePython.FromDistro(platform=platform, proc=proc)
-    sty.precache_comfy_deps(comfyDir=comfy_path, gpu=gpu, extraSpecs=cli_spec)
+    sty.dehydrate_comfy_deps(comfyDir=comfy_path, gpu=gpu, extraSpecs=cli_spec)
     sty.to_tarball()
 
 

--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -63,6 +63,7 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
         if fast_deps and args[0] in _dependency_cmds:
             # we're using the fast_deps behavior and just ran a command that invalidated the dependencies
             depComp = DependencyCompiler(cwd=workspace_path)
+            depComp.compile_deps()
             depComp.install_deps()
 
         return result.stdout

--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -63,7 +63,7 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
         if fast_deps and args[0] in _dependency_cmds:
             # we're using the fast_deps behavior and just ran a command that invalidated the dependencies
             depComp = DependencyCompiler(cwd=workspace_path)
-            depComp.install_comfy_deps()
+            depComp.install_deps()
 
         return result.stdout
     except subprocess.CalledProcessError as e:

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -229,7 +229,7 @@ def execute(
 
     if fast_deps:
         depComp = DependencyCompiler(cwd=repo_dir, gpu=gpu)
-        depComp.install_comfy_deps()
+        depComp.install_deps()
 
     if not skip_manager:
         update_node_id_cache()

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -229,6 +229,7 @@ def execute(
 
     if fast_deps:
         depComp = DependencyCompiler(cwd=repo_dir, gpu=gpu)
+        depComp.compile_deps()
         depComp.install_deps()
 
     if not skip_manager:

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -149,37 +149,22 @@ class StandalonePython:
     def install_comfy(self, *args: list[str], gpu_arg: str = "--nvidia"):
         self.run_comfy_cli("--here", "--skip-prompt", "install", "--fast-deps", gpu_arg, *args)
 
-    def compile_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
-        outDir = self.rpath if outDir is None else outDir
-
-        self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
-        self.dep_comp.compile_comfy_deps()
-
-    def install_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
-        outDir = self.rpath if outDir is None else outDir
-
-        self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
-        self.dep_comp.install_core_plus_ext()
-
-    def precache_comfy_deps(
+    def dehydrate_comfy_deps(
         self,
         comfyDir: PathLike,
         gpu: GPU_OPTION,
         outDir: Optional[PathLike] = None,
         extraSpecs: Optional[list[str]] = None,
     ):
-        outDir = self.rpath if outDir is None else outDir
-
         self.dep_comp = DependencyCompiler(
-            cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir, extraSpecs=extraSpecs
+            cwd=comfyDir,
+            executable=self.executable,
+            gpu=gpu,
+            outDir=self.rpath if outDir is None else outDir,
+            extraSpecs=extraSpecs,
         )
-        self.dep_comp.precache_comfy_deps()
-
-    def wheel_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
-        outDir = self.rpath if outDir is None else outDir
-
-        self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
-        self.dep_comp.wheel_comfy_deps()
+        self.dep_comp.compile_deps()
+        self.dep_comp.fetch_dep_wheels()
 
     def to_tarball(self, outPath: Optional[PathLike] = None, progress: bool = True):
         outPath = self.rpath.with_suffix(".tgz") if outPath is None else Path(outPath)

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -169,7 +169,7 @@ class StandalonePython:
         self.dep_comp = DependencyCompiler(
             executable=self.executable, outDir=self.rpath, reqFilesCore=[], reqFilesExt=[]
         )
-        self.dep_comp.install_wheels()
+        self.dep_comp.install_wheels_directly()
 
     def to_tarball(self, outPath: Optional[PathLike] = None, progress: bool = True):
         outPath = self.rpath.with_suffix(".tgz") if outPath is None else Path(outPath)

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -161,10 +161,18 @@ class StandalonePython:
         self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
         self.dep_comp.install_core_plus_ext()
 
-    def precache_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):
+    def precache_comfy_deps(
+        self,
+        comfyDir: PathLike,
+        gpu: GPU_OPTION,
+        outDir: Optional[PathLike] = None,
+        extraSpecs: Optional[list[str]] = None,
+    ):
         outDir = self.rpath if outDir is None else outDir
 
-        self.dep_comp = DependencyCompiler(cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir)
+        self.dep_comp = DependencyCompiler(
+            cwd=comfyDir, executable=self.executable, gpu=gpu, outDir=outDir, extraSpecs=extraSpecs
+        )
         self.dep_comp.precache_comfy_deps()
 
     def wheel_comfy_deps(self, comfyDir: PathLike, gpu: GPU_OPTION, outDir: Optional[PathLike] = None):

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -194,7 +194,7 @@ class StandalonePython:
 
         with Live(progress_table, refresh_per_second=10):
             with tarfile.open(outPath, "w:gz") as tar:
-                tar.add(self.rpath, filter=_filter)
+                tar.add(self.rpath.relative_to(Path(".").expanduser().resolve()), filter=_filter)
 
             if progress:
                 barProg.advance(addTar, _size)

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -166,7 +166,9 @@ class StandalonePython:
         self.dep_comp.fetch_dep_wheels()
 
     def rehydrate_comfy_deps(self):
-        self.dep_comp = DependencyCompiler(executable=self.executable, outDir=self.rpath)
+        self.dep_comp = DependencyCompiler(
+            executable=self.executable, outDir=self.rpath, reqFilesCore=[], reqFilesExt=[]
+        )
         self.dep_comp.install_wheels()
 
     def to_tarball(self, outPath: Optional[PathLike] = None, progress: bool = True):

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -153,18 +153,21 @@ class StandalonePython:
         self,
         comfyDir: PathLike,
         gpu: GPU_OPTION,
-        outDir: Optional[PathLike] = None,
         extraSpecs: Optional[list[str]] = None,
     ):
         self.dep_comp = DependencyCompiler(
             cwd=comfyDir,
             executable=self.executable,
             gpu=gpu,
-            outDir=self.rpath if outDir is None else outDir,
+            outDir=self.rpath,
             extraSpecs=extraSpecs,
         )
         self.dep_comp.compile_deps()
         self.dep_comp.fetch_dep_wheels()
+
+    def rehydrate_comfy_deps(self):
+        self.dep_comp = DependencyCompiler(executable=self.executable, outDir=self.rpath)
+        self.dep_comp.install_wheels()
 
     def to_tarball(self, outPath: Optional[PathLike] = None, progress: bool = True):
         outPath = self.rpath.with_suffix(".tgz") if outPath is None else Path(outPath)

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -90,7 +90,7 @@ def is_running(pid):
         return False
 
 
-def create_choice_completer(opts):
+def create_choice_completer(opts: list[str]):
     def f(incomplete: str) -> list[str]:
         return [opt for opt in opts if opt.startswith(incomplete)]
 

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -383,23 +383,6 @@ class DependencyCompiler:
                 else:
                     raise AttributeError
 
-    def install_core_plus_ext(self):
-        DependencyCompiler.Install(
-            cwd=self.cwd,
-            reqFile=self.out,
-            executable=self.executable,
-            extraUrl=self.gpuUrl,
-            override=self.override,
-        )
-
-    def sync_core_plus_ext(self):
-        DependencyCompiler.Sync(
-            cwd=self.cwd,
-            reqFile=self.out,
-            executable=self.executable,
-            extraUrl=self.gpuUrl,
-        )
-
     def handle_opencv(self):
         """as per the opencv docs, you should only have exactly one opencv package.
         headless is more suitable for comfy than the gui version, so remove gui if
@@ -421,24 +404,22 @@ class DependencyCompiler:
                     if "opencv-python==" not in line:
                         f.write(line)
 
-    def compile_comfy_deps(self):
+    def compile_deps(self):
         self.make_override()
         self.compile_core_plus_ext()
         self.handle_opencv()
 
-    def precache_comfy_deps(self):
-        self.compile_comfy_deps()
+    def fetch_dep_dists(self):
         DependencyCompiler.Download(
             cwd=self.cwd,
             reqFile=self.out,
             executable=self.executable,
             extraUrl=self.gpuUrl,
             noDeps=True,
-            out=self.outDir / "cache",
+            out=self.outDir / "dists",
         )
 
-    def wheel_comfy_deps(self):
-        self.compile_comfy_deps()
+    def fetch_dep_wheels(self):
         DependencyCompiler.Wheel(
             cwd=self.cwd,
             reqFile=self.out,
@@ -448,8 +429,23 @@ class DependencyCompiler:
             out=self.outDir / "wheels",
         )
 
-    def install_comfy_deps(self):
-        DependencyCompiler.Install_Build_Deps(executable=self.executable)
+    def install_core_plus_ext(self):
+        DependencyCompiler.Install(
+            cwd=self.cwd,
+            reqFile=self.out,
+            executable=self.executable,
+            extraUrl=self.gpuUrl,
+            override=self.override,
+        )
 
-        self.compile_comfy_deps()
+    def sync_core_plus_ext(self):
+        DependencyCompiler.Sync(
+            cwd=self.cwd,
+            reqFile=self.out,
+            executable=self.executable,
+            extraUrl=self.gpuUrl,
+        )
+
+    def install_deps(self):
+        self.compile_deps()
         self.install_core_plus_ext()

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -351,19 +351,24 @@ class DependencyCompiler:
                 f.write(line)
             f.write("\n")
 
-            for spec in self.extraSpecs:
-                f.write(spec)
-            f.write("\n")
-
     def compile_core_plus_ext(self):
+        reqExtras = self.outDir / "requirements.extra"
         # clean up
+        reqExtras.unlink(missing_ok=True)
         self.out.unlink(missing_ok=True)
+
+        # make the extra specs file
+        if self.extraSpecs:
+            with reqExtras.open("w") as f:
+                for spec in self.extraSpecs:
+                    f.write(spec)
+                f.write("\n")
 
         while True:
             try:
                 DependencyCompiler.Compile(
                     cwd=self.cwd,
-                    reqFiles=(self.reqFilesCore + self.reqFilesExt),
+                    reqFiles=self.reqFilesCore + self.reqFilesExt + ([reqExtras] if self.extraSpecs else []),
                     executable=self.executable,
                     override=self.override,
                     out=self.out,

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -150,6 +150,7 @@ class DependencyCompiler:
         extra_index_url: Optional[str] = None,
         find_links: Optional[list[str]] = None,
         index_strategy: Optional[str] = "unsafe-best-match",
+        no_deps: bool = False,
         no_index: bool = False,
         override: Optional[PathLike] = None,
     ) -> subprocess.CompletedProcess[Any]:
@@ -175,6 +176,9 @@ class DependencyCompiler:
 
         if index_strategy is not None:
             cmd.extend(["--index-strategy", "unsafe-best-match"])
+
+        if no_deps:
+            cmd.append("--no-deps")
 
         if no_index:
             cmd.append("--no-index")
@@ -433,6 +437,7 @@ class DependencyCompiler:
             reqFile=self.out,
             executable=self.executable,
             find_links=[self.outDir / "dists"],
+            no_deps=True,
             no_index=True,
         )
 
@@ -442,6 +447,7 @@ class DependencyCompiler:
             reqFile=self.out,
             executable=self.executable,
             find_links=[self.outDir / "wheels"],
+            no_deps=True,
             no_index=True,
         )
 

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -34,7 +34,6 @@ def test_compile(mock_prompt_select):
         reqFilesExt=[reqsDir / "x_reqs.txt", reqsDir / "y_reqs.txt"],
     )
 
-    DependencyCompiler.Install_Build_Deps()
     depComp.make_override()
     depComp.compile_core_plus_ext()
 


### PR DESCRIPTION
Also adds a `--rehydrate` option to the `standalone` command. So if you make a standalone python tarball via:

```bash
comfy-cli --skip-prompt --workspace <foo-path> install --fast-deps --amd
comfy-cli --workspace <foo-path> standalone --amd
```

In the same directory as the tarball you can then run:

```bash
comfy-cli standalone --amd --rehydrate
```

Running the above rehydrate command will unpack the tarball and install any wheels cached in the tarball