### PR TITLE
Fix unnecessary full file download when checking URL authorization

### DIFF
--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -55,7 +55,7 @@ def check_unauthorized(url: str, headers: Optional[dict] = None) -> bool:
         bool: True if the response status code is 401, False otherwise.
     """
     try:
-        response = requests.get(url, headers=headers, allow_redirects=True)
+        response = requests.get(url, headers=headers, allow_redirects=True, stream=True)
         return response.status_code == 401
     except requests.RequestException:
         # If there's an error making the request, we can't determine if it's unauthorized


### PR DESCRIPTION

Found a bug when running `comfy-cli model download --url https://huggingface.co/Comfy-Org/flux1-schnell/resolve/main/flux1-schnell-fp8.safetensors`

it will fully download the model first before going into `download_file(url, local_filepath, headers)` . 

Model gets downloaded twice, first time was to verify hf repo access, and second time was the actual download.


```
response = requests.get(url, headers=headers, allow_redirects=True, stream=True)
```

simple fix is to add `stream=True` to requests.get in `check_unauthorized()` to prevent full file download 