### PR TITLE
default to not packing/unpacking wheels into standalone python bundle

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -576,6 +576,13 @@ def standalone(
             help="setuptools-style requirement specificer pointing to an instance of comfy-cli",
         ),
     ] = "comfy-cli",
+    pack_wheels: Annotated[
+        bool,
+        typer.Option(
+            show_default=False,
+            help="Pack requirement wheels in archive when creating standalone bundle",
+        ),
+    ] = False,
     platform: Annotated[
         Optional[constants.OS],
         typer.Option(
@@ -605,10 +612,10 @@ def standalone(
 
     if rehydrate:
         sty = StandalonePython.FromTarball(fpath="python.tgz")
-        sty.rehydrate_comfy_deps()
+        sty.rehydrate_comfy_deps(packWheels=pack_wheels)
     else:
         sty = StandalonePython.FromDistro(platform=platform, proc=proc)
-        sty.dehydrate_comfy_deps(comfyDir=comfy_path, extraSpecs=cli_spec)
+        sty.dehydrate_comfy_deps(comfyDir=comfy_path, extraSpecs=[cli_spec], packWheels=pack_wheels)
         sty.to_tarball()
 
 

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -115,7 +115,7 @@ class StandalonePython:
         for pycache in self.rpath.glob("**/__pycache__"):
             shutil.rmtree(pycache)
 
-    def run_module(self, mod: str, *args: list[str]):
+    def run_module(self, mod: str, *args: str):
         cmd: list[str] = [
             str(self.executable),
             "-m",
@@ -125,10 +125,10 @@ class StandalonePython:
 
         subprocess.run(cmd, check=True)
 
-    def pip_install(self, *args: list[str]):
+    def pip_install(self, *args: str):
         self.run_module("pip", "install", *args)
 
-    def uv_install(self, *args: list[str]):
+    def uv_install(self, *args: str):
         self.run_module("uv", "pip", "install", *args)
 
     def install_comfy_cli(self, dev: bool = False):
@@ -137,10 +137,10 @@ class StandalonePython:
         else:
             self.uv_install("comfy_cli")
 
-    def run_comfy_cli(self, *args: list[str]):
+    def run_comfy_cli(self, *args: str):
         self.run_module("comfy_cli", *args)
 
-    def install_comfy(self, *args: list[str], gpu_arg: str = "--nvidia"):
+    def install_comfy(self, *args: str, gpu_arg: str = "--nvidia"):
         self.run_comfy_cli("--here", "--skip-prompt", "install", "--fast-deps", gpu_arg, *args)
 
     def dehydrate_comfy_deps(
@@ -170,7 +170,6 @@ class StandalonePython:
             self.dep_comp.install_wheels_directly()
         else:
             self.dep_comp.install_deps()
-
 
     def to_tarball(self, outPath: Optional[PathLike] = None, show_progress: bool = True):
         # remove any __pycache__ before creating archive

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -147,6 +147,7 @@ class StandalonePython:
         self,
         comfyDir: PathLike,
         extraSpecs: Optional[list[str]] = None,
+        packWheels: bool = False,
     ):
         self.dep_comp = DependencyCompiler(
             cwd=comfyDir,
@@ -156,14 +157,20 @@ class StandalonePython:
         )
         self.dep_comp.compile_deps()
 
-        skip_uv = get_os() == OS.WINDOWS
-        self.dep_comp.fetch_dep_wheels(skip_uv=skip_uv)
+        if packWheels:
+            skip_uv = get_os() == OS.WINDOWS
+            self.dep_comp.fetch_dep_wheels(skip_uv=skip_uv)
 
-    def rehydrate_comfy_deps(self):
+    def rehydrate_comfy_deps(self, packWheels: bool = False):
         self.dep_comp = DependencyCompiler(
             executable=self.executable, outDir=self.rpath, reqFilesCore=[], reqFilesExt=[]
         )
-        self.dep_comp.install_wheels_directly()
+
+        if packWheels:
+            self.dep_comp.install_wheels_directly()
+        else:
+            self.dep_comp.install_deps()
+
 
     def to_tarball(self, outPath: Optional[PathLike] = None, show_progress: bool = True):
         # remove any __pycache__ before creating archive

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -184,7 +184,7 @@ class DependencyCompiler:
         override: Optional[PathLike] = None,
         reqs: Optional[list[str]] = None,
         reqFile: Optional[list[PathLike]] = None,
-    ) -> subprocess.CompletedProcess[Any]:
+    ) -> None:
         cmd = [
             str(executable),
             "-m",
@@ -232,7 +232,7 @@ class DependencyCompiler:
         executable: PathLike = sys.executable,
         extraUrl: Optional[str] = None,
         index_strategy: str = "unsafe-best-match",
-    ) -> subprocess.CompletedProcess[Any]:
+    ) -> None:
         cmd = [
             str(executable),
             "-m",
@@ -262,7 +262,7 @@ class DependencyCompiler:
         out: Optional[PathLike] = None,
         reqs: Optional[list[str]] = None,
         reqFile: Optional[list[PathLike]] = None,
-    ) -> subprocess.CompletedProcess[Any]:
+    ) -> None:
         """For now, the `download` cmd has no uv support, so use pip"""
         cmd = [
             str(executable),
@@ -298,7 +298,7 @@ class DependencyCompiler:
         out: Optional[PathLike] = None,
         reqs: Optional[list[str]] = None,
         reqFile: Optional[list[PathLike]] = None,
-    ) -> subprocess.CompletedProcess[Any]:
+    ) -> None:
         """For now, the `wheel` cmd has no uv support, so use pip"""
         cmd = [
             str(executable),
@@ -480,20 +480,20 @@ class DependencyCompiler:
     def install_deps(self):
         DependencyCompiler.Install(
             cwd=self.cwd,
-            reqFile=[self.out],
             executable=self.executable,
             extra_index_url=self.gpuUrl,
             override=self.override,
+            reqFile=[self.out],
         )
 
     def install_dists(self):
         DependencyCompiler.Install(
             cwd=self.cwd,
-            reqFile=[self.out],
             executable=self.executable,
             find_links=[self.outDir / "dists"],
             no_deps=True,
             no_index=True,
+            reqFile=[self.out],
         )
 
     def install_wheels(self):


### PR DESCRIPTION
When dehydrating/hydrating a standalone python bundle with the `standalone` cmd, it will now by default skip packing/unpacking wheels into the bundle. If you want the old behavior, pass `standalone --pack-wheels`