### PR TITLE
ci: retry PyPI install smoke test to tolerate index propagation

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -26,7 +26,10 @@ jobs:
 
       - name: Extract version from tag
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Update version in pyproject.toml
         run: |
@@ -72,10 +75,22 @@ jobs:
 
       - name: Extract version from tag
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Install Comfy CLI via pip and Test
-        run: pip install comfy-cli==${{env.VERSION}}
+        run: |
+          # PyPI's index can lag behind a successful upload by a minute or
+          # two, so retry before failing the job.
+          for i in 1 2 3 4 5 6 7 8; do
+            pip install --no-cache-dir "comfy-cli==${VERSION}" && exit 0
+            echo "Attempt $i: package not yet available on PyPI, waiting 15s..."
+            sleep 15
+          done
+          echo "::error::Failed to install comfy-cli==${VERSION} after 8 attempts"
+          exit 1
 
       - name: Test Comfy CLI Help
         run: comfy --help


### PR DESCRIPTION
## Summary

The post-publish smoke test in `publish_package.yml` failed on the v1.7.3 release ([run 24876171699](https://github.com/Comfy-Org/comfy-cli/actions/runs/24876171699/job/72833237338)) even though the package itself uploaded successfully. The install job ran ~30s after publish and pip reported no matching distribution — PyPI's index simply had not yet surfaced the new version. The previous TestPyPI validation step had a retry loop for exactly this reason; it was lost when trusted publishing replaced it.

Changes:
- Retry `pip install comfy-cli==$VERSION` up to 8× with 15s between attempts (~2 min total) before failing the job, with a clear `::error::` annotation on final failure.
- Strip the leading `v` from the tag-derived `VERSION` in both jobs so `pyproject.toml` and the install specifier use the PEP 440 canonical form (`1.7.3`) rather than relying on implicit normalization. pip was already normalizing `==v1.7.3` transparently, so this is hygiene rather than a functional fix.
