### PR TITLE
fix: make e2e test_node resilient to transient git clone failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,8 +5,8 @@ on:
       - main
     paths:
       - "comfy_cli/**"
+      - "tests/e2e/**"
       - "!.github/**"
-      - "!tests/**"
       - "!.coveragerc"
       - "!.gitignore"
   pull_request:
@@ -14,8 +14,8 @@ on:
       - main
     paths:
       - "comfy_cli/**"
+      - "tests/e2e/**"
       - "!.github/**"
-      - "!tests/**"
       - "!.coveragerc"
       - "!.gitignore"
 

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -95,26 +95,33 @@ def test_model(comfy_cli):
 @e2e_test
 def test_node(comfy_cli, workspace):
     node = "comfyui-animatediff-evolved"
-    proc = exec(
-        f"""
-            {comfy_cli} node install {node}
-        """
-    )
-    assert 0 == proc.returncode
+
+    # Use --exit-on-fail so the CLI returns non-zero on git clone failure
+    # instead of silently succeeding. Retry to handle transient network
+    # errors (GitHub rate-limiting git clones on Actions runners).
+    for attempt in range(3):
+        proc = exec(
+            f"""
+                {comfy_cli} node install --exit-on-fail {node}
+            """
+        )
+        if proc.returncode == 0:
+            break
+    assert proc.returncode == 0, f"node install failed after 3 attempts:\n{proc.stderr}"
 
     proc = exec(
         f"""
             {comfy_cli} node reinstall {node}
         """
     )
-    assert 0 == proc.returncode
+    assert proc.returncode == 0
 
     proc = exec(
         f"""
             {comfy_cli} node show all
         """
     )
-    assert 0 == proc.returncode
+    assert proc.returncode == 0
     assert node in proc.stdout
 
     proc = exec(


### PR DESCRIPTION
The `test_node e2e` test flakes intermittently on all platforms (Ubuntu, macOS, Windows) because `git clone` of `comfyui-animatediff-evolved` fails with exit code 128 due to GitHub rate-limiting on Actions runners.

Two problems made this worse than it needed to be.
First, `comfy node install` returns exit code 0 even when git clone fails internally (ComfyUI-Manager's cm-cli.py swallows the exception). The test passed the returncode check and then failed with a confusing "node not in list" assertion. 
Second, a single transient network error caused the whole test to fail with no retry.

This adds `--exit-on-fail` to the install command so the CLI properly reports failure, and wraps the install in a retry loop (3 attempts) to handle transient network errors.