### PR TITLE
fix: use asyncio.run in background_launch for Python 3.14 compat

### DIFF
--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -225,8 +225,7 @@ def background_launch(extra, frontend_pr=None):
 
     cmd.extend(extra)
 
-    loop = asyncio.get_event_loop()
-    log = loop.run_until_complete(launch_and_monitor(cmd, listen, port))
+    log = asyncio.run(launch_and_monitor(cmd, listen, port))
 
     if log is not None:
         print(

--- a/tests/comfy_cli/command/test_launch_background.py
+++ b/tests/comfy_cli/command/test_launch_background.py
@@ -1,0 +1,73 @@
+"""Regression tests for `comfy launch --background`.
+
+Guards against the Python 3.14 crash where `asyncio.get_event_loop()` raised
+`RuntimeError: There is no current event loop in thread 'MainThread'` because
+implicit main-thread loop creation was removed. `background_launch` now uses
+`asyncio.run(...)`, which works identically on 3.10-3.14+.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from comfy_cli.command import launch
+
+
+@patch("comfy_cli.command.launch.os._exit")
+@patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
+@patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_drives_coroutine_without_event_loop_error(
+    mock_config_manager, mock_check_running, mock_monitor, mock_exit
+):
+    """The background monitor path must run the coroutine without touching
+    the removed `asyncio.get_event_loop()` implicit-loop behavior."""
+    mock_config_manager.return_value.background = None
+    mock_monitor.return_value = None
+
+    # No RuntimeError should escape here on Python 3.14 (or any 3.10+ version),
+    # and the monitor coroutine must actually be awaited.
+    launch.background_launch(extra=[])
+
+    mock_monitor.assert_awaited_once()
+    mock_exit.assert_called_once_with(1)
+
+
+def test_background_launch_does_not_use_deprecated_get_event_loop():
+    """`asyncio.run` is the forward-compatible idiom; `asyncio.get_event_loop`
+    (removed-behavior on 3.14) must not reappear in the launch module."""
+    import inspect
+
+    source = inspect.getsource(launch)
+    assert "asyncio.get_event_loop()" not in source
+    assert "asyncio.run(" in source
+
+
+@patch("comfy_cli.command.launch.os._exit")
+@patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
+@patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_surfaces_error_log(mock_config_manager, mock_check_running, mock_monitor, mock_exit):
+    """When the monitor returns a failure log, it is rendered and the process
+    exits non-zero."""
+    mock_config_manager.return_value.background = None
+    mock_monitor.return_value = ["boom\n"]
+
+    with patch("comfy_cli.command.launch.print") as mock_print:
+        launch.background_launch(extra=[])
+
+    mock_monitor.assert_awaited_once()
+    assert mock_print.called
+    mock_exit.assert_called_once_with(1)
+
+
+@patch("comfy_cli.command.launch.utils.is_running", return_value=True)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_refuses_when_already_running(mock_config_manager, mock_is_running):
+    """A second background launch is rejected before reaching the asyncio path."""
+    import typer
+
+    mock_config_manager.return_value.background = ("127.0.0.1", 8188, 4242)
+
+    with pytest.raises(typer.Exit):
+        launch.background_launch(extra=[])


### PR DESCRIPTION
## ELI-5

Starting ComfyUI "in the background" (`comfy launch --background`) crashed on
Python 3.14 with `RuntimeError: There is no current event loop in thread 'MainThread'`.
Old Python would quietly conjure an event loop for you when you asked for one;
Python 3.14 removed that magic. This swaps the old two-step
`get_event_loop()` + `run_until_complete()` for the modern one-liner
`asyncio.run(...)`, which creates, runs, and cleans up its own loop and behaves
the same on Python 3.10 through 3.14+.

## What changed

- `comfy_cli/command/launch.py` — `background_launch()` now calls
  `asyncio.run(launch_and_monitor(...))` instead of
  `asyncio.get_event_loop().run_until_complete(...)`. This was the only
  `asyncio.get_event_loop()` call site in the codebase.
- Added `tests/comfy_cli/command/test_launch_background.py` — regression tests
  for the background-launch path.

## Why it's safe

`launch_and_monitor` drives the child process with `subprocess.Popen` + reader
threads and uses no asyncio primitives (no tasks, async generators, or loop
executor), so a fresh create/run/close loop lifecycle is equivalent to the old
ambient-loop behavior. `background_launch` is only ever invoked synchronously
from the Typer command, so there is never an enclosing running loop for
`asyncio.run` to conflict with. Foreground `comfy launch` was never affected (it
uses `subprocess.run`). No `sys.version_info` conditional was added —
`asyncio.run` is universal, so a guard would just be a dead code path.

## Testing

- New tests **fail** on Python 3.14 against the pre-fix code with the exact
  `RuntimeError`, and **pass** with the fix.
- Verified `pytest tests/comfy_cli/command/test_launch_background.py` green on
  **Python 3.14** and **Python 3.11** (plus the existing launch suite on 3.11).
- `ruff format --check` and `ruff check` clean.

Closes #479

---

Notes for the reviewer:
- The `test_background_launch_does_not_use_deprecated_get_event_loop` test is a
  lightweight source-level tripwire guarding against reintroduction of the
  removed idiom; the behavioral tests are the substantive proof.
