### PR TITLE
numpy<2 override

### DIFF
--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -52,6 +52,7 @@ class DependencyCompiler:
         # ensure usage of {gpu} version of pytorch
         --extra-index-url {gpuUrl}
         torch
+        torchaudio
         torchsde
         torchvision
     """
@@ -367,6 +368,10 @@ class DependencyCompiler:
             if self.gpu is not None and self.gpuUrl is not None:
                 f.write(DependencyCompiler.overrideGpu.format(gpu=self.gpu, gpuUrl=self.gpuUrl))
                 f.write("\n\n")
+
+            # TODO: remove numpy<2 override once torch is compatible with numpy>=2
+            f.write("numpy<2\n")
+            f.write("\n\n")
 
         completed = DependencyCompiler.Compile(
             cwd=self.cwd,

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -7,8 +7,9 @@ from textwrap import dedent
 from typing import Any, Optional, Union, cast
 
 from comfy_cli import ui
-from comfy_cli.constants import GPU_OPTION
+from comfy_cli.constants import GPU_OPTION, OS
 from comfy_cli.typing import PathLike
+from comfy_cli.utils import get_os
 
 
 def _run(cmd: list[str], cwd: PathLike, check: bool = True) -> subprocess.CompletedProcess[Any]:
@@ -370,8 +371,9 @@ class DependencyCompiler:
                 f.write("\n\n")
 
             # TODO: remove numpy<2 override once torch is compatible with numpy>=2
-            f.write("numpy<2\n")
-            f.write("\n\n")
+            if get_os == OS.WINDOWS:
+                f.write("numpy<2\n")
+                f.write("\n\n")
 
         completed = DependencyCompiler.Compile(
             cwd=self.cwd,

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -371,7 +371,7 @@ class DependencyCompiler:
                 f.write("\n\n")
 
             # TODO: remove numpy<2 override once torch is compatible with numpy>=2
-            if get_os == OS.WINDOWS:
+            if get_os() == OS.WINDOWS:
                 f.write("numpy<2\n")
                 f.write("\n\n")
 


### PR DESCRIPTION
Fixes #163

Temporary fix for the numpy>=2 plus pytorch 2.4.0 plus windows bug. Should likely be removed once pytorch 2.4.1 comes out. See: https://github.com/pytorch/pytorch/issues/131668#issuecomment-2307447045