### PR TITLE
Remove comfy-cli as a dependency for standalone.

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -629,7 +629,7 @@ def standalone(
         sty.rehydrate_comfy_deps(packWheels=pack_wheels)
     else:
         sty = StandalonePython.FromDistro(platform=platform, proc=proc)
-        sty.dehydrate_comfy_deps(comfyDir=comfy_path, extraSpecs=[cli_spec], packWheels=pack_wheels)
+        sty.dehydrate_comfy_deps(comfyDir=comfy_path, extraSpecs=[], packWheels=pack_wheels)
         sty.to_tarball()
 
 


### PR DESCRIPTION
Not needed right now.