### PR TITLE
--listen doesn't work on launch command

### DIFF
--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -153,7 +153,7 @@ def background_launch(extra):
         for i in range(len(extra) - 1):
             if extra[i] == "--port":
                 port = extra[i + 1]
-            if listen[i] == "--listen":
+            if extra[i] == "--listen":
                 listen = extra[i + 1]
 
         if len(extra) > 0:


### PR DESCRIPTION
Doing:
```
comfy launch --background -- --listen 0.0.0.0 --cpu
```
doesn't work because of a typo.

Here a small fix.