### PR TITLE
Fixes the 'read operation timed out' exception.

### DIFF
--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -69,7 +69,9 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: Optional[dict
     """Helper function to download a file."""
     local_filepath.parent.mkdir(parents=True, exist_ok=True)  # Ensure the directory exists
 
-    with httpx.stream("GET", url, follow_redirects=True, headers=headers) as response:
+    timeout = httpx.Timeout(timeout=5.0, read=None)  # Default timeout with no read timeout
+
+    with httpx.stream("GET", url, follow_redirects=True, headers=headers, timeout=timeout) as response:
         if response.status_code == 200:
             total = int(response.headers["Content-Length"])
             try:


### PR DESCRIPTION
When using the 'comfy model download' command to download large models from Civitai, an exception with the message 'The read operation timed out' is frequently thrown. This change prevents the exception from occurring.

This is a proposal to fix the issue: https://github.com/Comfy-Org/comfy-cli/issues/210