### PR TITLE
fix: handle unknown node IDs in comfy run without crashing

### DIFF
--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -178,7 +178,9 @@ class WorkflowExecution:
         self.progress.update(self.overall_task, completed=self.total_nodes - len(self.remaining_nodes))
 
     def get_node_title(self, node_id):
-        node = self.workflow[node_id]
+        node = self.workflow.get(node_id)
+        if node is None:
+            return str(node_id)
         if "_meta" in node and "title" in node["_meta"]:
             return node["_meta"]["title"]
         return node["class_type"]
@@ -187,7 +189,10 @@ class WorkflowExecution:
         if not self.verbose:
             return
 
-        node = self.workflow[node_id]
+        node = self.workflow.get(node_id)
+        if node is None:
+            pprint(f"{type} : [bright_black]({node_id})[/]")
+            return
         class_type = node["class_type"]
         title = self.get_node_title(node_id)
 

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -114,6 +114,52 @@ class TestWatchExecution:
         mock_execution.watch_execution()
         assert "1" in mock_execution.remaining_nodes
 
+    def test_unknown_node_ids_do_not_crash(self, mock_execution):
+        prompt_id = "test-prompt"
+        mock_execution.prompt_id = prompt_id
+
+        messages = [
+            _make_msg("executing", prompt_id, node="1"),
+            _make_msg("executing", prompt_id, node="406.0.0.428"),
+            json.dumps(
+                {"type": "progress", "data": {"prompt_id": prompt_id, "node": "406.0.0.428", "value": 5, "max": 10}}
+            ),
+            _make_msg("executed", prompt_id, node="406.0.0.428"),
+            json.dumps({"type": "execution_cached", "data": {"prompt_id": prompt_id, "nodes": ["999"]}}),
+            _make_msg("executing", prompt_id, node=None),
+        ]
+        mock_ws = MagicMock()
+        mock_ws.recv.side_effect = messages
+        mock_execution.ws = mock_ws
+
+        mock_execution.watch_execution()
+
+    def test_unknown_node_ids_verbose(self, workflow):
+        prompt_id = "test-prompt"
+        progress = MagicMock()
+        progress.add_task.return_value = 0
+        execution = WorkflowExecution(
+            workflow=workflow,
+            host="127.0.0.1",
+            port=8188,
+            verbose=True,
+            progress=progress,
+            local_paths=False,
+            timeout=30,
+        )
+        execution.prompt_id = prompt_id
+
+        messages = [
+            _make_msg("executing", prompt_id, node="406.0.0.428"),
+            json.dumps({"type": "execution_cached", "data": {"prompt_id": prompt_id, "nodes": ["999"]}}),
+            _make_msg("executing", prompt_id, node=None),
+        ]
+        mock_ws = MagicMock()
+        mock_ws.recv.side_effect = messages
+        execution.ws = mock_ws
+
+        execution.watch_execution()
+
     def test_collects_image_outputs(self, mock_execution):
         prompt_id = "test-prompt"
         mock_execution.prompt_id = prompt_id


### PR DESCRIPTION
When workflows use loop/iteration nodes (like ComfyUI-Loop-image or Easy-Use), the ComfyUI server sends websocket messages with composite node IDs like `406.0.0.428` that don't exist in the original workflow dict. This caused `comfy run` to crash with a `KeyError` even though the workflow executed successfully and all outputs were saved.

Changed `get_node_title()` and `log_node()` to use `dict.get()` instead of `dict[]` for workflow lookups. Unknown node IDs now fall back to displaying the raw ID string instead of crashing. The workflow execution itself is unaffected since `remaining_nodes.discard()` was already safe for unknown keys.

Added tests covering unknown node IDs through all message types (executing, progress, executed, execution_cached) in both normal and `--verbose` modes.

Fixes #278