### PR TITLE
update ruff, enable PyUpgrade rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           (^.*\.(json|txt)$)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.12.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -2,13 +2,12 @@ import os
 import subprocess
 import sys
 import webbrowser
-from typing import Optional
+from typing import Annotated, Optional
 
 import questionary
 import typer
 from rich import print as rprint
 from rich.console import Console
-from typing_extensions import Annotated, List
 
 from comfy_cli import constants, env_checker, logging, tracking, ui, utils
 from comfy_cli.command import custom_nodes
@@ -487,7 +486,7 @@ def stop():
 @tracking.track_command()
 def launch(
     background: Annotated[bool, typer.Option(help="Launch ComfyUI in background")] = False,
-    extra: List[str] = typer.Argument(None),
+    extra: list[str] = typer.Argument(None),
 ):
     launch_command(background, extra)
 

--- a/comfy_cli/command/custom_nodes/bisect_custom_nodes.py
+++ b/comfy_cli/command/custom_nodes/bisect_custom_nodes.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
 import typer
-from typing_extensions import Annotated
 
 from comfy_cli.command.custom_nodes.cm_cli_util import execute_cm_cli
 from comfy_cli.command.launch import launch as launch_command

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -4,12 +4,11 @@ import platform
 import subprocess
 import sys
 import uuid
-from typing import Optional
+from typing import Annotated, Optional
 
 import typer
 from rich import print
 from rich.console import Console
-from typing_extensions import Annotated, List
 
 from comfy_cli import logging, tracking, ui, utils
 from comfy_cli.command.custom_nodes.bisect_custom_nodes import bisect_app
@@ -151,7 +150,7 @@ def execute_install_script(repo_path):
         # import pdb
         # pdb.set_trace()
         print("Install: pip packages")
-        with open(requirements_path, "r", encoding="utf-8") as requirements_file:
+        with open(requirements_path, encoding="utf-8") as requirements_file:
             for line in requirements_file:
                 # From Yoland: disable pip override
                 # package_name = remap_pip_package(line.strip())
@@ -269,7 +268,7 @@ def node_completer(incomplete: str) -> list[str]:
         config_manager = ConfigManager()
         tmp_path = os.path.join(config_manager.get_config_path(), "tmp", "node-cache.list")
 
-        with open(tmp_path, "r", encoding="UTF-8", errors="ignore") as cache_file:
+        with open(tmp_path, encoding="UTF-8", errors="ignore") as cache_file:
             return [node_id for node_id in cache_file.readlines() if node_id.startswith(incomplete)]
 
     except Exception:
@@ -285,7 +284,7 @@ def node_or_all_completer(incomplete: str) -> list[str]:
         if "all".startswith(incomplete):
             all_opt = ["all"]
 
-        with open(tmp_path, "r", encoding="UTF-8", errors="ignore") as cache_file:
+        with open(tmp_path, encoding="UTF-8", errors="ignore") as cache_file:
             return [node_id for node_id in cache_file.readlines() if node_id.startswith(incomplete)] + all_opt
 
     except Exception:
