### PR TITLE
feat(run): auto-convert UI-format workflows via server endpoint

### DIFF
--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -19,11 +19,14 @@ from comfy_cli.workspace_manager import WorkspaceManager
 workspace_manager = WorkspaceManager()
 
 
+def is_ui_workflow(workflow) -> bool:
+    return isinstance(workflow, dict) and "nodes" in workflow and "links" in workflow
+
+
 def load_api_workflow(file: str):
     with open(file, encoding="utf-8") as f:
         workflow = json.load(f)
-        # Check for litegraph properties to ensure this isnt a UI workflow file
-        if "nodes" in workflow and "links" in workflow:
+        if is_ui_workflow(workflow):
             return None
 
         # Try validating the first entry to ensure it has a node class property
@@ -35,6 +38,45 @@ def load_api_workflow(file: str):
         return workflow
 
 
+class WorkflowConverterUnavailable(Exception):
+    """The running ComfyUI server doesn't expose /workflow/convert."""
+
+
+def convert_ui_workflow_via_server(workflow: dict, host: str, port: int, timeout: int) -> dict:
+    """POST a UI-format workflow to the server's /workflow/convert and return API-format JSON.
+
+    Raises WorkflowConverterUnavailable if the server doesn't expose the endpoint.
+    Raises typer.Exit on other conversion failures.
+    """
+    url = f"http://{host}:{port}/workflow/convert"
+    req = request.Request(url, json.dumps(workflow).encode("utf-8"))
+    req.add_header("Content-Type", "application/json")
+    try:
+        resp = request.urlopen(req, timeout=timeout)
+    except urllib.error.HTTPError as e:
+        if e.code in (404, 405):
+            raise WorkflowConverterUnavailable() from e
+        body = e.read().decode("utf-8", errors="replace").strip()
+        pprint(f"[bold red]Workflow conversion failed (HTTP {e.code}): {body[:500]}[/bold red]")
+        raise typer.Exit(code=1) from e
+    except urllib.error.URLError as e:
+        pprint(f"[bold red]Workflow conversion failed: {e.reason}[/bold red]")
+        raise typer.Exit(code=1) from e
+    return json.loads(resp.read())
+
+
+def _print_converter_unavailable_help() -> None:
+    pprint(
+        "[bold red]UI-format workflow detected, but the running ComfyUI server[/bold red]\n"
+        "[bold red]doesn't expose a /workflow/convert endpoint to convert it to API format.[/bold red]\n"
+        "\n"
+        "[yellow]Workarounds:[/yellow]\n"
+        "[yellow]  * Install a custom node that adds /workflow/convert on the server[/yellow]\n"
+        "[yellow]  * Or, in the ComfyUI frontend, enable Dev Mode under Settings and use[/yellow]\n"
+        "[yellow]    'Workflow > Export (API)' to save your workflow as API format[/yellow]"
+    )
+
+
 def execute(workflow: str, host, port, wait=True, verbose=False, local_paths=False, timeout=30):
     workflow_name = os.path.abspath(os.path.expanduser(workflow))
     if not os.path.isfile(workflow):
@@ -44,15 +86,25 @@ def execute(workflow: str, host, port, wait=True, verbose=False, local_paths=Fal
         )
         raise typer.Exit(code=1)
 
-    workflow = load_api_workflow(workflow)
-
-    if not workflow:
-        pprint("[bold red]Specified workflow does not appear to be an API workflow json file[/bold red]")
-        raise typer.Exit(code=1)
-
     if not check_comfy_server_running(port, host):
         pprint(f"[bold red]ComfyUI not running on specified address ({host}:{port})[/bold red]")
         raise typer.Exit(code=1)
