### PR TITLE
Update default python to 3.12.8 for standalone.

### DIFF
--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -80,4 +80,4 @@ SUPPORTED_PT_EXTENSIONS = (".ckpt", ".pt", ".bin", ".pth", ".safetensors")
 NODE_ZIP_FILENAME = "node.zip"
 
 # The default version to download from python-build-standalone.
-DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION = "3.12.7"
+DEFAULT_STANDALONE_PYTHON_DOWNLOAD_VERSION = "3.12.8"


### PR DESCRIPTION
Fixes integration tests.