### PR TITLE
fix: apply --pr validation and passthrough for --cpu install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Comfy provides commands that allow you to easily run the installed ComfyUI.
   `comfy install --pr "https://github.com/comfyanonymous/ComfyUI/pull/1234"`
 
   - If you want to run ComfyUI with a specific pull request, you can use the `--pr` option. This will automatically install the specified pull request and run ComfyUI with it.
-  - Important: When using --pr, any --version and --commit parameters are ignored. The PR branch will be checked out regardless of version settings.
+  - Important: The --pr option cannot be combined with --version or --commit and will be rejected if used together.
 
 - To test a frontend pull request:
 

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -269,6 +269,11 @@ def install(
         rprint("[bold red]Python version 3.9 or higher is required to run ComfyUI.[/bold red]")
         rprint(f"You are currently using Python version {env_checker.format_python_version(checker.python_version)}.")
     platform = utils.get_os()
+
+    if pr and (version not in {None, "nightly"} or commit):
+        rprint("--pr cannot be used with --version or --commit")
+        raise typer.Exit(code=1)
+
     if cpu:
         rprint("[bold yellow]Installing for CPU[/bold yellow]")
         install_inner.execute(
@@ -286,6 +291,7 @@ def install(
             skip_requirement=skip_requirement,
             fast_deps=fast_deps,
             manager_commit=manager_commit,
+            pr=pr,
         )
         rprint(f"ComfyUI is installed at: {comfy_path}")
         return None
@@ -323,10 +329,6 @@ def install(
         rprint(
             "[bold red]No GPU option selected or `--cpu` enabled, use --\\[gpu option] flag (e.g. --nvidia) to pick GPU. use `--cpu` to install for CPU. Exiting...[/bold red]"
         )
-        raise typer.Exit(code=1)
-
-    if pr and (version not in {None, "nightly"} or commit):
-        rprint("--pr cannot be used with --version or --commit")
         raise typer.Exit(code=1)
 
     install_inner.execute(

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -312,6 +312,47 @@ class TestCommandLineIntegration:
         assert "--pr cannot be used" not in result.stdout
         assert mock_execute.called
 
+    @patch("comfy_cli.command.install.execute")
+    @patch("comfy_cli.cmdline.check_comfy_repo", return_value=(False, None))
+    @patch("comfy_cli.cmdline.workspace_manager")
+    @patch("comfy_cli.tracking.prompt_tracking_consent")
+    def test_cpu_pr_conflict_with_version(self, mock_track, mock_ws, mock_check, mock_execute, runner):
+        """Test that --cpu --pr with --version is rejected"""
+        mock_ws.get_workspace_path.return_value = ("/tmp/test", None)
+        result = runner.invoke(app, ["--skip-prompt", "install", "--cpu", "--pr", "#123", "--version", "1.0.0"])
+
+        assert result.exit_code != 0
+        assert "--pr cannot be used" in result.stdout
+        assert not mock_execute.called
+
+    @patch("comfy_cli.command.install.execute")
+    @patch("comfy_cli.cmdline.check_comfy_repo", return_value=(False, None))
+    @patch("comfy_cli.cmdline.workspace_manager")
+    @patch("comfy_cli.tracking.prompt_tracking_consent")
+    def test_cpu_pr_conflict_with_commit(self, mock_track, mock_ws, mock_check, mock_execute, runner):
+        """Test that --cpu --pr with --commit is rejected"""
+        mock_ws.get_workspace_path.return_value = ("/tmp/test", None)
+        result = runner.invoke(
+            app, ["--skip-prompt", "install", "--cpu", "--pr", "#123", "--version", "nightly", "--commit", "abc123"]
+        )
+
+        assert result.exit_code != 0
+        assert "--pr cannot be used" in result.stdout
+        assert not mock_execute.called
+
+    @patch("comfy_cli.command.install.execute")
+    @patch("comfy_cli.cmdline.check_comfy_repo", return_value=(False, None))
+    @patch("comfy_cli.cmdline.workspace_manager")
+    @patch("comfy_cli.tracking.prompt_tracking_consent")
+    def test_cpu_pr_passes_pr_to_execute(self, mock_track, mock_ws, mock_check, mock_execute, runner):
+        """Test that --cpu --pr passes pr parameter to install_inner.execute"""
+        mock_ws.get_workspace_path.return_value = ("/tmp/test", None)
+        runner.invoke(app, ["--skip-prompt", "install", "--cpu", "--pr", "#123"])
+
+        assert mock_execute.called
+        call_kwargs = mock_execute.call_args.kwargs
+        assert call_kwargs.get("pr") == "#123"
+
 
 class TestPRInfoDataClass:
     """Test PRInfo data class"""


### PR DESCRIPTION
The --pr/--version/--commit conflict check was placed after the `if cpu:` early return, so `comfy install --cpu --pr 123` silently ignored the PR reference. The CPU path also never passed pr= to install_inner.execute.

Moved the validation before the early return and added pr=pr to the CPU install path.

Spotted in https://github.com/Comfy-Org/comfy-cli/pull/365#discussion_r2918603920