### PR TITLE
feat(registry): resolve PEP 621 dynamic version from [tool.comfy.version].path

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -975,6 +975,17 @@ def validate_node_for_publishing():
     # Perform some validation logic here
     typer.echo("Validating node configuration...")
     config = extract_node_configuration()
+    if config is None:
+        raise typer.Exit(code=1)
+
+    if not config.project.version:
+        # Escape `[` chars so rich doesn't parse `[tool.comfy.version]` and
+        # `["version"]` as markup tags; `]` doesn't need escaping.
+        print(
+            "[red]Error: project version is empty. Set `project.version` in pyproject.toml, "
+            r'or configure `\[tool.comfy.version].path` if using `dynamic = \["version"]`.[/red]'
+        )
+        raise typer.Exit(code=1)
 
     # Run security checks first
     typer.echo("Running security checks...")

--- a/comfy_cli/registry/config_parser.py
+++ b/comfy_cli/registry/config_parser.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import re
 import subprocess
 from urllib.parse import urlparse, urlunparse
@@ -21,6 +22,26 @@ from comfy_cli.registry.types import (
 # preceded by whitespace, so VCS URL fragments (`#subdirectory=`, `#egg=`) and
 # direct-URL hashes (`#sha256=`) survive.
 _inline_comment_re: re.Pattern[str] = re.compile(r"(^|\s+)#.*$")
+
+# For `dynamic = ["version"]`: match a top-level `__version__` or `VERSION` assignment in a source file. Anchored
+# to start-of-line (MULTILINE) so single-line comments are skipped. Horizontal whitespace only — no cross-line
+# matching. Supports an optional PEP 526 type annotation. Straight quotes only. Backslash is excluded from the
+# value class — escape sequences (`\n`, `\t`, `\"`, ...) cause the regex to fail to match, surfacing as a
+# "could not find" warning rather than being silently misinterpreted. PEP 440 versions are ASCII-only so this
+# is a clean fail-closed contract; users with auto-generated `__version__` containing escapes must clean up
+# their source. The single-alternative character class also makes catastrophic backtracking impossible.
+#
+# Recommended user layout: a dedicated `_version.py` / `__version__.py` (NOT the package's `__init__.py`), so
+# nothing in the file — module docstrings, assignments referenced in text, etc. — can collide with this regex.
+# This matches hatch/setuptools convention for dynamic-version source files.
+_VERSION_RE: re.Pattern[str] = re.compile(
+    r"""^(?P<name>__version__|VERSION)
+        (?:[\t ]*:[\t ]*[^=\n]+)?
+        [\t ]*=[\t ]*
+        (?:"(?P<dq>[^"\\\n]*)"|'(?P<sq>[^'\\\n]*)')
+        """,
+    re.MULTILINE | re.VERBOSE,
+)
 
 
 def create_comfynode_config():
@@ -281,6 +302,162 @@ def initialize_project_config():
         raise OSError("Failed to write 'pyproject.toml'") from e
 
 
+def _resolve_dynamic_version(pyproject_dir: pathlib.Path, rel_path: str) -> str:
+    """Read a version from a source file referenced by `[tool.comfy.version].path`.
+
+    No Python execution — just text I/O and a regex, matching the contract
+    agreed in issue #294. Returns empty string on any failure and emits a
+    user-visible warning so scanning contexts degrade gracefully.
+    """
+    # Reject paths that are absolute under either POSIX or Windows rules —
+    # `pathlib.Path.is_absolute()` alone is OS-specific (e.g., `/etc/foo` is
+    # not considered absolute on Windows because it has no drive), and we
+    # want identical rejection behavior regardless of the host OS.
+    if pathlib.PurePosixPath(rel_path).is_absolute() or pathlib.PureWindowsPath(rel_path).is_absolute():
+        typer.echo(
+            f"Warning: `[tool.comfy.version].path` must be relative to pyproject.toml "
+            f"(got `{rel_path}`). No version will be populated."
+        )
+        return ""
+    path_obj = pathlib.Path(rel_path)
+
+    pyproject_dir = pyproject_dir.resolve()
+    resolved = (pyproject_dir / path_obj).resolve()
+    try:
+        resolved.relative_to(pyproject_dir)
+    except ValueError:
+        typer.echo(
+            f"Warning: `[tool.comfy.version].path` must point inside the project directory "
+            f"(got `{rel_path}`). No version will be populated."
+        )
+        return ""
+
+    try:
+        # `utf-8-sig` transparently strips a leading BOM — some Windows editors
+        # add one, and it would defeat the `^__version__` anchor otherwise.
+        text = resolved.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError) as e:
+        typer.echo(f"Warning: could not read version file `{rel_path}`: {e}. No version will be populated.")
+        return ""
+
+    match = _VERSION_RE.search(text)
+    if not match:
+        typer.echo(
+            f"Warning: could not find `__version__` or `VERSION` in `{rel_path}`. "
+            f'The version file must contain a line like `__version__ = "1.2.3"`. '
+            f"No version will be populated."
+        )
+        return ""
+
+    # Exactly one of `dq` / `sq` was consumed by the regex. An empty capture
+    # (`""` / `''`) is a valid match the regex accepts; if followed by another
+    # quote the concat check below intercepts it (this also covers the
+    # triple-quoted `"""..."""` case), otherwise we return "" and the
+    # publish-layer guard surfaces it.
+    raw = match.group("dq") if match.group("dq") is not None else match.group("sq")
+
+    # Python concatenates adjacent string literals: `__version__ = "1." "2.3"`
+    # (with or without whitespace between, quote styles freely mixed) evaluates
+    # to "1.2.3". The regex captures only the first literal, so silently
+    # returning `"1."` would POST a wrong version. Look ahead on the same line:
+    # if the first non-whitespace char is a quote, reject the concatenation.
+    # `;` (statement separator) and `#` (comment) are preserved because neither
+    # starts with a quote.
+    rest_of_line = text[match.end() :].split("\n", 1)[0]
+    stripped_rest = rest_of_line.lstrip(" \t")
+    if stripped_rest and stripped_rest[0] in ('"', "'"):
+        typer.echo(
+            f"Warning: `{match.group('name')}` in `{rel_path}` uses adjacent-string-literal "
+            f"concatenation, which is not supported. Use a single assignment like "
+            f'`{match.group("name")} = "1.2.3"`. No version will be populated.'
+        )
+        return ""
+
+    return raw.strip()
+
+
+def _parse_dynamic_fields(project_data) -> list[str]:
+    """Return the `project.dynamic` field as a list of strings.
+
+    Warns and returns `[]` if `dynamic` is present but has the wrong shape
+    (e.g. a scalar string — a common PEP 621 misconfiguration).
+    """
+    dynamic_raw = project_data.get("dynamic", [])
+    # tomlkit.Array inherits from list, so valid arrays (including empty `[]`)
+    # pass through. Everything else is a misconfiguration.
+    if not isinstance(dynamic_raw, (list, tuple)):
+        typer.echo(
+            "Warning: `project.dynamic` must be an array of strings. "
+            'Use `dynamic = ["version"]` instead. '
+            "No dynamic fields will be honored."
+        )
+        return []
+    return [str(d) for d in dynamic_raw]
+
+
+def _extract_version(project_data, comfy_data, pyproject_dir: pathlib.Path) -> str:
+    """Return the project version, honoring PEP 621 `dynamic = ["version"]`.
+
+    - Static `project.version` wins if present.
+    - If absent and `"version"` is in `project.dynamic`, resolve via
+      `[tool.comfy.version].path` (text-read + regex, no Python execution).
+    - Otherwise return empty (existing behavior).
+    """
+    static_version = project_data.get("version", "")
+    dynamic_fields = _parse_dynamic_fields(project_data)
+    # Type-check runs BEFORE the truthy check so falsy non-strings (`version = 0`,
+    # `version = 0.0`, `version = false`, `version = []`, `version = {}`) produce
+    # the same named "must be a string" warning as truthy non-strings (`version = 1`,
+    # `version = ["1","2"]`, `version = { path = "_v.py" }`). With the order reversed,
+    # they would silently fall through to the dynamic branch and the user would
+    # only see the downstream "project version is empty" error at publish time.
+    if not isinstance(static_version, str):
+        typer.echo("Warning: `project.version` must be a string. No version will be populated.")
+        return ""
+    if static_version:
+        # Strip so `version = "  1.0.0  "` doesn't get POSTed with surrounding
+        # whitespace. A whitespace-only `version = "   "` becomes "" and the
+        # publish-layer guard surfaces it as "project version is empty".
+        return static_version.strip()
+
+    if "version" not in dynamic_fields:
+        return ""
+
+    version_cfg = comfy_data.get("version")
+    if version_cfg is None:
+        typer.echo(
+            'Warning: `dynamic = ["version"]` declared but `[tool.comfy.version].path` is not set. '
+            "See https://docs.comfy.org/registry/specifications for dynamic-version setup. "
+            "No version will be populated."
+        )
+        return ""
+    if not isinstance(version_cfg, dict):
+        # A non-table value under `[tool.comfy].version` — the user likely
+        # wrote `version = "x"` scalar (or any other type) instead of a nested
+        # table.
+        typer.echo(
+            "Warning: `[tool.comfy].version` must be a table with a `path` key. "
+            'Use `[tool.comfy.version]` with `path = "..."` instead. '
+            "No version will be populated."
+        )
+        return ""
+    # Order matters: check type BEFORE falsy-ness so that `path = 0` / `false`
+    # / `[]` / `{}` produce a type warning, not a misleading "not set" warning.
+    path_value = version_cfg.get("path")
+    if path_value is not None and not isinstance(path_value, str):
+        typer.echo("Warning: `[tool.comfy.version].path` must be a string. No version will be populated.")
+        return ""
+    if not path_value:
+        typer.echo(
+            "Warning: `[tool.comfy.version].path` is not set. "
+            "See https://docs.comfy.org/registry/specifications for dynamic-version setup. "
+            "No version will be populated."
+        )
+        return ""
+
+    return _resolve_dynamic_version(pyproject_dir, path_value)
+
+
 def extract_node_configuration(
     path: str = os.path.join(os.getcwd(), "pyproject.toml"),
 ) -> PyProjectConfig | None:
