### PR TITLE
dependabot config for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 1
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -58,7 +58,7 @@ jobs:
       #     comfy --help
 
       - name: Publish distribution to Official PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   test-pip-installation:
     name: Test Comfy CLI Installation via pip


### PR DESCRIPTION
I noticed that the GitHub actions are quite old here, and I'm too lazy to update them manually all the time - so let's make sure that Depandobot does a PR with updates once a month and it doesn't take up developer's time.

Also pinned the **3rd** party action by hash to remove the last warning (`Unpinned tag for a non-immutable Action in workflow`) from GitHub on this topic: