### PR TITLE
Use constant for downloading python standalone version.

### DIFF
--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -77,3 +77,6 @@ class GPU_OPTION(str, Enum):
 SUPPORTED_PT_EXTENSIONS = (".ckpt", ".pt", ".bin", ".pth", ".safetensors")
 
 NODE_ZIP_FILENAME = "node.zip"
+
+# The default version to download from python-build-standalone.
+DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION = "3.12.6"

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -2,9 +2,10 @@ import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
+
 import requests
 
-from comfy_cli.constants import OS, PROC, DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION
+from comfy_cli.constants import DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION, OS, PROC
 from comfy_cli.typing import PathLike
 from comfy_cli.utils import create_tarball, download_url, extract_tarball, get_os, get_proc
 from comfy_cli.uv import DependencyCompiler

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -2,10 +2,9 @@ import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
-
 import requests
 
-from comfy_cli.constants import OS, PROC
+from comfy_cli.constants import OS, PROC, DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION
 from comfy_cli.typing import PathLike
 from comfy_cli.utils import create_tarball, download_url, extract_tarball, get_os, get_proc
 from comfy_cli.uv import DependencyCompiler
@@ -28,7 +27,7 @@ _asset_url_prefix = "https://github.com/indygreg/python-build-standalone/release
 def download_standalone_python(
     platform: Optional[str] = None,
     proc: Optional[str] = None,
-    version: str = "3.12.5",
+    version: str = DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION,
     tag: str = "latest",
     flavor: str = "install_only",
     cwd: PathLike = ".",
@@ -65,7 +64,7 @@ class StandalonePython:
     def FromDistro(
         platform: Optional[str] = None,
         proc: Optional[str] = None,
-        version: str = "3.12.6",
+        version: str = DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION,
         tag: str = "latest",
         flavor: str = "install_only",
         cwd: PathLike = ".",


### PR DESCRIPTION
Keep the version in a single place for easy upgrades.