### PR TITLE
Add ROCm 7.2 support and default to it

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -450,7 +450,7 @@ def install(
         ),
     ] = None,
     cuda_version: Annotated[CUDAVersion | None, typer.Option(show_default=False)] = None,
-    rocm_version: Annotated[ROCmVersion, typer.Option(show_default=True)] = ROCmVersion.v6_3,
+    rocm_version: Annotated[ROCmVersion, typer.Option(show_default=True)] = ROCmVersion.v7_2,
     amd: Annotated[
         bool | None,
         typer.Option(

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -51,7 +51,7 @@ def pip_install_comfyui_dependencies(
     skip_torch_or_directml: bool,
     skip_requirement: bool,
     python: str = sys.executable,
-    rocm_version: constants.ROCmVersion = constants.ROCmVersion.v6_3,
+    rocm_version: constants.ROCmVersion = constants.ROCmVersion.v7_2,
     cuda_tag: str | None = None,
 ):
     os.chdir(repo_dir)
@@ -153,7 +153,7 @@ def execute(
     gpu: constants.GPU_OPTION | None = None,
     cuda_version: constants.CUDAVersion | None = None,
     cuda_tag: str | None = None,
-    rocm_version: constants.ROCmVersion = constants.ROCmVersion.v6_3,
+    rocm_version: constants.ROCmVersion = constants.ROCmVersion.v7_2,
     plat: constants.OS = None,
     skip_torch_or_directml: bool = False,
     skip_requirement: bool = False,

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -89,6 +89,7 @@ class CUDAVersion(str, Enum):
 
 
 class ROCmVersion(str, Enum):
+    v7_2 = "7.2"
     v7_1 = "7.1"
     v7_0 = "7.0"
     v6_3 = "6.3"

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -122,11 +122,11 @@ def parse_req_file(rf: PathLike, skips: list[str] | None = None):
 
 class DependencyCompiler:
     cpuPytorchUrl = "https://download.pytorch.org/whl/cpu"
-    rocmPytorchUrl = "https://download.pytorch.org/whl/rocm6.3"
+    rocmPytorchUrl = "https://download.pytorch.org/whl/rocm7.2"
     nvidiaPytorchUrl = "https://download.pytorch.org/whl/cu126"
 
     cpuTorchBackend = "cpu"
-    rocmTorchBackend = "rocm6.3"
+    rocmTorchBackend = "rocm7.2"
     nvidiaTorchBackend = "cu126"
 
     overrideGpu = dedent(

--- a/tests/comfy_cli/test_install_python_resolution.py
+++ b/tests/comfy_cli/test_install_python_resolution.py
@@ -283,6 +283,7 @@ class TestTorchInstallCommands:
     @pytest.mark.parametrize(
         "rocm_version,expected_url",
         [
+            (constants.ROCmVersion.v7_2, "https://download.pytorch.org/whl/rocm7.2"),
             (constants.ROCmVersion.v7_1, "https://download.pytorch.org/whl/rocm7.1"),
             (constants.ROCmVersion.v7_0, "https://download.pytorch.org/whl/rocm7.0"),
             (constants.ROCmVersion.v6_3, "https://download.pytorch.org/whl/rocm6.3"),

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -89,7 +89,7 @@ def test_torch_backend_nvidia():
 
 def test_torch_backend_amd():
     depComp = DependencyCompiler(cwd=temp, gpu=GPU_OPTION.AMD, outDir=temp, reqFilesCore=[], reqFilesExt=[])
-    assert depComp.torchBackend == "rocm6.3"
+    assert depComp.torchBackend == "rocm7.2"
     assert depComp.gpuUrl == DependencyCompiler.rocmPytorchUrl
 
 


### PR DESCRIPTION
Closes #472.

`comfy install --gpu amd` currently defaults to ROCm 6.3, and the `ROCmVersion` enum stops at 7.1, so there's no way to pull the current ROCm 7.2 PyTorch wheels. PyTorch now ships ROCm 7.2 wheels at `https://download.pytorch.org/whl/rocm7.2`, so this adds `7.2` to the enum and makes it the default. Follows the same shape as #379 (which added the flag and bumped the default 6.1 → 6.3), including the test updates.

### Changes
- `constants.py`: add `v7_2 = "7.2"` to `ROCmVersion`.
- `cmdline.py` / `command/install.py`: bump default `rocm_version` `v6_3` → `v7_2`.
- `uv.py`: bump `rocmPytorchUrl` and `rocmTorchBackend` `rocm6.3` → `rocm7.2`.
- `tests/uv/test_uv.py`: `test_torch_backend_amd` now expects the `rocm7.2` default backend.
- `tests/comfy_cli/test_install_python_resolution.py`: add the `7.2 → whl/rocm7.2` case to the parametrized URL test.

Users can still pin an older build with `--rocm-version 7.1` (or 6.x).

### Why bumping the default is safe for older cards
The ROCm 7.2 wheel is built for a wide arch list, so RDNA2/older cards stay covered, not just RDNA3/4: gfx900, gfx906, gfx908, gfx90a, gfx942, gfx950, gfx1030, gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1200, gfx1201


### Tested
Verified `torch 2.12.1+rocm7.2` installs and initializes from the rocm7.2 index on two AMD systems:

| GPU | Arch | ROCm | torch | `cuda.is_available()` |
|-----|------|------|-------|-----------------------|
| AMD Radeon AI PRO R9700 | gfx1201 (RDNA4) | 7.2.0 | 2.12.1+rocm7.2 | True |
| Radeon 8060S / Ryzen AI Max+ 395 (Strix Halo) | gfx1151 (RDNA3.5) | 7.2.1 | 2.12.1+rocm7.2 | True |

Unit tests pass locally: `pytest tests/uv/test_uv.py tests/comfy_cli/test_install_python_resolution.py` → 61 passed.
