### PR TITLE
Refactor node show argument to use Enum for better validation and clarity

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -341,9 +341,8 @@ def show(
 @app.command("simple-show", help="Show node list (simple mode)")
 @tracking.track_command("node")
 def simple_show(
-    arg: str = typer.Argument(
-        help="[installed|enabled|not-installed|disabled|all|snapshot|snapshot-list]",
-        autocompletion=show_completer,
+    arg: ShowTarget = typer.Argument(
+        help="Target to display",
     ),
     channel: Annotated[
         Optional[str],
@@ -359,22 +358,9 @@ def simple_show(
         autocompletion=mode_completer,
     ),
 ):
-    valid_commands = [
-        "installed",
-        "enabled",
-        "not-installed",
-        "disabled",
-        "all",
-        "snapshot",
-        "snapshot-list",
-    ]
-    if arg not in valid_commands:
-        typer.echo(f"Invalid command: `show {arg}`", err=True)
-        raise typer.Exit(code=1)
-
     validate_mode(mode)
 
-    execute_cm_cli(["simple-show", arg], channel=channel, mode=mode)
+    execute_cm_cli(["simple-show", arg.value], channel=channel, mode=mode)
 
 
 # install, reinstall, uninstall


### PR DESCRIPTION
Refactor `node show` argument to use a typed Enum instead of a raw string.

- Replace manual string validation with `ShowTarget(StrEnum)`
- Improve CLI validation and error message clarity
