### PR TITLE
fix: parsing of booleans from config file

### DIFF
--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -42,6 +42,17 @@ class ConfigManager:
         """
         return self.config["DEFAULT"].get(key, None)  # Returns None if the key does not exist
 
+    def get_bool(self, key) -> bool | None:
+        """
+        Get a boolean value from the config file using configparser's built-in
+        getboolean, which accepts: true/false, yes/no, on/off, 1/0 (case-insensitive).
+
+        Returns None if the key does not exist.
+        """
+        if not self.config.has_option("DEFAULT", key):
+            return None
+        return self.config.getboolean("DEFAULT", key)
+
     def get_or_override(self, env_key: str, config_key: str, set_value: str | None = None) -> str | None:
         """
         Resolves and conditionally stores a config value.
@@ -119,15 +130,12 @@ class ConfigManager:
         else:
             data.append(("Recent ComfyUI workspace", "No recent run"))
 
-        if self.config.has_option("DEFAULT", constants.CONFIG_KEY_ENABLE_TRACKING):
+        tracking = self.get_bool(constants.CONFIG_KEY_ENABLE_TRACKING)
+        if tracking is not None:
             data.append(
                 (
                     "Tracking Analytics",
-                    (
-                        "Enabled"
-                        if self.config["DEFAULT"][constants.CONFIG_KEY_ENABLE_TRACKING] == "True"
-                        else "Disabled"
-                    ),
+                    "Enabled" if tracking else "Disabled",
                 )
             )
 

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -45,7 +45,7 @@ def track_event(event_name: str, properties: any = None):
     if properties is None:
         properties = {}
     logging.debug(f"tracking event called with event_name: {event_name} and properties: {properties}")
-    # enable_tracking = config_manager.get(constants.CONFIG_KEY_ENABLE_TRACKING)
+    # enable_tracking = config_manager.get_bool(constants.CONFIG_KEY_ENABLE_TRACKING)
     enable_tracking = False
     if not enable_tracking:
         return
@@ -83,7 +83,7 @@ def track_command(sub_command: str = None):
 
 
 def prompt_tracking_consent(skip_prompt: bool = False, default_value: bool = False):
-    tracking_enabled = config_manager.get(constants.CONFIG_KEY_ENABLE_TRACKING)
+    tracking_enabled = config_manager.get_bool(constants.CONFIG_KEY_ENABLE_TRACKING)
     if tracking_enabled is not None:
         return
 
@@ -112,7 +112,7 @@ def init_tracking(enable_tracking: bool):
 
     # Note: only called once when the user interacts with the CLI for the
     #  first time iff the permission is granted.
-    install_event_triggered = config_manager.get(constants.CONFIG_KEY_INSTALL_EVENT_TRIGGERED)
+    install_event_triggered = config_manager.get_bool(constants.CONFIG_KEY_INSTALL_EVENT_TRIGGERED)
     if not install_event_triggered:
         logging.debug("Tracking install event.")
         config_manager.set(constants.CONFIG_KEY_INSTALL_EVENT_TRIGGERED, "True")


### PR DESCRIPTION
Fixes #337

### Why

Boolean values in the config are expressed as strings. Wherever we work with them, we have to parse them correctly.

For example here:
```python
self.config["DEFAULT"][constants.CONFIG_KEY_ENABLE_TRACKING] == "True"
```

The user has to be precise here with their config. 

That also led to #337, which describes how tracking currently cannot be disabled, [because we incorrectly parse the string](https://github.com/Comfy-Org/comfy-cli/issues/337#issuecomment-3503677185) by treating it as if it was a boolean in `tracking.py`.

### What

I'm adding a `get_bool` function to the `ConfigManager` to solve parsing booleans from config once. It's using `configparser`'s own mechanism to convert a string to a boolean and accepts additional values like `true`, `yes`, `on`, `1` case-insensitive.  

