### PR TITLE
removed patch that forced numpy<2 on windows

### DIFF
--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -399,11 +399,6 @@ class DependencyCompiler:
                 f.write(DependencyCompiler.overrideGpu.format(gpu=self.gpu, gpuUrl=self.gpuUrl))
                 f.write("\n\n")
 
-            # TODO: remove numpy<2 override once torch is compatible with numpy>=2
-            if get_os() == OS.WINDOWS:
-                f.write("numpy<2\n")
-                f.write("\n\n")
-
         completed = DependencyCompiler.Compile(
             cwd=self.cwd,
             reqFiles=self.reqFilesCore,


### PR DESCRIPTION
now that pytorch has updated beyond the broken 2.4 release, we can now remove the patch that forced numpy<2 on windows. We should test this on windows first before pulling this in