### PR TITLE
refactor(cql): extract shared is_loopback_host() for the two SSRF fetch guards (BE-2154)

### DIFF
--- a/comfy_cli/cql/_net.py
+++ b/comfy_cli/cql/_net.py
@@ -1,0 +1,28 @@
+"""Shared network-target helpers for CQL loaders."""
+
+from __future__ import annotations
+
+import ipaddress
+
+__all__ = ["is_loopback_host"]
+
+
+def is_loopback_host(hostname: str) -> bool:
+    """True if *hostname* refers to a loopback interface.
+
+    Expects an already-parsed hostname (e.g. ``urllib.parse.urlsplit(url).hostname``,
+    which strips IPv6 brackets). Matches the literal name ``localhost`` and any
+    address ``ipaddress`` classifies as loopback (127.0.0.0/8, ::1). Used to refuse
+    SSRF fetches to non-loopback targets in local mode.
+
+    NOTE: this deliberately includes the ipaddress fallback, so it must NOT be used
+    for the require-HTTPS gates in comfy_client._assert_safe_url or
+    oauth._assert_https_or_loopback — those need exact-literal membership.
+    """
+    h = (hostname or "").strip().lower()
+    if h == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import copy
 import difflib
-import ipaddress
 import json
 import logging
 import urllib.error
@@ -21,6 +20,8 @@ import uuid as _uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any
+
+from comfy_cli.cql._net import is_loopback_host
 
 # ---------------------------------------------------------------------------
 # Types — mirrors nodegraph/types.go
@@ -1044,7 +1045,6 @@ class Graph:
 
 _logger = logging.getLogger(__name__)
 
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
 _MAX_OBJECT_INFO_BYTES = 64 * 1024 * 1024
 
 
