### PR TITLE
test: add coverage for download_url and tarball round-trip in utils.py

### DIFF
--- a/tests/comfy_cli/test_utils.py
+++ b/tests/comfy_cli/test_utils.py
@@ -1,0 +1,55 @@
+import io
+from unittest.mock import MagicMock, patch
+
+from comfy_cli.utils import create_tarball, download_url, extract_tarball
+
+
+class _FakeRaw(io.BytesIO):
+    """BytesIO that accepts decode_content kwarg like urllib3 responses.
+
+    The production code does ``response.raw.read = functools.partial(
+    response.raw.read, decode_content=True)`` which monkey-patches the
+    read method.  A plain BytesIO would blow up because its read() does
+    not accept that kwarg.
+    """
+
+    def read(self, amt=-1, decode_content=False):
+        return super().read(amt)
+
+
+class TestDownloadUrl:
+    @patch("comfy_cli.utils.requests.get")
+    def test_writes_file(self, mock_get, tmp_path):
+        content = b"file contents here"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Length": str(len(content))}
+        mock_response.raw = _FakeRaw(content)
+        mock_get.return_value = mock_response
+
+        result = download_url("http://example.com/f.bin", "f.bin", cwd=tmp_path, show_progress=False)
+        assert result == tmp_path / "f.bin"
+        assert (tmp_path / "f.bin").read_bytes() == content
+
+
+class TestTarballRoundTrip:
+    def test_create_and_extract(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        src = tmp_path / "mydir"
+        src.mkdir()
+        (src / "hello.txt").write_text("hello world")
+        (src / "sub").mkdir()
+        (src / "sub" / "nested.txt").write_text("nested content")
+
+        tarball = tmp_path / "mydir.tgz"
+        with patch("comfy_cli.utils.Live"):
+            create_tarball(src, tarball, cwd=tmp_path)
+        assert tarball.exists()
+
+        dest = tmp_path / "extracted"
+        with patch("comfy_cli.utils.Live"):
+            extract_tarball(tarball, dest)
+
+        assert (dest / "hello.txt").read_text() == "hello world"
+        assert (dest / "sub" / "nested.txt").read_text() == "nested content"


### PR DESCRIPTION
Two tests for the non-trivial logic in utils.py.

`test_writes_file` exercises the full `download_url` pipeline with a mocked HTTP response. The function monkey-patches `response.raw.read` via `functools.partial(..., decode_content=True)`, so the test uses a custom `_FakeRaw(BytesIO)` subclass that accepts that kwarg — a plain BytesIO would blow up. Verifies the file lands on disk with correct contents.

`test_create_and_extract` does a real filesystem round-trip through `create_tarball` and `extract_tarball`: creates a directory tree, archives it, extracts to a new location, and verifies file contents survive. This covers the path arithmetic (`inPath.relative_to(cwd)`, `inPath.with_name(old_name)`), the CWD-dependent `extractall`, and the `shutil.move` rename. Rich `Live` display is mocked out since both functions have a latent `NameError` when `show_progress=False` (`progress_table` is only defined inside the `if show_progress` block).