### PR TITLE
fix: handle missing Content-Length header in download_file

### DIFF
--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -69,13 +69,18 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
 
     with httpx.stream("GET", url, follow_redirects=True, headers=headers) as response:
         if response.status_code == 200:
-            total = int(response.headers["Content-Length"])
+            content_length = response.headers.get("Content-Length")
+            total = int(content_length) if content_length is not None else None
+            if total is not None:
+                description = f"Downloading {total // 1024 // 1024} MB"
+            else:
+                description = "Downloading..."
             try:
                 with open(local_filepath, "wb") as f:
                     for data in ui.show_progress(
                         response.iter_bytes(),
                         total,
-                        description=f"Downloading {total // 1024 // 1024} MB",
+                        description=description,
                     ):
                         f.write(data)
             except KeyboardInterrupt:

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -86,6 +86,24 @@ def test_download_file_success(mock_stream, tmp_path):
 
 
 @patch("httpx.stream")
+def test_download_file_success_without_content_length(mock_stream, tmp_path):
+    """Download should succeed when Content-Length header is missing (e.g. chunked/gzip responses)."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.iter_bytes.return_value = [b"chunk1", b"chunk2"]
+    mock_response.__enter__ = Mock(return_value=mock_response)
+    mock_response.__exit__ = Mock(return_value=None)
+    mock_stream.return_value = mock_response
+
+    test_file = tmp_path / "test.txt"
+    download_file("http://example.com", test_file)
+
+    assert test_file.exists()
+    assert test_file.read_bytes() == b"chunk1chunk2"
+
+
+@patch("httpx.stream")
 def test_download_file_failure(mock_stream):
     mock_response = Mock()
     mock_response.status_code = 404


### PR DESCRIPTION
download_file() crashes with a KeyError when the server response doesn't include a Content-Length header. This happens with chunked transfer encoding, which is common when servers apply gzip compression or when downloading from certain CDNs.

The fix uses .get() instead of direct dict access. When Content-Length is missing, the progress bar falls back to an indeterminate style instead of crashing.

This is the proper fix for the issue described in #242. That PR worked around it by forcing Accept-Encoding: identity on all downloads, which would disable compression and slow things down for everyone. This fix handles the root cause in download_file itself so all callers benefit.

Closes #242