### PR TITLE
fix: handle inline comments in requirements.txt parsing

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -171,13 +171,8 @@ def execute_install_script(repo_path):
     if os.path.exists(requirements_path):
         print("Install: pip packages")
         python = resolve_workspace_python(workspace_manager.workspace_path)
-        with open(requirements_path, encoding="utf-8") as requirements_file:
-            for line in requirements_file:
-                package_name = line.strip()
-                if package_name and not package_name.startswith("#"):
-                    install_cmd = [python, "-m", "pip", "install", package_name]
-                    if package_name.strip() != "":
-                        try_install_script(repo_path, install_cmd)
+        install_cmd = [python, "-m", "pip", "install", "-r", requirements_path]
+        try_install_script(repo_path, install_cmd)
 
     if os.path.exists(install_script_path):
         print("Install: install script")

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -171,7 +171,10 @@ def execute_install_script(repo_path):
     if os.path.exists(requirements_path):
         print("Install: pip packages")
         python = resolve_workspace_python(workspace_manager.workspace_path)
-        install_cmd = [python, "-m", "pip", "install", "-r", requirements_path]
+        # Absolute path so pip doesn't re-resolve it against cwd=repo_path
+        # in try_install_script, which would double the path if repo_path
+        # is relative.
+        install_cmd = [python, "-m", "pip", "install", "-r", os.path.abspath(requirements_path)]
         try_install_script(repo_path, install_cmd)
 
     if os.path.exists(install_script_path):

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -17,6 +17,11 @@ from comfy_cli.registry.types import (
     URLs,
 )
 
+# Mirrors pip's requirements-file comment rule: `#` only starts a comment when
+# preceded by whitespace, so VCS URL fragments (`#subdirectory=`, `#egg=`) and
+# direct-URL hashes (`#sha256=`) survive.
+_inline_comment_re: re.Pattern[str] = re.compile(r"(^|\s+)#.*$")
+
 
 def create_comfynode_config():
     # Create the initial structure of the TOML document
@@ -249,7 +254,15 @@ def initialize_project_config():
     # Handle dependencies
     if os.path.exists("requirements.txt"):
         with open("requirements.txt") as req_file:
-            dependencies = [line.strip() for line in req_file if line.strip()]
+            dependencies: list[str] = []
+            for raw in req_file:
+                # Strip inline/full-line comments, then skip pip-requirements-file
+                # options (-r, -e, -c, --index-url, ...) which are not valid
+                # PEP 508 deps and would break downstream build tooling.
+                line = _inline_comment_re.sub("", raw).strip()
+                if not line or line.startswith("-"):
+                    continue
+                dependencies.append(line)
         project["dependencies"] = dependencies
     else:
         print("Warning: 'requirements.txt' not found. No dependencies will be added.")

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -260,7 +260,12 @@ def initialize_project_config():
                 # options (-r, -e, -c, --index-url, ...) which are not valid
                 # PEP 508 deps and would break downstream build tooling.
                 line = _inline_comment_re.sub("", raw).strip()
-                if not line or line.startswith("-"):
+                if not line:
+                    continue
+                if line.startswith("-"):
+                    print(
+                        f"Warning: skipping pip-only option from requirements.txt (not valid as PEP 508 dep): {line!r}"
+                    )
                     continue
                 dependencies.append(line)
         project["dependencies"] = dependencies

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -37,6 +37,11 @@ def _check_call(cmd: list[str], cwd: PathLike | None = None):
 
 _req_name_re: re.Pattern[str] = re.compile(r"require\s([\w-]+)")
 
+# Mirrors pip's requirements-file comment rule (pip._internal.req.req_file.COMMENT_RE):
+# `#` only starts a comment when preceded by whitespace (or starts the line), so
+# VCS URL fragments like `#subdirectory=pkg` and `#egg=foo` survive.
+_inline_comment_re: re.Pattern[str] = re.compile(r"(^|\s+)#.*$")
+
 
 def _req_re_closure(name: str) -> re.Pattern[str]:
     return re.compile(rf"({name}\S+)")
@@ -64,8 +69,8 @@ def parse_req_file(rf: PathLike, skips: list[str] | None = None):
     opts: list[str] = []
     with open(rf) as f:
         for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
+            line = _inline_comment_re.sub("", line).strip()
+            if not line:
                 continue
             elif "==" in line and line.split("==")[0] in skips:
                 continue

