### PR TITLE
fixed run error where output is None but tries to find images

### DIFF
--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -265,7 +265,7 @@ class WorkflowExecution:
 
         output = data["output"]
 
-        if "images" not in output:
+        if output is None or "images" not in output:
             return
 
         for img in output["images"]:


### PR DESCRIPTION
An error that I found while running `comfy launch background` and trying to `comfy run`. After initial run, which works fine, the second run within the same comfy errors out. It expects output from non-previewable nodes. It errors out because of that.
