### PR TITLE
Add Ruff dependencies and warning message when custom nodes are using eval or exec calls

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -709,14 +709,16 @@ def publish(
     # Run security checks first
     typer.echo("Running security checks...")
     try:
-        # Run ruff check with security rules
-        cmd = ["ruff", "check", ".", "--select", "S102,S307"]
+        # Run ruff check with security rules and --exit-zero to only warn
+        cmd = ["ruff", "check", ".", "--select", "S102,S307", "--exit-zero"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
-        if result.returncode != 0:
-            print("[red]Security issues found:[/red]")
+        if result.stdout:  # Changed from checking returncode to checking if there's output
+            print("[yellow]Security warnings found:[/yellow]")  # Changed from red to yellow to indicate warning
             print(result.stdout)
-            raise typer.Exit(code=1)
+            print("[bold yellow]We will soon disable exec and eval, so this will be an error soon.[/bold yellow]")
+            # TODO: re-enable exit when we disable exec and eval
+            # raise typer.Exit(code=1)
 
     except FileNotFoundError:
         print("[red]Ruff is not installed. Please install it with 'pip install ruff'[/red]")

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -710,7 +710,7 @@ def publish(
     typer.echo("Running security checks...")
     try:
         # Run ruff check with security rules and --exit-zero to only warn
-        cmd = ["ruff", "check", ".", "--select", "S102,S307", "--exit-zero"]
+        cmd = ["ruff", "check", ".", "-q", "--select", "S102,S307", "--exit-zero"]
         result = subprocess.run(cmd, capture_output=True, text=True)
 
         if result.stdout:  # Changed from checking returncode to checking if there's output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "typing-extensions>=4.7.0",
   "uv",
   "websocket-client",
+  "ruff",
   "semver~=3.0.2",
 ]
 

--- a/tests/comfy_cli/command/nodes/test_publish.py
+++ b/tests/comfy_cli/command/nodes/test_publish.py
@@ -13,11 +13,16 @@ def test_publish_fails_on_security_violations():
     mock_result.returncode = 1
     mock_result.stdout = "S102 Use of exec() detected"
 
-    with patch("subprocess.run", return_value=mock_result):
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("typer.prompt", return_value="test-token"),
+    ):
         result = runner.invoke(app, ["publish"])
 
-        assert result.exit_code == 1
-        assert "Security issues found" in result.stdout
+        # TODO: re-enable exit when we disable exec and eval
+        # assert result.exit_code == 1
+        # assert "Security issues found" in result.stdout
+        assert "Security warnings found" in result.stdout
 
 
 def test_publish_continues_on_no_security_violations():

--- a/tests/comfy_cli/command/nodes/test_publish.py
+++ b/tests/comfy_cli/command/nodes/test_publish.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from comfy_cli.command.custom_nodes.command import app
+
+runner = CliRunner()
+
+
+def test_publish_fails_on_security_violations():
+    # Mock subprocess.run to simulate security violations
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = "S102 Use of exec() detected"
+
+    with patch("subprocess.run", return_value=mock_result):
+        result = runner.invoke(app, ["publish"])
+
+        assert result.exit_code == 1
+        assert "Security issues found" in result.stdout
+
+
+def test_publish_continues_on_no_security_violations():
+    # Mock subprocess.run to simulate no violations
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = ""
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("comfy_cli.command.custom_nodes.command.extract_node_configuration") as mock_extract,
+        patch("typer.prompt") as mock_prompt,
+        patch("comfy_cli.command.custom_nodes.command.registry_api.publish_node_version") as mock_publish,
+        patch("comfy_cli.command.custom_nodes.command.zip_files") as mock_zip,
+        patch("comfy_cli.command.custom_nodes.command.upload_file_to_signed_url") as mock_upload,
+    ):
+        # Setup the mocks
+        mock_extract.return_value = {"name": "test-node"}
+        mock_prompt.return_value = "test-token"
+        mock_publish.return_value = MagicMock(signedUrl="https://test.url")
+
+        # Run the publish command
+        _result = runner.invoke(app, ["publish"])
+
+        # Verify the publish flow continued
+        assert mock_extract.called
+        assert mock_publish.called
+        assert mock_zip.called
+        assert mock_upload.called
+
+
+def test_publish_handles_missing_ruff():
+    with patch("subprocess.run", side_effect=FileNotFoundError()):
+        result = runner.invoke(app, ["publish"])
+
+        assert result.exit_code == 1
+        assert "Ruff is not installed" in result.stdout
+
+
+def test_publish_with_token_option():
+    # Mock subprocess.run to simulate no violations
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = ""
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("comfy_cli.command.custom_nodes.command.extract_node_configuration") as mock_extract,
+        patch("comfy_cli.command.custom_nodes.command.registry_api.publish_node_version") as mock_publish,
+        patch("comfy_cli.command.custom_nodes.command.zip_files") as mock_zip,
+        patch("comfy_cli.command.custom_nodes.command.upload_file_to_signed_url") as mock_upload,
+    ):
+        # Setup the mocks
+        mock_extract.return_value = {"name": "test-node"}
+        mock_publish.return_value = MagicMock(signedUrl="https://test.url")
+
+        # Run the publish command with token
+        _result = runner.invoke(app, ["publish", "--token", "test-token"])
+
+        # Verify the publish flow worked with provided token
+        assert mock_extract.called
+        assert mock_publish.called
+        assert mock_zip.called
+        assert mock_upload.called


