### PR TITLE
fix: unable get ComfyUI-Manager path when its folder name is lowercase in case-sensitive file system

### DIFF
--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -30,13 +30,15 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
         print("\n[bold red]ComfyUI path is not resolved.[/bold red]\n", file=sys.stderr)
         raise typer.Exit(code=1)
 
-    cm_cli_path = os.path.join(workspace_path, "custom_nodes", "ComfyUI-Manager", "cm-cli.py")
-    if not os.path.exists(cm_cli_path):
+    cm_path = workspace_manager.get_comfyui_manager_path()
+    if cm_path is None:
         print(
-            f"\n[bold red]ComfyUI-Manager not found: {cm_cli_path}[/bold red]\n",
+            f"\n[bold red]ComfyUI-Manager not found: {cm_path}[/bold red]\n",
             file=sys.stderr,
         )
         raise typer.Exit(code=1)
+
+    cm_cli_path = os.path.join(cm_path, "cm-cli.py")
 
     cmd = [sys.executable, cm_cli_path] + args
 

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -482,7 +482,15 @@ def update_node_id_cache():
     config_manager = ConfigManager()
     workspace_path = workspace_manager.workspace_path
 
-    cm_cli_path = os.path.join(workspace_path, "custom_nodes", "ComfyUI-Manager", "cm-cli.py")
+    cm_path = workspace_manager.get_comfyui_manager_path()
+    if cm_path is None:
+        print(
+            f"\n[bold red]ComfyUI-Manager not found: {cm_path}[/bold red]\n",
+            file=sys.stderr,
+        )
+        raise typer.Exit(code=1)
+
+    cm_cli_path = os.path.join(cm_path, "cm-cli.py")
 
     tmp_path = os.path.join(config_manager.get_config_path(), "tmp")
     if not os.path.exists(tmp_path):

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -156,7 +156,7 @@ def pip_install_comfyui_dependencies(
 
 # install requirements for manager
 def pip_install_manager_dependencies(repo_dir):
-    os.chdir(os.path.join(repo_dir, "custom_nodes", "ComfyUI-Manager"))
+    os.chdir(os.path.join(repo_dir, "custom_nodes", "comfyui-manager"))
     subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], check=True)
 
 
@@ -229,7 +229,7 @@ def execute(
     if skip_manager:
         rprint("Skipping installation of ComfyUI-Manager. (by --skip-manager)")
     else:
-        manager_repo_dir = os.path.join(repo_dir, "custom_nodes", "ComfyUI-Manager")
+        manager_repo_dir = os.path.join(repo_dir, "custom_nodes", "comfyui-manager")
 
         if os.path.exists(manager_repo_dir):
             if restore and not fast_deps:

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -262,16 +262,27 @@ class WorkspaceManager:
         if self.workspace_path is None:
             return None
 
-        # To check more robustly, verify up to the `.git` path.
-        manager_path = os.path.join(self.workspace_path, "custom_nodes", "ComfyUI-Manager")
-        return manager_path
+        # ComfyUI-Manager may in lower case folder name (registry name)
+        possible_paths = [
+            os.path.join(self.workspace_path, "custom_nodes", "ComfyUI-Manager"),
+            os.path.join(self.workspace_path, "custom_nodes", "comfyui-manager")
+        ]
+        for manager_path in possible_paths:
+            if os.path.exists(manager_path):
+                return manager_path
+            else:
+                return None
 
     def is_comfyui_manager_installed(self):
         if self.workspace_path is None:
             return False
 
+        manager_path = self.get_comfyui_manager_path()
+        if manager_path is None:
+            return False
+
         # To check more robustly, verify up to the `.git` path.
-        manager_git_path = os.path.join(self.workspace_path, "custom_nodes", "ComfyUI-Manager", ".git")
+        manager_git_path = os.path.join(manager_path, ".git")
         return os.path.exists(manager_git_path)
 
     def scan_dir(self):

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -270,8 +270,7 @@ class WorkspaceManager:
         for manager_path in possible_paths:
             if os.path.exists(manager_path):
                 return manager_path
-            else:
-                return None
+        return None
 
     def is_comfyui_manager_installed(self):
         if self.workspace_path is None:


### PR DESCRIPTION
ComfyUI-Manager now [suggests to install in lowercase folder name](https://github.com/ltdrdata/ComfyUI-Manager#installation) (also its registry node name). 
![CleanShot 2025-03-01 at 15 06 45@2x](https://github.com/user-attachments/assets/32c8dfcd-21ef-4be9-9dd8-7d7dcc26de0d)

However, the current logic only use the name `ComfyUI-Manager` to get path, which would ignores the lowercase name `comfyui-manager` in case-sensitive filesystems.

In addition, I changed the default ComfyUI-Manager installation path to use lowercase folder names as suggested in its `README.md`.