### PR TITLE
bug: handle subfolder missing in image output

### DIFF
--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -190,7 +190,7 @@ class WorkflowExecution:
 
     def format_image_path(self, img):
         filename = img["filename"]
-        subfolder = img["subfolder"]
+        subfolder = img["subfolder"] if "subfolder" in img else None
         output_type = img["type"] or "output"
 
         if self.local_paths:


### PR DESCRIPTION
Fix `KeyError` caused by `subfolder` field missing in the image output.

Encountered this issue with this [workflow](https://github.com/PowerHouseMan/ComfyUI-AdvancedLivePortrait). The return does not have the `subfolder` field.