### PR TITLE
fix: handle missing cm-cli gracefully in comfy update

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -416,7 +416,10 @@ def update(
             check=True,
         )
 
-    custom_nodes.command.update_node_id_cache()
+    try:
+        custom_nodes.command.update_node_id_cache()
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        rprint(f"[yellow]Failed to update node id cache: {e}[/yellow]")
 
 
 @app.command(help="Run API workflow file using the ComfyUI launched by `comfy launch --background`")

--- a/tests/comfy_cli/test_cmdline_python_resolution.py
+++ b/tests/comfy_cli/test_cmdline_python_resolution.py
@@ -35,9 +35,10 @@ class TestUpdateComfy:
             patch(
                 "comfy_cli.cmdline.custom_nodes.command.update_node_id_cache",
                 side_effect=FileNotFoundError("cm-cli not found"),
-            ),
+            ) as mock_cache,
         ):
             cmdline.update(target="comfy")
+        mock_cache.assert_called_once()
 
 
 class TestDependency:

--- a/tests/comfy_cli/test_cmdline_python_resolution.py
+++ b/tests/comfy_cli/test_cmdline_python_resolution.py
@@ -25,6 +25,20 @@ class TestUpdateComfy:
         assert pip_call is not None, "pip install call not found"
         assert pip_call[0] == "/resolved/python"
 
+    def test_update_comfy_succeeds_when_cm_cli_missing(self, tmp_path):
+        """Regression test for #403: comfy update must not crash when cm-cli is absent."""
+        with (
+            patch("comfy_cli.cmdline.resolve_workspace_python", return_value="/resolved/python"),
+            patch.object(cmdline.workspace_manager, "workspace_path", str(tmp_path)),
+            patch("comfy_cli.cmdline.os.chdir"),
+            patch("comfy_cli.cmdline.subprocess.run"),
+            patch(
+                "comfy_cli.cmdline.custom_nodes.command.update_node_id_cache",
+                side_effect=FileNotFoundError("cm-cli not found"),
+            ),
+        ):
+            cmdline.update(target="comfy")
+
 
 class TestDependency:
     def test_passes_python_to_compiler(self, tmp_path):


### PR DESCRIPTION
Closes #403

## Summary

- `comfy update comfy` crashes with `FileNotFoundError` when ComfyUI-Manager (cm-cli) is not installed, even though the core update (git pull + pip install) already succeeded.
- The fix wraps `update_node_id_cache()` in `cmdline.py` with a try/except, matching the pattern already used in `install.py` ([line 290-294](https://github.com/Comfy-Org/comfy-cli/blob/8baa2406d48a6b28a3b0e6f19d1be954c74aff0a/comfy_cli/command/install.py#L290-L294)). The function itself stays strict — callers that know cm-cli is optional handle it at the call site.

## Test plan

- [x] Added regression test `test_update_comfy_succeeds_when_cm_cli_missing` — mocks `update_node_id_cache` to raise `FileNotFoundError` and asserts `cmdline.update()` completes without crashing
- [x] Full unit test suite passes (626 passed)
- [x] Lint clean (`ruff check` + `ruff format --check`)