### PR TITLE
fix: support PEP 639 SPDX license identifiers in pyproject.toml

### DIFF
--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -27,7 +27,7 @@ def create_comfynode_config():
     project["description"] = ""
     project["version"] = "1.0.0"
     project["dependencies"] = tomlkit.aot()
-    project["license"] = "LICENSE"
+    project["license"] = "MIT"
 
     urls = tomlkit.table()
     urls["Repository"] = ""
@@ -207,10 +207,8 @@ def initialize_project_config():
     project["description"] = ""
     project["version"] = "1.0.0"
 
-    # Update the license field to comply with pyproject.toml spec
-    license_table = tomlkit.inline_table()
-    license_table["file"] = "LICENSE"
-    project["license"] = license_table
+    # Use PEP 639 SPDX license identifier
+    project["license"] = "MIT"
 
     # [project].classifiers Classifiers uncommentable hint for OS/GPU support
     # Attach classifiers comments to the project, below of "license" field.
@@ -218,7 +216,7 @@ def initialize_project_config():
     #
     # [project]
     # ...
-    # license = {file = "LICENSE"}
+    # license = "MIT"
     # # classifiers = [
     # #     # For OS-independent nodes (works on all operating systems)
     # ...
@@ -304,9 +302,6 @@ def extract_node_configuration(
     license_data = project_data.get("license", {})
     if isinstance(license_data, str):
         license = License(text=license_data)
-        typer.echo(
-            'Warning: License should be in one of these two formats: license = {file = "LICENSE"} OR license = {text = "MIT License"}. Please check the documentation: https://docs.comfy.org/registry/specifications.'
-        )
     elif isinstance(license_data, dict):
         if "file" in license_data or "text" in license_data:
             license = License(file=license_data.get("file", ""), text=license_data.get("text", ""))

--- a/tests/comfy_cli/registry/test_config_parser.py
+++ b/tests/comfy_cli/registry/test_config_parser.py
@@ -87,10 +87,14 @@ def test_extract_node_configuration_success(mock_toml_data):
         assert result.tool_comfy.models[0] == Model(location="model1.bin", model_url="https://example.com/model1")
 
 
-def test_extract_node_configuration_license_text():
+@pytest.mark.parametrize(
+    "license_str",
+    ["MIT", "Apache-2.0", "GPL-3.0-or-later", "MIT License"],
+)
+def test_extract_node_configuration_license_spdx_string(license_str):
     mock_data = {
         "project": {
-            "license": "MIT License",
+            "license": license_str,
         },
     }
     with (
@@ -101,7 +105,7 @@ def test_extract_node_configuration_license_text():
         result = extract_node_configuration("fake_path.toml")
         assert result is not None, "Expected PyProjectConfig, got None"
         assert isinstance(result, PyProjectConfig)
-        assert result.project.license == License(text="MIT License")
+        assert result.project.license == License(text=license_str)
 
 
 def test_extract_node_configuration_license_text_dict():
@@ -122,22 +126,6 @@ def test_extract_node_configuration_license_text_dict():
         assert result.project.license == License(
             text="MIT License\n\nCopyright (c) 2023 Example Corp\n\nPermission is hereby granted..."
         )
-
-
-def test_extract_license_incorrect_format():
-    mock_data = {
-        "project": {"license": "MIT"},
-    }
-    with (
-        patch("os.path.isfile", return_value=True),
-        patch("builtins.open", mock_open()),
-        patch("tomlkit.load", return_value=mock_data),
-    ):
-        result = extract_node_configuration("fake_path.toml")
-
-        assert result is not None, "Expected PyProjectConfig, got None"
-        assert isinstance(result, PyProjectConfig)
-        assert result.project.license == License(text="MIT")
 
 
 def test_extract_node_configuration_with_os_classifiers():


### PR DESCRIPTION
Using the modern PEP 639 SPDX license format like `license = "MIT"` in pyproject.toml would trigger a spurious warning asking users to switch to the deprecated `license = {file = "LICENSE"}` format. The parser already handled string licenses correctly internally, it just warned about them unnecessarily.

Removed the warning for string license values since `license = "MIT"` is the current recommended format per PEP 639. Also updated `comfy node init` to generate `license = "MIT"` instead of `license = {file = "LICENSE"}` in new pyproject.toml files. The deprecated dict formats (`{file = "..."}` and `{text = "..."}`) continue to work without warnings.

Fixes #295