### PR TITLE
chore(numpy): remove pin for "numpy<2"

### DIFF
--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -405,9 +405,6 @@ class DependencyCompiler:
                 f.write(DependencyCompiler.overrideGpu.format(gpu=self.gpu, gpuUrl=self.gpuUrl))
                 f.write("\n\n")
 
-                f.write("numpy<2\n")
-                f.write("\n\n")
-
         completed = DependencyCompiler.Compile(
             cwd=self.cwd,
             reqFiles=self.reqFilesCore,

--- a/tests/uv/mock_requirements/requirements.compiled
+++ b/tests/uv/mock_requirements/requirements.compiled
@@ -8,7 +8,7 @@ mpmath==1.3.0
     #   -r /home/tel/git/comfy-cli/tests/uv/mock_requirements/y_reqs.txt
     #   sympy
     # from https://download.pytorch.org/whl/rocm6.1
-numpy==1.26.4
+numpy==2.0.2
     # via
     #   --override override.txt
     #   -r /home/tel/git/comfy-cli/tests/uv/mock_requirements/x_reqs.txt

--- a/tests/uv/mock_requirements/y_reqs.txt
+++ b/tests/uv/mock_requirements/y_reqs.txt
@@ -1,4 +1,4 @@
 mpmath==1.3.0
-numpy<=1.5.0
+numpy<=2.0.2
 sympy>=1.13.0
 tqdm==2.0.0


### PR DESCRIPTION
Following up with [the changes](https://github.com/Comfy-Org/ComfyUI-Manager/commit/785268efa64c9387c4a72fe7297485024c26a22f) in the ComfyUI Manager we decided to remove here pin of `numpy<2` as well.