### PR TITLE
refactor: add where.resolve_default() to centralize where_default config read (BE-2142)

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -1370,14 +1370,9 @@ def _is_cloud(where: str | None) -> bool:
     for ``jobs ls/status/watch``.
     """
     from comfy_cli import where as where_module
-    from comfy_cli.config_manager import ConfigManager
 
     try:
-        config_value = ConfigManager().get(where_module.CONFIG_KEY_WHERE_DEFAULT)
-    except Exception:  # noqa: BLE001 — never let a bad config break routing
-        config_value = None
-    try:
-        decision = where_module.resolve(flag=where, config_value=config_value)
+        decision = where_module.resolve_default(flag=where)
     except ValueError:
         # Invalid value — fall back to local; the validating command
         # (cmdline.py top-level option) will surface ``where_invalid``.

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -40,17 +40,10 @@ def _resolved_where(where: str | None) -> str:
 
     # Mirror comfy_cli.target.resolve_target()'s defensive fallback: a corrupt
     # config must not take the whole `comfy nodes *` surface down with a
-    # traceback before the structured renderer ever runs.
-    config_value: str | None = None
+    # traceback before the structured renderer ever runs (resolve_default reads
+    # the persisted where_default defensively for the same reason).
     try:
-        from comfy_cli.config_manager import ConfigManager
-
-        config_value = ConfigManager().get(where_module.CONFIG_KEY_WHERE_DEFAULT)
-    except Exception:  # noqa: BLE001 — never break routing on a bad config
-        config_value = None
-
-    try:
-        decision = where_module.resolve(flag=where, config_value=config_value)
+        decision = where_module.resolve_default(flag=where)
     except ValueError:
         # An invalid persisted where_default shouldn't be fatal; fall back to
         # the flag (if valid) or auto-detect with the bad config value dropped.

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -92,12 +92,8 @@ def _get_graph(input_path: str | None, host: str | None, port: int | None, on_st
             return Graph.load(input_path=input_path, host=host or "127.0.0.1", port=port or 8188)
         # Live fetch: resolve mode from global routing chain, then use resilient loader.
         from comfy_cli import where as where_module
-        from comfy_cli.config_manager import ConfigManager
 
-        decision = where_module.resolve(
-            flag=None,
-            config_value=ConfigManager().get(where_module.CONFIG_KEY_WHERE_DEFAULT),
-        )
+        decision = where_module.resolve_default()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
         from comfy_cli.cql.loader import resilient_load_object_info
 

--- a/comfy_cli/command/workflow_fragments.py
+++ b/comfy_cli/command/workflow_fragments.py
@@ -329,12 +329,9 @@ def _load_object_info(renderer, *, input_path: str | None, host: str | None, por
             p = Path(input_path).expanduser()
             return json.loads(p.read_text(encoding="utf-8"))
         from comfy_cli import where as where_module
-        from comfy_cli.config_manager import ConfigManager
         from comfy_cli.cql.loader import resilient_load_object_info
 
-        decision = where_module.resolve(
-            flag=None, config_value=ConfigManager().get(where_module.CONFIG_KEY_WHERE_DEFAULT)
-        )
+        decision = where_module.resolve_default()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
         return resilient_load_object_info(mode=mode, host=host or "127.0.0.1", port=port or 8188)
     except (OSError, json.JSONDecodeError) as e:

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -77,6 +77,30 @@ def resolve(
     return WhereResolution(target=WhereTarget.LOCAL, source="default")
 
 
+def resolve_default(
+    flag: str | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    project_value: str | None = _UNSET,
+) -> WhereResolution:
+    """``resolve()`` with the persisted ``where_default`` config read for you.
+
+    Convenience for the common call site that just wants routing resolved
+    against the config file: it looks up ``CONFIG_KEY_WHERE_DEFAULT`` internally
+    (defensively — a broken config never breaks routing, it just drops to the
+    next precedence source) and forwards everything to :func:`resolve`. Callers
+    keep their own error handling for the ``ValueError`` a bad ``flag``/env/
+    project/config value raises, and their own shaping of the result.
+    """
+    from comfy_cli.config_manager import ConfigManager
+
+    try:
+        config_value = ConfigManager().get(CONFIG_KEY_WHERE_DEFAULT)
+    except Exception:  # noqa: BLE001 — never let a bad config break routing
+        config_value = None
+    return resolve(flag=flag, env=env, config_value=config_value, project_value=project_value)
+
+
 def _project_where_default() -> str | None:
     """``defaults.where`` from the project/1 ``comfy.yaml`` governing cwd, if
     any. Discovery itself never raises (see :mod:`comfy_cli.project`); a

--- a/tests/comfy_cli/auth/test_where.py
+++ b/tests/comfy_cli/auth/test_where.py
@@ -45,6 +45,61 @@ def test_resolve_invalid_raises():
 
 
 # ---------------------------------------------------------------------------
