### PR TITLE
feat: add CUDA 13.0 support

### DIFF
--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -72,6 +72,7 @@ COMFY_ORIGIN_URL_CHOICES = {
 
 
 class CUDAVersion(str, Enum):
+    v13_0 = "13.0"
     v12_9 = "12.9"
     v12_6 = "12.6"
     v12_4 = "12.4"

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -171,6 +171,14 @@ def test_nvidia_custom_cuda_version():
     assert depComp.gpuUrl == "https://download.pytorch.org/whl/cu118"
 
 
+def test_nvidia_cuda_13():
+    depComp = DependencyCompiler(
+        cwd=temp, gpu=GPU_OPTION.NVIDIA, outDir=temp, reqFilesCore=[], reqFilesExt=[], cuda_version="13.0"
+    )
+    assert depComp.torchBackend == "cu130"
+    assert depComp.gpuUrl == "https://download.pytorch.org/whl/cu130"
+
+
 def test_amd_custom_rocm_version():
     depComp = DependencyCompiler(
         cwd=temp, gpu=GPU_OPTION.AMD, outDir=temp, reqFilesCore=[], reqFilesExt=[], rocm_version="7.1"


### PR DESCRIPTION
Adds `v13_0 = "13.0"` to the `CUDAVersion` enum so users can pass `--cuda-version 13.0` when installing with `--nvidia`. This is needed for newer GPUs (e.g. RTX 5060 Ti) that ship with CUDA 13.0 drivers.

Without this, users with CUDA 13.0 have to manually uninstall torch and reinstall with the correct wheel outside of comfy-cli.

Related: #397