@@ -384,7 +383,7 @@ def simple_show(
 @app.command(help="Install custom nodes")
 @tracking.track_command("node")
 def install(
-    nodes: List[str] = typer.Argument(..., help="List of custom nodes to install", autocompletion=node_completer),
+    nodes: list[str] = typer.Argument(..., help="List of custom nodes to install", autocompletion=node_completer),
     channel: Annotated[
         Optional[str],
         typer.Option(
@@ -431,7 +430,7 @@ def install(
 @app.command(help="Reinstall custom nodes")
 @tracking.track_command("node")
 def reinstall(
-    nodes: List[str] = typer.Argument(..., help="List of custom nodes to reinstall", autocompletion=node_completer),
+    nodes: list[str] = typer.Argument(..., help="List of custom nodes to reinstall", autocompletion=node_completer),
     channel: Annotated[
         Optional[str],
         typer.Option(
@@ -466,7 +465,7 @@ def reinstall(
 @app.command(help="Uninstall custom nodes")
 @tracking.track_command("node")
 def uninstall(
-    nodes: List[str] = typer.Argument(..., help="List of custom nodes to uninstall", autocompletion=node_completer),
+    nodes: list[str] = typer.Argument(..., help="List of custom nodes to uninstall", autocompletion=node_completer),
     channel: Annotated[
         Optional[str],
         typer.Option(
@@ -512,7 +511,7 @@ def update_node_id_cache():
 @app.command(help="Update custom nodes or ComfyUI")
 @tracking.track_command("node")
 def update(
-    nodes: List[str] = typer.Argument(
+    nodes: list[str] = typer.Argument(
         ...,
         help="[all|List of custom nodes to update]",
         autocompletion=node_or_all_completer,
@@ -541,7 +540,7 @@ def update(
 @app.command(help="Disable custom nodes")
 @tracking.track_command("node")
 def disable(
-    nodes: List[str] = typer.Argument(
+    nodes: list[str] = typer.Argument(
         ...,
         help="[all|List of custom nodes to disable]",
         autocompletion=node_or_all_completer,
@@ -568,7 +567,7 @@ def disable(
 @app.command(help="Enable custom nodes")
 @tracking.track_command("node")
 def enable(
-    nodes: List[str] = typer.Argument(
+    nodes: list[str] = typer.Argument(
         ...,
         help="[all|List of custom nodes to enable]",
         autocompletion=node_or_all_completer,
@@ -595,7 +594,7 @@ def enable(
 @app.command(help="Fix dependencies of custom nodes")
 @tracking.track_command("node")
 def fix(
-    nodes: List[str] = typer.Argument(
+    nodes: list[str] = typer.Argument(
         ...,
         help="[all|List of custom nodes to fix]",
         autocompletion=node_or_all_completer,

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -2,7 +2,7 @@ import os
 import platform
 import subprocess
 import sys
-from typing import Dict, List, Optional, TypedDict
+from typing import Optional, TypedDict
 from urllib.parse import urlparse
 
 import requests
@@ -389,7 +389,7 @@ def handle_github_rate_limit(response):
         raise GitHubRateLimitError(message)
 
 
-def fetch_github_releases(repo_owner: str, repo_name: str) -> List[Dict[str, str]]:
+def fetch_github_releases(repo_owner: str, repo_name: str) -> list[dict[str, str]]:
     """
     Fetch the list of releases from the GitHub API.
     Handles rate limiting by logging the wait time.
@@ -425,11 +425,11 @@ class GithubRelease(TypedDict):
     download_url: str
 
 
-def parse_releases(releases: List[Dict[str, str]]) -> List[GithubRelease]:
+def parse_releases(releases: list[dict[str, str]]) -> list[GithubRelease]:
     """
     Parse the list of releases fetched from the GitHub API into a list of GithubRelease objects.
     """
-    parsed_releases: List[GithubRelease] = []
+    parsed_releases: list[GithubRelease] = []
     for release in releases:
         tag = release["tag_name"]
         if tag.lower() in ["latest", "nightly"]:
@@ -441,7 +441,7 @@ def parse_releases(releases: List[Dict[str, str]]) -> List[GithubRelease]:
     return parsed_releases
 
 
-def select_version(releases: List[GithubRelease], version: str) -> Optional[GithubRelease]:
+def select_version(releases: list[GithubRelease], version: str) -> Optional[GithubRelease]:
     """
     Given a list of Github releases, select the release that matches the specified version.
     """

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -1,13 +1,12 @@
 import os
 import pathlib
 import sys
-from typing import List, Optional, Tuple
+from typing import Annotated, Optional
 from urllib.parse import unquote, urlparse
 
 import requests
 import typer
 from rich import print
-from typing_extensions import Annotated
 
 from comfy_cli import constants, tracking, ui
 from comfy_cli.config_manager import ConfigManager
@@ -39,7 +38,7 @@ def potentially_strip_param_url(path_name: str) -> str:
     return path_name
 
 
-def check_huggingface_url(url: str) -> Tuple[bool, Optional[str], Optional[str], Optional[str], Optional[str]]:
+def check_huggingface_url(url: str) -> tuple[bool, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """
     Check if the given URL is a Hugging Face URL and extract relevant information.
 
@@ -76,7 +75,7 @@ def check_huggingface_url(url: str) -> Tuple[bool, Optional[str], Optional[str],
     return True, repo_id, filename, folder_name, branch_name
 
 
-def check_civitai_url(url: str) -> Tuple[bool, bool, int, int]:
+def check_civitai_url(url: str) -> tuple[bool, bool, int, int]:
     """
     Returns:
         is_civitai_model_url: True if the url is a civitai model url
@@ -314,7 +313,7 @@ def remove(
         help="The relative path from the current workspace where the models are stored.",
         show_default=True,
     ),
-    model_names: Optional[List[str]] = typer.Option(
+    model_names: Optional[list[str]] = typer.Option(
         None,
         help="List of model filenames to delete, separated by spaces",
         show_default=False,

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -98,7 +98,7 @@ class ExecutionProgress(Progress):
         )
 
         for task in self.tasks:
-            percent = "[progress.percentage]{task.percentage:>3.0f}%".format(task=task)
+            percent = "[progress.percentage]{task.percentage:>3.0f}%".format(task=task)  # noqa
             if task.fields.get("progress_type") == "overall":
                 overall_table = Table.grid(*table_columns, padding=(0, 1), expand=self.expand)
                 overall_table.add_row(BarColumn().render(task), percent, TimeElapsedColumn().render(task))

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -1,17 +1,17 @@
 import configparser
 import os
 from importlib.metadata import version
-from typing import Optional, Tuple
+from typing import Optional
 
 from comfy_cli import constants, logging
 from comfy_cli.utils import get_os, is_running, singleton
 
 
 @singleton
-class ConfigManager(object):
+class ConfigManager:
     def __init__(self):
         self.config = configparser.ConfigParser()
-        self.background: Optional[Tuple[str, int, int]] = None
+        self.background: Optional[tuple[str, int, int]] = None
         self.load()
 
     @staticmethod

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -28,8 +28,8 @@ def format_python_version(version_info):
         str: The formatted Python version string.
     """
     if version_info.major == 3 and version_info.minor > 8:
-        return "{}.{}.{}".format(version_info.major, version_info.minor, version_info.micro)
-    return "[bold red]{}.{}.{}[/bold red]".format(version_info.major, version_info.minor, version_info.micro)
+        return f"{version_info.major}.{version_info.minor}.{version_info.micro}"
+    return f"[bold red]{version_info.major}.{version_info.minor}.{version_info.micro}[/bold red]"
 
 
 def check_comfy_server_running(port=8188, host="localhost"):
@@ -47,7 +47,7 @@ def check_comfy_server_running(port=8188, host="localhost"):
 
 
 @singleton
-class EnvChecker(object):
+class EnvChecker:
     """
     Provides an `EnvChecker` class to check the current environment and print information about it.
 

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -65,7 +65,7 @@ def create_comfynode_config():
     try:
         with open("pyproject.toml", "w") as toml_file:
             toml_file.write(tomlkit.dumps(document))
-    except IOError as e:
+    except OSError as e:
         raise Exception("Failed to write 'pyproject.toml'") from e
 
 
@@ -166,7 +166,7 @@ def validate_version(version: str, field_name: str) -> str:
 def initialize_project_config():
     create_comfynode_config()
 
-    with open("pyproject.toml", "r") as file:
+    with open("pyproject.toml") as file:
         document = tomlkit.parse(file.read())
 
     # Get the current git remote URL
@@ -237,7 +237,7 @@ def initialize_project_config():
 
     # Handle dependencies
     if os.path.exists("requirements.txt"):
-        with open("requirements.txt", "r") as req_file:
+        with open("requirements.txt") as req_file:
             dependencies = [line.strip() for line in req_file if line.strip()]
         project["dependencies"] = dependencies
     else:
@@ -248,8 +248,8 @@ def initialize_project_config():
         with open("pyproject.toml", "w") as toml_file:
             toml_file.write(tomlkit.dumps(document))
         print("pyproject.toml has been created successfully in the current directory.")
-    except IOError as e:
-        raise IOError("Failed to write 'pyproject.toml'") from e
+    except OSError as e:
+        raise OSError("Failed to write 'pyproject.toml'") from e
 
 
 def extract_node_configuration(
@@ -259,7 +259,7 @@ def extract_node_configuration(
         ui.display_error_message("No pyproject.toml file found in the current directory.")
         return None
 
-    with open(path, "r") as file:
+    with open(path) as file:
         data = tomlkit.load(file)
 
     project_data = data.get("project", {})

--- a/comfy_cli/registry/types.py
+++ b/comfy_cli/registry/types.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Optional
 
 
 @dataclass
 class NodeVersion:
     changelog: str
-    dependencies: List[str]
+    dependencies: list[str]
     deprecated: bool
     id: str
     version: str
@@ -21,7 +21,7 @@ class Node:
     license: Optional[str] = None
     icon: Optional[str] = None
     repository: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
     latest_version: Optional[NodeVersion] = None
 
 
@@ -50,8 +50,8 @@ class ComfyConfig:
     publisher_id: str = ""
     display_name: str = ""
     icon: str = ""
-    models: List[Model] = field(default_factory=list)
-    includes: List[str] = field(default_factory=list)
+    models: list[Model] = field(default_factory=list)
+    includes: list[str] = field(default_factory=list)
     banner_url: str = ""
     web: Optional[str] = None
 
@@ -68,11 +68,11 @@ class ProjectConfig:
     description: str = ""
     version: str = "1.0.0"
     requires_python: str = ">= 3.9"
-    dependencies: List[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
     license: License = field(default_factory=License)
     urls: URLs = field(default_factory=URLs)
-    supported_os: List[str] = field(default_factory=list)
-    supported_accelerators: List[str] = field(default_factory=list)
+    supported_os: list[str] = field(default_factory=list)
+    supported_accelerators: list[str] = field(default_factory=list)
     supported_comfyui_version: str = ""
     supported_comfyui_frontend_version: str = ""
 

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union
 
 import questionary
 import typer
@@ -35,11 +35,11 @@ def show_progress(iterable, total, description="Downloading..."):
             progress.update(task, advance=len(chunk))
 
 
-ChoiceType = Union[str, Choice, Dict[str, Any]]
+ChoiceType = Union[str, Choice, dict[str, Any]]
 
 
 def prompt_autocomplete(
-    question: str, choices: List[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
+    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
 ) -> Optional[ChoiceType]:
     """
     Asks a single select question using questionary and returns the selected response.
@@ -59,7 +59,7 @@ def prompt_autocomplete(
 
 
 def prompt_select(
-    question: str, choices: List[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
+    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
 ) -> Optional[ChoiceType]:
     """
     Asks a single select question using questionary and returns the selected response.
@@ -81,7 +81,7 @@ def prompt_select(
 E = TypeVar("E", bound=Enum)
 
 
-def prompt_select_enum(question: str, choices: List[E], force_prompting: bool = False) -> Optional[E]:
+def prompt_select_enum(question: str, choices: list[E], force_prompting: bool = False) -> Optional[E]:
     """
     Asks a single select question using questionary and returns the selected response.
 
@@ -123,7 +123,7 @@ def prompt_input(question: str, default: str = "", force_prompting: bool = False
     return questionary.text(question, default=default).ask()
 
 
-def prompt_multi_select(prompt: str, choices: List[str]) -> List[str]:
+def prompt_multi_select(prompt: str, choices: list[str]) -> list[str]:
     """
     Prompts the user to select multiple items from a list of choices.
 
@@ -154,7 +154,7 @@ def prompt_confirm_action(prompt: str, default: bool) -> bool:
     return typer.confirm(prompt)
 
 
-def display_table(data: List[Tuple], column_names: List[str], title: str = "") -> None:
+def display_table(data: list[tuple], column_names: list[str], title: str = "") -> None:
     """
     Displays a list of tuples in a table format using Rich.
 

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -457,7 +457,7 @@ class DependencyCompiler:
         headless is more suitable for comfy than the gui version, so remove gui if
         headless is present. TODO: add support for contrib pkgs. see: https://github.com/opencv/opencv-python"""
 
-        with open(self.out, "r") as f:
+        with open(self.out) as f:
             lines = f.readlines()
 
         guiFound, headlessFound = False, False

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import git
 import typer
@@ -25,7 +25,7 @@ class ModelPath:
 class Model:
     name: Optional[str] = None
     url: Optional[str] = None
-    paths: List[ModelPath] = field(default_factory=list)
+    paths: list[ModelPath] = field(default_factory=list)
     hash: Optional[str] = None
     type: Optional[str] = None
 
@@ -45,11 +45,11 @@ class CustomNode:
 @dataclass
 class ComfyLockYAMLStruct:
     basics: Basics
-    models: List[Model] = field(default_factory=list)
-    custom_nodes: List[CustomNode] = field(default_factory=list)
+    models: list[Model] = field(default_factory=list)
+    custom_nodes: list[CustomNode] = field(default_factory=list)
 
 
-def check_comfy_repo(path) -> Tuple[bool, Optional[git.Repo]]:
+def check_comfy_repo(path) -> tuple[bool, Optional[git.Repo]]:
     if not os.path.exists(path):
         return False, None
     try:
@@ -190,7 +190,7 @@ class WorkspaceManager:
 
         return os.path.abspath(os.path.expanduser(self.specified_workspace))
 
-    def get_workspace_path(self) -> Tuple[str, WorkspaceType]:
+    def get_workspace_path(self) -> tuple[str, WorkspaceType]:
         """
         Retrieves a workspace path based on user input and defaults. This function does not validate the existence of a validate ComfyUI workspace.
         1. Specified Workspace (--workspace)
@@ -302,7 +302,7 @@ class WorkspaceManager:
     def load_metadata(self):
         file_path = os.path.join(self.workspace_path, constants.COMFY_LOCK_YAML_FILE)
         if os.path.exists(file_path):
-            with open(file_path, "r", encoding="utf-8") as file:
+            with open(file_path, encoding="utf-8") as file:
                 return yaml.safe_load(file)
         else:
             return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,4 +74,5 @@ lint.select = [
   "E9", # default
   "F",  # default
   "I",  # isort-like behavior (import statement sorting)
+  "UP", # pyupgrade
 ]

--- a/tests/comfy_cli/test_install.py
+++ b/tests/comfy_cli/test_install.py
@@ -1,4 +1,3 @@
-from typing import Dict, List
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -125,7 +124,7 @@ def test_parse_releases_mixed():
 
 
 def test_parse_releases_empty_list():
-    input_releases: List[Dict[str, str]] = []
+    input_releases: list[dict[str, str]] = []
 
     result = parse_releases(input_releases)
 
@@ -142,7 +141,7 @@ def test_parse_releases_invalid_semver():
 
 
 # Sample data for tests
-sample_releases: List[GithubRelease] = [
+sample_releases: list[GithubRelease] = [
     {"version": semver.VersionInfo.parse("1.0.0"), "tag": "v1.0.0", "download_url": "url1"},
     {"version": semver.VersionInfo.parse("1.1.0"), "tag": "v1.1.0", "download_url": "url2"},
     {"version": semver.VersionInfo.parse("2.0.0"), "tag": "v2.0.0", "download_url": "url3"},

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -61,7 +61,7 @@ def test_compile(mock_prompt_select):
     depComp.make_override()
     depComp.compile_core_plus_ext()
 
-    with open(mockReqsDir / "requirements.compiled", "r") as known, open(temp / "requirements.compiled", "r") as test:
+    with open(mockReqsDir / "requirements.compiled") as known, open(temp / "requirements.compiled") as test:
         # compare all non-commented lines in generated file vs reference file
         knownLines, testLines = [
             [line for line in known.readlines() if not line.strip().startswith("#")],


### PR DESCRIPTION
Dropped syntax of Python 3.8 (`Tuple`, `Dict`, `List`)

This `UP` rule will come in handy soon when we stop supporting Python 3.9 - this rule makes it easy to increase the minimum Python version.