### PR TITLE
Fix #403: [Bug] FileNotFoundError: cm-cli not found when running "com...

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -728,7 +728,8 @@ def update_node_id_cache():
     workspace_path = workspace_manager.workspace_path
 
     if not find_cm_cli():
-        raise FileNotFoundError("cm-cli not found")
+        print("[bold yellow]ComfyUI-Manager is not installed. Skipping node ID cache update.[/bold yellow]")
+        return
 
     tmp_path = os.path.join(config_manager.get_config_path(), "tmp")
     if not os.path.exists(tmp_path):

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from typer.testing import CliRunner
 
-from comfy_cli.command.custom_nodes.command import app
+from comfy_cli.command.custom_nodes.command import app, update_node_id_cache
 
 runner = CliRunner()
 
@@ -274,6 +274,13 @@ def test_update_calls_update_node_id_cache():
         assert result.exit_code == 0
         mock_execute.assert_called_once()
         mock_cache.assert_called_once()
+
+
+def test_update_node_id_cache_skips_gracefully_when_cm_cli_missing():
+    """update_node_id_cache should return without error when cm-cli is not installed."""
+    with patch("comfy_cli.command.custom_nodes.command.find_cm_cli", return_value=False):
+        # Should not raise FileNotFoundError
+        update_node_id_cache()
 
 
 def test_uninstall_calls_execute():


### PR DESCRIPTION
Closes #403

## Motivation

`update_node_id_cache()` in `comfy_cli/command/custom_nodes/command.py` raised a hard `FileNotFoundError` when `cm-cli` (ComfyUI-Manager) was not present, causing `comfy update` to crash even though the core update had already completed successfully. ComfyUI-Manager is an optional component, so its absence should not be a fatal error.

## Changes

**`comfy_cli/command/custom_nodes/command.py`** (line 731):
- Replaced `raise FileNotFoundError("cm-cli not found")` with a printed warning message and an early `return`, allowing `update_node_id_cache()` to exit cleanly when `find_cm_cli()` returns falsy.

**`tests/comfy_cli/command/nodes/test_node_install.py`**:
- Added `update_node_id_cache` to the import line.
- Added `test_update_node_id_cache_skips_gracefully_when_cm_cli_missing()`, which patches `find_cm_cli` to return `False` and asserts that `update_node_id_cache()` completes without raising `FileNotFoundError`.

## Testing

The new unit test covers the fix directly:

```
tests/comfy_cli/command/nodes/test_node_install.py::test_update_node_id_cache_skips_gracefully_when_cm_cli_missing
```

`find_cm_cli` is patched to `False`, confirming the early-return path executes without exception. Manually running `comfy update` in an environment without ComfyUI-Manager installed now prints the yellow warning and exits cleanly instead of crashing.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*