### PR TITLE
test: fix os.chdir leak and ConfigManager disk writes in install tests

### DIFF
--- a/tests/comfy_cli/conftest.py
+++ b/tests/comfy_cli/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _preserve_cwd():
+    """Restore the working directory after every test.
+
+    Several functions in comfy_cli.command.install (execute,
+    pip_install_comfyui_dependencies) call os.chdir() as a side effect.
+    Without this fixture the changed CWD leaks into subsequent tests and
+    can cause hard-to-debug failures.
+    """
+    original = os.getcwd()
+    yield
+    os.chdir(original)

--- a/tests/comfy_cli/test_file_utils.py
+++ b/tests/comfy_cli/test_file_utils.py
@@ -1,19 +1,6 @@
-import os
 import zipfile
-from pathlib import Path
-
-import pytest
 
 from comfy_cli import file_utils
-
-
-@pytest.fixture(autouse=True)
-def restore_cwd():
-    original_cwd = Path.cwd()
-    try:
-        yield
-    finally:
-        os.chdir(original_cwd)
 
 
 def test_zip_files_respects_comfyignore(tmp_path, monkeypatch):

--- a/tests/comfy_cli/test_global_python_install.py
+++ b/tests/comfy_cli/test_global_python_install.py
@@ -87,6 +87,7 @@ class TestGlobalPythonInstallExecute:
             patch("comfy_cli.command.install.pip_install_comfyui_dependencies") as mock_pip,
             patch("comfy_cli.command.install.DependencyCompiler") as MockCompiler,
             patch("comfy_cli.command.install.WorkspaceManager"),
+            patch("comfy_cli.config_manager.ConfigManager"),
             patch.object(install.workspace_manager, "skip_prompting", True),
             patch.object(install.workspace_manager, "setup_workspace_manager"),
         ):

--- a/tests/comfy_cli/test_install_python_resolution.py
+++ b/tests/comfy_cli/test_install_python_resolution.py
@@ -55,6 +55,7 @@ class TestExecute:
             patch("comfy_cli.command.install.check_comfy_repo", return_value=(True, None)),
             patch("comfy_cli.command.install.pip_install_comfyui_dependencies") as mock_pip_deps,
             patch("comfy_cli.command.install.WorkspaceManager"),
+            patch("comfy_cli.config_manager.ConfigManager"),
             patch.object(install.workspace_manager, "skip_prompting", True),
             patch.object(install.workspace_manager, "setup_workspace_manager"),
         ):
@@ -79,6 +80,7 @@ class TestExecute:
             patch("comfy_cli.command.install.check_comfy_repo", return_value=(True, None)),
             patch("comfy_cli.command.install.DependencyCompiler") as MockCompiler,
             patch("comfy_cli.command.install.WorkspaceManager"),
+            patch("comfy_cli.config_manager.ConfigManager"),
             patch.object(install.workspace_manager, "skip_prompting", True),
             patch.object(install.workspace_manager, "setup_workspace_manager"),
         ):
@@ -109,6 +111,7 @@ class TestExecute:
             patch("comfy_cli.command.install.check_comfy_repo", return_value=(True, None)),
             patch("comfy_cli.command.install.DependencyCompiler") as MockCompiler,
             patch("comfy_cli.command.install.WorkspaceManager"),
+            patch("comfy_cli.config_manager.ConfigManager"),
             patch.object(install.workspace_manager, "skip_prompting", True),
             patch.object(install.workspace_manager, "setup_workspace_manager"),
         ):


### PR DESCRIPTION
## Summary

Follow-up to #394. Fixes two test hygiene issues found during review in tests that call `install.execute()`:

- **CWD leak**: `execute()` and `pip_install_comfyui_dependencies()` call `os.chdir(repo_dir)` as a side effect, leaking the changed working directory into subsequent tests. Added an autouse `_preserve_cwd` fixture in `tests/comfy_cli/conftest.py` that saves and restores `os.getcwd()` around every test.

- **ConfigManager disk writes**: Tests calling `execute(skip_manager=True)` hit the real `ConfigManager().set()` which writes to `~/.config/comfy-cli/config.ini`. Added `patch("comfy_cli.config_manager.ConfigManager")` to the 4 affected callsites in `test_install_python_resolution.py` and `test_global_python_install.py`.