### PR DESCRIPTION
Implemented security checks using Ruff to identify specific violations (S102, S307) in Python files.

Test against reactor node:
```
(comfycli-dev) ➜  comfyui-reactor-node git:(main) comfy node publish --token="fdsafdsa"
Validating node configuration...
Running security checks...
Security warnings found:
r_basicsr/utils/options.py:77:16: S307 Use of possibly insecure function;
consider using `ast.literal_eval`
   |
75 |     # list
76 |     if value.startswith('['):
77 |         return eval(value)
   |                ^^^^^^^^^^^ S307
78 |     # str
79 |     return value
   |

r_basicsr/utils/options.py:128:13: S102 Use of `exec` detected
    |
126 |             eval_str += '=value'
127 |             # using exec function
128 |             exec(eval_str)
    |             ^^^^ S102
129 |
130 |     opt['auto_resume'] = args.auto_resume
    |

r_facelib/detection/yolov5face/models/yolo.py:188:13: S307 Use of possibly
insecure function; consider using `ast.literal_eval`
    |
186 |     layers, save, c2 = [], [], ch[-1]  # layers, savelist, ch out
187 |     for i, (f, n, m, args) in enumerate(d["backbone"] + d["head"]):  #
from, number, module, args
188 |         m = eval(m) if isinstance(m, str) else m  # eval strings
    |             ^^^^^^^ S307
189 |         for j, a in enumerate(args):
190 |             try:
    |

r_facelib/detection/yolov5face/models/yolo.py:191:27: S307 Use of possibly
insecure function; consider using `ast.literal_eval`
    |
189 |         for j, a in enumerate(args):
190 |             try:
191 |                 args = eval(a) if isinstance(a, str) else a  # eval
strings
    |                           ^^^^^^^ S307
192 |             except:
193 |                 pass
    |

scripts/r_masking/core.py:110:15: S307 Use of possibly insecure function;
consider using `ast.literal_eval`
    |
108 |     }
109 |     code = f'lambda _cls, {arg_list}: _tuple_new(_cls, ({arg_list}))'
110 |     __new__ = eval(code, namespace)
    |               ^^^^^^^^^^^^^^^^^^^^^ S307
111 |     __new__.__name__ = '__new__'
112 |     __new__.__doc__ = f'Create new instance of {typename}({arg_list})'
    |

Found 5 errors.

We will soon disable exec and eval, so this will be an error soon.
Publishing node version...
{'personal_access_token': 'fdsafdsa', 'node': {'id': 'comfyui-reactor-node', 'description': 'The Fast and Simple Face Swap Extension Node for ComfyUI, based on ReActor SD-WebUI Face Swap Extension', 'icon': '', 'name': 'comfyui-reactor-node', 'license': '{"file": "LICENSE"}', 'repository': 'https://github.com/Gourieff/comfyui-reactor-node'}, 'node_version': {'version': '0.5.2-a2', 'dependencies': ['insightface==0.7.3', 'onnx>=1.14.0', 'opencv-python>=4.7.0.72', 'numpy==1.26.3', 'segment_anything', 'albumentations>=1.4.16', 'ultralytics']}}
{'Failed to publish node version: 400 {"message":"Invalid personal access
token"}\n'}
```