### PR TITLE
fix: update typer to >=0.12.4 for PEP 604 union type support

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -76,7 +76,6 @@ def entry(
         bool | None,
         typer.Option(
             show_default=False,
-            is_flag=True,
             help="Execute from recent path",
             callback=g_exclusivity.validate,
         ),
@@ -85,7 +84,6 @@ def entry(
         bool | None,
         typer.Option(
             show_default=False,
-            is_flag=True,
             help="Execute from current path",
             callback=g_exclusivity.validate,
         ),
@@ -94,7 +92,6 @@ def entry(
         bool,
         typer.Option(
             show_default=False,
-            is_flag=True,
             help="Do not prompt user for input, use default options",
         ),
     ] = False,
@@ -103,7 +100,6 @@ def entry(
         typer.Option(
             show_default=False,
             hidden=True,
-            is_flag=True,
             help="Enable tracking",
         ),
     ] = False,
@@ -112,7 +108,6 @@ def entry(
         "--version",
         "-v",
         help="Print version and exit",
-        is_flag=True,
     ),
 ):
     if version:

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -200,19 +200,16 @@ def restore_snapshot(
     pip_non_url: bool | None = typer.Option(
         default=None,
         show_default=False,
-        is_flag=True,
         help="Restore for pip packages registered on PyPI.",
     ),
     pip_non_local_url: bool | None = typer.Option(
         default=None,
         show_default=False,
-        is_flag=True,
         help="Restore for pip packages registered at web URLs.",
     ),
     pip_local_url: bool | None = typer.Option(
         default=None,
         show_default=False,
-        is_flag=True,
         help="Restore for pip packages specified by local paths.",
     ),
 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "ruff",
   "semver~=3.0.2",
   "tomlkit",
-  "typer>=0.9",
+  "typer>=0.12.4",
   "typing-extensions>=4.7",
   "uv",
   "websocket-client",


### PR DESCRIPTION
Fixes #355

PR #349 changed `Optional[bool]` type hints to `bool | None` syntax, but typer < 0.12.4 does not support PEP 604 union types, causing `RuntimeError: Type not yet supported: bool | None`.

**Changes:**
- Update typer dependency from `>=0.9` to `>=0.12.4` (adds PEP 604 support via [typer#548](https://github.com/fastapi/typer/pull/548))
- Remove deprecated `is_flag` parameter from `typer.Option()` calls (deprecated in typer 0.15.0, never worked properly)

**Testing:**
- All unit tests pass
- CLI works with typer 0.12.4 (minimum) and 0.21.1 (latest)
- No breaking changes - existing `click<=8.1.8` pin is compatible with typer 0.12.4+