### PR TITLE
chore(generate): rename X-Comfy-Env header to Comfy-Env

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -305,7 +305,7 @@ def _refresh() -> None:
     url = spec.base_url() + "/openapi.yml"
     try:
         with httpx.Client(timeout=30.0, follow_redirects=True) as cli:
-            r = cli.get(url, headers={"X-Comfy-Env": "comfy-cli", "User-Agent": "comfy-cli/api"})
+            r = cli.get(url, headers={"Comfy-Env": "comfy-cli", "User-Agent": "comfy-cli/api"})
             r.raise_for_status()
     except httpx.HTTPError as e:
         rprint(f"[bold red]Failed to fetch {url}: {e}[/bold red]")

--- a/comfy_cli/command/generate/client.py
+++ b/comfy_cli/command/generate/client.py
@@ -85,7 +85,7 @@ def _auth_headers(api_key: str, extra: dict[str, str] | None = None) -> dict[str
     #   - "comfyui-..." API keys → X-API-Key (validated by sha256 lookup)
     #   - Firebase ID tokens     → Authorization: Bearer (validated as a JWT)
     # See comfy-api server/middleware/authentication/comfy_firebase_auth.go.
-    headers = {"User-Agent": "comfy-cli/api", "X-Comfy-Env": "comfy-cli"}
+    headers = {"User-Agent": "comfy-cli/api", "Comfy-Env": "comfy-cli"}
     if api_key.startswith("comfyui-"):
         headers["X-API-Key"] = api_key
     else:

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -393,7 +393,7 @@ def test_refresh_writes_cache(runner, monkeypatch, tmp_path):
     assert r.exit_code == 0, r.stdout
     assert "Refreshed" in r.stdout
     assert (tmp_path / "openapi-cache.yml").exists()
-    assert captured["headers"].get("X-Comfy-Env") == "comfy-cli"
+    assert captured["headers"].get("Comfy-Env") == "comfy-cli"
 
 
 def test_refresh_network_failure(runner, monkeypatch):

--- a/tests/comfy_cli/command/generate/test_client.py
+++ b/tests/comfy_cli/command/generate/test_client.py
@@ -74,7 +74,7 @@ def test_send_request_uses_x_api_key_for_comfyui_keys(monkeypatch):
     client.send_request(ep, {"prompt": "x", "width": 1, "height": 1}, flags, api_key="comfyui-abc")
     assert captured["headers"]["X-API-Key"] == "comfyui-abc"
     assert "Authorization" not in captured["headers"]
-    assert captured["headers"]["X-Comfy-Env"] == "comfy-cli"
+    assert captured["headers"]["Comfy-Env"] == "comfy-cli"
 
 
 def test_send_request_uses_bearer_for_firebase_tokens(monkeypatch):

--- a/tests/comfy_cli/command/generate/test_upload.py
+++ b/tests/comfy_cli/command/generate/test_upload.py
@@ -28,7 +28,7 @@ def test_request_signed_url_posts_hash(monkeypatch):
     assert body["upload_url"] == "https://signed/up"
     assert captured["json"] == {"file_name": "cat.png", "content_type": "image/png", "file_hash": "deadbeef"}
     assert captured["headers"]["X-API-Key"] == "comfyui-test"
-    assert captured["headers"]["X-Comfy-Env"] == "comfy-cli"
+    assert captured["headers"]["Comfy-Env"] == "comfy-cli"
     assert captured["url"].endswith("/customers/storage")
 
 


### PR DESCRIPTION
Renames the partner-node request header from `X-Comfy-Env` to `Comfy-Env`. Updates both call sites (`client._auth_headers`, `app._refresh`) and the three tests that assert on it.