+# resolve_default: reads the persisted where_default config key for the caller
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfigManager:
+    """Stand-in for ConfigManager whose ``get`` behaviour is programmable."""
+
+    _value: str | None = None
+    _raise: bool = False
+
+    def get(self, key):
+        assert key == where_module.CONFIG_KEY_WHERE_DEFAULT
+        if self._raise:
+            raise RuntimeError("corrupt config")
+        return self._value
+
+
+@pytest.fixture
+def fake_config(monkeypatch):
+    import comfy_cli.config_manager as cm
+
+    monkeypatch.setattr(cm, "ConfigManager", _FakeConfigManager)
+    return _FakeConfigManager
+
+
+def test_resolve_default_uses_config_value(fake_config, monkeypatch):
+    monkeypatch.setattr(fake_config, "_value", "cloud")
+    r = where_module.resolve_default(env={}, project_value=None)
+    assert r.target is where_module.WhereTarget.CLOUD
+    assert r.source == "config"
+
+
+def test_resolve_default_flag_beats_config(fake_config, monkeypatch):
+    monkeypatch.setattr(fake_config, "_value", "cloud")
+    r = where_module.resolve_default(flag="local", env={}, project_value=None)
+    assert r.target is where_module.WhereTarget.LOCAL
+    assert r.source == "flag"
+
+
+def test_resolve_default_broken_config_falls_through(fake_config, monkeypatch):
+    """A config read that raises never breaks routing — it drops to None."""
+    monkeypatch.setattr(fake_config, "_raise", True)
+    r = where_module.resolve_default(env={}, project_value=None)
+    assert r.target is where_module.WhereTarget.LOCAL
+    assert r.source == "default"
+
+
+def test_resolve_default_forwards_project_value(fake_config, monkeypatch):
+    monkeypatch.setattr(fake_config, "_value", "local")
+    r = where_module.resolve_default(env={}, project_value="cloud")
+    assert r.target is where_module.WhereTarget.CLOUD
+    assert r.source == "project"
+
+
+# ---------------------------------------------------------------------------
 # project/1 precedence: flag → env → project → config → auto
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## ELI-5

Four different commands (`jobs`, `nodes`, `workflow`, `workflow fragments`) each
figured out "local or cloud?" by copy-pasting the same two-part dance: read the
saved `where_default` setting out of the config file, then hand it to
`where.resolve()`. This PR moves that little dance into one helper —
`where.resolve_default(flag)` — that lives next to the config key it reads. Each
command now calls the helper instead of repeating the config lookup, so there's
one less line and one less import at every site, and the config-key coupling
lives in the module that owns it.

## What changed

- **`comfy_cli/where.py`**: new thin convenience `resolve_default(flag=None, *, env=None, project_value=_UNSET)`.
  It reads `CONFIG_KEY_WHERE_DEFAULT` internally (defensively — a broken config
  read drops to `None` rather than breaking routing) and forwards everything to
  `resolve()`. It does **not** shape the result or swallow the `ValueError` a bad
  value raises — callers keep their own error/result handling.
- **4 call sites** switched to `resolve_default()`:
  - `command/jobs.py` `_is_cloud` — keeps its `except ValueError → return False`.
  - `command/nodes.py` `_resolved_where` — keeps its `except ValueError → re-resolve with config_value=None`.
  - `command/workflow.py` `_get_graph`.
  - `command/workflow_fragments.py` `_load_object_info`.
- **Tests**: 4 new cases in `tests/comfy_cli/auth/test_where.py` covering
  config-value use, flag precedence, a broken-config fall-through, and
  project_value forwarding.

Per the ticket, the speculative `resolve_default_or_exit` envelope variant was
**dropped** — the four sites' error handling and result shaping genuinely differ
(bool vs `'local'|'cloud'` string vs enum compare), so a one-size wrapper
wouldn't fit. Only the basic decision-returning helper ships.

`command/setup.py` is intentionally **not** touched — it calls `where._parse()`
for early validation and never does the config-read+resolve dance (correctly out
of scope per the downgraded ticket).

## Judgment call

`workflow.py` / `workflow_fragments.py` previously did the config read *without*
their own try/except (it sat inside an outer `try` that only catches
`LoadError`/`OSError`). Routing them through `resolve_default` means a
config-read exception is now swallowed to `None` instead of propagating. This is
strictly more robust and matches the module's stated "never let a bad config
break routing" philosophy that `jobs`/`nodes` already implement — but it is a
(near-nil, since `ConfigManager.get` returns `None` for a missing key rather
than raising) behavior change, flagged here for the reviewer.

## Testing

- `ruff format --check` + `ruff check` on all touched files: clean.
- `pytest tests/comfy_cli/auth/test_where.py`: 20 passed (incl. 4 new).
- Broader `pytest tests/comfy_cli`: 515 passed, 1 pre-existing failure
  (`test_uses_resolved_python` — needs the `cm-cli` binary, fails identically on
  `origin/main`, unrelated to this change).
