### PR TITLE
fix(generate): include bundled openapi.yml in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ scripts.comfycli = "comfy_cli.__main__:main"
 where = [ "." ]
 include = [ "comfy_cli*" ]
 
+[tool.setuptools.package-data]
+"comfy_cli.command.generate.spec" = [ "openapi.yml" ]
+
 [tool.ruff]
 target-version = "py310"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ where = [ "." ]
 include = [ "comfy_cli*" ]
 
 [tool.setuptools.package-data]
-"comfy_cli.command.generate.spec" = [ "openapi.yml" ]
+"comfy_cli.command.generate" = [ "spec/openapi.yml" ]
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
## Summary
- Add `[tool.setuptools.package-data]` entry so `comfy_cli/command/generate/spec/openapi.yml` is included in built wheels.
- Without this, installed packages fail with `SpecError: openapi.yml not found` on any `comfy generate` invocation.

## Test plan
- [ ] Build wheel and confirm `openapi.yml` is present under `comfy_cli/command/generate/spec/`.
- [ ] Install wheel into a clean env and run `comfy generate list`.