### PR TITLE
use gh:comfy-org/cookiecutter-comfy-extension instead

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -953,7 +953,7 @@ def scaffold_cookiecutter():
 
     try:
         cookiecutter.main.cookiecutter(
-            "https://github.com/Comfy-Org/cookiecutter-comfy-extension.git",
+            "gh:comfy-org/cookiecutter-comfy-extension",
             overwrite_if_exists=True,
         )
         console.print("[bold green]✓ Custom node project created successfully![/bold green]")


### PR DESCRIPTION
resolved cookiecut issue https://github.com/Comfy-Org/cookiecutter-comfy-extension/issues/6
use gh:comfy-org/cookiecutter-comfy-extension because we use gh in cookiecut end.
video is 

https://github.com/user-attachments/assets/5efae105-58f8-422a-af24-a3894c0c8d75

