### PR TITLE
feat: refactor env command to use ui.display_table for consistent table display

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -527,9 +527,8 @@ def which():
 @tracking.track_command()
 def env():
     check_for_updates()
-    _env_checker = EnvChecker()
     
-    env_data = _env_checker.fill_print_table()
+    env_data = EnvChecker().fill_print_table()
     
     workspace_data = workspace_manager.fill_print_table()
     
@@ -540,7 +539,6 @@ def env():
         column_names=[":laptop_computer: Environment", "Value"],
         title="Environment Information",
     )
-
 
 
 @app.command(hidden=True)

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -528,9 +528,19 @@ def which():
 def env():
     check_for_updates()
     _env_checker = EnvChecker()
-    table = _env_checker.fill_print_table()
-    workspace_manager.fill_print_table(table)
-    console.print(table)
+    
+    env_data = _env_checker.fill_print_table()
+    
+    workspace_data = workspace_manager.fill_print_table()
+    
+    all_data = env_data + workspace_data
+    
+    ui.display_table(
+        data=all_data,
+        column_names=[":laptop_computer: Environment", "Value"],
+        title="Environment Information",
+    )
+
 
 
 @app.command(hidden=True)

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -63,47 +63,61 @@ class ConfigManager(object):
                 self.remove_background()
 
     def fill_print_env(self, table):
-        table.add_row("Config Path", self.get_config_file_path())
+        env_data = self.get_env_data()
+        
+        for key, value in env_data:
+            table.add_row(key, value)
+
+    def get_env_data(self):
+        """
+        Get environment data as a list of tuples for display.
+
+        Returns:
+            List[Tuple[str, str]]: List of (key, value) tuples for environment data.
+        """
+        data = []
+        data.append(("Config Path", self.get_config_file_path()))
 
         launch_extras = ""
         if self.config.has_option("DEFAULT", "default_workspace"):
-            table.add_row(
+            data.append((
                 "Default ComfyUI workspace",
                 self.config["DEFAULT"][constants.CONFIG_KEY_DEFAULT_WORKSPACE],
-            )
-
+            ))
             launch_extras = self.config["DEFAULT"].get(constants.CONFIG_KEY_DEFAULT_LAUNCH_EXTRAS, "")
         else:
-            table.add_row("Default ComfyUI workspace", "No default ComfyUI workspace")
+            data.append(("Default ComfyUI workspace", "No default ComfyUI workspace"))
 
         if launch_extras == "":
             launch_extras = "[bold red]None[/bold red]"
 
-        table.add_row("Default ComfyUI launch extra options", launch_extras)
+        data.append(("Default ComfyUI launch extra options", launch_extras))
 
         if self.config.has_option("DEFAULT", constants.CONFIG_KEY_RECENT_WORKSPACE):
-            table.add_row(
+            data.append((
                 "Recent ComfyUI workspace",
                 self.config["DEFAULT"][constants.CONFIG_KEY_RECENT_WORKSPACE],
-            )
+            ))
         else:
-            table.add_row("Recent ComfyUI workspace", "No recent run")
+            data.append(("Recent ComfyUI workspace", "No recent run"))
 
         if self.config.has_option("DEFAULT", "enable_tracking"):
-            table.add_row(
+            data.append((
                 "Tracking Analytics",
                 ("Enabled" if self.config["DEFAULT"]["enable_tracking"] == "True" else "Disabled"),
-            )
+            ))
 
         if self.config.has_option("DEFAULT", constants.CONFIG_KEY_BACKGROUND):
             bg_info = self.background
             if bg_info:
-                table.add_row(
+                data.append((
                     "Background ComfyUI",
                     f"http://{bg_info[0]}:{bg_info[1]} (pid={bg_info[2]})",
-                )
+                ))
         else:
-            table.add_row("Background ComfyUI", "[bold red]No[/bold red]")
+            data.append(("Background ComfyUI", "[bold red]No[/bold red]"))
+
+        return data
 
     def remove_background(self):
         del self.config["DEFAULT"]["background"]

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -62,11 +62,6 @@ class ConfigManager(object):
             if not is_running(self.background[2]):
                 self.remove_background()
 
-    def fill_print_env(self, table):
-        env_data = self.get_env_data()
-        
-        for key, value in env_data:
-            table.add_row(key, value)
 
     def get_env_data(self):
         """

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -11,7 +11,6 @@ from rich.table import Table
 
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.utils import singleton
-from comfy_cli import ui
 
 console = Console()
 

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -7,7 +7,6 @@ import sys
 
 import requests
 from rich.console import Console
-from rich.table import Table
 
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.utils import singleton

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.utils import singleton
+from comfy_cli import ui
 
 console = Console()
 
@@ -89,25 +90,25 @@ class EnvChecker(object):
         self.virtualenv_path = os.environ.get("VIRTUAL_ENV") if os.environ.get("VIRTUAL_ENV") else None
         self.conda_env = os.environ.get("CONDA_DEFAULT_ENV") if os.environ.get("CONDA_DEFAULT_ENV") else None
 
-    # TODO: use ui.display_table
     def fill_print_table(self):
-        table = Table(":laptop_computer: Environment", "Value")
-        table.add_row("Python Version", format_python_version(sys.version_info))
-        table.add_row("Python Executable", sys.executable)
-        table.add_row(
+        data = []
+        data.append(("Python Version", format_python_version(sys.version_info)))
+        data.append(("Python Executable", sys.executable))
+        data.append((
             "Virtualenv Path",
             self.virtualenv_path if self.virtualenv_path else "Not Used",
-        )
-        table.add_row("Conda Env", self.conda_env if self.conda_env else "Not Used")
+        ))
+        data.append(("Conda Env", self.conda_env if self.conda_env else "Not Used"))
 
-        ConfigManager().fill_print_env(table)
+        config_data = ConfigManager().get_env_data()
+        data.extend(config_data)
 
         if check_comfy_server_running():
-            table.add_row(
+            data.append((
                 "Comfy Server Running",
                 "[bold green]Yes[/bold green]\nhttp://localhost:8188",
-            )
+            ))
         else:
-            table.add_row("Comfy Server Running", "[bold red]No[/bold red]")
+            data.append(("Comfy Server Running", "[bold red]No[/bold red]"))
 
-        return table
+        return data

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -311,8 +311,10 @@ class WorkspaceManager:
         file_path = os.path.join(self.workspace_path, constants.COMFY_LOCK_YAML_FILE)
         save_yaml(file_path, self.metadata)
 
-    def fill_print_table(self, table):
-        table.add_row(
+    def fill_print_table(self):
+        data = []
+        data.append((
             "Current selected workspace",
             f"[bold green]→ {self.workspace_path}[/bold green]",
-        )
+        ))
+        return data

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -312,9 +312,4 @@ class WorkspaceManager:
         save_yaml(file_path, self.metadata)
 
     def fill_print_table(self):
-        data = []
-        data.append((
-            "Current selected workspace",
-            f"[bold green]→ {self.workspace_path}[/bold green]",
-        ))
-        return data
+        return [("Current selected workspace", f"[bold green]→ {self.workspace_path}[/bold green]")]


### PR DESCRIPTION
## What changed
Updated the `comfy env` command to use our existing `ui.display_table()` function instead of manually creating Rich Table objects.

## Why
- Keeps table rendering consistent across the codebase
- Follows the pattern we already use elsewhere
- Makes the code cleaner by separating data from presentation

## Changes made
- Modified `EnvChecker.fill_print_table()` to return data tuples instead of creating a table
- Updated `WorkspaceManager.fill_print_table()` to return data tuples too
- Changed the env command to collect all data first, then render it with `ui.display_table()`

The output looks exactly the same to users.
| after | before |
| ----- | -------| 
| ![after](https://github.com/user-attachments/assets/5c9d9956-89fe-4e16-b64c-afa7db429f6f) | ![before](https://github.com/user-attachments/assets/25e1a283-4f5c-4b6a-9a01-504d9ad6f39d) |