@@ -288,12 +465,30 @@ def extract_node_configuration(
         ui.display_error_message("No pyproject.toml file found in the current directory.")
         return None
 
-    with open(path) as file:
-        data = tomlkit.load(file)
+    try:
+        # `utf-8-sig` strips a leading BOM if present — Windows editors sometimes
+        # write one, and tomlkit would otherwise report `Empty key at line 1 col 0`.
+        # `UnicodeDecodeError` must be in the except tuple: it is a `ValueError`,
+        # not an `OSError`, and would otherwise escape and crash the caller.
+        with open(path, encoding="utf-8-sig") as file:
+            data = tomlkit.load(file)
+    except (OSError, UnicodeDecodeError, tomlkit.exceptions.TOMLKitError) as e:
+        ui.display_error_message(f"Could not parse `{path}`: {e}")
+        return None
 
     project_data = data.get("project", {})
+    if not isinstance(project_data, dict):
+        # Degenerate TOML like `project = "hello"` at the root. Keep scanning
+        # contexts alive by treating it as "no project metadata".
+        typer.echo("Warning: `project` in pyproject.toml must be a table. Using defaults.")
+        project_data = {}
     urls_data = project_data.get("urls", {})
-    comfy_data = data.get("tool", {}).get("comfy", {})
+    if not isinstance(urls_data, dict):
+        urls_data = {}
+    tool_data = data.get("tool", {})
+    comfy_data = tool_data.get("comfy", {}) if isinstance(tool_data, dict) else {}
+    if not isinstance(comfy_data, dict):
+        comfy_data = {}
 
     dependencies = project_data.get("dependencies", [])
     supported_comfyui_frontend_version = ""
@@ -307,7 +502,7 @@ def extract_node_configuration(
         dep for dep in dependencies if not (isinstance(dep, str) and dep.startswith("comfyui-frontend-package"))
     ]
 
-    supported_comfyui_version = data.get("tool", {}).get("comfy", {}).get("requires-comfyui", "")
+    supported_comfyui_version = comfy_data.get("requires-comfyui", "")
 
     classifiers = project_data.get("classifiers", [])
     supported_os = validate_and_extract_os_classifiers(classifiers)
@@ -334,10 +529,13 @@ def extract_node_configuration(
             'Warning: License should be in one of these two formats: license = {file = "LICENSE"} OR license = {text = "MIT License"}. Please check the documentation: https://docs.comfy.org/registry/specifications.'
         )
 
+    pyproject_dir = pathlib.Path(path).parent
+    version = _extract_version(project_data, comfy_data, pyproject_dir)
+
     project = ProjectConfig(
         name=project_data.get("name", ""),
         description=project_data.get("description", ""),
-        version=project_data.get("version", ""),
+        version=version,
         requires_python=project_data.get("requires-python", ""),
         dependencies=dependencies,
         license=license,

--- a/tests/comfy_cli/command/nodes/test_publish.py
+++ b/tests/comfy_cli/command/nodes/test_publish.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from comfy_cli.command.custom_nodes.command import app
+from comfy_cli.registry.types import ComfyConfig, ProjectConfig, PyProjectConfig
 
 runner = CliRunner()
 
@@ -143,6 +144,36 @@ def test_publish_exits_on_upload_failure():
         assert mock_publish.called
         assert mock_zip.called
         assert mock_upload.called
+
+
+def test_publish_fails_when_config_is_none():
+    # extract_node_configuration returns None when pyproject.toml is missing;
+    # validate_node_for_publishing must exit 1 (not crash on the subsequent
+    # `config.project.version` access).
+    with patch(
+        "comfy_cli.command.custom_nodes.command.extract_node_configuration",
+        return_value=None,
+    ):
+        result = runner.invoke(app, ["validate"])
+        assert result.exit_code == 1
+
+
+def test_publish_fails_when_version_is_empty():
+    # Guards against issue #294: dynamic versions that failed to resolve must
+    # not silently POST an empty `version` to the registry. validate_node_for_publishing
+    # should exit 1 with a user-facing error pointing at [tool.comfy.version].path.
+    empty_version_config = PyProjectConfig(
+        project=ProjectConfig(name="x", version=""),
+        tool_comfy=ComfyConfig(publisher_id="pub"),
+    )
+    with patch(
+        "comfy_cli.command.custom_nodes.command.extract_node_configuration",
+        return_value=empty_version_config,
+    ):
+        result = runner.invoke(app, ["validate"])
+        assert result.exit_code == 1
+        assert "project version is empty" in result.stdout
+        assert "[tool.comfy.version].path" in result.stdout
 
 
 def test_publish_with_includes_parameter():

--- a/tests/comfy_cli/registry/test_config_parser.py
+++ b/tests/comfy_cli/registry/test_config_parser.py
@@ -212,6 +212,576 @@ def test_extract_node_configuration_with_requires_comfyui():
         assert result.project.supported_comfyui_version == "2.0.0"
 
 
+def _write_pyproject(tmp_path, body: str) -> str:
+    """Write a pyproject.toml in tmp_path and return its absolute path as a string."""
+    p = tmp_path / "pyproject.toml"
+    p.write_text(body)
+    return str(p)
+
+
+def test_dynamic_version_resolved_from_double_quoted_literal(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text('__version__ = "1.2.3"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "pkg/__init__.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+
+
+def test_dynamic_version_resolved_from_VERSION_name(tmp_path):
+    (tmp_path / "_version.py").write_text('VERSION = "2.0.0"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_version.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "2.0.0"
+
+
+def test_dynamic_version_resolved_from_single_quotes(tmp_path):
+    (tmp_path / "_v.py").write_text("__version__ = '0.9.1'\n")
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "0.9.1"
+
+
+def test_dynamic_version_resolved_with_type_annotation(tmp_path):
+    (tmp_path / "_v.py").write_text('__version__: str = "3.4.5"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "3.4.5"
+
+
+def test_dynamic_version_ignores_commented_line(tmp_path):
+    # The `^` anchor ensures a commented-out line is not matched.
+    (tmp_path / "_v.py").write_text('# __version__ = "9.9.9"\n__version__ = "1.0.0"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.0.0"
+
+
+def test_dynamic_version_first_match_wins(tmp_path):
+    (tmp_path / "_v.py").write_text('__version__ = "1.0.0"\n__version__ = "2.0.0"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.0.0"
+
+
+def test_static_version_wins_over_tool_comfy_version(tmp_path):
+    # Defensive: if a user accidentally has both, the static `project.version`
+    # wins without ever reading the file (no warning, no resolution).
+    (tmp_path / "_v.py").write_text('__version__ = "9.9.9"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\nversion = "1.0.0"\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.0.0"
+
+
+@patch("typer.echo")
+def test_dynamic_version_without_tool_comfy_version_warns(mock_echo, tmp_path):
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\ndynamic = ["version"]\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("[tool.comfy.version].path" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_absolute_path_rejected(mock_echo, tmp_path):
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "/etc/passwd"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("must be relative" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_windows_absolute_path_rejected(mock_echo, tmp_path):
+    # Ensure a Windows-style absolute path is also rejected when tests run
+    # on POSIX (and vice versa) — the check is OS-agnostic.
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = \'C:\\Windows\\version.py\'\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("must be relative" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_path_traversal_rejected(mock_echo, tmp_path):
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "../../etc/passwd"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("inside the project directory" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_missing_file_warns(mock_echo, tmp_path):
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "does_not_exist.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("could not read" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_no_match_warns(mock_echo, tmp_path):
+    (tmp_path / "_v.py").write_text('other_var = "1.2.3"\nsome_other = 42\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("could not find" in str(c) for c in mock_echo.call_args_list)
+
+
+def test_dynamic_version_handles_utf8_bom(tmp_path):
+    # Windows editors that write a UTF-8 BOM must not defeat the `^` anchor.
+    (tmp_path / "_v.py").write_bytes(b'\xef\xbb\xbf__version__ = "1.2.3"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+
+
+@patch("typer.echo")
+def test_dynamic_version_invalid_utf8_warns(mock_echo, tmp_path):
+    # Non-UTF-8 content must not crash the parser (UnicodeDecodeError is a
+    # ValueError, not an OSError — must be caught explicitly).
+    (tmp_path / "_v.py").write_bytes(b"\xff\xfe\x00\x00garbage bytes")
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("could not read" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_scalar_tool_comfy_version_warns(mock_echo, tmp_path):
+    # User misplaced a scalar version under [tool.comfy] instead of [project].
+    # Warning should name the shape problem, not the path problem.
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy]\nversion = "1.2.3"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("must be a table" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_malformed_dynamic_scalar_string_warns(mock_echo, tmp_path):
+    # User wrote `dynamic = "version"` (scalar) instead of `dynamic = ["version"]`.
+    # Silent-skip would leave them confused; warn explicitly.
+    (tmp_path / "_v.py").write_text('__version__ = "1.0.0"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = "version"\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("must be an array of strings" in str(c) for c in mock_echo.call_args_list)
+
+
+def test_dynamic_version_indented_only_does_not_match(tmp_path):
+    # Regex anchor `^` must reject indented `__version__` assignments (inside
+    # classes/functions). File has ONLY the indented form — expect no match
+    # and empty version.
+    (tmp_path / "_v.py").write_text('class Foo:\n    __version__ = "1.2.3"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+
+
+def test_dynamic_version_trailing_inline_comment_resolves(tmp_path):
+    # `__version__ = "1.2.3"  # stable` must resolve to "1.2.3" (regex stops
+    # capture at the closing quote, trailing comment ignored).
+    (tmp_path / "_v.py").write_text('__version__ = "1.2.3"  # stable release\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+
+
+@patch("typer.echo")
+def test_dynamic_version_path_is_directory_warns(mock_echo, tmp_path):
+    # `path` pointing at a directory must degrade gracefully (IsADirectoryError
+    # is an OSError subclass) and surface a "could not read" warning.
+    (tmp_path / "subdir").mkdir()
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "subdir"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("could not read" in str(c) for c in mock_echo.call_args_list)
+
+
+def test_padded_static_version_is_stripped(tmp_path):
+    # Static `version = "  1.0.0  "` must be normalized — registries should not
+    # receive whitespace padding.
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\nversion = "  1.0.0  "\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.0.0"
+
+
+@patch("typer.echo")
+def test_dynamic_version_non_string_path_warns_as_type_error(mock_echo, tmp_path):
+    # A non-string `path` value must produce a type warning, not a misleading
+    # "could not read file `42`" OS error.
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = 42\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("must be a string" in str(c) for c in mock_echo.call_args_list)
+    # Must NOT fall through to an OS "could not read" warning
+    assert not any("could not read" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_static_version_happy_path_emits_no_version_warnings(mock_echo, tmp_path):
+    # Regression guard for the common case: static version, no dynamic, no
+    # [tool.comfy.version]. Must not emit ANY version/dynamic-related warning
+    # (only unrelated warnings like the pre-existing "License..." one are allowed).
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\nversion = "1.2.3"\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+    noisy = [
+        str(c)
+        for c in mock_echo.call_args_list
+        if "version" in str(c).lower() or "dynamic" in str(c).lower() or "tool.comfy" in str(c).lower()
+    ]
+    assert noisy == [], f"Unexpected version/dynamic warnings on happy path: {noisy}"
+
+
+# --- Fix K: non-dict `project` / `tool` degrade gracefully ---
+
+
+def test_malformed_toml_does_not_crash(tmp_path):
+    # Invalid TOML (syntax error) must not crash the parser — scanning
+    # contexts would lose the whole pack inventory otherwise.
+    (tmp_path / "pyproject.toml").write_text('[project\nname = "x"\n')  # missing `]`
+    result = extract_node_configuration(str(tmp_path / "pyproject.toml"))
+    assert result is None  # graceful None return, no exception
+
+
+def test_pyproject_with_utf8_bom_parses_successfully(tmp_path):
+    # Windows editors (e.g., Notepad with legacy settings, Visual Studio) write
+    # a UTF-8 BOM on save. `encoding="utf-8-sig"` strips it transparently; without
+    # this, tomlkit sees `﻿` as the first character and reports a cryptic
+    # `Empty key at line 1 col 0`.
+    (tmp_path / "pyproject.toml").write_bytes(b'\xef\xbb\xbf[project]\nname = "x"\nversion = "1.0.0"\n')
+    result = extract_node_configuration(str(tmp_path / "pyproject.toml"))
+    assert result is not None
+    assert result.project.name == "x"
+    assert result.project.version == "1.0.0"
+
+
+def test_pyproject_with_invalid_utf8_returns_none_gracefully(tmp_path):
+    # `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so it must be in
+    # the except tuple explicitly. Without it, a pyproject.toml with non-UTF-8
+    # bytes raises a raw traceback instead of the friendly error shown for every
+    # other file-read failure.
+    (tmp_path / "pyproject.toml").write_bytes(b'[project]\nname = "x"\nx = "\xff\xfe garbage"\n')
+    result = extract_node_configuration(str(tmp_path / "pyproject.toml"))
+    assert result is None
+
+
+@patch("typer.echo")
+def test_static_version_non_string_scalar_rejected(mock_echo, tmp_path):
+    # PEP 621 requires `version` to be a string. A non-string scalar must now
+    # produce a typed warning, not be silently coerced via `str()`.
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\nversion = 1\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("`project.version` must be a string" in s for s in call_strs)
+
+
+@patch("typer.echo")
+def test_static_version_array_rejected(mock_echo, tmp_path):
+    # Without the type check, `str(['1', '2'])` would POST `"['1', '2']"` to
+    # the registry. Must be rejected.
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\nversion = ["1", "2"]\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("`project.version` must be a string" in s for s in call_strs)
+
+
+@patch("typer.echo")
+def test_static_version_inline_table_rejected(mock_echo, tmp_path):
+    # Users conflating PEP 621 static and our `[tool.comfy.version]` might write
+    # `version = { path = "_v.py" }`. Without the type check this POSTed as
+    # `"{'path': '_v.py'}"`. Catch it up front.
+    path = _write_pyproject(tmp_path, '[project]\nname = "x"\nversion = { path = "_v.py" }\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("`project.version` must be a string" in s for s in call_strs)
+
+
+@patch("typer.echo")
+def test_project_scalar_at_root_does_not_crash(mock_echo, tmp_path):
+    # Malformed TOML: `project = "hello"` at root. Must not crash — used to
+    # raise AttributeError: 'String' object has no attribute 'get'.
+    path = _write_pyproject(tmp_path, 'project = "hello"\n[tool.comfy]\nPublisherId = "x"\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("`project` in pyproject.toml must be a table" in str(c) for c in mock_echo.call_args_list)
+
+
+@pytest.mark.parametrize("value", ["0", "0.0", "false", "[]", "{}"])
+@patch("typer.echo")
+def test_static_version_falsy_non_string_rejected(mock_echo, tmp_path, value):
+    # Regression guard: the type check must fire for FALSY non-strings too
+    # (`version = 0`, `version = 0.0`, `version = false`, `version = []`,
+    # `version = {}`). Earlier the truthy check (`if static_version:`) gated
+    # the isinstance check, so these silently fell through to the dynamic
+    # branch and the user only saw the downstream "project version is empty"
+    # error.
+    path = _write_pyproject(tmp_path, f'[project]\nname = "x"\nversion = {value}\n')
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("`project.version` must be a string" in s for s in call_strs), (
+        f"value={value}: no type warning; saw {call_strs}"
+    )
+
+
+# --- Fix A (padded-static): strip semantics, already tested; add padded-dynamic variant ---
+
+
+def test_dynamic_version_padded_literal_is_stripped(tmp_path):
+    # `__version__ = "  1.2.3  "` — the `.strip()` in _resolve_dynamic_version
+    # already handles this, pinning the behavior here for regression safety.
+    (tmp_path / "_v.py").write_text('__version__ = "  1.2.3  "\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+
+
+# --- Fix N: falsy-but-typed path values must trigger the type warning ---
+
+
+@patch("typer.echo")
+def test_dynamic_version_empty_path_string_warns_as_not_set(mock_echo, tmp_path):
+    # `path = ""` explicitly set to empty string — equivalent to unset.
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = ""\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("path` is not set" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_dynamic_version_table_missing_path_key_warns_as_not_set(mock_echo, tmp_path):
+    # `[tool.comfy.version]` table exists but has no `path` key.
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("path` is not set" in str(c) for c in mock_echo.call_args_list)
+
+
+@patch("typer.echo")
+def test_falsy_nonstring_path_values_warn_as_type_mismatch(mock_echo, tmp_path):
+    # `path = 0 / false / [] / {}` are all truthy-falsy edge cases. They must
+    # produce a "must be a string" warning, not the misleading "path is not set".
+    for falsy in ["0", "false", "[]", "{}"]:
+        mock_echo.reset_mock()
+        path = _write_pyproject(
+            tmp_path,
+            f'[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = {falsy}\n',
+        )
+        result = extract_node_configuration(path)
+        assert result is not None
+        assert result.project.version == ""
+        call_strs = [str(c) for c in mock_echo.call_args_list]
+        assert any("must be a string" in s for s in call_strs), f"falsy={falsy}: no type warning"
+        assert not any("path` is not set" in s for s in call_strs), f"falsy={falsy}: got misleading 'not set' warning"
+
+
+# --- Backslash in value: regex rejects, surfaces as "could not find" ---
+
+
+@patch("typer.echo")
+def test_dynamic_version_backslash_in_value_not_matched(mock_echo, tmp_path):
+    # The regex excludes `\` from the value class entirely, so any escape
+    # sequence in the literal causes the regex to fail to match. Users get
+    # a clear "could not find" warning rather than a silently misinterpreted
+    # value. PEP 440 versions are ASCII-only so this is a clean fail-closed
+    # contract; users with auto-generated `__version__` containing escapes
+    # must clean up their source.
+    (tmp_path / "_v.py").write_text('__version__ = "1.0\\n"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    assert any("could not find" in str(c) for c in mock_echo.call_args_list)
+
+
+# --- H2 (Round 5): adjacent-string-literal concatenation detection ---
+
+
+@patch("typer.echo")
+def test_dynamic_version_adjacent_literals_double_quote_warns(mock_echo, tmp_path):
+    # Python evaluates `"1." "2.3"` as `"1.2.3"` via implicit concatenation.
+    # Without this check, the regex captures only `"1."` and we silently POST
+    # the wrong version. The same-line look-ahead rejects concatenation so the
+    # publish-layer guard exits 1 instead of shipping `"1."` to the registry.
+    (tmp_path / "_v.py").write_text('__version__ = "1." "2.3"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("adjacent-string-literal concatenation" in s for s in call_strs), (
+        f"no concatenation warning; saw {call_strs}"
+    )
+
+
+@patch("typer.echo")
+def test_dynamic_version_adjacent_literals_no_whitespace_warns(mock_echo, tmp_path):
+    # Python accepts `"1.""2.3"` (no whitespace between) — still concatenation.
+    (tmp_path / "_v.py").write_text('__version__ = "1.""2.3"\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("adjacent-string-literal concatenation" in s for s in call_strs)
+
+
+@patch("typer.echo")
+def test_dynamic_version_adjacent_literals_single_quote_warns(mock_echo, tmp_path):
+    # Detection must fire for single-quoted literals too.
+    (tmp_path / "_v.py").write_text("__version__ = '1.' '2.3'\n")
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("adjacent-string-literal concatenation" in s for s in call_strs)
+
+
+@patch("typer.echo")
+def test_dynamic_version_adjacent_literals_mixed_quotes_warns(mock_echo, tmp_path):
+    # Python allows mixing quote styles across adjacent literals: `"1." '2.3'`
+    # evaluates to `"1.2.3"`. The check must inspect for ANY quote, not just
+    # the matched quote, so a `"..." '...'` or `'...' "..."` pair still fires.
+    (tmp_path / "_v.py").write_text("__version__ = \"1.\" '2.3'\n")
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == ""
+    call_strs = [str(c) for c in mock_echo.call_args_list]
+    assert any("adjacent-string-literal concatenation" in s for s in call_strs)
+
+
+def test_dynamic_version_semicolon_after_literal_still_resolves(tmp_path):
+    # Negative control: `; x = 1` on the same line must NOT trigger the
+    # concatenation check (`;` isn't a quote). Pins the narrow look-ahead
+    # so a future broadening to "any trailing content" can't silently
+    # regress this case.
+    (tmp_path / "_v.py").write_text('__version__ = "1.2.3"; x = 1\n')
+    path = _write_pyproject(
+        tmp_path,
+        '[project]\nname = "x"\ndynamic = ["version"]\n\n[tool.comfy.version]\npath = "_v.py"\n',
+    )
+    result = extract_node_configuration(path)
+    assert result is not None
+    assert result.project.version == "1.2.3"
+
+
 def test_validate_and_extract_os_classifiers_valid():
     """Test OS validation with valid classifiers."""
     classifiers = [


### PR DESCRIPTION
Fixes #294

## Summary

Custom node authors using `dynamic = ["version"]` in `pyproject.toml` (PEP 621) previously got a silent failure — the version was read as `""` and POSTed to the registry anyway. This PR adds a comfy-native `[tool.comfy.version]` section that tells us where to read the version from, and a publish-time guard so empty versions never reach the registry.

```toml
[project]
name = "my-node"
dynamic = ["version"]

[tool.comfy.version]
path = "my_node/__init__.py"
```

The file is text-read and a single anchored regex extracts `__version__` or `VERSION`. No Python execution — this was the hard constraint agreed with @ltdrdata in the issue thread (env-sensitive, slow, breaks the Manager's "quick scan of installed packs" use case). The schema matches @Lex-DRL's proposal that got a 👍 in the thread.

## Behavior

- **Static `project.version` present** → used as-is (existing behavior, no change).
- **`"version"` in `project.dynamic`** → resolve via `[tool.comfy.version].path`.
- **Any resolution failure** (missing section, absolute path, path escaping project dir, missing file, no regex match) → warn via `typer.echo` and fall back to empty version. This keeps scanning contexts graceful — they never crash on malformed pack configs.
- **Publish-time** → `validate_node_for_publishing()` now exits `1` with a clear message if the resolved version is empty, so we never silently POST an empty version to the registry. This is the behavior change that actually fixes the bug.

## Regex

```python
^(?:__version__|VERSION)
    (?:[\t ]*:[\t ]*[^=\n]+)?   # optional PEP 526 annotation
    [\t ]*=[\t ]*
    (?:"(?P<dq>[^"\n]+)"|'(?P<sq>[^'\n]+)')
```

Start-of-line anchored (MULTILINE) so single-line comments are skipped. Horizontal whitespace only — no cross-line matching. Both quote styles. PEP 526 type annotation tolerated.

**Documented limitations** (unchanged from @Lex-DRL's proposal):
- Only static string literals work — computed `__version__` (f-strings, `get_distribution().version`, etc.) doesn't.
- Only `__version__` and `VERSION` names.
- Matching lines inside multiline string/docstring contexts can be picked up (first-match-wins). Keep version files trivial.

## Non-goals (punted to follow-ups)

- **`[tool.hatch.version]` passthrough**: zero-config for existing hatch users, ~10 LOC. Easy follow-up if the community asks for it; kept out of v1 to avoid coupling to a second schema.
- **`[tool.setuptools.dynamic] attr = "..."`**: requires Python module loading. Explicitly out of scope per the issue discussion.

## Test plan

New tests in `tests/comfy_cli/registry/test_config_parser.py` (12 cases, all using real `tmp_path` files):

- [x] Dynamic version resolved from `__version__` (double-quoted, single-quoted, with PEP 526 annotation).
- [x] Dynamic version resolved from `VERSION` name.
- [x] Commented `# __version__ = "x"` line correctly ignored (`^` anchor).
- [x] First match wins if the file has multiple `__version__` lines.
- [x] Static `project.version` beats `[tool.comfy.version]` when both present (no accidental resolution).
- [x] `dynamic = ["version"]` with no `[tool.comfy.version]` → warn + empty.
- [x] Absolute path → warn + empty.
- [x] Path traversal (`../../etc/passwd`) → warn + empty.
- [x] Missing file → warn + empty.
- [x] File exists but no match → warn + empty.

Plus in `tests/comfy_cli/command/nodes/test_publish.py`:

- [x] `comfy node validate` exits `1` with the helpful error when `project.version` is empty.

CI:
- [x] `pytest tests/comfy_cli/` — 687 passed, 6 skipped (+13 new).
- [x] `ruff check .` and `ruff format --check .` — clean.

## Risk / blast radius

- Static-version path untouched — pure regression test pass for existing users.
- Publish-time empty-version guard is new strictness, but only fires on configurations that were already broken (registry would have received `""`).
- No new dependencies. No API changes to `registry/types.py`.