### PR TITLE
Fix comfy-cli install --cpu still installs CUDA version of PyTorch

### DIFF
--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -123,6 +123,27 @@ def pip_install_comfyui_dependencies(
                 + pip_url,
                 check=False,
             )
+
+        # install torch for CPU
+        if gpu is None:  # Currently, when install for CPU, gpu is None
+            pip_url = [
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/cpu",
+            ]
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "torch",
+                    "torchvision",
+                    "torchaudio",
+                ]
+                + pip_url,
+                check=False,
+            )
+
         if result and result.returncode != 0:
             rprint("Failed to install PyTorch dependencies. Please check your environment (`comfy env`) and try again")
             sys.exit(1)


### PR DESCRIPTION
Fixes #344

## Tested

- **Environment:** WSL2 Ubuntu 24.04, Python 3.12.3
- **Install Command:**  
  `comfy --skip-prompt install --cpu --skip-manager --url https://github.com/comfyanonymous/ComfyUI@v0.7.0`  
  ✅ Installs CPU-only PyTorch
- **Minimal ComfyUI workflow on CPU:**  
  1. Load Image  
  2. Custom torch operation (image duplication + horizontal concat)  
  3. Preview Image  
  ✅ CPU-only torch operations work as expected
