### PR TITLE
chore: move CI to use Python 3.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
       - name: Check out code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'  # Follow the min version in pyproject.toml
+          python-version: '3.10'  # Follow the min version in pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [
@@ -55,7 +55,7 @@ dependencies = [
 ]
 
 optional-dependencies.dev = [ "pre-commit", "pytest", "pytest-cov", "ruff" ]
-urls.Repository = "https://github.com/drip-art/comfy-cli.git"
+urls.Repository = "https://github.com/Comfy-Org/comfy-cli.git"
 scripts.comfy = "comfy_cli.__main__:main"
 scripts.comfy-cli = "comfy_cli.__main__:main"
 scripts.comfycli = "comfy_cli.__main__:main"


### PR DESCRIPTION
Python 3.9 is already EOL, some packages does not have proper versions for it and CI fails.