### PR TITLE
ci: add token permissions

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,3 @@
-codecov:
-  allow_coverage_offsets: true  # Avoid "Missing base report" due to committing with "[CI skip]"
-
 comment:
   layout: "diff, files"
 
@@ -9,3 +6,4 @@ coverage:
     project:
       default:
         threshold: 0.1%
+    patch: off

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,6 +19,9 @@ on:
       - "!.coveragerc"
       - "!.gitignore"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "Run Tests on Multiple Platforms"

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [ created ]
 
+permissions:
+  contents: read
+
 jobs:
   build-n-publish-pypi:
     name: Build and publish Python distributions to PyPI

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruff_check.yml
+++ b/.github/workflows/ruff_check.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ruff_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-on-gpu.yml
+++ b/.github/workflows/run-on-gpu.yml
@@ -22,6 +22,9 @@ on:
       - "!.coveragerc"
       - "!.gitignore"
 
+permissions:
+  contents: read
+
 jobs:
   test-cli-gpu:
     name: "Run Tests on GPU Runners"

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - comfy_cli/**
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - comfy_cli/**
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: windows-latest

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -150,12 +150,6 @@ class ConfigManager:
         del self.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
         self.write_config()
         self.background = None
-        # will remove in this PR, just to test CodeCov comments by token testriction
-        x = 0
-        x = x + 1
-        x = x + 2
-        x = x + 3
-        self.dummy_value = x
 
     def get_cli_version(self):
         # Note: this approach should work for users installing the CLI via

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -150,6 +150,12 @@ class ConfigManager:
         del self.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
         self.write_config()
         self.background = None
+        # will remove in this PR, just to test CodeCov comments by token testriction
+        x = 0
+        x = x + 1
+        x = x + 2
+        x = x + 3
+        self.dummy_value = x
 
     def get_cli_version(self):
         # Note: this approach should work for users installing the CLI via


### PR DESCRIPTION
This PR should remove the `Medium` security complaints:

<img width="1059" height="966" alt="Screenshot from 2025-08-04 19-12-44" src="https://github.com/user-attachments/assets/e62869b7-1562-411a-a232-083fbbdc2dcf" />

In `publish_package.yml`

```
permissions:
  contents: read
```

should be ok, as the next lines are still present for publishing at the **job level** that has higher priority then global one: 

```
permissions:
      id-token: write  # IMPORTANT: this permission is mandatory for trusted 
```