### PR TITLE
draft: support pip version ComfyUI-Manager

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -165,23 +165,12 @@ def install(
             callback=validate_version,
         ),
     ] = "nightly",
-    manager_url: Annotated[
-        str,
-        typer.Option(
-            show_default=False,
-            help="url or local path pointing to the ComfyUI-Manager git repo to be installed. A specific branch can optionally be specified using a setuptools-like syntax, eg https://foo.git@bar",
-        ),
-    ] = constants.COMFY_MANAGER_GITHUB_URL,
     restore: Annotated[
         bool,
         typer.Option(
             show_default=False,
             help="Restore dependencies for installed ComfyUI if not installed",
         ),
-    ] = False,
-    skip_manager: Annotated[
-        bool,
-        typer.Option(show_default=False, help="Skip installing the manager component"),
     ] = False,
     skip_torch_or_directml: Annotated[
         bool,
@@ -243,10 +232,6 @@ def install(
             help="Use new fast dependency installer",
         ),
     ] = False,
-    manager_commit: Annotated[
-        Optional[str],
-        typer.Option(help="Specify commit hash for ComfyUI-Manager"),
-    ] = None,
 ):
     check_for_updates()
     checker = EnvChecker()
@@ -272,10 +257,8 @@ def install(
         rprint("[bold yellow]Installing for CPU[/bold yellow]")
         install_inner.execute(
             url,
-            manager_url,
             comfy_path,
             restore,
-            skip_manager,
             commit=commit,
             version=version,
             gpu=None,
@@ -284,7 +267,6 @@ def install(
             skip_torch_or_directml=skip_torch_or_directml,
             skip_requirement=skip_requirement,
             fast_deps=fast_deps,
-            manager_commit=manager_commit,
         )
         rprint(f"ComfyUI is installed at: {comfy_path}")
         return None
@@ -340,10 +322,8 @@ def install(
 
     install_inner.execute(
         url,
-        manager_url,
         comfy_path,
         restore,
-        skip_manager,
         commit=commit,
         gpu=gpu,
         version=version,
@@ -352,7 +332,6 @@ def install(
         skip_torch_or_directml=skip_torch_or_directml,
         skip_requirement=skip_requirement,
         fast_deps=fast_deps,
-        manager_commit=manager_commit,
     )
 
     rprint(f"ComfyUI is installed at: {comfy_path}")

--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -30,15 +30,7 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
         print("\n[bold red]ComfyUI path is not resolved.[/bold red]\n", file=sys.stderr)
         raise typer.Exit(code=1)
 
-    cm_cli_path = os.path.join(workspace_path, "custom_nodes", "ComfyUI-Manager", "cm-cli.py")
-    if not os.path.exists(cm_cli_path):
-        print(
-            f"\n[bold red]ComfyUI-Manager not found: {cm_cli_path}[/bold red]\n",
-            file=sys.stderr,
-        )
-        raise typer.Exit(code=1)
-
-    cmd = [sys.executable, cm_cli_path] + args
+    cmd = [sys.executable, '-m', 'comfyui_manager.cm_cli'] + args
 
     if channel is not None:
         cmd += ["--channel", channel]

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -482,14 +482,12 @@ def update_node_id_cache():
     config_manager = ConfigManager()
     workspace_path = workspace_manager.workspace_path
 
-    cm_cli_path = os.path.join(workspace_path, "custom_nodes", "ComfyUI-Manager", "cm-cli.py")
-
     tmp_path = os.path.join(config_manager.get_config_path(), "tmp")
     if not os.path.exists(tmp_path):
         os.makedirs(tmp_path)
 
     cache_path = os.path.join(tmp_path, "node-cache.list")
-    cmd = [sys.executable, cm_cli_path, "export-custom-node-ids", cache_path]
+    cmd = [sys.executable, "-m", "comfyui_manager.cm_cli", "export-custom-node-ids", cache_path]
 
     new_env = os.environ.copy()
     new_env["COMFYUI_PATH"] = workspace_path

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -14,7 +14,6 @@ class PROC(str, Enum):
 
 
 COMFY_GITHUB_URL = "https://github.com/comfyanonymous/ComfyUI"
-COMFY_MANAGER_GITHUB_URL = "https://github.com/ltdrdata/ComfyUI-Manager"
 
 DEFAULT_COMFY_MODEL_PATH = "models"
 DEFAULT_COMFY_WORKSPACE = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "ruff",
   "semver~=3.0.2",
   "cookiecutter",
+  "comfyui-manager"
 ]
 
 [project.optional-dependencies]

--- a/tests/comfy_cli/command/test_command.py
+++ b/tests/comfy_cli/command/test_command.py
@@ -44,9 +44,8 @@ def test_install_here(cmd, runner, mock_execute, mock_prompt_select_enum):
     assert result.exit_code == 0, result.stdout
 
     args, _ = mock_execute.call_args
-    url, manager_url, comfy_path, *_ = args
+    url, comfy_path, *_ = args
     assert url == "https://github.com/comfyanonymous/ComfyUI"
-    assert manager_url == "https://github.com/ltdrdata/ComfyUI-Manager"
     assert comfy_path == os.path.join(os.getcwd(), "ComfyUI")
 
 


### PR DESCRIPTION
modified: Added `comfyui_manager` to requirements instead of cloning ComfyUI-Manager
modified: Execute `python -m comfyui_manager.cm_cli` instead of `cm-cli.sh`
modified: Removed unnecessary Manager installation code

---
requires comfyui_manager>=4.0.0b3