### PR TITLE
Fix Windows Unicode error in node commands

### DIFF
--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -57,7 +57,7 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
     print(f"Execute from: {workspace_path}")
 
     try:
-        result = subprocess.run(cmd, env=new_env, check=True, capture_output=True, text=True)
+        result = subprocess.run(cmd, env=new_env, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
         print(result.stdout)
 
         if fast_deps and args[0] in _dependency_cmds:

--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -57,7 +57,9 @@ def execute_cm_cli(args, channel=None, fast_deps=False, mode=None) -> str | None
     print(f"Execute from: {workspace_path}")
 
     try:
-        result = subprocess.run(cmd, env=new_env, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+        result = subprocess.run(
+            cmd, env=new_env, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
         print(result.stdout)
 
         if fast_deps and args[0] in _dependency_cmds:


### PR DESCRIPTION
## Summary
- Fixes UnicodeDecodeError when running `comfy node show all` on Windows
- Adds explicit UTF-8 encoding with error handling to subprocess calls in ComfyUI-Manager integration

## Test plan
- [ ] Verify Windows e2e tests pass for `test_node` function
- [ ] Test `comfy node show all` command on Windows environment
- [ ] Ensure other node commands continue to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)