### PR TITLE
[Registry] Publish all files tracked by git

### DIFF
--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import httpx
 import requests
-from pathspec import pathspec
 
 from comfy_cli import ui
 

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -110,11 +110,12 @@ def zip_files(zip_filename):
 
     with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk("."):
-            if ".git" in dirs:  # Still skip .git directory
+            if ".git" in dirs:
                 dirs.remove(".git")
             for file in files:
                 file_path = os.path.join(root, file)
-                if zip_filename in file_path:  # Skip the zip file itself
+                # Skip zipping the zip file itself
+                if zip_filename in file_path:
                     continue
                 relative_path = os.path.relpath(file_path, start=".")
                 zipf.write(file_path, relative_path)

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -100,6 +100,8 @@ def zip_files(zip_filename):
         spec = pathspec.PathSpec.from_lines("gitwildmatch", gitignore.splitlines())
     else:
         # Empty spec that doesn't match any files when in CI or no .gitignore exists
+        if is_ci:
+            print("Disregarding .gitignore in CI environment")
         spec = pathspec.PathSpec.from_lines("gitwildmatch", [])
 
     with zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED) as zipf:

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -90,6 +90,9 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: Optional[dict
 
 
 def zip_files(zip_filename):
+    """
+    Zip all files in the current directory that are tracked by git.
+    """
     try:
         # Get list of git-tracked files using git ls-files
         import subprocess

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -62,6 +62,30 @@ def create_comfynode_config():
         raise Exception("Failed to write 'pyproject.toml'") from e
 
 
+def sanitize_node_name(name: str) -> str:
+    """Remove common ComfyUI-related prefixes from a string.
+
+    Args:
+        name: The string to process
+
+    Returns:
+        The string with any ComfyUI-related prefix removed
+    """
+    name = name.lower()
+    prefixes = [
+        "comfyui-",
+        "comfyui_",
+        "comfy-",
+        "comfy_",
+        "comfy",
+        "comfyui",
+    ]
+
+    for prefix in prefixes:
+        name = name.removeprefix(prefix)
+    return name
+
+
 def initialize_project_config():
     create_comfynode_config()
 
@@ -86,7 +110,7 @@ def initialize_project_config():
     urls = project.get("urls", tomlkit.table())
     urls["Repository"] = git_remote_url
     project["urls"] = urls
-    project["name"] = repo_name
+    project["name"] = sanitize_node_name(repo_name)
     project["description"] = ""
     project["version"] = "1.0.0"
 

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -62,30 +62,6 @@ def create_comfynode_config():
         raise Exception("Failed to write 'pyproject.toml'") from e
 
 
-def sanitize_node_name(name: str) -> str:
-    """Remove common ComfyUI-related prefixes from a string.
-
-    Args:
-        name: The string to process
-
-    Returns:
-        The string with any ComfyUI-related prefix removed
-    """
-    name = name.lower()
-    prefixes = [
-        "comfyui-",
-        "comfyui_",
-        "comfy-",
-        "comfy_",
-        "comfy",
-        "comfyui",
-    ]
-
-    for prefix in prefixes:
-        name = name.removeprefix(prefix)
-    return name
-
-
 def initialize_project_config():
     create_comfynode_config()
 
@@ -110,7 +86,7 @@ def initialize_project_config():
     urls = project.get("urls", tomlkit.table())
     urls["Repository"] = git_remote_url
     project["urls"] = urls
-    project["name"] = sanitize_node_name(repo_name)
+    project["name"] = repo_name
     project["description"] = ""
     project["version"] = "1.0.0"
 


### PR DESCRIPTION
Previously, we checked gitignore for files that should not be published. However, some .gitignores were out of sync with files that are already tracked by git. Simplify the implementation by calling `git ls-files`