### PR TITLE
Fix for hanging when run in an off-line environment 

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -242,7 +242,7 @@ def install(
         ),
     ] = False,
 ):
-    check_for_updates()
+    check_for_updates(timeout=3)
     checker = EnvChecker()
 
     comfy_path, _ = workspace_manager.get_workspace_path()
@@ -518,7 +518,7 @@ def which():
 @app.command(help="Print out current environment variables.")
 @tracking.track_command()
 def env():
-    check_for_updates()
+    check_for_updates(timeout=3)
     _env_checker = EnvChecker()
     table = _env_checker.fill_print_table()
     workspace_manager.fill_print_table(table)

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -108,7 +108,7 @@ def launch(
     background: bool = False,
     extra: list[str] | None = None,
 ):
-    check_for_updates()
+    check_for_updates(timeout=3)
     resolved_workspace = workspace_manager.workspace_path
 
     if not resolved_workspace:

--- a/comfy_cli/update.py
+++ b/comfy_cli/update.py
@@ -9,10 +9,19 @@ from rich.panel import Panel
 console = Console()
 
 
-def check_for_newer_pypi_version(package_name, current_version):
+def check_for_newer_pypi_version(package_name: str, current_version: str, timeout: float) -> tuple[bool, str]:
+    """
+    Checks if a newer version of the specified package is available on PyPI.
+
+    :param package_name: The name of the package to check.
+    :param current_version: The current version of the package.
+    :param timeout: Timeout in seconds for the request to PyPI.
+    :return: A tuple where the first value indicates if a newer version is available,
+             and the second value is the latest version (or the current version if no update is found).
+    """
     url = f"https://pypi.org/pypi/{package_name}/json"
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=timeout)
         response.raise_for_status()  # Raises stored HTTPError, if one occurred
         latest_version = response.json()["info"]["version"]
 
@@ -21,24 +30,38 @@ def check_for_newer_pypi_version(package_name, current_version):
 
         return False, current_version
     except requests.RequestException:
-        # print(f"Error checking latest version: {e}")
+        # Fail quietly on timeout or any request exception
         return False, current_version
 
 
-def check_for_updates():
+def check_for_updates(timeout: float = 10) -> None:
+    """
+    Checks for updates to the 'comfy-cli' package by comparing the current version
+    to the latest version on PyPI. If a newer version is available, a notification
+    is displayed.
+
+    :param timeout: (default 10) Timeout in seconds for the request to check for updates.
+                    If not provided, no timeout is enforced.
+    """
     current_version = get_version_from_pyproject()
-    has_newer, newer_version = check_for_newer_pypi_version("comfy-cli", current_version)
+    has_newer, newer_version = check_for_newer_pypi_version("comfy-cli", current_version, timeout=timeout)
 
     if has_newer:
         notify_update(current_version, newer_version)
 
 
-def get_version_from_pyproject():
+def get_version_from_pyproject() -> str:
     package_metadata = metadata("comfy-cli")
     return package_metadata["Version"]
 
 
-def notify_update(current_version: str, newer_version: str):
+def notify_update(current_version: str, newer_version: str) -> None:
+    """
+    Notifies the user that a newer version of the 'comfy-cli' package is available.
+
+    :param current_version: The current version of the package.
+    :param newer_version: The newer version available on PyPI.
+    """
     message = (
         f":sparkles: Newer version of [bold magenta]comfy-cli[/bold magenta] is available: [bold green]{newer_version}[/bold green].\n"
         f"Current version: [bold cyan]{current_version}[/bold cyan]\n"


### PR DESCRIPTION
Proposed fix for the issue where running in an off-line environment hangs on check_for_updates.  

Adds a default 10 second timeout to the request
Shortened to 3 second timeout in the launcher and env command calls where check_for_updates is not a requirement. 

Consistent with the previous request code, if it times out it will fail quietly and return false and the current version.

https://github.com/Comfy-Org/comfy-cli/issues/175

Also added PEP 585 type hints to functions in the updates module.