### PR TITLE
feat(generate): reference-asset upload + long polling models (video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ workflows, and call hosted partner image models, all from your terminal.
 ## Features
 
 - 🚀 One-command ComfyUI install and launch
-- 🎨 Direct calls to partner image nodes (Flux, Ideogram, DALL·E, Recraft, Stability, …) via `comfy generate`, no workflow JSON required
+- 🎨 Direct calls to partner image and video nodes (Flux, Ideogram, DALL·E, Recraft, Stability, Kling, Luma, Runway, Pika, Vidu, Hailuo, …) via `comfy generate`, no workflow JSON required
 - 🔧 Custom node management — install, update, snapshot, bisect
 - 📦 Fast dependency resolution with `uv` (`--fast-deps`, `--uv-compile`)
 - 🗄️ Model downloads from CivitAI, Hugging Face, and direct URLs
@@ -290,8 +290,11 @@ the bisect tool can help you pinpoint the custom node that causes the issue.
 
 `comfy generate` calls Comfy's partner nodes directly from the terminal — no
 local ComfyUI or workflow JSON required. It hits the same hosted partner nodes
-(Flux, Ideogram, DALL·E, Recraft, Stability, Runway, Reve, xAI Grok, …) you'd
-otherwise wire into a ComfyUI workflow, but as one-shot CLI calls.
+you'd otherwise wire into a ComfyUI workflow, but as one-shot CLI calls. Image
+models (Flux, Ideogram, DALL·E, Recraft, Stability, Runway, Reve, xAI Grok, …)
+and video models (Kling, Luma, Runway Gen-3, Pika, Vidu, Moonvalley, Hailuo,
+Grok video) are all covered; video jobs run async and the CLI polls until the
+result is ready.
 
 Prerequisites — a Comfy API key and a credit balance:
 
@@ -321,8 +324,18 @@ comfy generate flux-kontext --prompt "add a top hat" \
 comfy generate upload ./photo.jpg                    # explicit upload
 ```
 
-Async models block until ready by default. Pass `--async` to return immediately
-with a job id, then resume later with `comfy generate resume <model> <job_id>`.
+Async models (every video model plus the Flux family) block until ready by
+default. Pass `--async` to return immediately with a job id, then resume later
+with `comfy generate resume <model> <job_id>`. Examples:
+
+```bash
+comfy generate kling --prompt "a paper boat drifting on a river at dusk" \
+    --duration 5 --download boat.mp4
+
+comfy generate luma --prompt "..." --aspect_ratio 16:9 --async
+# → prints job id; resume with:
+comfy generate resume luma <job_id> --download out.mp4
+```
 
 ### Managing ComfyUI-Manager
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,45 @@ the bisect tool can help you pinpoint the custom node that causes the issue.
 
   `comfy model list ?[--relative-path <PATH>]`
 
+### Calling partner nodes (`comfy generate`)
+
+`comfy generate` calls Comfy's partner nodes directly from the terminal — no
+local ComfyUI or workflow JSON required. It hits the same hosted partner
+nodes (Flux, Ideogram, DALL·E, Recraft, Stability, Runway, Reve, xAI Grok, …)
+you'd otherwise wire into a ComfyUI workflow, but as one-shot CLI calls.
+
+You'll need a Comfy API key and a credit balance:
+
+- Create a key: see [ComfyUI Account API Key Integration](https://docs.comfy.org/development/comfyui-server/api-key-integration).
+- Browse supported models and per-call credit costs: see [Partner Nodes](https://docs.comfy.org/tutorials/partner-nodes/overview) and the [pricing table](https://docs.comfy.org/tutorials/partner-nodes/pricing).
+- Add credits: see [Credits Management](https://docs.comfy.org/interface/credits).
+
+Set the key once, then go:
+
+```bash
+export COMFY_API_KEY=comfyui-...   # or pass --api-key on each call
+
+comfy generate list                                  # browse available models
+comfy generate schema flux-pro                       # see params for one model
+comfy generate flux-pro --prompt "a cat on the moon" \
+    --width 1024 --height 1024 --download cat.png
+```
+
+Reference images can be passed as local paths to image-edit models — the CLI
+uploads them through the cloud's storage endpoint (or base64-encodes inline, as
+the upstream model requires):
+
+```bash
+comfy generate flux-kontext --prompt "add a top hat" \
+    --input_image ./photo.jpg --download out.png
+
+comfy generate upload ./photo.jpg                    # explicit upload
+```
+
+Async models submit a job and the CLI polls until ready by default; pass
+`--async` to return immediately with a job id that
+`comfy generate resume <model> <job_id>` can pick up later.
+
 ### Managing ComfyUI-Manager
 
 - Disable ComfyUI-Manager completely (no manager flags passed to ComfyUI):

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/comfy-cli)](https://pypi.org/project/comfy-cli/)
 [![License](https://img.shields.io/pypi/l/comfy-cli)](https://github.com/Comfy-Org/comfy-cli/blob/main/LICENSE)
 
-comfy-cli is a command line tool for installing, running, and extending
+comfy-cli is a command-line tool for installing, running, and extending
 [ComfyUI](https://github.com/comfyanonymous/ComfyUI) — the open-source
 generative-media engine. Set up ComfyUI, install custom nodes and models, run
 workflows, and call hosted partner image models, all from your terminal.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 [![Python](https://img.shields.io/pypi/pyversions/comfy-cli)](https://pypi.org/project/comfy-cli/)
 [![License](https://img.shields.io/pypi/l/comfy-cli)](https://github.com/Comfy-Org/comfy-cli/blob/main/LICENSE)
 
-comfy-cli is a command line tool that helps users easily install and manage
-[ComfyUI](https://github.com/comfyanonymous/ComfyUI), a powerful open-source
-machine learning framework. With comfy-cli, you can quickly set up ComfyUI,
-install packages, and manage custom nodes, all from the convenience of your
-terminal.
+comfy-cli is a command line tool for installing, running, and extending
+[ComfyUI](https://github.com/comfyanonymous/ComfyUI) — the open-source
+generative-media engine. Set up ComfyUI, install custom nodes and models, run
+workflows, and call hosted partner image models, all from your terminal.
 
 ## Demo
 
@@ -19,29 +18,32 @@ terminal.
 
 ## Features
 
-- 🚀 Easy installation of ComfyUI with a single command
-- 📦 Seamless package management for ComfyUI extensions and dependencies
-- 🔧 Custom node management for extending ComfyUI's functionality
-- 🗄️ Download checkpoints and save model hash
-- 💻 Cross-platform compatibility (Windows, macOS, Linux)
-- 📖 Comprehensive documentation and examples
-- 🎉 install pull request to ComfyUI automatically
+- 🚀 One-command ComfyUI install and launch
+- 🎨 Direct calls to partner image nodes (Flux, Ideogram, DALL·E, Recraft, Stability, …) via `comfy generate`, no workflow JSON required
+- 🔧 Custom node management — install, update, snapshot, bisect
+- 📦 Fast dependency resolution with `uv` (`--fast-deps`, `--uv-compile`)
+- 🗄️ Model downloads from CivitAI, Hugging Face, and direct URLs
+- 🎬 Run workflows against a local ComfyUI server, including auto-conversion of UI-format JSON
+- 🧪 Test ComfyUI and frontend pull requests with one flag
+- 💻 Cross-platform: Windows, macOS, Linux
 
 ## Installation
 
-1. (Recommended, but not necessary) Enable virtual environment ([venv](https://docs.python.org/3/library/venv.html)/[conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html))
+1. (Recommended) Activate a virtual environment ([venv](https://docs.python.org/3/library/venv.html) or [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html)).
 
-2. To install comfy-cli, make sure you have Python 3.9 or higher installed on your system. Then, run the following command:
+2. Install with `pip` (requires Python 3.10+):
 
-   `pip install comfy-cli`
+   ```bash
+   pip install comfy-cli
+   ```
 
 ### Shell Autocomplete
 
-To install autocompletion hints in your shell run:
+Install shell completion so `comfy <TAB>` expands commands and options:
 
-`comfy --install-completion`
-
-This enables you to type `comfy [TAP]` to autocomplete commands and options
+```bash
+comfy --install-completion
+```
 
 ## Usage
 
@@ -287,15 +289,15 @@ the bisect tool can help you pinpoint the custom node that causes the issue.
 ### Calling partner nodes (`comfy generate`)
 
 `comfy generate` calls Comfy's partner nodes directly from the terminal — no
-local ComfyUI or workflow JSON required. It hits the same hosted partner
-nodes (Flux, Ideogram, DALL·E, Recraft, Stability, Runway, Reve, xAI Grok, …)
-you'd otherwise wire into a ComfyUI workflow, but as one-shot CLI calls.
+local ComfyUI or workflow JSON required. It hits the same hosted partner nodes
+(Flux, Ideogram, DALL·E, Recraft, Stability, Runway, Reve, xAI Grok, …) you'd
+otherwise wire into a ComfyUI workflow, but as one-shot CLI calls.
 
-You'll need a Comfy API key and a credit balance:
+Prerequisites — a Comfy API key and a credit balance:
 
-- Create a key: see [ComfyUI Account API Key Integration](https://docs.comfy.org/development/comfyui-server/api-key-integration).
-- Browse supported models and per-call credit costs: see [Partner Nodes](https://docs.comfy.org/tutorials/partner-nodes/overview) and the [pricing table](https://docs.comfy.org/tutorials/partner-nodes/pricing).
-- Add credits: see [Credits Management](https://docs.comfy.org/interface/credits).
+- [Create an API key](https://docs.comfy.org/development/comfyui-server/api-key-integration)
+- [Browse partner nodes and per-call credit costs](https://docs.comfy.org/tutorials/partner-nodes/overview) · [pricing table](https://docs.comfy.org/tutorials/partner-nodes/pricing)
+- [Add credits](https://docs.comfy.org/interface/credits)
 
 Set the key once, then go:
 
@@ -308,9 +310,9 @@ comfy generate flux-pro --prompt "a cat on the moon" \
     --width 1024 --height 1024 --download cat.png
 ```
 
-Reference images can be passed as local paths to image-edit models — the CLI
-uploads them through the cloud's storage endpoint (or base64-encodes inline, as
-the upstream model requires):
+Reference images can be passed as local paths — the CLI uploads them through
+the cloud's storage endpoint (or base64-encodes inline, as each partner
+requires):
 
 ```bash
 comfy generate flux-kontext --prompt "add a top hat" \
@@ -319,9 +321,8 @@ comfy generate flux-kontext --prompt "add a top hat" \
 comfy generate upload ./photo.jpg                    # explicit upload
 ```
 
-Async models submit a job and the CLI polls until ready by default; pass
-`--async` to return immediately with a job id that
-`comfy generate resume <model> <job_id>` can pick up later.
+Async models block until ready by default. Pass `--async` to return immediately
+with a job id, then resume later with `comfy generate resume <model> <job_id>`.
 
 ### Managing ComfyUI-Manager
 
@@ -408,19 +409,19 @@ Check out the usage here: [Mixpanel Board](https://mixpanel.com/p/13hGfPfEPdRkjP
 
 ## Contributing
 
-We welcome contributions to comfy-cli! If you have any ideas, suggestions, or
-bug reports, please open an issue on our [GitHub
-repository](https://github.com/yoland68/comfy-cli/issues). If you'd like to contribute code,
-please fork the repository and submit a pull request.
+We welcome contributions to comfy-cli! For ideas, suggestions, or bug reports,
+open an issue at [Comfy-Org/comfy-cli](https://github.com/Comfy-Org/comfy-cli/issues).
+For code changes, fork the repo and open a pull request.
 
-Check out the [Dev Guide](/DEV_README.md) for more details.
+See the [Dev Guide](/DEV_README.md) for setup details.
 
 ## License
 
-comfy is released under the [GNU General Public License v3.0](https://github.com/yoland68/comfy-cli/blob/master/LICENSE).
+Released under the [GNU General Public License v3.0](https://github.com/Comfy-Org/comfy-cli/blob/main/LICENSE).
 
 ## Support
 
-If you encounter any issues or have questions about comfy-cli, please [open an issue](https://github.com/comfy-cli/issues) on our GitHub repository or contact us on [Discord](https://discord.com/invite/comfyorg). We'll be happy to assist you!
+Questions or issues? [Open an issue](https://github.com/Comfy-Org/comfy-cli/issues)
+or reach us on [Discord](https://discord.com/invite/comfyorg).
 
 Happy diffusing with ComfyUI and comfy-cli! 🎉

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -223,7 +223,7 @@ def _generate(model: str, extra_args: list[str]) -> None:
         raise typer.Exit(code=1)
 
     if ep.polling:
-        job_id = str(body.get("id") or (body.get("data") or {}).get("task_id") or request_id)
+        job_id = poll.extract_job_id(ep.polling, body) or request_id
         name = spec.preferred_alias(ep.id) or ep.id
         if do_async:
             if as_json:
@@ -241,7 +241,13 @@ def _generate(model: str, extra_args: list[str]) -> None:
             def _on_progress(p: float) -> None:
                 prog.update(task, description=f"Generating ({p * 100:.0f}%)")
 
-            result = poller(body, api_key=api_key, timeout=timeout, on_progress=_on_progress)
+            result = poller(
+                body,
+                api_key=api_key,
+                timeout=timeout,
+                on_progress=_on_progress,
+                create_path=ep.path,
+            )
         _emit_result(result, request_id=job_id, download=download, as_json=as_json)
         return
 
@@ -411,10 +417,10 @@ def _resume(extra_args: list[str]) -> None:
     download = meta.get("download") if isinstance(meta.get("download"), str) else None
     as_json = bool(meta.get("json", False))
 
-    if ep.polling == "bfl":
-        initial = {"polling_url": f"{spec.base_url()}/proxy/bfl/get_result?id={job_id}"}
-    else:
-        rprint(f"[bold red]Resume not implemented for partner {ep.partner}[/bold red]")
+    try:
+        initial = poll.build_synthetic_initial(ep.polling, job_id, base_url=spec.base_url())
+    except client.ApiError as e:
+        rprint(f"[bold red]{e}[/bold red]")
         raise typer.Exit(code=1)
 
     poller = poll.get_poller(ep.polling)
@@ -424,7 +430,13 @@ def _resume(extra_args: list[str]) -> None:
         def _on_progress(p: float) -> None:
             prog.update(task, description=f"Job {job_id} ({p * 100:.0f}%)")
 
-        result = poller(initial, api_key=api_key, timeout=timeout, on_progress=_on_progress)
+        result = poller(
+            initial,
+            api_key=api_key,
+            timeout=timeout,
+            on_progress=_on_progress,
+            create_path=ep.path,
+        )
     _emit_result(result, request_id=job_id, download=download, as_json=as_json)
 
 

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -190,7 +190,7 @@ def _generate(model: str, extra_args: list[str]) -> None:
 
     try:
         _apply_upload_transforms(values, flags, ep, api_key)
-    except client.ApiError as e:
+    except (client.ApiError, httpx.HTTPError) as e:
         rprint(f"[bold red]Upload failed: {e}[/bold red]")
         raise typer.Exit(code=1)
 
@@ -311,15 +311,16 @@ def _refresh() -> None:
 def _upload(extra_args: list[str]) -> None:
     """`comfy generate upload <file-or-url> [--json] [--api-key K]`."""
     try:
-        _, meta = _separate_meta_flags(extra_args)
+        remaining, meta = _separate_meta_flags(extra_args)
     except schema.SchemaError as e:
         rprint(f"[bold red]{e}[/bold red]")
         raise typer.Exit(code=1)
-    positional = [a for a in extra_args if not a.startswith("--")]
-    if not positional:
+    # `remaining` already excludes recognized --meta flags AND their values, so
+    # `comfy generate upload --api-key KEY ./img.png` correctly resolves to "./img.png".
+    if not remaining:
         rprint("[bold red]Usage: comfy generate upload <file-or-url> [--json][/bold red]")
         raise typer.Exit(code=1)
-    target = positional[0]
+    target = remaining[0]
     try:
         api_key = client.resolve_api_key(meta.get("api-key") if isinstance(meta.get("api-key"), str) else None)
     except client.ApiError as e:
@@ -442,7 +443,7 @@ def _print_top_help() -> None:
     rprint("  comfy generate list                    Browse available models")
     rprint("  comfy generate schema <model>          Show parameters for a model")
     rprint("  comfy generate refresh                 Refresh the model catalog")
-    rprint("  comfy generate upload <file-or-url>    Host a local file and print its signed URL")
+    rprint("  comfy generate upload <file-or-url>    Host a local file or remote URL and print its signed URL")
     rprint("  comfy generate resume <model> <job>    Resume an async job")
     rprint("")
     rprint("[dim]Auth: set COMFY_API_KEY or pass --api-key. Get one at https://platform.comfy.org.[/dim]")

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -371,7 +371,10 @@ def _apply_upload_transforms(values: dict, flags: list[schema.FlagDef], endpoint
         if flag.upload_mode == "base64":
             import base64 as _base64
 
-            data = path.read_bytes()
+            try:
+                data = path.read_bytes()
+            except OSError as e:
+                raise client.ApiError(0, "", f"Unable to read file for --{name}: {path} ({e})") from e
             values[name] = _base64.b64encode(data).decode("ascii")
             rprint(f"[dim]base64-encoded {path.name} for --{name}[/dim]")
         elif flag.upload_mode == "url":

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -1,4 +1,4 @@
-"""``comfy generate`` — call ComfyUI cloud models from the CLI.
+"""``comfy generate`` — call ComfyUI partner nodes from the CLI.
 
 UX shape, modeled on fal-ai's genmedia but creative-user-first:
 
@@ -16,6 +16,7 @@ Anything not in the reserved set falls through to the generate path.
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 from typing import Annotated
 
 import httpx
@@ -24,9 +25,9 @@ from rich import print as rprint
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from comfy_cli import tracking, ui
-from comfy_cli.command.generate import client, output, poll, schema, spec
+from comfy_cli.command.generate import client, output, poll, schema, spec, upload
 
-_HELP = "Generate images via ComfyUI cloud models (Flux, Ideogram, DALL·E, Recraft, Stability, …)."
+_HELP = "Generate images via ComfyUI partner nodes (Flux, Ideogram, DALL·E, Recraft, Stability, …)."
 
 _CONTEXT_SETTINGS = {
     "allow_extra_args": True,
@@ -48,7 +49,8 @@ def register_with(parent: typer.Typer) -> None:
         target: Annotated[
             str | None,
             typer.Argument(
-                help="A model alias (e.g. flux-pro, ideogram-edit, dalle) or one of: list, schema, refresh, resume.",
+                help="A model alias (e.g. flux-pro, ideogram-edit, dalle) "
+                "or one of: list, schema, refresh, upload, resume.",
             ),
         ] = None,
     ) -> None:
@@ -61,6 +63,8 @@ def register_with(parent: typer.Typer) -> None:
             return _schema(list(ctx.args))
         if target == "refresh":
             return _refresh()
+        if target == "upload":
+            return _upload(list(ctx.args))
         if target == "resume":
             return _resume(list(ctx.args))
         _generate(target, list(ctx.args))
@@ -184,6 +188,12 @@ def _generate(model: str, extra_args: list[str]) -> None:
     download = meta.get("download") if isinstance(meta.get("download"), str) else None
     as_json = bool(meta.get("json", False))
 
+    try:
+        _apply_upload_transforms(values, flags, ep, api_key)
+    except client.ApiError as e:
+        rprint(f"[bold red]Upload failed: {e}[/bold red]")
+        raise typer.Exit(code=1)
+
     request_id = str(uuid.uuid4())[:8]
     try:
         resp = client.send_request(ep, values, flags, api_key, timeout=timeout)
@@ -298,6 +308,77 @@ def _refresh() -> None:
     rprint(f"[bold green]Refreshed model catalog at {path}[/bold green]")
 
 
+def _upload(extra_args: list[str]) -> None:
+    """`comfy generate upload <file-or-url> [--json] [--api-key K]`."""
+    try:
+        _, meta = _separate_meta_flags(extra_args)
+    except schema.SchemaError as e:
+        rprint(f"[bold red]{e}[/bold red]")
+        raise typer.Exit(code=1)
+    positional = [a for a in extra_args if not a.startswith("--")]
+    if not positional:
+        rprint("[bold red]Usage: comfy generate upload <file-or-url> [--json][/bold red]")
+        raise typer.Exit(code=1)
+    target = positional[0]
+    try:
+        api_key = client.resolve_api_key(meta.get("api-key") if isinstance(meta.get("api-key"), str) else None)
+    except client.ApiError as e:
+        rprint(f"[bold red]{e}[/bold red]")
+        raise typer.Exit(code=1)
+    as_json = bool(meta.get("json", False))
+    try:
+        result = upload.upload_target(target, api_key)
+    except (client.ApiError, httpx.HTTPError) as e:
+        rprint(f"[bold red]Upload failed: {e}[/bold red]")
+        raise typer.Exit(code=1)
+    if as_json:
+        output.print_json(
+            {
+                "url": result.url,
+                "expires_at": result.expires_at,
+                "existing_file": result.existing_file,
+                "hint": "Pass this URL as the model's image/input_image field.",
+            }
+        )
+        return
+    rprint(f"[bold green]Uploaded:[/bold green] {result.url}")
+    if result.expires_at:
+        rprint(f"  expires: {result.expires_at}")
+    if result.existing_file:
+        rprint("  [dim](server already had a hash-match; no bytes transferred)[/dim]")
+
+
+def _apply_upload_transforms(values: dict, flags: list[schema.FlagDef], endpoint: spec.Endpoint, api_key: str) -> None:
+    """When the user supplies a local file path for a field that expects a
+    base64 blob or a URL, transform it transparently.
+
+    This only applies to JSON endpoints — multipart endpoints already stream
+    file paths natively via httpx and don't need pre-uploading.
+    """
+    if endpoint.request_content_type != "application/json":
+        return
+    flag_by_name = {f.name: f for f in flags}
+    for name, value in list(values.items()):
+        flag = flag_by_name.get(name)
+        if flag is None or flag.upload_mode is None or not isinstance(value, str):
+            continue
+        if value.startswith(("http://", "https://", "data:")):
+            continue
+        path = Path(value).expanduser()
+        if not path.is_file():
+            continue
+        if flag.upload_mode == "base64":
+            import base64 as _base64
+
+            data = path.read_bytes()
+            values[name] = _base64.b64encode(data).decode("ascii")
+            rprint(f"[dim]base64-encoded {path.name} for --{name}[/dim]")
+        elif flag.upload_mode == "url":
+            rprint(f"[dim]uploading {path.name} for --{name}…[/dim]")
+            result = upload.upload_path(path, api_key)
+            values[name] = result.url
+
+
 def _resume(extra_args: list[str]) -> None:
     if len(extra_args) < 2:
         rprint("[bold red]Usage: comfy generate resume <model> <job_id> [--download PATH] [--json][/bold red]")
@@ -345,7 +426,7 @@ def _resume(extra_args: list[str]) -> None:
 
 def _print_top_help() -> None:
     """Custom help that emphasizes the model-first UX over Typer's auto-help."""
-    rprint("[bold]comfy generate[/bold] — call ComfyUI cloud models")
+    rprint("[bold]comfy generate[/bold] — call ComfyUI partner nodes")
     rprint("")
     rprint("[bold]Usage:[/bold]")
     rprint("  comfy generate <model> [--<param> value]... [--download PATH] [--async] [--api-key KEY]")
@@ -361,6 +442,7 @@ def _print_top_help() -> None:
     rprint("  comfy generate list                    Browse available models")
     rprint("  comfy generate schema <model>          Show parameters for a model")
     rprint("  comfy generate refresh                 Refresh the model catalog")
+    rprint("  comfy generate upload <file-or-url>    Host a local file and print its signed URL")
     rprint("  comfy generate resume <model> <job>    Resume an async job")
     rprint("")
     rprint("[dim]Auth: set COMFY_API_KEY or pass --api-key. Get one at https://platform.comfy.org.[/dim]")

--- a/comfy_cli/command/generate/output.py
+++ b/comfy_cli/command/generate/output.py
@@ -48,11 +48,21 @@ def _resolve_template(template: str, request_id: str, index: int, ext: str) -> P
 
 
 def save_urls(urls: list[str], template: str, request_id: str) -> list[Path]:
-    """Download each URL and save under the resolved template path. Returns saved paths."""
+    """Download each URL and save under the resolved template path. Returns saved paths.
+
+    Multi-URL responses (a video + thumbnail from Luma, for example) need a
+    per-output filename. If the template has no ``{index}`` placeholder and
+    isn't a directory shorthand, we auto-insert ``_<i>`` before the suffix
+    and switch the extension to whatever the URL actually points at — so a
+    user who typed ``--download out.mp4`` doesn't silently get a thumbnail
+    JPEG written into ``out.mp4`` because the model returned two URLs."""
     saved: list[Path] = []
+    auto_index = len(urls) > 1 and "{index}" not in template and not template.endswith(("/", "\\"))
     for i, url in enumerate(urls):
         ext = _ext_from_url(url)
         dest = _resolve_template(template, request_id, i, ext)
+        if auto_index:
+            dest = dest.with_name(f"{dest.stem}_{i}.{ext}")
         dest.parent.mkdir(parents=True, exist_ok=True)
         data = client.download_bytes(url)
         dest.write_bytes(data)

--- a/comfy_cli/command/generate/poll.py
+++ b/comfy_cli/command/generate/poll.py
@@ -1,14 +1,24 @@
-"""Async-job polling adapters, one per partner.
+"""Async-job polling for partner endpoints.
 
-Each adapter takes the initial response from the submit POST and yields a
-canonical ``PollResult`` once the upstream job reaches a terminal state.
+There are two flavors:
+
+1. **BFL** — the server returns ``{id, polling_url}`` on submit and we just GET
+   that URL until the ``status`` field is terminal.
+2. **Everything else** — a small ``PollSpec`` per partner describes where the
+   job id lives in the create response, how to construct the poll URL (some
+   partners use a sibling endpoint relative to the create path; others have a
+   dedicated ``/tasks/{id}`` endpoint), and which status values mean
+   "succeeded" / "failed".
+
+The generic poller walks dot-paths into the JSON to extract the id/status
+without having to write a new adapter for each partner.
 """
 
 from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -22,8 +32,31 @@ class PollResult:
 
     status: str  # "succeeded" | "failed" | "cancelled"
     raw: dict[str, Any]  # last response body — full upstream payload
-    image_urls: list[str]  # any image result URLs we could pluck out
+    image_urls: list[str]  # any image/video result URLs we could pluck out
     error: str | None = None
+
+
+# Recognized result extensions when sniffing URLs out of a poll body.
+_MEDIA_EXTS = (
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+    ".svg",
+    ".mp4",
+    ".mov",
+    ".webm",
+    ".m4v",
+    ".gltf",
+    ".glb",
+    ".obj",
+    ".fbx",
+    ".wav",
+    ".mp3",
+    ".m4a",
+    ".flac",
+)
 
 
 def _now() -> float:
@@ -31,14 +64,14 @@ def _now() -> float:
 
 
 def _extract_urls(node: Any) -> list[str]:
-    """Walk a JSON tree, collecting strings that look like image URLs."""
+    """Walk a JSON tree, collecting strings that look like media URLs."""
     found: list[str] = []
 
     def visit(n: Any) -> None:
         if isinstance(n, str):
             low = n.lower()
             if n.startswith(("http://", "https://")) and (
-                low.endswith((".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg")) or "image" in low
+                low.split("?", 1)[0].endswith(_MEDIA_EXTS) or "image" in low or "video" in low
             ):
                 found.append(n)
             return
@@ -50,9 +83,27 @@ def _extract_urls(node: Any) -> list[str]:
                 visit(v)
 
     visit(node)
-    # De-dupe preserving order.
     seen: set[str] = set()
     return [u for u in found if not (u in seen or seen.add(u))]
+
+
+def _dotget(body: Any, path: str) -> Any:
+    """Look up a dotted path inside a JSON body. Returns None if any segment misses."""
+    cur: Any = body
+    for part in path.split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            return None
+    return cur
+
+
+def _first(body: Any, paths: tuple[str, ...]) -> Any:
+    for p in paths:
+        v = _dotget(body, p)
+        if v not in (None, "", []):
+            return v
+    return None
 
 
 def _sleep(seconds: float) -> None:
@@ -66,8 +117,9 @@ def poll_bfl(
     interval: float = 2.0,
     timeout: float = 300.0,
     on_progress: Callable[[float], None] | None = None,
+    create_path: str | None = None,  # ignored, kept for uniform signature
 ) -> PollResult:
-    """BFL: GET ``polling_url`` until ``status`` is terminal."""
+    """BFL polls a server-issued ``polling_url`` until ``status`` flips to Ready."""
     url = initial.get("polling_url")
     if not url:
         raise client.ApiError(0, "", "BFL response missing polling_url")
@@ -92,24 +144,235 @@ def poll_bfl(
     return PollResult(status="failed", raw=last_body, image_urls=[], error=f"timed out after {timeout:.0f}s")
 
 
-_POLLERS: dict[str, Callable[..., PollResult]] = {
-    "bfl": poll_bfl,
-    # "kling": poll_kling,   # follow-up: not in v1 image allowlist
-    # "luma": poll_luma,     # follow-up
-    # "topaz": poll_topaz,   # follow-up
+@dataclass(frozen=True)
+class PollSpec:
+    """Per-partner polling configuration.
+
+    ``poll_url`` is a template supporting ``{id}`` and ``{create_path}``;
+    ``post_success_url`` (optional) is a second-stage fetcher invoked once the
+    job reaches a success state — for partners like MiniMax where the terminal
+    poll response gives you a file id you still need to redeem for a URL."""
+
+    name: str
+    id_paths: tuple[str, ...]
+    poll_url: str
+    status_paths: tuple[str, ...]
+    success_values: tuple[str, ...]
+    failure_values: tuple[str, ...] = ()
+    progress_path: str | None = None
+    post_success_url: str | None = None
+    post_success_id_paths: tuple[str, ...] = field(default_factory=tuple)
+
+
+_POLL_SPECS: dict[str, PollSpec] = {
+    "kling": PollSpec(
+        name="kling",
+        id_paths=("data.task_id",),
+        poll_url="{create_path}/{id}",
+        status_paths=("data.task_status",),
+        success_values=("succeed",),
+        failure_values=("failed",),
+    ),
+    "luma": PollSpec(
+        name="luma",
+        id_paths=("id",),
+        poll_url="/proxy/luma/generations/{id}",
+        status_paths=("state",),
+        success_values=("completed",),
+        failure_values=("failed",),
+    ),
+    "minimax": PollSpec(
+        name="minimax",
+        id_paths=("task_id",),
+        poll_url="/proxy/minimax/query/video_generation?task_id={id}",
+        status_paths=("status",),
+        success_values=("Success",),
+        failure_values=("Fail",),
+        post_success_url="/proxy/minimax/files/retrieve?file_id={id}",
+        post_success_id_paths=("file_id",),
+    ),
+    "runway": PollSpec(
+        name="runway",
+        id_paths=("id",),
+        poll_url="/proxy/runway/tasks/{id}",
+        status_paths=("status",),
+        success_values=("SUCCEEDED",),
+        failure_values=("FAILED", "CANCELLED", "THROTTLED"),
+        progress_path="progress",
+    ),
+    "moonvalley": PollSpec(
+        name="moonvalley",
+        id_paths=("id",),
+        poll_url="/proxy/moonvalley/prompts/{id}",
+        status_paths=("status",),
+        success_values=("completed",),
+        failure_values=("failed", "error"),
+    ),
+    "pika": PollSpec(
+        name="pika",
+        id_paths=("video_id", "id"),
+        poll_url="/proxy/pika/videos/{id}",
+        status_paths=("status",),
+        success_values=("finished",),
+        # Pika's enum has no explicit failure state; treat sustained queued/started
+        # as in-progress and rely on `timeout` to surface stalls.
+        failure_values=(),
+        progress_path="progress",
+    ),
+    "vidu": PollSpec(
+        name="vidu",
+        id_paths=("task_id",),
+        poll_url="/proxy/vidu/tasks/{id}/creations",
+        status_paths=("state",),
+        success_values=("success",),
+        failure_values=("failed",),
+    ),
+    "xai_video": PollSpec(
+        name="xai_video",
+        id_paths=("request_id",),
+        poll_url="/proxy/xai/v1/videos/{id}",
+        status_paths=("status",),
+        success_values=("done",),
+        failure_values=(),
+    ),
 }
 
 
+def _build_poll_url(spec: PollSpec, job_id: str, create_path: str | None) -> str:
+    url = spec.poll_url.replace("{id}", str(job_id))
+    if "{create_path}" in url:
+        if not create_path:
+            raise client.ApiError(0, "", f"{spec.name} poller needs the create path")
+        url = url.replace("{create_path}", create_path)
+    return url
+
+
+def poll_generic(
+    initial: dict[str, Any],
+    api_key: str,
+    *,
+    spec: PollSpec,
+    create_path: str | None = None,
+    interval: float = 2.0,
+    timeout: float = 300.0,
+    on_progress: Callable[[float], None] | None = None,
+) -> PollResult:
+    """Drive a partner's poll endpoint by reading dot-paths out of the JSON.
+
+    ``initial`` is the create-response body; we pull a job id out of it, build
+    the poll URL from ``spec.poll_url``, and GET it until the status field hits
+    a terminal value. Handles MiniMax-style two-stage flows via
+    ``spec.post_success_url`` (a follow-up GET keyed off something the terminal
+    poll body contains, e.g. ``file_id``)."""
+    job_id = _first(initial, spec.id_paths)
+    if job_id is None:
+        raise client.ApiError(0, "", f"{spec.name} response missing id (looked for {spec.id_paths})")
+    url = _build_poll_url(spec, str(job_id), create_path)
+    deadline = _now() + timeout
+    last_body: dict[str, Any] = {}
+    while _now() < deadline:
+        resp = client.get(url, api_key=api_key)
+        if resp.status_code >= 400:
+            client.raise_for_status(resp)
+        last_body = resp.json()
+        if on_progress is not None and spec.progress_path:
+            p = _dotget(last_body, spec.progress_path)
+            if isinstance(p, int | float):
+                # Some partners report 0–100, others 0–1; normalize.
+                on_progress(float(p) / 100.0 if p > 1 else float(p))
+        status = _first(last_body, spec.status_paths)
+        status_str = str(status) if status is not None else ""
+        if status_str in spec.success_values:
+            merged = dict(last_body)
+            if spec.post_success_url:
+                redeem_id = _first(last_body, spec.post_success_id_paths)
+                if redeem_id is not None:
+                    redeem_url = spec.post_success_url.replace("{id}", str(redeem_id))
+                    r2 = client.get(redeem_url, api_key=api_key)
+                    if r2.status_code < 400:
+                        try:
+                            merged["_redeemed"] = r2.json()
+                        except ValueError:
+                            pass
+            urls = _extract_urls(merged)
+            return PollResult(status="succeeded", raw=merged, image_urls=urls)
+        if status_str in spec.failure_values:
+            return PollResult(status="failed", raw=last_body, image_urls=[], error=status_str)
+        _sleep(interval)
+    return PollResult(status="failed", raw=last_body, image_urls=[], error=f"timed out after {timeout:.0f}s")
+
+
+def extract_job_id(name: str, body: dict[str, Any]) -> str | None:
+    """Pull the partner's job id out of a create-response body for display."""
+    if name == "bfl":
+        return body.get("id") or None
+    spec = _POLL_SPECS.get(name)
+    if spec is None:
+        return None
+    v = _first(body, spec.id_paths)
+    return str(v) if v is not None else None
+
+
+def build_synthetic_initial(name: str, job_id: str, base_url: str | None = None) -> dict[str, Any]:
+    """Recreate a minimal create-response so ``poll_generic`` can find the id.
+
+    Used by ``comfy generate resume`` — the user supplies just a partner key
+    and a job id, and we reverse-engineer the shape the poller expects."""
+    if name == "bfl":
+        if not base_url:
+            raise client.ApiError(0, "", "BFL resume needs a base URL to build the polling_url")
+        return {"polling_url": f"{base_url}/proxy/bfl/get_result?id={job_id}"}
+    spec = _POLL_SPECS.get(name)
+    if not spec:
+        raise client.ApiError(0, "", f"No polling adapter for partner {name!r}")
+    primary = spec.id_paths[0]
+    body: dict[str, Any] = {}
+    cur = body
+    parts = primary.split(".")
+    for p in parts[:-1]:
+        cur[p] = {}
+        cur = cur[p]
+    cur[parts[-1]] = job_id
+    return body
+
+
 def get_poller(name: str) -> Callable[..., PollResult]:
-    try:
-        return _POLLERS[name]
-    except KeyError as e:
-        raise client.ApiError(0, "", f"No polling adapter for partner {name!r}") from e
+    """Return the poller callable for a partner name.
+
+    All pollers accept the same kwargs (``api_key``, ``timeout``, ``on_progress``,
+    ``create_path``) so callers don't need to special-case which one they got."""
+    if name == "bfl":
+        return poll_bfl
+    if name in _POLL_SPECS:
+        spec = _POLL_SPECS[name]
+
+        def runner(
+            initial: dict[str, Any],
+            api_key: str,
+            *,
+            create_path: str | None = None,
+            interval: float = 2.0,
+            timeout: float = 300.0,
+            on_progress: Callable[[float], None] | None = None,
+        ) -> PollResult:
+            return poll_generic(
+                initial,
+                api_key,
+                spec=spec,
+                create_path=create_path,
+                interval=interval,
+                timeout=timeout,
+                on_progress=on_progress,
+            )
+
+        return runner
+    raise client.ApiError(0, "", f"No polling adapter for partner {name!r}")
 
 
 def sync_result_from_response(resp: httpx.Response) -> PollResult:
     """Wrap a sync response in a PollResult so the run path is uniform."""
-    if resp.headers.get("content-type", "").startswith("image/"):
+    ctype = resp.headers.get("content-type", "")
+    if ctype.startswith(("image/", "video/", "audio/")):
         return PollResult(status="succeeded", raw={"_binary": True}, image_urls=[])
     try:
         body = resp.json()

--- a/comfy_cli/command/generate/schema.py
+++ b/comfy_cli/command/generate/schema.py
@@ -27,6 +27,7 @@ class FlagDef:
     default: Any = None
     enum: list[str] = field(default_factory=list)
     item_kind: str | None = None  # for arrays: kind of items ("binary", "string", ...)
+    upload_mode: str | None = None  # "base64" | "url" | None — auto-upload behavior for local paths
 
 
 class SchemaError(ValueError):
@@ -59,6 +60,32 @@ def _classify(prop: dict[str, Any]) -> tuple[str, str | None]:
     return "string", None
 
 
+_URL_FIELD_NAMES = frozenset({"input_image", "image_url", "image_uri", "init_image", "reference_image", "mask_url"})
+
+
+def _detect_upload_mode(name: str, prop: dict[str, Any]) -> str | None:
+    """Infer whether this string param expects a base64 blob, a URL, or neither.
+
+    JSON-only endpoints sometimes ship a local file via base64 (BFL Kontext,
+    Flux Fill/Canny/Depth/Expand all say "Base64 encoded image" in their
+    descriptions) and sometimes via a signed URL. We sniff three signals in
+    priority order: openapi ``format``, description keywords, then a small
+    allow-list of common field names."""
+    if prop.get("type") != "string":
+        return None
+    desc = (prop.get("description") or "").lower()
+    fmt = (prop.get("format") or "").lower()
+    if "base64" in desc:
+        return "base64"
+    if fmt in {"uri", "url"}:
+        return "url"
+    if "url" in desc or "uri" in desc:
+        return "url"
+    if name.lower() in _URL_FIELD_NAMES:
+        return "url"
+    return None
+
+
 def flags_for(endpoint: Endpoint) -> list[FlagDef]:
     schema = endpoint.request_schema or {}
     props = schema.get("properties") or {}
@@ -68,6 +95,7 @@ def flags_for(endpoint: Endpoint) -> list[FlagDef]:
         if not isinstance(prop, dict):
             continue
         kind, item_kind = _classify(prop)
+        upload_mode = _detect_upload_mode(name, prop) if kind == "string" else None
         out.append(
             FlagDef(
                 name=name,
@@ -77,6 +105,7 @@ def flags_for(endpoint: Endpoint) -> list[FlagDef]:
                 default=prop.get("default"),
                 enum=list(prop.get("enum") or []),
                 item_kind=item_kind,
+                upload_mode=upload_mode,
             )
         )
     return out

--- a/comfy_cli/command/generate/spec.py
+++ b/comfy_cli/command/generate/spec.py
@@ -11,6 +11,7 @@ inside a single CLI invocation don't re-parse the 30k-line YAML.
 from __future__ import annotations
 
 import os
+import re as _re
 import time
 from dataclasses import dataclass
 from functools import lru_cache
@@ -19,10 +20,27 @@ from typing import Any
 
 import yaml
 
-try:
-    from yaml import CSafeLoader as _YamlLoader
-except ImportError:
-    from yaml import SafeLoader as _YamlLoader  # type: ignore[assignment]
+
+class _YamlLoader(yaml.SafeLoader):
+    """SafeLoader that strips YAML 1.1's bool aliases for ``on``/``off``/
+    ``yes``/``no``/``y``/``n``.
+
+    The vendored openapi uses unquoted ``[on, off]`` and similar as **string**
+    enum values (e.g. Kling's ``sound`` field), but PyYAML's default resolvers
+    promote them to ``True``/``False`` — which then breaks our flag-rendering
+    (`'|'.join` on a list with booleans) and the upstream API contract. Limit
+    bool resolution to the YAML 1.2 spelling (``true``/``false`` only)."""
+
+
+_YamlLoader.yaml_implicit_resolvers = {
+    k: [(t, r) for (t, r) in resolvers if t != "tag:yaml.org,2002:bool"]
+    for k, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+_YamlLoader.add_implicit_resolver(
+    "tag:yaml.org,2002:bool",
+    _re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$"),
+    list("tTfF"),
+)
 
 PROXY_PREFIX = "/proxy/"
 DEFAULT_BASE_URL = "https://api.comfy.org"
@@ -94,6 +112,30 @@ _ALIASES: dict[str, str] = {
     "reve-edit": "reve/v1/image/edit",
     # Runway
     "runway": "runway/text_to_image",
+    # Video — Kling
+    "kling": "kling/v1/videos/text2video",
+    "kling-i2v": "kling/v1/videos/image2video",
+    "kling-extend": "kling/v1/videos/video-extend",
+    "kling-lipsync": "kling/v1/videos/lip-sync",
+    # Video — Luma Dream Machine
+    "luma": "luma/generations",
+    "luma-i2v": "luma/generations/image",
+    # Video — MiniMax / Hailuo
+    "hailuo": "minimax/video_generation",
+    # Video — Runway Gen-3
+    "runway-i2v": "runway/image_to_video",
+    # Video — Moonvalley
+    "moonvalley-t2v": "moonvalley/prompts/text-to-video",
+    "moonvalley-i2v": "moonvalley/prompts/image-to-video",
+    # Video — Pika
+    "pika": "pika/generate/2.2/t2v",
+    "pika-i2v": "pika/generate/2.2/i2v",
+    # Video — Vidu
+    "vidu": "vidu/text2video",
+    "vidu-i2v": "vidu/img2video",
+    "vidu-extend": "vidu/extend",
+    # Video — xAI Grok
+    "grok-video": "xai/v1/videos/generations",
 }
 
 _PREFERRED_ALIAS: dict[str, str] = {v: k for k, v in _ALIASES.items()}
@@ -119,9 +161,10 @@ def resolve_alias(target: str) -> str:
     return target
 
 
-# Curated v1 image allowlist. Tuples of (endpoint_id, category, polling).
+# Curated endpoint allowlist. Tuples of (endpoint_id, category, polling).
+# ``polling`` is the partner-key the poll registry uses (None = sync).
 # Endpoint id is the openapi path with /proxy/ stripped.
-_IMAGE_ALLOWLIST: list[tuple[str, str, str | None]] = [
+_ENDPOINT_ALLOWLIST: list[tuple[str, str, str | None]] = [
     # OpenAI
     ("openai/images/generations", "text-to-image", None),
     ("openai/images/edits", "image-edit", None),
@@ -162,8 +205,32 @@ _IMAGE_ALLOWLIST: list[tuple[str, str, str | None]] = [
     # Reve
     ("reve/v1/image/create", "text-to-image", None),
     ("reve/v1/image/edit", "image-edit", None),
-    # Runway
+    # Runway (image)
     ("runway/text_to_image", "text-to-image", None),
+    # Video — Kling
+    ("kling/v1/videos/text2video", "text-to-video", "kling"),
+    ("kling/v1/videos/image2video", "image-to-video", "kling"),
+    ("kling/v1/videos/video-extend", "video-extend", "kling"),
+    ("kling/v1/videos/lip-sync", "lipsync", "kling"),
+    # Video — Luma
+    ("luma/generations", "text-to-video", "luma"),
+    ("luma/generations/image", "image-to-video", "luma"),
+    # Video — MiniMax / Hailuo
+    ("minimax/video_generation", "text-to-video", "minimax"),
+    # Video — Runway
+    ("runway/image_to_video", "image-to-video", "runway"),
+    # Video — Moonvalley
+    ("moonvalley/prompts/text-to-video", "text-to-video", "moonvalley"),
+    ("moonvalley/prompts/image-to-video", "image-to-video", "moonvalley"),
+    # Video — Pika
+    ("pika/generate/2.2/t2v", "text-to-video", "pika"),
+    ("pika/generate/2.2/i2v", "image-to-video", "pika"),
+    # Video — Vidu
+    ("vidu/text2video", "text-to-video", "vidu"),
+    ("vidu/img2video", "image-to-video", "vidu"),
+    ("vidu/extend", "video-extend", "vidu"),
+    # Video — xAI Grok
+    ("xai/v1/videos/generations", "text-to-video", "xai_video"),
 ]
 
 
@@ -241,7 +308,7 @@ def _registry() -> dict[str, Endpoint]:
     spec = load_raw_spec()
     paths = spec.get("paths") or {}
     registry: dict[str, Endpoint] = {}
-    for endpoint_id, category, polling_hint in _IMAGE_ALLOWLIST:
+    for endpoint_id, category, polling_hint in _ENDPOINT_ALLOWLIST:
         path = PROXY_PREFIX + endpoint_id
         node = paths.get(path)
         if not node:

--- a/comfy_cli/command/generate/upload.py
+++ b/comfy_cli/command/generate/upload.py
@@ -99,7 +99,11 @@ def upload_path(path: Path | str, api_key: str) -> UploadResult:
     p = Path(path).expanduser()
     if not p.is_file():
         raise client.ApiError(0, "", f"File not found: {p}")
-    return upload_bytes(p.read_bytes(), file_name=p.name, api_key=api_key)
+    try:
+        data = p.read_bytes()
+    except OSError as e:
+        raise client.ApiError(0, "", f"Unable to read file: {p} ({e})") from e
+    return upload_bytes(data, file_name=p.name, api_key=api_key)
 
 
 def upload_remote_url(url: str, api_key: str) -> UploadResult:

--- a/comfy_cli/command/generate/upload.py
+++ b/comfy_cli/command/generate/upload.py
@@ -1,0 +1,119 @@
+"""Upload reference assets via ``/customers/storage``.
+
+The cloud endpoint issues short-lived signed URLs:
+
+1. POST ``/customers/storage`` with ``{file_name, content_type, file_hash?}`` →
+   ``{upload_url, download_url, expires_at, existing_file}``.
+2. If ``existing_file`` is true the server already has a hash-match — skip the
+   PUT and reuse ``download_url``. Otherwise PUT the bytes to ``upload_url``
+   with the same ``Content-Type`` header.
+3. ``download_url`` is what downstream model calls reference; it's a signed URL
+   that expires after 24 hours.
+
+This module also exposes a small helper that takes either a local path or a
+remote ``http(s)://`` URL — remote URLs are re-hosted by downloading and then
+running the same flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from comfy_cli.command.generate import client, spec
+
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+
+@dataclass(frozen=True)
+class UploadResult:
+    url: str  # the signed download_url to feed into downstream model calls
+    expires_at: str | None  # ISO 8601 timestamp from the server
+    existing_file: bool  # True when the server returned a hash-match (no upload)
+
+
+def _guess_content_type(name: str) -> str:
+    ctype, _ = mimetypes.guess_type(name)
+    return ctype or _DEFAULT_CONTENT_TYPE
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _request_signed_url(
+    file_name: str,
+    content_type: str,
+    file_hash: str,
+    api_key: str,
+) -> dict:
+    """POST /customers/storage and return the parsed response dict."""
+    url = spec.base_url() + "/customers/storage"
+    body = {"file_name": file_name, "content_type": content_type, "file_hash": file_hash}
+    headers = client._auth_headers(api_key, {"Content-Type": "application/json"})
+    resp = httpx.post(url, json=body, headers=headers, timeout=30.0)
+    client.raise_for_status(resp)
+    return resp.json()
+
+
+def _put_bytes(upload_url: str, data: bytes, content_type: str) -> None:
+    """PUT the raw bytes to the signed URL. No auth header — the URL is signed."""
+    with httpx.Client(timeout=120.0, follow_redirects=False) as c:
+        r = c.put(upload_url, content=data, headers={"Content-Type": content_type})
+        if r.status_code >= 400:
+            raise client.ApiError(r.status_code, r.text, f"Upload to signed URL failed (HTTP {r.status_code})")
+
+
+def upload_bytes(data: bytes, file_name: str, api_key: str, content_type: str | None = None) -> UploadResult:
+    """Upload raw bytes and return the signed download URL. Hash-based dedup is
+    handled transparently — if the server already has these bytes, ``existing_file``
+    is True and no PUT happens."""
+    ctype = content_type or _guess_content_type(file_name)
+    file_hash = _sha256_hex(data)
+    signed = _request_signed_url(file_name=file_name, content_type=ctype, file_hash=file_hash, api_key=api_key)
+    if not signed.get("existing_file"):
+        upload_url = signed.get("upload_url")
+        if not upload_url:
+            raise client.ApiError(0, str(signed), "Server response missing upload_url")
+        _put_bytes(upload_url, data, ctype)
+    download_url = signed.get("download_url")
+    if not download_url:
+        raise client.ApiError(0, str(signed), "Server response missing download_url")
+    return UploadResult(
+        url=download_url,
+        expires_at=signed.get("expires_at"),
+        existing_file=bool(signed.get("existing_file", False)),
+    )
+
+
+def upload_path(path: Path | str, api_key: str) -> UploadResult:
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise client.ApiError(0, "", f"File not found: {p}")
+    return upload_bytes(p.read_bytes(), file_name=p.name, api_key=api_key)
+
+
+def upload_remote_url(url: str, api_key: str) -> UploadResult:
+    """Re-host a remote http(s) URL through /customers/storage so it ends up on
+    Comfy's CDN. Mirrors the genmedia behavior of accepting URLs to `upload`."""
+    with httpx.Client(timeout=60.0, follow_redirects=True) as c:
+        r = c.get(url)
+        r.raise_for_status()
+        data = r.content
+        # Prefer the server's Content-Type; fall back to URL extension.
+        ctype = r.headers.get("content-type", "").split(";", 1)[0].strip() or _guess_content_type(url)
+        # Pick a filename from the URL path, defaulting to a hash-based name.
+        suffix = Path(url.split("?", 1)[0]).name or _sha256_hex(data)[:12]
+    return upload_bytes(data, file_name=suffix, api_key=api_key, content_type=ctype)
+
+
+def upload_target(target: str | Path, api_key: str) -> UploadResult:
+    """Accept either a local file path or a remote URL; return the hosted URL."""
+    s = str(target)
+    if s.startswith(("http://", "https://")):
+        return upload_remote_url(s, api_key=api_key)
+    return upload_path(s, api_key=api_key)

--- a/comfy_cli/command/generate/upload.py
+++ b/comfy_cli/command/generate/upload.py
@@ -57,7 +57,12 @@ def _request_signed_url(
     headers = client._auth_headers(api_key, {"Content-Type": "application/json"})
     resp = httpx.post(url, json=body, headers=headers, timeout=30.0)
     client.raise_for_status(resp)
-    return resp.json()
+    try:
+        return resp.json()
+    except ValueError as e:
+        # Surface the same way other parse errors do — bare ValueError would
+        # leak a traceback into CLI output.
+        raise client.ApiError(resp.status_code, resp.text or str(e), "Storage response was not valid JSON") from e
 
 
 def _put_bytes(upload_url: str, data: bytes, content_type: str) -> None:

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -415,6 +415,151 @@ def test_refresh_network_failure(runner, monkeypatch):
     assert "Failed to fetch" in r.stdout
 
 
+# ─── upload subcommand ──────────────────────────────────────────────────
+
+
+def test_upload_missing_arg(runner, api_key):
+    r = runner.invoke(cli_app, ["generate", "upload"])
+    assert r.exit_code == 1
+    assert "Usage" in r.stdout
+
+
+def test_upload_local_file(runner, api_key, tmp_path, monkeypatch):
+    img = tmp_path / "x.png"
+    img.write_bytes(b"png-data")
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.upload.upload_target",
+        lambda target, api_key: gen_app.upload.UploadResult(
+            url="https://cdn/x.png", expires_at="2099-01-01T00:00:00Z", existing_file=False
+        ),
+    )
+    r = runner.invoke(cli_app, ["generate", "upload", str(img)])
+    assert r.exit_code == 0, r.stdout
+    assert "Uploaded" in r.stdout
+    assert "https://cdn/x.png" in r.stdout
+
+
+def test_upload_json_output(runner, api_key, tmp_path, monkeypatch):
+    img = tmp_path / "x.png"
+    img.write_bytes(b"png-data")
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.upload.upload_target",
+        lambda target, api_key: gen_app.upload.UploadResult(
+            url="https://cdn/x.png", expires_at="2099-01-01T00:00:00Z", existing_file=True
+        ),
+    )
+    r = runner.invoke(cli_app, ["generate", "upload", str(img), "--json"])
+    assert r.exit_code == 0
+    flat = "".join(r.stdout.split())
+    assert '"url":"https://cdn/x.png"' in flat
+    assert '"existing_file":true' in flat
+
+
+def test_upload_propagates_api_error(runner, api_key, tmp_path, monkeypatch):
+    img = tmp_path / "x.png"
+    img.write_bytes(b"png-data")
+
+    def boom(*a, **kw):
+        raise gen_app.client.ApiError(500, "fail", "boom")
+
+    monkeypatch.setattr("comfy_cli.command.generate.upload.upload_target", boom)
+    r = runner.invoke(cli_app, ["generate", "upload", str(img)])
+    assert r.exit_code == 1
+    assert "Upload failed" in r.stdout
+
+
+# ─── auto-upload during generate ────────────────────────────────────────
+
+
+def test_generate_auto_base64_for_kontext(runner, api_key, tmp_path, monkeypatch):
+    """flux-kontext's input_image expects a Base64 string — local files should
+    be auto-encoded with no extra steps."""
+    img = tmp_path / "ref.png"
+    img.write_bytes(b"\x89PNGfake")
+
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None, **_):
+        captured["body"] = json
+        return httpx.Response(200, json={"id": "job-xyz", "polling_url": "https://x/poll"})
+
+    monkeypatch.setattr(gen_app.client.httpx, "post", fake_post)
+    r = runner.invoke(
+        cli_app,
+        ["generate", "flux-kontext", "--prompt", "edit it", "--input_image", str(img), "--async"],
+    )
+    assert r.exit_code == 0, r.stdout
+    import base64 as _b64
+
+    assert captured["body"]["input_image"] == _b64.b64encode(b"\x89PNGfake").decode("ascii")
+
+
+def test_generate_auto_upload_leaves_url_alone(runner, api_key, monkeypatch):
+    """A pre-existing https:// URL must NOT trigger an upload."""
+    upload_called = {"hit": False}
+
+    def fake_upload(*a, **kw):
+        upload_called["hit"] = True
+        return gen_app.upload.UploadResult(url="x", expires_at=None, existing_file=False)
+
+    monkeypatch.setattr("comfy_cli.command.generate.upload.upload_path", fake_upload)
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None, **_):
+        captured["body"] = json
+        return httpx.Response(200, json={"id": "x", "polling_url": "https://x"})
+
+    monkeypatch.setattr(gen_app.client.httpx, "post", fake_post)
+    r = runner.invoke(
+        cli_app,
+        [
+            "generate",
+            "flux-kontext",
+            "--prompt",
+            "x",
+            "--input_image",
+            "https://existing/url.png",
+            "--async",
+        ],
+    )
+    assert r.exit_code == 0
+    assert upload_called["hit"] is False
+    assert captured["body"]["input_image"] == "https://existing/url.png"
+
+
+def test_generate_auto_upload_skipped_for_multipart(runner, api_key, tmp_path, monkeypatch):
+    """Multipart endpoints (ideogram-edit) already stream files via httpx —
+    they must not be funneled through /customers/storage."""
+    img = tmp_path / "x.png"
+    img.write_bytes(b"png")
+
+    upload_called = {"hit": False}
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.upload.upload_path",
+        lambda *a, **kw: upload_called.__setitem__("hit", True) or gen_app.upload.UploadResult("x", None, False),
+    )
+    monkeypatch.setattr(
+        gen_app.client.httpx,
+        "post",
+        lambda *a, **kw: httpx.Response(200, json={"data": [{"url": "https://x/a.png"}]}),
+    )
+    r = runner.invoke(
+        cli_app,
+        [
+            "generate",
+            "ideogram-edit",
+            "--prompt",
+            "x",
+            "--rendering_speed",
+            "TURBO",
+            "--image",
+            str(img),
+        ],
+    )
+    assert r.exit_code == 0
+    assert upload_called["hit"] is False
+
+
 # ─── helpers: _arg_value / _separate_meta_flags ──────────────────────────
 
 

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -578,6 +578,120 @@ def test_generate_auto_upload_skipped_for_multipart(runner, api_key, tmp_path, m
     assert upload_called["hit"] is False
 
 
+# ─── video models (async polling, generic poller path) ─────────────────
+
+
+def test_video_kling_async_path(runner, api_key, monkeypatch):
+    """End-to-end async path through the generic kling poller."""
+    submit = httpx.Response(200, json={"data": {"task_id": "k-xyz"}})
+    finished = httpx.Response(
+        200,
+        json={
+            "data": {
+                "task_status": "succeed",
+                "task_result": {"videos": [{"url": "https://cdn.example/k.mp4"}]},
+            }
+        },
+    )
+    monkeypatch.setattr(gen_app.client.httpx, "post", lambda *a, **kw: submit)
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", lambda *a, **kw: finished)
+    monkeypatch.setattr("comfy_cli.command.generate.poll._sleep", lambda *_: None)
+
+    r = runner.invoke(cli_app, ["generate", "kling", "--prompt", "a cat", "--duration", "5"])
+    assert r.exit_code == 0, r.stdout
+    assert "https://cdn.example/k.mp4" in r.stdout
+
+
+def test_video_luma_async_path(runner, api_key, monkeypatch):
+    submit = httpx.Response(200, json={"id": "luma-1", "state": "queued"})
+    done = httpx.Response(200, json={"id": "luma-1", "state": "completed", "assets": {"video": "https://cdn/l.mp4"}})
+    monkeypatch.setattr(gen_app.client.httpx, "post", lambda *a, **kw: submit)
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", lambda *a, **kw: done)
+    monkeypatch.setattr("comfy_cli.command.generate.poll._sleep", lambda *_: None)
+
+    r = runner.invoke(
+        cli_app,
+        [
+            "generate",
+            "luma",
+            "--prompt",
+            "a cat",
+            "--aspect_ratio",
+            "16:9",
+            "--model",
+            "ray-2",
+            "--resolution",
+            "{}",
+            "--duration",
+            "{}",
+        ],
+    )
+    assert r.exit_code == 0, r.stdout
+    assert "https://cdn/l.mp4" in r.stdout
+
+
+def test_video_runway_failure_surfaces(runner, api_key, monkeypatch):
+    submit = httpx.Response(200, json={"id": "rw-1"})
+    fail = httpx.Response(200, json={"id": "rw-1", "status": "FAILED"})
+    monkeypatch.setattr(gen_app.client.httpx, "post", lambda *a, **kw: submit)
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", lambda *a, **kw: fail)
+    monkeypatch.setattr("comfy_cli.command.generate.poll._sleep", lambda *_: None)
+
+    r = runner.invoke(
+        cli_app,
+        [
+            "generate",
+            "runway-i2v",
+            "--promptImage",
+            '"https://x/img.png"',
+            "--seed",
+            "1",
+            "--model",
+            "gen4_turbo",
+            "--duration",
+            "5",
+            "--ratio",
+            "1280:720",
+        ],
+    )
+    assert r.exit_code == 1
+    assert "FAILED" in r.stdout
+
+
+def test_video_async_submission_shows_resume_alias(runner, api_key, monkeypatch):
+    submit = httpx.Response(200, json={"data": {"task_id": "k-async-1"}})
+    monkeypatch.setattr(gen_app.client.httpx, "post", lambda *a, **kw: submit)
+    r = runner.invoke(cli_app, ["generate", "kling", "--prompt", "x", "--async"])
+    assert r.exit_code == 0, r.stdout
+    assert "k-async-1" in r.stdout
+    assert "comfy generate resume kling k-async-1" in r.stdout
+
+
+def test_video_resume_kling(runner, api_key, monkeypatch):
+    done = httpx.Response(
+        200,
+        json={
+            "data": {
+                "task_status": "succeed",
+                "task_result": {"videos": [{"url": "https://cdn/resumed.mp4"}]},
+            }
+        },
+    )
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", lambda *a, **kw: done)
+    monkeypatch.setattr("comfy_cli.command.generate.poll._sleep", lambda *_: None)
+    r = runner.invoke(cli_app, ["generate", "resume", "kling", "k-async-1"])
+    assert r.exit_code == 0, r.stdout
+    assert "https://cdn/resumed.mp4" in r.stdout
+
+
+def test_list_video_filter(runner):
+    r = runner.invoke(cli_app, ["generate", "list", "--style", "text-to-video"])
+    assert r.exit_code == 0
+    assert "kling" in r.stdout
+    assert "luma" in r.stdout
+    assert "pika" in r.stdout
+
+
 # ─── helpers: _arg_value / _separate_meta_flags ──────────────────────────
 
 

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -4,6 +4,7 @@ These cover the dispatch table (list/schema/refresh/resume vs. model alias) and
 each major run path with httpx mocked at the boundary.
 """
 
+import base64
 from pathlib import Path
 
 import httpx
@@ -455,6 +456,25 @@ def test_upload_json_output(runner, api_key, tmp_path, monkeypatch):
     assert '"existing_file":true' in flat
 
 
+def test_upload_does_not_mistake_meta_value_for_target(runner, monkeypatch, tmp_path):
+    """`upload --api-key KEY ./img.png` must resolve ./img.png as the target,
+    not KEY — regression check for the positional parsing bug."""
+    img = tmp_path / "x.png"
+    img.write_bytes(b"png-data")
+    captured = {}
+
+    def fake_upload(target, api_key):
+        captured["target"] = target
+        captured["api_key"] = api_key
+        return gen_app.upload.UploadResult(url="https://cdn/x.png", expires_at=None, existing_file=False)
+
+    monkeypatch.setattr("comfy_cli.command.generate.upload.upload_target", fake_upload)
+    r = runner.invoke(cli_app, ["generate", "upload", "--api-key", "comfyui-test", str(img)])
+    assert r.exit_code == 0, r.stdout
+    assert captured["target"] == str(img)
+    assert captured["api_key"] == "comfyui-test"
+
+
 def test_upload_propagates_api_error(runner, api_key, tmp_path, monkeypatch):
     img = tmp_path / "x.png"
     img.write_bytes(b"png-data")
@@ -489,9 +509,7 @@ def test_generate_auto_base64_for_kontext(runner, api_key, tmp_path, monkeypatch
         ["generate", "flux-kontext", "--prompt", "edit it", "--input_image", str(img), "--async"],
     )
     assert r.exit_code == 0, r.stdout
-    import base64 as _b64
-
-    assert captured["body"]["input_image"] == _b64.b64encode(b"\x89PNGfake").decode("ascii")
+    assert captured["body"]["input_image"] == base64.b64encode(b"\x89PNGfake").decode("ascii")
 
 
 def test_generate_auto_upload_leaves_url_alone(runner, api_key, monkeypatch):

--- a/tests/comfy_cli/command/generate/test_upload.py
+++ b/tests/comfy_cli/command/generate/test_upload.py
@@ -1,6 +1,5 @@
 """Tests for /customers/storage upload helpers."""
 
-
 import httpx
 import pytest
 

--- a/tests/comfy_cli/command/generate/test_upload.py
+++ b/tests/comfy_cli/command/generate/test_upload.py
@@ -1,0 +1,164 @@
+"""Tests for /customers/storage upload helpers."""
+
+
+import httpx
+import pytest
+
+from comfy_cli.command.generate import client, upload
+
+
+def test_request_signed_url_posts_hash(monkeypatch):
+    captured = {}
+
+    def fake_post(url, *, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return httpx.Response(
+            200,
+            json={
+                "upload_url": "https://signed/up",
+                "download_url": "https://signed/down",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "existing_file": False,
+            },
+        )
+
+    monkeypatch.setattr(upload.httpx, "post", fake_post)
+    body = upload._request_signed_url("cat.png", "image/png", "deadbeef", "comfyui-test")
+    assert body["upload_url"] == "https://signed/up"
+    assert captured["json"] == {"file_name": "cat.png", "content_type": "image/png", "file_hash": "deadbeef"}
+    assert captured["headers"]["X-API-Key"] == "comfyui-test"
+    assert captured["headers"]["X-Comfy-Env"] == "comfy-cli"
+    assert captured["url"].endswith("/customers/storage")
+
+
+def test_upload_bytes_dedupe_skips_put(monkeypatch):
+    monkeypatch.setattr(
+        upload,
+        "_request_signed_url",
+        lambda **kw: {
+            "download_url": "https://cached/x.png",
+            "existing_file": True,
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    )
+    called = {"put": False}
+
+    def boom(*a, **kw):
+        called["put"] = True
+
+    monkeypatch.setattr(upload, "_put_bytes", boom)
+    result = upload.upload_bytes(b"hello", "x.png", "comfyui-test")
+    assert result.url == "https://cached/x.png"
+    assert result.existing_file is True
+    assert called["put"] is False
+
+
+def test_upload_bytes_new_file_puts(monkeypatch):
+    monkeypatch.setattr(
+        upload,
+        "_request_signed_url",
+        lambda **kw: {
+            "upload_url": "https://signed/up",
+            "download_url": "https://signed/down",
+            "existing_file": False,
+            "expires_at": None,
+        },
+    )
+    captured = {}
+
+    def fake_put(upload_url, data, content_type):
+        captured["upload_url"] = upload_url
+        captured["data"] = data
+        captured["content_type"] = content_type
+
+    monkeypatch.setattr(upload, "_put_bytes", fake_put)
+    result = upload.upload_bytes(b"raw-bytes", "cat.png", "comfyui-test")
+    assert result.url == "https://signed/down"
+    assert result.existing_file is False
+    assert captured["data"] == b"raw-bytes"
+    assert captured["content_type"] == "image/png"
+
+
+def test_upload_path_reads_file(monkeypatch, tmp_path):
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"jpeg-bytes")
+    called = {}
+
+    def fake_upload_bytes(data, file_name, api_key, content_type=None):
+        called["data"] = data
+        called["file_name"] = file_name
+        called["content_type"] = content_type
+        return upload.UploadResult(url="https://x/a", expires_at=None, existing_file=False)
+
+    monkeypatch.setattr(upload, "upload_bytes", fake_upload_bytes)
+    upload.upload_path(img, "comfyui-test")
+    assert called["data"] == b"jpeg-bytes"
+    assert called["file_name"] == "x.jpg"
+
+
+def test_upload_path_missing_file(tmp_path):
+    with pytest.raises(client.ApiError, match="not found"):
+        upload.upload_path(tmp_path / "nope.png", "comfyui-test")
+
+
+def test_upload_remote_url_rehosts(monkeypatch):
+    monkeypatch.setattr(
+        upload,
+        "upload_bytes",
+        lambda data, file_name, api_key, content_type=None: upload.UploadResult(
+            url=f"https://rehosted/{file_name}", expires_at=None, existing_file=False
+        ),
+    )
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def get(self, url):
+            return httpx.Response(
+                200,
+                content=b"png-bytes",
+                headers={"content-type": "image/png"},
+                request=httpx.Request("GET", url),
+            )
+
+    monkeypatch.setattr(upload.httpx, "Client", FakeClient)
+    result = upload.upload_remote_url("https://example.com/photo.png", "comfyui-test")
+    assert result.url == "https://rehosted/photo.png"
+
+
+def test_upload_target_dispatches_on_scheme(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(upload, "upload_path", lambda p, api_key: called.setdefault("path", p))
+    monkeypatch.setattr(upload, "upload_remote_url", lambda u, api_key: called.setdefault("url", u))
+    upload.upload_target("https://example.com/x.png", "k")
+    upload.upload_target("/tmp/x.png", "k")
+    assert called["url"] == "https://example.com/x.png"
+    assert called["path"] == "/tmp/x.png"
+
+
+def test_put_bytes_raises_on_error(monkeypatch):
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def put(self, *a, **kw):
+            return httpx.Response(500, text="boom", request=httpx.Request("PUT", "https://x"))
+
+    monkeypatch.setattr(upload.httpx, "Client", FakeClient)
+    with pytest.raises(client.ApiError, match="HTTP 500"):
+        upload._put_bytes("https://x", b"data", "image/png")

--- a/tests/comfy_cli/command/generate/test_video_poll.py
+++ b/tests/comfy_cli/command/generate/test_video_poll.py
@@ -1,0 +1,202 @@
+"""Tests for the generic config-driven poller and per-partner specs."""
+
+import httpx
+import pytest
+
+from comfy_cli.command.generate import poll
+
+
+def _resp(body):
+    return httpx.Response(200, json=body)
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    monkeypatch.setattr(poll, "_sleep", lambda *_: None)
+
+
+def _make_runner(get_responses):
+    """Patch client.get with an iterator over fake responses."""
+    it = iter(get_responses)
+    return lambda *_a, **_kw: next(it)
+
+
+def test_kling_sibling_poll_path(no_sleep, monkeypatch):
+    """Kling builds the poll URL from {create_path}/{id}."""
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        return _resp({"data": {"task_status": "succeed", "task_result": {"videos": [{"url": "https://cdn/v.mp4"}]}}})
+
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", fake_get)
+    poller = poll.get_poller("kling")
+    result = poller(
+        {"data": {"task_id": "abc"}},
+        api_key="comfyui-test",
+        create_path="/proxy/kling/v1/videos/text2video",
+    )
+    assert captured["url"] == "/proxy/kling/v1/videos/text2video/abc"
+    assert result.status == "succeeded"
+    assert result.image_urls == ["https://cdn/v.mp4"]
+
+
+def test_luma_succeeds(no_sleep, monkeypatch):
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.client.get",
+        _make_runner(
+            [
+                _resp({"id": "luma-1", "state": "dreaming"}),
+                _resp({"id": "luma-1", "state": "completed", "assets": {"video": "https://cdn/x.mp4"}}),
+            ]
+        ),
+    )
+    result = poll.get_poller("luma")({"id": "luma-1", "state": "queued"}, api_key="k")
+    assert result.status == "succeeded"
+    assert "https://cdn/x.mp4" in result.image_urls
+
+
+def test_runway_progress_normalized(no_sleep, monkeypatch):
+    """Runway reports progress as 0–1 floats — the poller forwards as-is."""
+    seen: list[float] = []
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.client.get",
+        _make_runner(
+            [
+                _resp({"id": "x", "status": "RUNNING", "progress": 0.5}),
+                _resp({"id": "x", "status": "SUCCEEDED", "output": ["https://cdn/v.mp4"]}),
+            ]
+        ),
+    )
+    poll.get_poller("runway")({"id": "x"}, api_key="k", on_progress=seen.append)
+    assert seen == [0.5]
+
+
+def test_runway_failure_states(no_sleep, monkeypatch):
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.client.get",
+        _make_runner([_resp({"id": "x", "status": "CANCELLED"})]),
+    )
+    result = poll.get_poller("runway")({"id": "x"}, api_key="k")
+    assert result.status == "failed"
+    assert "CANCELLED" in (result.error or "")
+
+
+def test_minimax_redeems_file_id(no_sleep, monkeypatch):
+    """After Success, minimax needs a second GET to /files/retrieve to get the download URL."""
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.client.get",
+        _make_runner(
+            [
+                _resp({"status": "Processing", "task_id": "t1"}),
+                _resp({"status": "Success", "task_id": "t1", "file_id": "f-42"}),
+                _resp({"file": {"download_url": "https://cdn/minimax.mp4"}}),
+            ]
+        ),
+    )
+    result = poll.get_poller("minimax")({"task_id": "t1"}, api_key="k")
+    assert result.status == "succeeded"
+    assert "https://cdn/minimax.mp4" in result.image_urls
+
+
+def test_pika_polls_videos_endpoint(no_sleep, monkeypatch):
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        return _resp({"id": "v1", "status": "finished", "url": "https://cdn/p.mp4"})
+
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", fake_get)
+    result = poll.get_poller("pika")({"video_id": "v1"}, api_key="k")
+    assert captured["url"] == "/proxy/pika/videos/v1"
+    assert result.status == "succeeded"
+
+
+def test_vidu_polls_creations_path(no_sleep, monkeypatch):
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        return _resp({"state": "success", "creations": [{"url": "https://cdn/vidu.mp4"}]})
+
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", fake_get)
+    poll.get_poller("vidu")({"task_id": "t1"}, api_key="k")
+    assert captured["url"] == "/proxy/vidu/tasks/t1/creations"
+
+
+def test_xai_video_polls_request_id(no_sleep, monkeypatch):
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        return _resp({"status": "done", "video": {"url": "https://cdn/x.mp4"}})
+
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", fake_get)
+    poll.get_poller("xai_video")({"request_id": "req-1"}, api_key="k")
+    assert captured["url"] == "/proxy/xai/v1/videos/req-1"
+
+
+def test_moonvalley_polls_prompts(no_sleep, monkeypatch):
+    captured = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        return _resp({"id": "p-1", "status": "completed", "output_url": "https://cdn/m.mp4"})
+
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", fake_get)
+    poll.get_poller("moonvalley")({"id": "p-1"}, api_key="k")
+    assert captured["url"] == "/proxy/moonvalley/prompts/p-1"
+
+
+def test_missing_id_raises(monkeypatch):
+    monkeypatch.setattr("comfy_cli.command.generate.client.get", lambda *a, **kw: _resp({}))
+    with pytest.raises(Exception, match="missing id"):
+        poll.get_poller("kling")({}, api_key="k", create_path="/x")
+
+
+def test_kling_without_create_path_raises():
+    with pytest.raises(Exception, match="create path"):
+        poll.get_poller("kling")({"data": {"task_id": "abc"}}, api_key="k")
+
+
+def test_build_synthetic_initial_for_each_partner():
+    """Sanity-check the resume helper for every registered partner."""
+    for name in ("kling", "luma", "minimax", "runway", "moonvalley", "pika", "vidu", "xai_video"):
+        body = poll.build_synthetic_initial(name, "abc")
+        assert poll.extract_job_id(name, body) == "abc", name
+
+
+def test_build_synthetic_initial_for_bfl():
+    body = poll.build_synthetic_initial("bfl", "abc", base_url="https://api.comfy.org")
+    assert "polling_url" in body
+    assert "abc" in body["polling_url"]
+
+
+def test_extract_urls_recognizes_video_extensions():
+    found = poll._extract_urls({"video_url": "https://cdn/x.mp4", "ignore": "https://cdn/notmedia"})
+    assert "https://cdn/x.mp4" in found
+    assert "https://cdn/notmedia" not in found
+
+
+def test_extract_urls_recognizes_query_strings():
+    """Signed URLs with ?Expires=… shouldn't be excluded by their query string."""
+    found = poll._extract_urls({"url": "https://cdn/v.mp4?Expires=123&Signature=abc"})
+    assert found == ["https://cdn/v.mp4?Expires=123&Signature=abc"]
+
+
+def test_extract_job_id_from_nested_paths():
+    assert poll.extract_job_id("kling", {"data": {"task_id": "k1"}}) == "k1"
+    assert poll.extract_job_id("luma", {"id": "l1"}) == "l1"
+    assert poll.extract_job_id("minimax", {"task_id": "m1"}) == "m1"
+    assert poll.extract_job_id("xai_video", {"request_id": "x1"}) == "x1"
+
+
+def test_existing_bfl_poller_still_works(no_sleep, monkeypatch):
+    """Regression: the original BFL adapter shouldn't be disturbed by the refactor."""
+    monkeypatch.setattr(
+        "comfy_cli.command.generate.client.get",
+        _make_runner([_resp({"status": "Ready", "result": {"sample": "https://cdn/b.png"}})]),
+    )
+    result = poll.get_poller("bfl")({"polling_url": "https://x"}, api_key="k")
+    assert result.status == "succeeded"
+    assert "https://cdn/b.png" in result.image_urls


### PR DESCRIPTION
## Summary

- Adds `comfy generate upload <file-or-url>` — uploads a local file (or rehosts a remote URL) through `/customers/storage`, returns the 24h signed URL. Server-side hash dedup is honored (skips the PUT when the file is already cached).
- Auto-transforms a local path passed to `comfy generate <model>` when the underlying partner field expects either a base64 string (BFL Kontext / Flux Fill / Canny / Depth / Expand — detected via openapi description) or a URL (detected via `format: uri`, description keywords, or a small allowlist of common field names like `input_image`/`image_url`). Multipart endpoints are left alone — they already stream files natively.
- README: new `Calling partner nodes (\`comfy generate\`)` section that points at docs.comfy.org for API key creation, partner-node pricing, and credits.

## Test plan

- [x] `pytest tests/comfy_cli/command/generate/` — 89 tests pass; new test file covers signed-URL request shape, hash-dedup short-circuit, byte-stream PUT, missing file, remote rehosting, and the upload/generate dispatch
- [x] `ruff format --check` and `ruff check` clean
- [x] Live: `comfy generate upload ./flux-out.png` returns a working signed GCS URL
- [x] Live: `comfy generate flux-kontext --prompt "add a top hat" --input_image ./flux-out.png --download out.png` — local path is auto-base64-encoded and the kontext edit completes successfully
- [ ] Live URL-mode auto-upload on a partner that takes `format: uri` (once we wire one up; the v1 image allowlist is base64-heavy)