@@ -1102,14 +1102,7 @@ def _load_from_target(*, mode: str = "local", host: str = "127.0.0.1", port: int
     # Loopback guard for local targets
     if not target.is_cloud:
         parsed_host = urllib.parse.urlsplit(url).hostname or ""
-        host_l = parsed_host.lower()
-        is_loopback = host_l in _LOOPBACK_HOSTS
-        if not is_loopback:
-            try:
-                is_loopback = ipaddress.ip_address(host_l).is_loopback
-            except ValueError:
-                is_loopback = False
-        if not is_loopback:
+        if not is_loopback_host(parsed_host):
             raise LoadError(
                 f"Refusing to fetch object_info from non-loopback host {parsed_host!r} "
                 f"in local mode (potential SSRF). Use --where cloud for remote targets."

--- a/comfy_cli/cql/loader.py
+++ b/comfy_cli/cql/loader.py
@@ -19,7 +19,6 @@ and are short-circuited when no host is provided.
 from __future__ import annotations
 
 import hashlib
-import ipaddress
 import json
 import os
 import sys
@@ -29,6 +28,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from comfy_cli.cql._net import is_loopback_host
 from comfy_cli.cql.errors import CQLRuntimeError
 
 # Cap raw bytes read from disk or the network. Real `object_info` dumps are a
@@ -96,13 +96,7 @@ def _load_from_server(host: str, port: int, *, timeout: float) -> dict[str, Any]
     # own path; this loader is local-only by design.)
     parsed = urllib.parse.urlsplit(url)
     hostname = (parsed.hostname or "").strip().lower()
-    is_loopback = hostname == "localhost"
-    if not is_loopback:
-        try:
-            is_loopback = ipaddress.ip_address(hostname).is_loopback
-        except ValueError:
-            is_loopback = False
-    if not is_loopback:
+    if not is_loopback_host(hostname):
         raise CQLRuntimeError(
             f"refusing non-loopback CQL server target: {host}",
             details={"hint": "pass --input <path> for remote object_info dumps"},

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -1222,3 +1222,15 @@ def test_slot_address_with_dotted_input_name(graph, monkeypatch):
     # Must NOT raise "interior node images not found"; value lands on node 9's dotted widget.
     engine._apply_one_slot(wf, "10/9.images.image0", "X", graph)
     assert wf["definitions"]["subgraphs"][0]["nodes"][0]["widgets_values"][0] == "X"
+
+
+# ===========================================================================
+# SSRF loopback guard on the local object_info fetch
+# ===========================================================================
+
+
+def test_load_from_target_refuses_non_loopback_local_host():
+    from comfy_cli.cql.engine import LoadError, _load_from_target
+
+    with pytest.raises(LoadError, match="non-loopback"):
+        _load_from_target(mode="local", host="example.com", port=8188)

--- a/tests/comfy_cli/cql/test_loader.py
+++ b/tests/comfy_cli/cql/test_loader.py
@@ -6,8 +6,9 @@ import json
 
 import pytest
 
+from comfy_cli.cql import loader
 from comfy_cli.cql.errors import CQLRuntimeError
-from comfy_cli.cql.loader import load_graph, normalize
+from comfy_cli.cql.loader import _load_from_server, load_graph, normalize
 
 OBJECT_INFO = {
     "KSampler": {
@@ -118,3 +119,31 @@ def test_load_graph_bad_json(tmp_path):
 def test_normalize_rejects_garbage():
     with pytest.raises(CQLRuntimeError):
         normalize({"foo": 1, "bar": "baz"})
+
+
+class _FakeResp:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, _n=None):
+        return self._payload
+
+
+def test_load_from_server_refuses_non_loopback_host():
+    # SSRF guard: a public host must never be fetched by the local loader.
+    with pytest.raises(CQLRuntimeError, match="non-loopback"):
+        _load_from_server("example.com", 8188, timeout=0.1)
+
+
+def test_load_from_server_accepts_loopback(monkeypatch):
+    # 127.0.0.1 passes the guard and proceeds to the fetch (mocked here).
+    payload = json.dumps(OBJECT_INFO).encode("utf-8")
+    monkeypatch.setattr(loader._LOADER_OPENER, "open", lambda *a, **k: _FakeResp(payload))
+    g = _load_from_server("127.0.0.1", 8188, timeout=0.1)
+    assert {n["name"] for n in g["nodes"]} == {"KSampler", "CheckpointLoaderSimple"}

--- a/tests/comfy_cli/cql/test_net.py
+++ b/tests/comfy_cli/cql/test_net.py
@@ -1,0 +1,27 @@
+"""Unit tests for the shared loopback-host SSRF guard helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_cli.cql._net import is_loopback_host
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("localhost", True),
+        ("LOCALHOST", True),
+        ("127.0.0.1", True),
+        ("127.0.0.2", True),
+        ("127.5.5.5", True),
+        ("::1", True),
+        ("0.0.0.0", False),
+        ("10.0.0.5", False),
+        ("example.com", False),
+        ("", False),
+        ("not a host", False),
+    ],
+)
+def test_is_loopback_host(host, expected):
+    assert is_loopback_host(host) is expected


### PR DESCRIPTION
## ELI-5

Four different places in the CLI check "is this address just my own computer?" before doing something sensitive. Two of them (the CQL loaders that fetch `/object_info`) use the *exact same* recipe to answer that question — so this PR pulls that one recipe into a single shared helper instead of copy-pasting it. The other two checks look similar but are deliberately stricter (they guard sending secrets over plain HTTP), so this PR does **not** touch them.

## What changed

- New `comfy_cli/cql/_net.py` with a single `is_loopback_host(hostname)` helper: `localhost` literal fast-path, else `ipaddress.ip_address(h).is_loopback` (covers `127.0.0.0/8` and `::1`), `ValueError -> False`.
- `cql/engine.py` `_load_from_target` and `cql/loader.py` `_load_from_server` now call the shared helper instead of inlining the check.
- Removed the now-dead `_LOOPBACK_HOSTS` frozenset and unused `ipaddress` import from `engine.py`, and the unused `ipaddress` import from `loader.py`.
- Tests: new `tests/comfy_cli/cql/test_net.py` (parametrized helper coverage), plus guard-level regression tests that `_load_from_server` / `_load_from_target` refuse a non-loopback host and accept `127.0.0.1`.

## Behavior preserved exactly

Both guards already accepted `127.0.0.1` and `::1` via the `ipaddress` fallback, so this is a pure de-duplication with no behavior change. The engine set's `"[::1]"` / `"::1"` / `"127.0.0.1"` literals were redundant with that fallback (`urlsplit().hostname` strips IPv6 brackets, so `"[::1]"` was dead).

## Deliberately NOT touched (security)

The two require-HTTPS gates — `comfy_client._assert_safe_url` (and its own `_LOOPBACK_HOSTS` set) and `oauth._assert_https_or_loopback` — use exact-literal membership with **no** `ipaddress` fallback on purpose. Broadening them would let `127.x.x.x` / IPv6-loopback carry Bearer tokens / OAuth secrets over plaintext HTTP. Verified untouched: `git diff` shows no changes to either file.

## Testing

- `pytest tests/comfy_cli/cql/` → 103 passed.
- `ruff check` + `ruff format --check` clean on all six touched files.

## Judgment calls

- Added an engine-side guard regression test (`test_load_from_target_refuses_non_loopback_local_host`) in addition to the loader one — the ticket said "engine if easy", and it was.