+
+    with open(workflow_name, encoding="utf-8") as f:
+        raw_workflow = json.load(f)
+
+    if is_ui_workflow(raw_workflow):
+        pprint("[yellow]Detected UI-format workflow, converting via server's /workflow/convert...[/yellow]")
+        try:
+            workflow = convert_ui_workflow_via_server(raw_workflow, host, port, timeout)
+        except WorkflowConverterUnavailable:
+            _print_converter_unavailable_help()
+            raise typer.Exit(code=1)
+    else:
+        workflow = load_api_workflow(workflow_name)
+        if not workflow:
+            pprint("[bold red]Specified workflow does not appear to be an API workflow json file[/bold red]")
+            raise typer.Exit(code=1)
 
     progress = None
     start = time.time()

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -62,7 +62,15 @@ def convert_ui_workflow_via_server(workflow: dict, host: str, port: int, timeout
     except urllib.error.URLError as e:
         pprint(f"[bold red]Workflow conversion failed: {e.reason}[/bold red]")
         raise typer.Exit(code=1) from e
-    return json.loads(resp.read())
+    try:
+        converted = json.loads(resp.read())
+    except json.JSONDecodeError as e:
+        pprint("[bold red]Workflow conversion failed: server returned invalid JSON[/bold red]")
+        raise typer.Exit(code=1) from e
+    if not isinstance(converted, dict):
+        pprint("[bold red]Workflow conversion failed: expected a JSON object[/bold red]")
+        raise typer.Exit(code=1)
+    return converted
 
 
 def _print_converter_unavailable_help() -> None:

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -20,7 +20,11 @@ workspace_manager = WorkspaceManager()
 
 
 def is_ui_workflow(workflow) -> bool:
-    return isinstance(workflow, dict) and "nodes" in workflow and "links" in workflow
+    return (
+        isinstance(workflow, dict)
+        and isinstance(workflow.get("nodes"), list)
+        and isinstance(workflow.get("links"), list)
+    )
 
 
 def _validate_api_workflow(workflow):
@@ -87,8 +91,8 @@ def _print_converter_unavailable_help() -> None:
         "\n"
         "[yellow]Workarounds:[/yellow]\n"
         "[yellow]  * Install a custom node that adds /workflow/convert on the server[/yellow]\n"
-        "[yellow]  * Or, in the ComfyUI frontend, enable Dev Mode under Settings and use[/yellow]\n"
-        "[yellow]    'Workflow > Export (API)' to save your workflow as API format[/yellow]"
+        "[yellow]  * Or, in the ComfyUI frontend, use 'File > Export (API)' to save[/yellow]\n"
+        "[yellow]    your workflow as API format[/yellow]"
     )
 
 

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -23,19 +23,22 @@ def is_ui_workflow(workflow) -> bool:
     return isinstance(workflow, dict) and "nodes" in workflow and "links" in workflow
 
 
+def _validate_api_workflow(workflow):
+    """Return the workflow dict if it has the shape of API format, else None."""
+    if not isinstance(workflow, dict) or not workflow:
+        return None
+    node = workflow[next(iter(workflow))]
+    if not isinstance(node, dict) or "class_type" not in node:
+        return None
+    return workflow
+
+
 def load_api_workflow(file: str):
     with open(file, encoding="utf-8") as f:
         workflow = json.load(f)
-        if is_ui_workflow(workflow):
-            return None
-
-        # Try validating the first entry to ensure it has a node class property
-        node_id = next(iter(workflow))
-        node = workflow[node_id]
-        if "class_type" not in node:
-            return None
-
-        return workflow
+    if is_ui_workflow(workflow):
+        return None
+    return _validate_api_workflow(workflow)
 
 
 class WorkflowConverterUnavailable(Exception):
