### PR TITLE
fix: strip credentials from git remote URLs in comfy node init

### DIFF
--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+from urllib.parse import urlparse, urlunparse
 
 import tomlkit
 import tomlkit.exceptions
@@ -162,6 +163,18 @@ def validate_version(version: str, field_name: str) -> str:
     return version
 
 
+def _strip_url_credentials(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme in ("http", "https") and (parsed.username or parsed.password):
+        netloc = parsed.hostname or ""
+        if ":" in netloc:
+            netloc = f"[{netloc}]"
+        if parsed.port:
+            netloc += f":{parsed.port}"
+        return urlunparse(parsed._replace(netloc=netloc))
+    return url
+
+
 def initialize_project_config():
     create_comfynode_config()
 
@@ -171,6 +184,7 @@ def initialize_project_config():
     # Get the current git remote URL
     try:
         git_remote_url = subprocess.check_output(["git", "remote", "get-url", "origin"]).decode().strip()
+        git_remote_url = _strip_url_credentials(git_remote_url)
     except subprocess.CalledProcessError as e:
         raise Exception("Could not retrieve Git remote URL. Are you in a Git repository?") from e
 

--- a/tests/comfy_cli/command/nodes/test_node_init.py
+++ b/tests/comfy_cli/command/nodes/test_node_init.py
@@ -1,0 +1,39 @@
+import subprocess
+
+import tomlkit
+from typer.testing import CliRunner
+
+from comfy_cli.command.custom_nodes.command import app
+
+runner = CliRunner()
+
+
+def test_node_init_strips_credentials(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://ghp_FAKESECRET123@github.com/user/ComfyUI-TestNode.git"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "requirements.txt").write_text("requests\n")
+
+    result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 0
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    raw = tomlkit.dumps(data)
+    assert "ghp_FAKESECRET123" not in raw
+    assert data["project"]["urls"]["Repository"] == "https://github.com/user/ComfyUI-TestNode"
+
+
+def test_node_init_refuses_overwrite(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+
+    result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 1
+    assert "already exists" in result.stdout

--- a/tests/comfy_cli/registry/test_config_parser.py
+++ b/tests/comfy_cli/registry/test_config_parser.py
@@ -1,9 +1,13 @@
+import subprocess
 from unittest.mock import mock_open, patch
 
 import pytest
+import tomlkit
 
 from comfy_cli.registry.config_parser import (
+    _strip_url_credentials,
     extract_node_configuration,
+    initialize_project_config,
     validate_and_extract_accelerator_classifiers,
     validate_and_extract_os_classifiers,
     validate_version,
@@ -329,3 +333,81 @@ def test_validate_version_invalid(mock_echo):
         assert result == "", f"Version {version} should be invalid"
 
     assert mock_echo.call_count == len(invalid_versions)
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("https://github.com/user/repo.git", "https://github.com/user/repo.git"),
+        ("https://ghp_xxxx@github.com/user/repo.git", "https://github.com/user/repo.git"),
+        ("https://user:ghp_xxxx@github.com/user/repo.git", "https://github.com/user/repo.git"),
+        ("https://oauth2:token@gitlab.com:8443/user/repo.git", "https://gitlab.com:8443/user/repo.git"),
+        ("git@github.com:user/repo.git", "git@github.com:user/repo.git"),
+        ("https://user:@github.com/user/repo.git", "https://github.com/user/repo.git"),
+        ("https://:pass@github.com/user/repo.git", "https://github.com/user/repo.git"),
+        ("http://token@example.com/repo.git", "http://example.com/repo.git"),
+        ("https://user:pass@[::1]:8080/repo.git", "https://[::1]:8080/repo.git"),
+        ("git://github.com/user/repo.git", "git://github.com/user/repo.git"),
+        ("https://github.com:443/user/repo.git", "https://github.com:443/user/repo.git"),
+        ("ssh://git@github.com/user/repo.git", "ssh://git@github.com/user/repo.git"),
+    ],
+)
+def test_strip_url_credentials(url, expected):
+    assert _strip_url_credentials(url) == expected
+
+
+def test_initialize_project_config_strips_credentials(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://ghp_secret@github.com/user/ComfyUI-MyNode.git"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    urls = data["project"]["urls"]
+    assert urls["Repository"] == "https://github.com/user/ComfyUI-MyNode"
+    assert urls["Documentation"] == "https://github.com/user/ComfyUI-MyNode/wiki"
+    assert urls["Bug Tracker"] == "https://github.com/user/ComfyUI-MyNode/issues"
+    assert "ghp_secret" not in tomlkit.dumps(data)
+
+
+def test_initialize_project_config_clean_https(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/user/ComfyUI-MyNode.git"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    urls = data["project"]["urls"]
+    assert urls["Repository"] == "https://github.com/user/ComfyUI-MyNode"
+    assert urls["Documentation"] == "https://github.com/user/ComfyUI-MyNode/wiki"
+    assert urls["Bug Tracker"] == "https://github.com/user/ComfyUI-MyNode/issues"
+
+
+def test_initialize_project_config_ssh_remote(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:user/ComfyUI-TestNode.git"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    urls = data["project"]["urls"]
+    assert urls["Repository"] == "https://github.com/user/ComfyUI-TestNode"
+    assert urls["Documentation"] == "https://github.com/user/ComfyUI-TestNode/wiki"
+    assert urls["Bug Tracker"] == "https://github.com/user/ComfyUI-TestNode/issues"
+    assert data["project"]["name"] == "testnode"
+    assert data["tool"]["comfy"]["DisplayName"] == "ComfyUI-TestNode"


### PR DESCRIPTION
When a user has a personal access token or other credentials embedded in their git remote URL (e.g. https://token@github.com/user/repo.git), comfy node init writes that token into the generated pyproject.toml under Repository, Documentation, and Bug Tracker URLs. This is a security issue since the token can end up committed and pushed publicly.

This adds a small helper that strips credentials from the URL right after retrieving it from git, before it gets written anywhere. SSH URLs and clean HTTPS URLs pass through unchanged.

Fixes #342