--- a/tests/comfy_cli/registry/test_config_parser.py
+++ b/tests/comfy_cli/registry/test_config_parser.py
@@ -399,3 +399,96 @@ def test_initialize_project_config_ssh_remote(tmp_path, monkeypatch):
     assert urls["Bug Tracker"] == "https://github.com/user/ComfyUI-TestNode/issues"
     assert data["project"]["name"] == "testnode"
     assert data["tool"]["comfy"]["DisplayName"] == "ComfyUI-TestNode"
+
+
+# Issue #431: requirements.txt → pyproject.toml migration must produce
+# valid PEP 508 dependency specifiers. Inline comments, full-line comments,
+# and pip-specific options (-r, -e, --index-url, ...) are not valid deps.
+
+
+def _init_git_repo_with_reqs(tmp_path, requirements_content: str) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/user/ComfyUI-TestNode.git"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "requirements.txt").write_text(requirements_content)
+
+
+def test_initialize_project_config_strips_inline_comments(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _init_git_repo_with_reqs(
+        tmp_path,
+        "matplotlib>=3.3.0  # For visualization\nnumpy>=1.0 # trailing\n",
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    deps = [str(d) for d in data["project"]["dependencies"]]
+    assert deps == ["matplotlib>=3.3.0", "numpy>=1.0"]
+
+
+def test_initialize_project_config_skips_full_line_comments(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _init_git_repo_with_reqs(
+        tmp_path,
+        "# heading comment\nfoo>=1.0\n  # indented comment\nbar\n",
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    deps = [str(d) for d in data["project"]["dependencies"]]
+    assert deps == ["foo>=1.0", "bar"]
+
+
+def test_initialize_project_config_skips_pip_options(tmp_path, monkeypatch):
+    # `-r`, `-e`, `-c`, `--index-url`, `--extra-index-url`, `--find-links`
+    # are pip-requirements-file syntax, not PEP 508 dep specifiers. They must
+    # not land in [project.dependencies] where downstream build tools will
+    # error trying to parse them.
+    monkeypatch.chdir(tmp_path)
+    _init_git_repo_with_reqs(
+        tmp_path,
+        "-r other.txt\n"
+        "-e .\n"
+        "--index-url https://pypi.org/simple\n"
+        "--extra-index-url https://example.com/simple\n"
+        "--find-links ./local-wheels\n"
+        "foo>=1.0\n",
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    deps = [str(d) for d in data["project"]["dependencies"]]
+    assert deps == ["foo>=1.0"]
+
+
+def test_initialize_project_config_preserves_vcs_subdirectory_fragment(tmp_path, monkeypatch):
+    # Regression guard against a naive `split("#")[0]` fix — VCS fragments
+    # must survive because `#` is only a comment marker when preceded by
+    # whitespace (pip's rule).
+    monkeypatch.chdir(tmp_path)
+    _init_git_repo_with_reqs(
+        tmp_path,
+        "git+https://github.com/org/mono.git#subdirectory=pkg\n",
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    deps = [str(d) for d in data["project"]["dependencies"]]
+    assert deps == ["git+https://github.com/org/mono.git#subdirectory=pkg"]
+
+
+def test_initialize_project_config_vcs_with_inline_comment(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _init_git_repo_with_reqs(
+        tmp_path,
+        "git+https://github.com/org/mono.git#subdirectory=pkg  # monorepo dep\n",
+    )
+    initialize_project_config()
+    with open(tmp_path / "pyproject.toml") as f:
+        data = tomlkit.parse(f.read())
+    deps = [str(d) for d in data["project"]["dependencies"]]
+    assert deps == ["git+https://github.com/org/mono.git#subdirectory=pkg"]

--- a/tests/comfy_cli/registry/test_config_parser.py
+++ b/tests/comfy_cli/registry/test_config_parser.py
@@ -443,11 +443,12 @@ def test_initialize_project_config_skips_full_line_comments(tmp_path, monkeypatc
     assert deps == ["foo>=1.0", "bar"]
 
 
-def test_initialize_project_config_skips_pip_options(tmp_path, monkeypatch):
+def test_initialize_project_config_skips_pip_options(tmp_path, monkeypatch, capsys):
     # `-r`, `-e`, `-c`, `--index-url`, `--extra-index-url`, `--find-links`
     # are pip-requirements-file syntax, not PEP 508 dep specifiers. They must
     # not land in [project.dependencies] where downstream build tools will
-    # error trying to parse them.
+    # error trying to parse them. Each skipped line must also produce a
+    # visible warning so silent data loss is avoided.
     monkeypatch.chdir(tmp_path)
     _init_git_repo_with_reqs(
         tmp_path,
@@ -463,6 +464,9 @@ def test_initialize_project_config_skips_pip_options(tmp_path, monkeypatch):
         data = tomlkit.parse(f.read())
     deps = [str(d) for d in data["project"]["dependencies"]]
     assert deps == ["foo>=1.0"]
+    out = capsys.readouterr().out
+    for dropped in ["-r other.txt", "-e .", "--index-url", "--extra-index-url", "--find-links"]:
+        assert dropped in out, f"missing skip warning for {dropped!r}"
 
 
 def test_initialize_project_config_preserves_vcs_subdirectory_fragment(tmp_path, monkeypatch):

--- a/tests/comfy_cli/test_custom_nodes_python_resolution.py
+++ b/tests/comfy_cli/test_custom_nodes_python_resolution.py
@@ -63,6 +63,47 @@ class TestExecuteInstallScript:
         cmd = mock_check_call.call_args[0][0]
         assert cmd == ["/resolved/python", "install.py"]
 
+    def test_inline_comment_not_passed_to_pip(self, tmp_path):
+        # Issue #431 regression: inline comments in requirements.txt must not
+        # survive into the argv handed to pip. Pre-fix, the line was passed
+        # verbatim (e.g. "matplotlib>=3.3.0  # note") and pip rejected it.
+        (tmp_path / "requirements.txt").write_text("matplotlib>=3.3.0  # For visualization\n")
+
+        with (
+            patch(
+                "comfy_cli.command.custom_nodes.command.resolve_workspace_python",
+                return_value="/resolved/python",
+            ),
+            patch.object(command.workspace_manager, "workspace_path", str(tmp_path)),
+            patch("comfy_cli.command.custom_nodes.command.subprocess.check_call") as mock_check_call,
+        ):
+            command.execute_install_script(str(tmp_path))
+
+        for call in mock_check_call.call_args_list:
+            argv = call[0][0]
+            assert not any("#" in element for element in argv), f"inline comment leaked into pip argv: {argv!r}"
+
+    def test_uses_pip_install_r(self, tmp_path):
+        # Option C: delegate requirements-file parsing to pip via `-r <path>`.
+        # This lets pip handle inline comments, line continuations, VCS URL
+        # fragments, env markers, -e, -r, --index-url, etc.
+        requirements_path = tmp_path / "requirements.txt"
+        requirements_path.write_text("numpy>=1.0\n")
+
+        with (
+            patch(
+                "comfy_cli.command.custom_nodes.command.resolve_workspace_python",
+                return_value="/resolved/python",
+            ),
+            patch.object(command.workspace_manager, "workspace_path", str(tmp_path)),
+            patch("comfy_cli.command.custom_nodes.command.subprocess.check_call") as mock_check_call,
+        ):
+            command.execute_install_script(str(tmp_path))
+
+        mock_check_call.assert_called_once()
+        argv = mock_check_call.call_args[0][0]
+        assert argv == ["/resolved/python", "-m", "pip", "install", "-r", str(requirements_path)]
+
 
 class TestUpdateNodeIdCache:
     def test_uses_resolved_python(self, tmp_path):

--- a/tests/comfy_cli/test_custom_nodes_python_resolution.py
+++ b/tests/comfy_cli/test_custom_nodes_python_resolution.py
@@ -66,9 +66,10 @@ class TestExecuteInstallScript:
 
     def test_inline_comment_not_passed_to_pip(self, tmp_path):
         # Issue #431 regression: inline comments in requirements.txt must not
-        # survive into the argv handed to pip. Pre-fix, the line was passed
+        # survive into the argv handed to pip. Pre-fix, the raw line was passed
         # verbatim (e.g. "matplotlib>=3.3.0  # note") and pip rejected it.
-        (tmp_path / "requirements.txt").write_text("matplotlib>=3.3.0  # For visualization\n")
+        bad_spec = "matplotlib>=3.3.0  # For visualization"
+        (tmp_path / "requirements.txt").write_text(f"{bad_spec}\n")
 
         with (
             patch(
@@ -82,7 +83,7 @@ class TestExecuteInstallScript:
 
         for call in mock_check_call.call_args_list:
             argv = call[0][0]
-            assert not any("#" in element for element in argv), f"inline comment leaked into pip argv: {argv!r}"
+            assert bad_spec not in argv, f"raw comment-laden spec leaked into pip argv: {argv!r}"
 
     def test_uses_pip_install_r(self, tmp_path):
         # Option C: delegate requirements-file parsing to pip via `-r <path>`.

--- a/tests/comfy_cli/test_custom_nodes_python_resolution.py
+++ b/tests/comfy_cli/test_custom_nodes_python_resolution.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from comfy_cli.command.custom_nodes import command
@@ -103,6 +104,30 @@ class TestExecuteInstallScript:
         mock_check_call.assert_called_once()
         argv = mock_check_call.call_args[0][0]
         assert argv == ["/resolved/python", "-m", "pip", "install", "-r", str(requirements_path)]
+
+    def test_requirements_path_is_absolute_when_repo_path_is_relative(self, tmp_path, monkeypatch):
+        # try_install_script runs pip with cwd=repo_path. If requirements_path
+        # were relative, pip would resolve `-r <rel>/requirements.txt` against
+        # that cwd, producing a doubled path like <rel>/<rel>/requirements.txt.
+        # Guard: the `-r` target must be absolute regardless of the input.
+        (tmp_path / "requirements.txt").write_text("numpy>=1.0\n")
+        monkeypatch.chdir(tmp_path.parent)
+        relative_repo = tmp_path.name  # e.g. "test_requirements_path..." relative to cwd
+
+        with (
+            patch(
+                "comfy_cli.command.custom_nodes.command.resolve_workspace_python",
+                return_value="/resolved/python",
+            ),
+            patch.object(command.workspace_manager, "workspace_path", str(tmp_path)),
+            patch("comfy_cli.command.custom_nodes.command.subprocess.check_call") as mock_check_call,
+        ):
+            command.execute_install_script(relative_repo)
+
+        argv = mock_check_call.call_args[0][0]
+        target = argv[-1]
+        assert os.path.isabs(target), f"-r target is not absolute: {target!r}"
+        assert target == str(tmp_path / "requirements.txt")
 
 
 class TestUpdateNodeIdCache:

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -7,7 +7,7 @@ import pytest
 
 from comfy_cli import ui
 from comfy_cli.constants import GPU_OPTION
-from comfy_cli.uv import DependencyCompiler, _check_call
+from comfy_cli.uv import DependencyCompiler, _check_call, parse_req_file
 
 hereDir = Path(__file__).parent.resolve()
 mockComfyDir = hereDir / "mock_comfy"
@@ -360,3 +360,61 @@ def test_check_call_no_hint_for_pip_install_uv(capsys):
 
     captured = capsys.readouterr().out
     assert "network filesystem" not in captured
+
+
+# Issue #431: parse_req_file feeds its output into pip argv (pip download /
+# pip wheel). Inline comments would be rejected by pip; VCS URL fragments must
+# be preserved verbatim (e.g. `#subdirectory=pkg`, `#egg=foo`).
+
+
+def test_parse_req_file_strips_inline_comments(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("foo>=1.0  # trailing comment\n")
+    assert parse_req_file(rf) == ["foo>=1.0"]
+
+
+def test_parse_req_file_strips_inline_comment_with_single_space(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("bar==2.3 # single space before hash\n")
+    assert parse_req_file(rf) == ["bar==2.3"]
+
+
+def test_parse_req_file_skips_full_line_comments(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("# heading\nfoo>=1.0\n   # indented heading\nbaz\n")
+    assert parse_req_file(rf) == ["foo>=1.0", "baz"]
+
+
+def test_parse_req_file_preserves_vcs_subdirectory_fragment(tmp_path):
+    # Regression guard: any naive `split("#")[0]` would break this. `#` is only
+    # a comment marker when preceded by whitespace (pip's rule).
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("git+https://github.com/org/mono.git#subdirectory=pkg\n")
+    assert parse_req_file(rf) == ["git+https://github.com/org/mono.git#subdirectory=pkg"]
+
+
+def test_parse_req_file_preserves_vcs_egg_fragment(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("git+https://github.com/org/repo.git@main#egg=foo\n")
+    assert parse_req_file(rf) == ["git+https://github.com/org/repo.git@main#egg=foo"]
+
+
+def test_parse_req_file_preserves_direct_url_hash(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("foo @ https://host/f.whl#sha256=abc123\n")
+    assert parse_req_file(rf) == ["foo @ https://host/f.whl#sha256=abc123"]
+
+
+def test_parse_req_file_vcs_with_inline_comment_strips_only_comment(tmp_path):
+    # The trickiest case: a VCS spec with a fragment AND a trailing comment.
+    # Comment is preceded by whitespace so it must be stripped; fragment is
+    # part of the URL and must survive.
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("git+https://host/r.git#subdirectory=pkg  # note\n")
+    assert parse_req_file(rf) == ["git+https://host/r.git#subdirectory=pkg"]
+
+
+def test_parse_req_file_preserves_double_dash_options(tmp_path):
+    rf = tmp_path / "requirements.txt"
+    rf.write_text("--extra-index-url https://example.com/simple\nfoo\n")
+    assert parse_req_file(rf) == ["--extra-index-url", "https://example.com/simple", "foo"]

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -418,3 +418,11 @@ def test_parse_req_file_preserves_double_dash_options(tmp_path):
     rf = tmp_path / "requirements.txt"
     rf.write_text("--extra-index-url https://example.com/simple\nfoo\n")
     assert parse_req_file(rf) == ["--extra-index-url", "https://example.com/simple", "foo"]
+
+
+def test_parse_req_file_handles_crlf_line_endings(tmp_path):
+    # Windows-authored requirements.txt files use CRLF. Verify the comment
+    # stripper + .strip() cleanly handles the trailing \r.
+    rf = tmp_path / "requirements.txt"
+    rf.write_bytes(b"foo>=1.0  # note\r\nbar>=2.0\r\n")
+    assert parse_req_file(rf) == ["foo>=1.0", "bar>=2.0"]


### PR DESCRIPTION
## Summary

Fixes #431 — `comfy node install` on a custom node whose `requirements.txt` contains an inline comment (e.g. `matplotlib>=3.3.0  # For visualization`) fails with `ERROR: Invalid requirement`: pip receives the whole line verbatim because comfy-cli parses the file itself and passes each line as a single argv element.

Three locations in comfy-cli parse `requirements.txt` by hand, all with the same bug class:

| # | Location | Role |
|---|---|---|
| 1 | `execute_install_script` (`custom_nodes/command.py`) | Install deps of a registry-installed node via `pip install <spec>` per line |
| 2 | `parse_req_file` (`uv.py`) | Collect specs for uv's `download`/`wheel` argv |
| 3 | `initialize_project_config` (`registry/config_parser.py`) | Migrate `requirements.txt` → `pyproject.toml [project.dependencies]` |

## Fix

- **(1)** Delegate to `pip install -r <path>` — matches the four other `pip install -r` call sites already in the repo (`install.py:110,128`, `cmdline.py:415`, `command.py:397`). Fixes inline comments plus line continuations, `-e`, `-r`, `--index-url`, `--hash`, and environment markers for free.
- **(2), (3)** Strip inline comments using pip's exact regex `(^|\s+)#.*$`. Critically, `#` is only a comment marker when preceded by whitespace, so VCS URL fragments like `git+https://host/r.git#subdirectory=pkg` and direct-URL `#sha256=` hashes survive.
- **(3)** additionally filters pip-requirements-file options (`-r`, `-e`, `--index-url`, `--find-links`) that are not valid PEP 508 specifiers and would have corrupted `[project.dependencies]` in the generated `pyproject.toml`.

## Why not `line.split("#")[0]`?

A naive `split("#")[0]` silently breaks VCS URL fragments, turning `git+https://host/mono.git#subdirectory=pkg` into `git+https://host/mono.git` — pip would then fail to find `setup.py` at the monorepo root. Regression tests guard against this.

## Scope note

The reporter's traceback actually originates from ComfyUI-Manager's own `execute_install_script` (manager_core.py), not comfy-cli — for git-clone nodes ComfyUI-Manager doesn't call back into comfy-cli. comfy-cli has the same class of bug in its own registry-install path, which this PR fixes. ComfyUI-Manager needs a separate patch upstream.

## Test plan

- [x] 13 regression tests added across the three locations, including VCS-fragment preservation guards
- [x] All new tests fail on unpatched main (verified before implementing)
- [x] All new tests pass after fix
- [x] Full unit suite: 688 passed, 0 regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Regex verified byte-for-byte identical to pip's `pip._internal.req.req_file.COMMENT_RE` across 23 tricky inputs (tabs, multiple spaces, VCS fragments, direct-URL hashes, decorative `######`, mid-string `#` without whitespace, env markers, line continuations)
- [x] `pip install --dry-run -r <file>` verified to handle empty files, comment-only files, and the reporter's actual input shape
- [ ] Windows manual test (not available in CI) — the startup-scripts file format remains `[repo_path, *cmd]` as a Python list literal; cm-cli consumers using `subprocess.call(cmd[1:])` verbatim are unaffected