@@ -109,7 +112,7 @@ def execute(workflow: str, host, port, wait=True, verbose=False, local_paths=Fal
             _print_converter_unavailable_help()
             raise typer.Exit(code=1)
     else:
-        workflow = load_api_workflow(workflow_name)
+        workflow = _validate_api_workflow(raw_workflow)
         if not workflow:
             pprint("[bold red]Specified workflow does not appear to be an API workflow json file[/bold red]")
             raise typer.Exit(code=1)

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -37,14 +37,6 @@ def _validate_api_workflow(workflow):
     return workflow
 
 
-def load_api_workflow(file: str):
-    with open(file, encoding="utf-8") as f:
-        workflow = json.load(f)
-    if is_ui_workflow(workflow):
-        return None
-    return _validate_api_workflow(workflow)
-
-
 class WorkflowConverterUnavailable(Exception):
     """The running ComfyUI server doesn't expose /workflow/convert."""
 
@@ -86,8 +78,8 @@ def convert_ui_workflow_via_server(workflow: dict, host: str, port: int, timeout
 
 def _print_converter_unavailable_help() -> None:
     pprint(
-        "[bold red]UI-format workflow detected, but the running ComfyUI server[/bold red]\n"
-        "[bold red]doesn't expose a /workflow/convert endpoint to convert it to API format.[/bold red]\n"
+        "[bold red]This ComfyUI server doesn't expose a /workflow/convert endpoint[/bold red]\n"
+        "[bold red]to convert it to API format.[/bold red]\n"
         "\n"
         "[yellow]Workarounds:[/yellow]\n"
         "[yellow]  * Install a custom node that adds /workflow/convert on the server[/yellow]\n"

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -101,8 +101,12 @@ def execute(workflow: str, host, port, wait=True, verbose=False, local_paths=Fal
         pprint(f"[bold red]ComfyUI not running on specified address ({host}:{port})[/bold red]")
         raise typer.Exit(code=1)
 
-    with open(workflow_name, encoding="utf-8") as f:
-        raw_workflow = json.load(f)
+    try:
+        with open(workflow_name, encoding="utf-8") as f:
+            raw_workflow = json.load(f)
+    except json.JSONDecodeError as e:
+        pprint(f"[bold red]Specified workflow file is not valid JSON: {e}[/bold red]")
+        raise typer.Exit(code=1) from e
 
     if is_ui_workflow(raw_workflow):
         pprint("[yellow]Detected UI-format workflow, converting via server's /workflow/convert...[/yellow]")

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -70,8 +70,12 @@ def convert_ui_workflow_via_server(workflow: dict, host: str, port: int, timeout
     except json.JSONDecodeError as e:
         pprint("[bold red]Workflow conversion failed: server returned invalid JSON[/bold red]")
         raise typer.Exit(code=1) from e
-    if not isinstance(converted, dict):
-        pprint("[bold red]Workflow conversion failed: expected a JSON object[/bold red]")
+    if not isinstance(converted, dict) or not converted:
+        pprint("[bold red]Workflow conversion failed: expected a non-empty JSON object[/bold red]")
+        raise typer.Exit(code=1)
+    first = converted[next(iter(converted))]
+    if not isinstance(first, dict) or "class_type" not in first:
+        pprint("[bold red]Workflow conversion failed: returned data is not API workflow format[/bold red]")
         raise typer.Exit(code=1)
     return converted
 

--- a/comfy_cli/command/run.py
+++ b/comfy_cli/command/run.py
@@ -104,6 +104,9 @@ def execute(workflow: str, host, port, wait=True, verbose=False, local_paths=Fal
     try:
         with open(workflow_name, encoding="utf-8") as f:
             raw_workflow = json.load(f)
+    except OSError as e:
+        pprint(f"[bold red]Unable to read workflow file: {e}[/bold red]")
+        raise typer.Exit(code=1) from e
     except json.JSONDecodeError as e:
         pprint(f"[bold red]Specified workflow file is not valid JSON: {e}[/bold red]")
         raise typer.Exit(code=1) from e

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -1,13 +1,22 @@
+import io
 import json
 import os
 import tempfile
+import urllib.error
 from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
 from websocket import WebSocketException, WebSocketTimeoutException
 
-from comfy_cli.command.run import WorkflowExecution, execute, load_api_workflow
+from comfy_cli.command.run import (
+    WorkflowConverterUnavailable,
+    WorkflowExecution,
+    convert_ui_workflow_via_server,
+    execute,
+    is_ui_workflow,
+    load_api_workflow,
+)
 
 
 @pytest.fixture
@@ -78,6 +87,70 @@ class TestLoadApiWorkflow:
             result = load_api_workflow(f.name)
         os.unlink(f.name)
         assert result is None
+
+
+class TestIsUiWorkflow:
+    def test_detects_ui_workflow(self):
+        assert is_ui_workflow({"nodes": [{"id": 1}], "links": []})
+
+    def test_rejects_api_workflow(self):
+        assert not is_ui_workflow({"1": {"class_type": "X", "inputs": {}}})
+
+    def test_rejects_non_dict(self):
+        assert not is_ui_workflow(["nodes", "links"])
+        assert not is_ui_workflow(None)
+
+    def test_requires_both_keys(self):
+        assert not is_ui_workflow({"nodes": []})
+        assert not is_ui_workflow({"links": []})
+
+
+def _make_http_error(code: int, body: bytes = b"") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://127.0.0.1:8188/workflow/convert",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=io.BytesIO(body),
+    )
+
+
+class TestConvertUiWorkflowViaServer:
+    UI = {"nodes": [{"id": 1, "type": "X"}], "links": []}
+    CONVERTED = {"1": {"class_type": "X", "inputs": {}}}
+
+    def test_returns_api_format_on_success(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(self.CONVERTED).encode()
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp) as mock_open:
+            result = convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+
+        assert result == self.CONVERTED
+        sent_req = mock_open.call_args[0][0]
+        assert sent_req.full_url == "http://127.0.0.1:8188/workflow/convert"
+        assert json.loads(sent_req.data) == self.UI
+
+    @pytest.mark.parametrize("code", [404, 405])
+    def test_raises_unavailable_on_missing_endpoint(self, code):
+        with patch("comfy_cli.command.run.request.urlopen", side_effect=_make_http_error(code)):
+            with pytest.raises(WorkflowConverterUnavailable):
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+
+    def test_raises_typer_exit_on_server_error(self):
+        err = _make_http_error(500, b"conversion blew up")
+        with patch("comfy_cli.command.run.request.urlopen", side_effect=err):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
+    def test_raises_typer_exit_on_network_error(self):
+        with patch(
+            "comfy_cli.command.run.request.urlopen",
+            side_effect=urllib.error.URLError("Connection refused"),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
 
 
 class TestWatchExecution:
@@ -259,6 +332,20 @@ class TestExecuteErrorHandling:
             execute("/nonexistent/workflow.json", host="127.0.0.1", port=8188)
         assert exc_info.value.exit_code == 1
 
+    def test_rejects_invalid_workflow_format(self):
+        bad = {"1": {"no_class_type_here": "X"}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(bad, f)
+            f.flush()
+            path = f.name
+        try:
+            with patch("comfy_cli.command.run.check_comfy_server_running", return_value=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    execute(path, host="127.0.0.1", port=8188)
+                assert exc_info.value.exit_code == 1
+        finally:
+            os.unlink(path)
+
     def test_progress_stopped_on_error(self, workflow_file):
         with (
             patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
@@ -274,3 +361,60 @@ class TestExecuteErrorHandling:
             with pytest.raises(typer.Exit):
                 execute(workflow_file, host="127.0.0.1", port=8188, wait=True, timeout=30)
             mock_progress.stop.assert_called()
+
+
+class TestExecuteUiWorkflow:
+    UI = {"nodes": [{"id": 1, "type": "X"}], "links": []}
+    CONVERTED = {"1": {"class_type": "EmptyLatentImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}}}
+
+    @pytest.fixture
+    def ui_workflow_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(self.UI, f)
+            f.flush()
+            path = f.name
+        yield path
+        os.unlink(path)
+
+    def test_ui_workflow_is_converted_then_executed(self, ui_workflow_file):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(self.CONVERTED).encode()
+
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp) as mock_open,
+            patch("comfy_cli.command.run.ExecutionProgress"),
+            patch("comfy_cli.command.run.WorkflowExecution") as MockExec,
+        ):
+            mock_exec = MagicMock()
+            MockExec.return_value = mock_exec
+            mock_exec.outputs = []
+
+            execute(ui_workflow_file, host="127.0.0.1", port=8188, wait=True, timeout=30)
+
+            sent_req = mock_open.call_args[0][0]
+            assert sent_req.full_url == "http://127.0.0.1:8188/workflow/convert"
+            assert MockExec.call_args.args[0] == self.CONVERTED
+            mock_exec.queue.assert_called_once()
+
+    @pytest.mark.parametrize("code", [404, 405])
+    def test_ui_workflow_exits_when_endpoint_missing(self, ui_workflow_file, code):
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.command.run.request.urlopen", side_effect=_make_http_error(code)),
+            patch("comfy_cli.command.run.WorkflowExecution") as MockExec,
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                execute(ui_workflow_file, host="127.0.0.1", port=8188, wait=True, timeout=30)
+            assert exc_info.value.exit_code == 1
+            MockExec.assert_not_called()
+
+    def test_ui_workflow_exits_when_server_not_running(self, ui_workflow_file):
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=False),
+            patch("comfy_cli.command.run.request.urlopen") as mock_open,
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                execute(ui_workflow_file, host="127.0.0.1", port=8188)
+            assert exc_info.value.exit_code == 1
+            mock_open.assert_not_called()

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -152,6 +152,22 @@ class TestConvertUiWorkflowViaServer:
                 convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
             assert exc_info.value.exit_code == 1
 
+    def test_raises_typer_exit_on_invalid_json(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html>not json</html>"
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
+    def test_raises_typer_exit_on_non_object_response(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'["not", "an", "object"]'
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
 
 class TestWatchExecution:
     def test_successful_execution(self, mock_execution):

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -362,6 +362,19 @@ class TestExecuteErrorHandling:
         finally:
             os.unlink(path)
 
+    def test_rejects_malformed_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{ this is not valid json")
+            f.flush()
+            path = f.name
+        try:
+            with patch("comfy_cli.command.run.check_comfy_server_running", return_value=True):
+                with pytest.raises(typer.Exit) as exc_info:
+                    execute(path, host="127.0.0.1", port=8188)
+                assert exc_info.value.exit_code == 1
+        finally:
+            os.unlink(path)
+
     def test_progress_stopped_on_error(self, workflow_file):
         with (
             patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -15,7 +15,6 @@ from comfy_cli.command.run import (
     convert_ui_workflow_via_server,
     execute,
     is_ui_workflow,
-    load_api_workflow,
 )
 
 
@@ -61,32 +60,6 @@ def mock_execution(workflow):
 
 def _make_msg(msg_type, prompt_id, **data_fields):
     return json.dumps({"type": msg_type, "data": {"prompt_id": prompt_id, **data_fields}})
-
-
-class TestLoadApiWorkflow:
-    def test_valid_api_workflow(self, workflow_file):
-        result = load_api_workflow(workflow_file)
-        assert result is not None
-        assert "1" in result
-        assert result["1"]["class_type"] == "EmptyLatentImage"
-
-    def test_rejects_ui_workflow(self):
-        ui_workflow = {"nodes": [], "links": []}
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump(ui_workflow, f)
-            f.flush()
-            result = load_api_workflow(f.name)
-        os.unlink(f.name)
-        assert result is None
-
-    def test_rejects_invalid_node(self):
-        bad_workflow = {"1": {"not_class_type": "Foo"}}
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump(bad_workflow, f)
-            f.flush()
-            result = load_api_workflow(f.name)
-        os.unlink(f.name)
-        assert result is None
 
 
 class TestIsUiWorkflow:

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -168,6 +168,30 @@ class TestConvertUiWorkflowViaServer:
                 convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
             assert exc_info.value.exit_code == 1
 
+    def test_raises_typer_exit_on_empty_object_response(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"{}"
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
+    def test_raises_typer_exit_when_first_entry_is_not_a_node(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"1": "not-a-node-dict"}'
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
+    def test_raises_typer_exit_when_first_entry_missing_class_type(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"1": {"inputs": {}}}'
+        with patch("comfy_cli.command.run.request.urlopen", return_value=mock_resp):
+            with pytest.raises(typer.Exit) as exc_info:
+                convert_ui_workflow_via_server(self.UI, "127.0.0.1", 8188, timeout=30)
+            assert exc_info.value.exit_code == 1
+
 
 class TestWatchExecution:
     def test_successful_execution(self, mock_execution):

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -375,6 +375,28 @@ class TestExecuteErrorHandling:
         finally:
             os.unlink(path)
 
+    def test_rejects_unreadable_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{}")
+            path = f.name
+        try:
+            real_open = open
+
+            def fake_open(file, *args, **kwargs):
+                if file == path:
+                    raise PermissionError(13, "Permission denied", path)
+                return real_open(file, *args, **kwargs)
+
+            with (
+                patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+                patch("builtins.open", side_effect=fake_open),
+            ):
+                with pytest.raises(typer.Exit) as exc_info:
+                    execute(path, host="127.0.0.1", port=8188)
+                assert exc_info.value.exit_code == 1
+        finally:
+            os.unlink(path)
+
     def test_progress_stopped_on_error(self, workflow_file):
         with (
             patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -104,6 +104,19 @@ class TestIsUiWorkflow:
         assert not is_ui_workflow({"nodes": []})
         assert not is_ui_workflow({"links": []})
 
+    def test_rejects_api_workflow_with_nodes_and_links_as_keys(self):
+        # A pathological API workflow where node IDs happen to be the strings
+        # "nodes" and "links" should not be mistaken for UI format.
+        api = {
+            "nodes": {"class_type": "Foo", "inputs": {}},
+            "links": {"class_type": "Bar", "inputs": {}},
+        }
+        assert not is_ui_workflow(api)
+
+    def test_rejects_when_values_are_not_lists(self):
+        assert not is_ui_workflow({"nodes": "string", "links": "string"})
+        assert not is_ui_workflow({"nodes": 1, "links": 2})
+
 
 def _make_http_error(code: int, body: bytes = b"") -> urllib.error.HTTPError:
     return urllib.error.HTTPError(


### PR DESCRIPTION
## Summary

- `comfy run --workflow` now detects UI/save-format workflows (the default from ComfyUI's "Save" button) and POSTs them to the running server's `/workflow/convert` endpoint, then runs the converted API-format result.
- If the endpoint isn't available on the server (stock ComfyUI does not ship one — only custom nodes provide it), the CLI prints actionable guidance instead of the previous flat `"Specified workflow does not appear to be an API workflow json file"` rejection.
- Closes nothing yet — this is **Part 1 of #446**. A follow-up PR will add a client-side converter (using `/object_info`) so users don't need to install anything server-side.

## What changed in `comfy run --workflow`

| Input | Before | After |
|---|---|---|
| API-format JSON | Runs as today | Unchanged |
| UI-format JSON, server has `/workflow/convert` | "not an API workflow" → exit 1 | Auto-converts → runs |
| UI-format JSON, server lacks endpoint | "not an API workflow" → exit 1 | Friendly hint + exit 1 |
| Malformed JSON (no `class_type`, not UI) | "not an API workflow" → exit 1 | Same |
| Server unreachable | Reported after workflow load | Reported up front |

The hint when the endpoint is missing:

```
UI-format workflow detected, but the running ComfyUI server
doesn't expose a /workflow/convert endpoint to convert it to API format.

Workarounds:
  * Install a custom node that adds /workflow/convert on the server
  * Or, in the ComfyUI frontend, enable Dev Mode under Settings and use
    'Workflow > Export (API)' to save your workflow as API format
```

## Why this split

Part 2 (client-side converter) is ~1400 LOC of node-graph traversal — subgraphs, reroutes, bypassed nodes, dynamic combos, widget mapping via `/object_info`. Landing the server-endpoint path first keeps that review independent, and the contract here (`is_ui_workflow`, `convert_ui_workflow_via_server`, `WorkflowConverterUnavailable`, the hint text) is what Part 2 will plug into as a fallback.

## Test plan

- [x] `pytest tests/comfy_cli/command/test_run.py` — 28/28 pass (12 new)
- [x] `pytest tests/comfy_cli/` — 785/785 unit tests pass, no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Smoke-tested locally against ComfyUI 0.20.1 (CPU): UI workflow → endpoint missing → hint printed; API workflow → unchanged behavior (proceeds to `/prompt`)
- [ ] Smoke-test against a ComfyUI server with [SethRobinson's converter](https://github.com/SethRobinson/comfyui-workflow-to-api-converter-endpoint) installed to verify the success path end-to-end (covered by unit tests but worth a manual check before merge)

## New tests

- `TestIsUiWorkflow` — 4 tests for the format detector
- `TestConvertUiWorkflowViaServer` — success, missing endpoint (404 + 405 parametrized), HTTP 500, network error
- `TestExecuteUiWorkflow` — end-to-end conversion + execution, exits on missing endpoint, exits when server unreachable without attempting conversion
- `TestExecuteErrorHandling::test_rejects_invalid_workflow_format` — preserves the malformed-input rejection

Refs #446