### PR TITLE
fix: retry transient HTTP statuses and show friendly download errors

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -1174,7 +1174,7 @@ def registry_install(
     except DownloadException as e:
         logging.error(f"Failed to download node {node_id} version {node_version.version}: {e}")
         ui.display_error_message(f"Failed to download the custom node {node_id}: {e}")
-        return
+        raise typer.Exit(code=1) from None
 
     # Extract the downloaded archive to the custom_node directory on the workspace.
     logging.debug(f"Start extracting the node {node_id} version {node_version.version} to {custom_nodes_path}")

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -18,6 +18,7 @@ from comfy_cli.command.custom_nodes.cm_cli_util import execute_cm_cli, find_cm_c
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import NODE_ZIP_FILENAME
 from comfy_cli.file_utils import (
+    DownloadException,
     download_file,
     extract_package_as_zip,
     upload_file_to_signed_url,
@@ -1168,7 +1169,12 @@ def registry_install(
 
     local_filename = node_specific_path / f"{node_id}-{node_version.version}.zip"
     logging.debug(f"Start downloading the node {node_id} version {node_version.version} to {local_filename}")
-    download_file(node_version.download_url, local_filename)
+    try:
+        download_file(node_version.download_url, local_filename)
+    except DownloadException as e:
+        logging.error(f"Failed to download node {node_id} version {node_version.version}: {e}")
+        ui.display_error_message(f"Failed to download the custom node {node_id}: {e}")
+        return
 
     # Extract the downloaded archive to the custom_node directory on the workspace.
     logging.debug(f"Start extracting the node {node_id} version {node_version.version} to {custom_nodes_path}")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -354,7 +354,11 @@ def download(
             print(f"Model downloaded successfully to: {output_path}")
     else:
         print(f"Start downloading URL: {url} into {local_filepath}")
-        download_file(url, local_filepath, headers, downloader=resolved_downloader)
+        try:
+            download_file(url, local_filepath, headers, downloader=resolved_downloader)
+        except DownloadException as e:
+            print(f"[bold red]{e}[/bold red]")
+            raise typer.Exit(code=1) from None
 
     elapsed = time.monotonic() - start_time
     print(f"Done in {_format_elapsed(elapsed)}")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 import requests
 import typer
 from rich import print
+from rich.markup import escape
 
 from comfy_cli import constants, tracking, ui
 from comfy_cli.config_manager import ConfigManager
@@ -357,7 +358,9 @@ def download(
         try:
             download_file(url, local_filepath, headers, downloader=resolved_downloader)
         except DownloadException as e:
-            print(f"[bold red]{e}[/bold red]")
+            # escape() so a dynamic error message containing "[/]" or similar
+            # rich-markup syntax doesn't trigger MarkupError or get mis-rendered.
+            print(f"[bold red]{escape(str(e))}[/bold red]")
             raise typer.Exit(code=1) from None
 
     elapsed = time.monotonic() - start_time

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -82,6 +82,7 @@ def _poll_aria2_download(download) -> None:
         DownloadColumn(),
         TransferSpeedColumn(),
         TimeRemainingColumn(),
+        transient=True,
     ) as progress:
         task = progress.add_task("Downloading...", total=None)
 
@@ -172,6 +173,22 @@ _TRANSIENT_EXCEPTIONS = (
     httpx.ProtocolError,
     httpx.ProxyError,
 )
+# HTTP statuses that typically indicate a transient server-side or rate-limit
+# problem worth retrying with backoff. Auth/not-found/redirect statuses stay
+# out of this set so they fail fast.
+_RETRIABLE_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+
+class _TransientHTTPStatusError(Exception):
+    """Retriable HTTP status returned by the server (e.g. 500/503/429)."""
+
+    def __init__(self, status_code: int, reason: str):
+        self.status_code = status_code
+        self.reason = reason
+        super().__init__(f"HTTP {status_code}: {reason}")
+
+
+_RETRIABLE_EXCEPTIONS = _TRANSIENT_EXCEPTIONS + (_TransientHTTPStatusError,)
 
 
 def _cleanup_partial(filepath: pathlib.Path) -> None:
@@ -184,6 +201,8 @@ def _cleanup_partial(filepath: pathlib.Path) -> None:
 
 def _friendly_network_error(exc: Exception) -> str:
     """Return a user-friendly description of a network error."""
+    if isinstance(exc, _TransientHTTPStatusError):
+        return f"the server returned HTTP {exc.status_code}"
     if isinstance(exc, httpx.ReadTimeout):
         return "the server stopped sending data (read timeout)"
     if isinstance(exc, httpx.ConnectTimeout):
@@ -221,6 +240,8 @@ def _download_file_httpx(
             except _TRANSIENT_EXCEPTIONS:
                 error_body = ""
             status_reason = guess_status_code_reason(response.status_code, error_body)
+            if response.status_code in _RETRIABLE_STATUSES:
+                raise _TransientHTTPStatusError(response.status_code, status_reason)
             raise DownloadException(f"Failed to download file.\n{status_reason}")
 
         content_length = response.headers.get("Content-Length")
@@ -261,7 +282,7 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
         try:
             _download_file_httpx(url, local_filepath, headers, state=state)
             return
-        except _TRANSIENT_EXCEPTIONS as exc:
+        except _RETRIABLE_EXCEPTIONS as exc:
             last_exc = exc
             # Only clean up if _download_file_httpx actually opened the destination —
             # otherwise we'd delete an unrelated pre-existing file at the same path.

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 import time
 import zipfile
+from http import HTTPStatus
 
 import httpx
 import requests
@@ -202,7 +203,13 @@ def _cleanup_partial(filepath: pathlib.Path) -> None:
 def _friendly_network_error(exc: Exception) -> str:
     """Return a user-friendly description of a network error."""
     if isinstance(exc, _TransientHTTPStatusError):
-        return f"the server returned HTTP {exc.status_code}"
+        try:
+            phrase = HTTPStatus(exc.status_code).phrase
+            return f"the server returned HTTP {exc.status_code} {phrase}"
+        except ValueError:
+            return f"the server returned HTTP {exc.status_code}"
+    if isinstance(exc, httpx.InvalidURL):
+        return f"invalid URL ({exc})"
     if isinstance(exc, httpx.ReadTimeout):
         return "the server stopped sending data (read timeout)"
     if isinstance(exc, httpx.ConnectTimeout):
@@ -293,10 +300,12 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
                 print(f"Download error (attempt {attempt + 1}/{_DOWNLOAD_MAX_RETRIES}): {_friendly_network_error(exc)}")
                 print(f"Retrying in {wait}s...")
                 time.sleep(wait)
-        except httpx.HTTPError as exc:
+        except (httpx.HTTPError, httpx.InvalidURL) as exc:
             # Non-retriable httpx errors (e.g. UnsupportedProtocol, TooManyRedirects,
-            # DecodingError). Fail fast and convert to DownloadException so callers
-            # only need to handle one error type.
+            # DecodingError, InvalidURL). Fail fast and convert to DownloadException
+            # so callers only need to handle one error type.
+            # InvalidURL inherits directly from Exception (not HTTPError), hence the
+            # explicit inclusion.
             if state["file_opened"]:
                 _cleanup_partial(local_filepath)
             raise DownloadException(f"Download failed: {_friendly_network_error(exc)}") from exc

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -293,6 +293,13 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
                 print(f"Download error (attempt {attempt + 1}/{_DOWNLOAD_MAX_RETRIES}): {_friendly_network_error(exc)}")
                 print(f"Retrying in {wait}s...")
                 time.sleep(wait)
+        except httpx.HTTPError as exc:
+            # Non-retriable httpx errors (e.g. UnsupportedProtocol, TooManyRedirects,
+            # DecodingError). Fail fast and convert to DownloadException so callers
+            # only need to handle one error type.
+            if state["file_opened"]:
+                _cleanup_partial(local_filepath)
+            raise DownloadException(f"Download failed: {_friendly_network_error(exc)}") from exc
         except KeyboardInterrupt:
             # Only prompt/cleanup if we actually opened the destination this attempt.
             # If the interrupt arrived during connection setup, there is no partial

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -28,7 +28,7 @@ def show_progress(iterable, total, description="Downloading..."):
     Yields:
         bytes: Chunks of data as they are processed.
     """
-    with Progress() as progress:
+    with Progress(transient=True) as progress:
         task = progress.add_task(description, total=total)
         for chunk in iterable:
             yield chunk

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -181,4 +181,6 @@ def display_error_message(message: str) -> None:
     Args:
         message (str): The error message to display.
     """
-    console.print(f"[red]{message}[/]")
+    # markup=False so a dynamic message containing e.g. "[/]" doesn't raise
+    # MarkupError or silently strip bracketed substrings.
+    console.print(message, style="red", markup=False)

--- a/tests/comfy_cli/command/models/test_models.py
+++ b/tests/comfy_cli/command/models/test_models.py
@@ -490,3 +490,19 @@ class TestDownloadCommandErrorHandling:
         result = self._run_with_download_error(tmp_path, DownloadException("boom"))
 
         assert "Done in" not in result.output
+
+    def test_download_exception_with_markup_chars_does_not_crash(self, tmp_path):
+        """A DownloadException message containing rich-markup metacharacters (e.g. from a
+        server JSON body embedded via guess_status_code_reason) must not raise MarkupError
+        nor be silently stripped — the error must render literally and exit cleanly."""
+        from comfy_cli.file_utils import DownloadException
+
+        # Covers both the closing-tag crash case and the bracketed-style stripping case.
+        result = self._run_with_download_error(tmp_path, DownloadException("server said [/] at /path/[id]/resource"))
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "MarkupError" not in result.output
+        # Literal markup characters must survive to the output so the user sees the real message.
+        assert "[/]" in result.output
+        assert "[id]" in result.output

--- a/tests/comfy_cli/command/models/test_models.py
+++ b/tests/comfy_cli/command/models/test_models.py
@@ -435,3 +435,58 @@ class TestDownloadCommandDownloaderOption:
             assert mock_dl.called
             _, kwargs = mock_dl.call_args
             assert kwargs.get("downloader") == "httpx"
+
+
+class TestDownloadCommandErrorHandling:
+    """Verify DownloadException is rendered as a friendly one-line error (not a traceback)."""
+
+    def _run_with_download_error(self, tmp_path, exc):
+        with (
+            patch("comfy_cli.command.models.models.get_workspace", return_value=tmp_path),
+            patch("comfy_cli.command.models.models.download_file", side_effect=exc),
+            patch("comfy_cli.command.models.models.check_civitai_url", return_value=(False, False, None, None)),
+            patch(
+                "comfy_cli.command.models.models.check_huggingface_url",
+                return_value=(False, None, None, None, None),
+            ),
+            patch("comfy_cli.command.models.models.ui") as mock_ui,
+            patch("comfy_cli.command.models.models.config_manager"),
+            patch("comfy_cli.tracking.track_command", lambda _cmd: lambda fn: fn),
+        ):
+            mock_ui.prompt_input.side_effect = ["mymodel.bin", ""]
+            return runner.invoke(
+                app,
+                [
+                    "download",
+                    "--url",
+                    "http://example.com/model.bin",
+                    "--filename",
+                    "model.bin",
+                ],
+            )
+
+    def test_download_exception_exits_with_code_1(self, tmp_path):
+        from comfy_cli.file_utils import DownloadException
+
+        result = self._run_with_download_error(tmp_path, DownloadException("boom"))
+
+        assert result.exit_code == 1
+        assert "boom" in result.output
+
+    def test_download_exception_does_not_show_traceback(self, tmp_path):
+        from comfy_cli.file_utils import DownloadException
+
+        result = self._run_with_download_error(tmp_path, DownloadException("boom"))
+
+        assert "Traceback" not in result.output
+        assert "DownloadException" not in result.output
+        # Rich markup must be rendered as styling, not leak through as literal tags.
+        assert "[bold red]" not in result.output
+        assert "[/bold red]" not in result.output
+
+    def test_download_exception_skips_done_message(self, tmp_path):
+        from comfy_cli.file_utils import DownloadException
+
+        result = self._run_with_download_error(tmp_path, DownloadException("boom"))
+
+        assert "Done in" not in result.output

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -1,10 +1,11 @@
 import re
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
 from comfy_cli.command.custom_nodes.command import app
+from comfy_cli.file_utils import DownloadException
 
 runner = CliRunner()
 
@@ -334,3 +335,50 @@ def test_show_with_channel():
         mock_execute.assert_called_once()
         _, kwargs = mock_execute.call_args
         assert kwargs.get("channel") == "dev"
+
+
+class TestRegistryInstallDownloadError:
+    """registry-install must catch DownloadException, surface a friendly one-line
+    error via ui.display_error_message, and exit cleanly — never raise a traceback."""
+
+    def _invoke(self, tmp_path, download_side_effect):
+        fake_version = MagicMock(download_url="http://example.com/node.zip", version="1.0.0")
+
+        with (
+            patch("comfy_cli.command.custom_nodes.command.registry_api") as mock_api,
+            patch("comfy_cli.command.custom_nodes.command.workspace_manager") as mock_ws,
+            patch("comfy_cli.command.custom_nodes.command.download_file", side_effect=download_side_effect) as mock_dl,
+            patch("comfy_cli.command.custom_nodes.command.ui") as mock_ui,
+            patch("comfy_cli.command.custom_nodes.command.extract_package_as_zip") as mock_extract,
+            patch("comfy_cli.command.custom_nodes.command.execute_install_script") as mock_script,
+        ):
+            mock_api.install_node.return_value = fake_version
+            mock_ws.workspace_path = str(tmp_path)
+            result = runner.invoke(app, ["registry-install", "test-node"])
+            return result, mock_ui, mock_dl, mock_extract, mock_script
+
+    def test_download_exception_caught_and_reported(self, tmp_path):
+        result, mock_ui, mock_dl, mock_extract, mock_script = self._invoke(
+            tmp_path, DownloadException("server unreachable")
+        )
+
+        assert result.exit_code == 0
+        mock_dl.assert_called_once()
+        mock_ui.display_error_message.assert_called_once()
+        (msg,), _ = mock_ui.display_error_message.call_args
+        assert "test-node" in msg
+        assert "server unreachable" in msg
+
+    def test_no_extract_or_install_script_after_failure(self, tmp_path):
+        """After a download failure we must not try to unzip or run the install script."""
+        result, _mock_ui, _mock_dl, mock_extract, mock_script = self._invoke(tmp_path, DownloadException("boom"))
+
+        assert result.exit_code == 0
+        mock_extract.assert_not_called()
+        mock_script.assert_not_called()
+
+    def test_no_traceback_in_output(self, tmp_path):
+        result, _mock_ui, _mock_dl, _mock_extract, _mock_script = self._invoke(tmp_path, DownloadException("boom"))
+
+        assert "Traceback" not in result.output
+        assert "DownloadException" not in result.output

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -362,7 +362,8 @@ class TestRegistryInstallDownloadError:
             tmp_path, DownloadException("server unreachable")
         )
 
-        assert result.exit_code == 0
+        # Must exit non-zero so automation / CI can detect the failure.
+        assert result.exit_code == 1
         mock_dl.assert_called_once()
         mock_ui.display_error_message.assert_called_once()
         (msg,), _ = mock_ui.display_error_message.call_args
@@ -373,7 +374,7 @@ class TestRegistryInstallDownloadError:
         """After a download failure we must not try to unzip or run the install script."""
         result, _mock_ui, _mock_dl, mock_extract, mock_script = self._invoke(tmp_path, DownloadException("boom"))
 
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         mock_extract.assert_not_called()
         mock_script.assert_not_called()
 

--- a/tests/comfy_cli/test_ui.py
+++ b/tests/comfy_cli/test_ui.py
@@ -1,0 +1,49 @@
+import io
+
+from rich.console import Console
+
+import comfy_cli.ui as ui_module
+from comfy_cli.ui import display_error_message
+
+
+def _capture(fn, *args, **kwargs):
+    """Run fn against a Console that writes to an in-memory buffer, return the output string."""
+    buf = io.StringIO()
+    original = ui_module.console
+    ui_module.console = Console(file=buf, force_terminal=False, markup=True)
+    try:
+        fn(*args, **kwargs)
+    finally:
+        ui_module.console = original
+    return buf.getvalue()
+
+
+class TestDisplayErrorMessageMarkup:
+    """display_error_message must accept any string content without raising rich.errors.MarkupError
+    or silently stripping bracketed substrings. Error messages can contain server-controlled text
+    (e.g. JSON body echoed into a DownloadException) which may include arbitrary [ and ] chars."""
+
+    def test_plain_message_rendered(self):
+        out = _capture(display_error_message, "plain error")
+        assert "plain error" in out
+
+    def test_closing_tag_alone_does_not_crash(self):
+        # Prior to the fix this raised rich.errors.MarkupError on console.print.
+        out = _capture(display_error_message, "error with [/] in the middle")
+        assert "[/]" in out
+
+    def test_bracketed_substring_preserved(self):
+        # Prior to the fix "[id]" was consumed as an unknown style and stripped.
+        out = _capture(display_error_message, "URL /path/[id]/resource not found")
+        assert "[id]" in out
+        assert "/path/[id]/resource" in out
+
+    def test_multiple_markup_like_tokens(self):
+        out = _capture(display_error_message, "server said [redacted] at [host]:[port]")
+        assert "[redacted]" in out
+        assert "[host]" in out
+        assert "[port]" in out
+
+    def test_unbalanced_opening_bracket(self):
+        out = _capture(display_error_message, "unbalanced [tag without close")
+        assert "[tag without close" in out

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -735,3 +735,77 @@ class TestDownloadHTTPStatusRetry:
 
         assert dest.exists()
         assert dest.read_bytes() == b"IMPORTANT pre-existing data"
+
+
+class TestDownloadNonRetriableHTTPError:
+    """Non-retriable httpx errors (UnsupportedProtocol, TooManyRedirects, etc.) are wrapped
+    as DownloadException so callers only need to handle one error type and users don't
+    see a raw Python traceback."""
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_unsupported_protocol_wrapped(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = httpx.UnsupportedProtocol("Request URL has an unsupported protocol 'ftp://'")
+
+        with pytest.raises(DownloadException, match="Download failed") as exc_info:
+            download_file("ftp://example.com/model.bin", tmp_path / "model.bin")
+
+        assert isinstance(exc_info.value.__cause__, httpx.UnsupportedProtocol)
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_too_many_redirects_wrapped(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = httpx.TooManyRedirects("Exceeded maximum allowed redirects")
+
+        with pytest.raises(DownloadException, match="Download failed") as exc_info:
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert isinstance(exc_info.value.__cause__, httpx.TooManyRedirects)
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_decoding_error_wrapped(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = httpx.DecodingError("Invalid compressed data")
+
+        with pytest.raises(DownloadException, match="Download failed") as exc_info:
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert isinstance(exc_info.value.__cause__, httpx.DecodingError)
+        assert mock_stream.call_count == 1
+
+    @patch("httpx.stream")
+    def test_preexisting_file_preserved_on_non_retriable_error(self, mock_stream, tmp_path):
+        """A non-retriable httpx error before the output file is opened must not delete
+        an unrelated pre-existing file at the destination path."""
+        mock_stream.side_effect = httpx.UnsupportedProtocol("nope")
+
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"IMPORTANT pre-existing data")
+
+        with pytest.raises(DownloadException):
+            download_file("ftp://example.com/model.bin", dest)
+
+        assert dest.exists()
+        assert dest.read_bytes() == b"IMPORTANT pre-existing data"
+
+    @patch("httpx.stream")
+    def test_partial_file_cleaned_up_on_mid_stream_non_retriable(self, mock_stream, tmp_path):
+        """If a non-retriable error is raised AFTER the output file is opened (mid-stream),
+        the partial file is cleaned up."""
+        resp = Mock()
+        resp.status_code = 200
+        resp.headers = {"Content-Length": "100"}
+        resp.iter_bytes = Mock(side_effect=_make_failing_iter(b"partial", httpx.DecodingError("bad")))
+        resp.__enter__ = Mock(return_value=resp)
+        resp.__exit__ = Mock(return_value=None)
+        mock_stream.return_value = resp
+
+        dest = tmp_path / "model.bin"
+        with pytest.raises(DownloadException):
+            download_file("http://example.com/model.bin", dest)
+
+        assert not dest.exists()

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -10,6 +10,7 @@ from comfy_cli.file_utils import (
     DownloadException,
     _cleanup_partial,
     _friendly_network_error,
+    _TransientHTTPStatusError,
     check_unauthorized,
     download_file,
     extract_package_as_zip,
@@ -192,6 +193,16 @@ def _make_failing_iter(data=b"partial", exc=None):
     return factory
 
 
+def _make_status_response(status_code, body=b""):
+    """Create a mock httpx response for a non-200 status."""
+    mock = Mock()
+    mock.status_code = status_code
+    mock.read.return_value = body
+    mock.__enter__ = Mock(return_value=mock)
+    mock.__exit__ = Mock(return_value=None)
+    return mock
+
+
 class TestCleanupPartial:
     def test_removes_existing_file(self, tmp_path):
         f = tmp_path / "partial.bin"
@@ -235,6 +246,10 @@ class TestFriendlyNetworkError:
     def test_other_exception(self):
         msg = _friendly_network_error(RuntimeError("boom"))
         assert msg == "boom"
+
+    def test_transient_http_status(self):
+        msg = _friendly_network_error(_TransientHTTPStatusError(503, "Service Unavailable"))
+        assert "HTTP 503" in msg
 
 
 class TestDownloadTimeout:
@@ -528,3 +543,195 @@ class TestDownloadPartialCleanup:
         mock_prompt.assert_called_once()
         assert dest.exists()
         assert dest.read_bytes() == b"partial data"
+
+
+class TestDownloadHTTPStatusRetry:
+    """Retry behavior for transient HTTP status codes (5xx, 429, 408)."""
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_500_retried_and_succeeds(self, mock_stream, mock_sleep, tmp_path):
+        """Download retries on HTTP 500 and succeeds on the next attempt."""
+        mock_stream.side_effect = [
+            _make_status_response(500),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"ok"
+        assert mock_stream.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_502_retried(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = [
+            _make_status_response(502),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_503_retried(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = [
+            _make_status_response(503),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_504_retried(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = [
+            _make_status_response(504),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_429_retried(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = [
+            _make_status_response(429),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_408_retried(self, mock_stream, mock_sleep, tmp_path):
+        mock_stream.side_effect = [
+            _make_status_response(408),
+            _make_ok_response(content=b"ok"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_all_retries_exhausted_on_500(self, mock_stream, mock_sleep, tmp_path):
+        """After 3 failed attempts on 500, a DownloadException is raised with a friendly message."""
+        mock_stream.side_effect = [
+            _make_status_response(500),
+            _make_status_response(500),
+            _make_status_response(500),
+        ]
+
+        dest = tmp_path / "model.bin"
+        with pytest.raises(DownloadException, match="Download failed after 3 attempts") as exc_info:
+            download_file("http://example.com/model.bin", dest)
+
+        assert "HTTP 500" in str(exc_info.value)
+        assert mock_stream.call_count == 3
+        # The last transient HTTP error must be chained as __cause__ for debuggability.
+        assert isinstance(exc_info.value.__cause__, _TransientHTTPStatusError)
+        assert exc_info.value.__cause__.status_code == 500
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_retry_body_read_timeout_still_retries(self, mock_stream, mock_sleep, tmp_path):
+        """If reading the 500 response body itself times out, we still retry the request."""
+        fail_resp = Mock()
+        fail_resp.status_code = 500
+        fail_resp.read.side_effect = httpx.ReadTimeout("body read timed out")
+        fail_resp.__enter__ = Mock(return_value=fail_resp)
+        fail_resp.__exit__ = Mock(return_value=None)
+
+        mock_stream.side_effect = [fail_resp, _make_ok_response(content=b"ok")]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"ok"
+        assert mock_stream.call_count == 2
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_mixed_transient_errors_eventually_succeed(self, mock_stream, mock_sleep, tmp_path):
+        """Retries work across a mix of network-level and HTTP-status errors."""
+        mock_stream.side_effect = [
+            _make_status_response(503),
+            httpx.ReadTimeout("timeout"),
+            _make_ok_response(content=b"finally"),
+        ]
+
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"finally"
+        assert mock_stream.call_count == 3
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_404_not_retried(self, mock_stream, mock_sleep, tmp_path):
+        """404 fails fast without retry."""
+        mock_stream.return_value = _make_status_response(404)
+
+        with pytest.raises(DownloadException, match="Failed to download file"):
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_401_not_retried(self, mock_stream, mock_sleep, tmp_path):
+        """401 fails fast without retry."""
+        mock_stream.return_value = _make_status_response(401)
+
+        with pytest.raises(DownloadException, match="Failed to download file"):
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_403_not_retried(self, mock_stream, mock_sleep, tmp_path):
+        """403 fails fast without retry."""
+        mock_stream.return_value = _make_status_response(403)
+
+        with pytest.raises(DownloadException, match="Failed to download file"):
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_preexisting_file_preserved_on_http_status_retry_exhaust(self, mock_stream, mock_sleep, tmp_path):
+        """A pre-existing file at the destination is NOT deleted when all retries fail on HTTP 500.
+
+        The retriable HTTP status is raised before _download_file_httpx opens the output file.
+        """
+        mock_stream.side_effect = [
+            _make_status_response(500),
+            _make_status_response(500),
+            _make_status_response(500),
+        ]
+
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"IMPORTANT pre-existing data")
+
+        with pytest.raises(DownloadException, match="Download failed after 3 attempts"):
+            download_file("http://example.com/model.bin", dest)
+
+        assert dest.exists()
+        assert dest.read_bytes() == b"IMPORTANT pre-existing data"

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -247,9 +247,27 @@ class TestFriendlyNetworkError:
         msg = _friendly_network_error(RuntimeError("boom"))
         assert msg == "boom"
 
-    def test_transient_http_status(self):
-        msg = _friendly_network_error(_TransientHTTPStatusError(503, "Service Unavailable"))
+    def test_transient_http_status_known_code_includes_phrase(self):
+        # HTTP 503 -> "Service Unavailable" (from stdlib http.HTTPStatus).
+        msg = _friendly_network_error(_TransientHTTPStatusError(503, "some reason from body"))
         assert "HTTP 503" in msg
+        assert "Service Unavailable" in msg
+
+    def test_transient_http_status_500_includes_phrase(self):
+        msg = _friendly_network_error(_TransientHTTPStatusError(500, ""))
+        assert "HTTP 500" in msg
+        assert "Internal Server Error" in msg
+
+    def test_transient_http_status_unknown_code_falls_back(self):
+        # 599 is not a standard HTTPStatus; fall back to just the numeric code.
+        msg = _friendly_network_error(_TransientHTTPStatusError(599, "weird"))
+        assert "HTTP 599" in msg
+        # No crash, no stdlib phrase embedded (since there isn't one).
+
+    def test_invalid_url(self):
+        msg = _friendly_network_error(httpx.InvalidURL("Request URL is missing a scheme"))
+        assert "invalid URL" in msg
+        assert "missing a scheme" in msg
 
 
 class TestDownloadTimeout:
@@ -639,6 +657,8 @@ class TestDownloadHTTPStatusRetry:
             download_file("http://example.com/model.bin", dest)
 
         assert "HTTP 500" in str(exc_info.value)
+        # The stdlib HTTPStatus phrase is surfaced so the user knows what 500 means.
+        assert "Internal Server Error" in str(exc_info.value)
         assert mock_stream.call_count == 3
         # The last transient HTTP error must be chained as __cause__ for debuggability.
         assert isinstance(exc_info.value.__cause__, _TransientHTTPStatusError)
@@ -776,6 +796,37 @@ class TestDownloadNonRetriableHTTPError:
 
         assert isinstance(exc_info.value.__cause__, httpx.DecodingError)
         assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_invalid_url_wrapped(self, mock_stream, mock_sleep, tmp_path):
+        """httpx.InvalidURL does NOT subclass httpx.HTTPError — it must still be wrapped
+        as DownloadException so a malformed URL doesn't leak as a Typer traceback."""
+        mock_stream.side_effect = httpx.InvalidURL("Request URL is missing a scheme")
+
+        with pytest.raises(DownloadException, match="Download failed") as exc_info:
+            download_file("no-scheme-url", tmp_path / "model.bin")
+
+        assert isinstance(exc_info.value.__cause__, httpx.InvalidURL)
+        assert "invalid URL" in str(exc_info.value)
+        assert mock_stream.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("httpx.stream")
+    def test_invalid_url_preserves_preexisting_file(self, mock_stream, tmp_path):
+        """InvalidURL is raised before the output file is opened — any pre-existing
+        file at the destination path must be left intact."""
+        mock_stream.side_effect = httpx.InvalidURL("bad")
+
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"IMPORTANT pre-existing data")
+
+        with pytest.raises(DownloadException):
+            download_file("not-a-url", dest)
+
+        assert dest.exists()
+        assert dest.read_bytes() == b"IMPORTANT pre-existing data"
 
     @patch("httpx.stream")
     def test_preexisting_file_preserved_on_non_retriable_error(self, mock_stream, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #430.

Three focused changes that together address the bug report (visual glitches + verbose tracebacks when pasting many `comfy model download` commands into a shell):

- **Retry transient HTTP statuses.** `_download_file_httpx` now raises a private `_TransientHTTPStatusError` for statuses in `{408, 429, 500, 502, 503, 504}`, which the existing retry loop catches alongside network-level errors. CivitAI CDN blips and other transient server errors can now self-heal instead of aborting the download on the first attempt.
- **Friendly error rendering.** `comfy model download` catches `DownloadException` and prints a one-line red error before exiting with code 1, replacing the previous ~100-line Rich-panel Python traceback. `comfy node install` catches it the same way, using the existing `ui.display_error_message` path.
- **Transient progress bars.** `ui.show_progress` and `_poll_aria2_download` now use `transient=True`, so each progress bar is erased when its download completes. Running many `comfy model download` commands in sequence no longer leaves 30 persistent bars stacked in the terminal.

## Notes / follow-ups

- `Retry-After` header on 429 responses is not honored; fixed 2 s / 4 s backoff is used. Worth a follow-up if we see CivitAI or similar providers sending it.
- HuggingFace downloads (`huggingface_hub.hf_hub_download`) are not touched — they have their own error semantics.
- A pre-existing `raise DownloadException("Filename cannot be empty")` at `comfy_cli/command/models/models.py:315` still produces a traceback because it sits above the new `try/except`; unrelated to #430 and can be cleaned up separately.