### PR TITLE
Removing pypi `check_for_updates` from commands where it halts offline execution

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -20,7 +20,6 @@ from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import GPU_OPTION, CUDAVersion
 from comfy_cli.env_checker import EnvChecker
 from comfy_cli.standalone import StandalonePython
-#from comfy_cli.update import check_for_updates
 from comfy_cli.workspace_manager import WorkspaceManager, check_comfy_repo
 
 logging.setup_logging()
@@ -222,7 +221,6 @@ def install(
         ),
     ] = False,
 ):
-    #check_for_updates()
     checker = EnvChecker()
 
     comfy_path, _ = workspace_manager.get_workspace_path()
@@ -496,7 +494,6 @@ def which():
 @app.command(help="Print out current environment variables.")
 @tracking.track_command()
 def env():
-    #check_for_updates()
     _env_checker = EnvChecker()
     table = _env_checker.fill_print_table()
     workspace_manager.fill_print_table(table)

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -20,7 +20,7 @@ from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import GPU_OPTION, CUDAVersion
 from comfy_cli.env_checker import EnvChecker
 from comfy_cli.standalone import StandalonePython
-from comfy_cli.update import check_for_updates
+#from comfy_cli.update import check_for_updates
 from comfy_cli.workspace_manager import WorkspaceManager, check_comfy_repo
 
 logging.setup_logging()
@@ -222,7 +222,7 @@ def install(
         ),
     ] = False,
 ):
-    check_for_updates()
+    #check_for_updates()
     checker = EnvChecker()
 
     comfy_path, _ = workspace_manager.get_workspace_path()
@@ -496,7 +496,7 @@ def which():
 @app.command(help="Print out current environment variables.")
 @tracking.track_command()
 def env():
-    check_for_updates()
+    #check_for_updates()
     _env_checker = EnvChecker()
     table = _env_checker.fill_print_table()
     workspace_manager.fill_print_table(table)

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -15,7 +15,6 @@ from rich.panel import Panel
 from comfy_cli import constants, utils
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import check_comfy_server_running
-#from comfy_cli.update import check_for_updates
 from comfy_cli.workspace_manager import WorkspaceManager, WorkspaceType
 
 workspace_manager = WorkspaceManager()
@@ -108,7 +107,6 @@ def launch(
     background: bool = False,
     extra: list[str] | None = None,
 ):
-    #check_for_updates()
     resolved_workspace = workspace_manager.workspace_path
 
     if not resolved_workspace:

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -15,7 +15,7 @@ from rich.panel import Panel
 from comfy_cli import constants, utils
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import check_comfy_server_running
-from comfy_cli.update import check_for_updates
+#from comfy_cli.update import check_for_updates
 from comfy_cli.workspace_manager import WorkspaceManager, WorkspaceType
 
 workspace_manager = WorkspaceManager()
@@ -108,7 +108,7 @@ def launch(
     background: bool = False,
     extra: list[str] | None = None,
 ):
-    check_for_updates()
+    #check_for_updates()
     resolved_workspace = workspace_manager.workspace_path
 
     if not resolved_workspace:


### PR DESCRIPTION
Checking the version of comfy-cli in commands where internet-access is not necessary, such as `comfy launch` and `comfy env` causes comfy-cli to hang in a docker container (or offline) environment.

I opened an issue to describe this
https://github.com/Comfy-Org/comfy-cli/issues/175

This PR removes just those calls to `check_for_updates()` that ping pypi each time a `comfy launch` is run or a `comfy env` is checked where offline operation can otherwise work perfectly.