### PR TITLE
ci: add label-triggered Cursor review workflow

### DIFF
--- a/.github/workflows/ci-cursor-review.yml
+++ b/.github/workflows/ci-cursor-review.yml
@@ -1,0 +1,56 @@
+# Description: Team-gated multi-model Cursor review — a thin caller for the
+# reusable workflow in Comfy-Org/github-workflows, which is the single source of
+# truth for the panel, judge, prompts, and scripts. Triggered by the
+# 'cursor-review' label.
+#
+# Access control (team-only, two layers):
+#   1. Only users with triage permission or higher can apply a label in a public
+#      repo, so the public cannot trigger this.
+#   2. The reusable workflow's secret-bearing jobs do not run on fork PRs (forks
+#      get no secrets), so CURSOR_API_KEY is reachable only on internal branches.
+name: CI - Cursor Review
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Re-labeling cancels an in-flight run for the same PR + label.
+  group: cursor-review-pr-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
+  cancel-in-progress: true
+
+jobs:
+  cursor-review:
+    if: github.event.action == 'labeled' && github.event.label.name == 'cursor-review'
+    # SHA-pinned. Bump this SHA to pick up upstream changes; keep
+    # `workflows_ref` matching so prompts/scripts load from the same commit as
+    # the workflow definition.
+    uses: Comfy-Org/github-workflows/.github/workflows/cursor-review.yml@047ca48febe3a6647608ed2e0c4331b491cb9d6a # github-workflows#9
+    with:
+      # Overriding diff_excludes replaces the reusable default wholesale, so
+      # this restates the generated/vendored defaults and adds this repo's
+      # heavy paths (uv lockfile, demo media, bundled uv test fixtures).
+      diff_excludes: >-
+        :!**/package-lock.json
+        :!**/yarn.lock
+        :!**/pnpm-lock.yaml
+        :!**/node_modules/**
+        :!**/.claude/**
+        :!**/dist/**
+        :!**/vendor/**
+        :!**/*.generated.*
+        :!**/*.min.js
+        :!**/*.min.css
+        :!uv.lock
+        :!assets/**
+        :!tests/uv/**
+      # Load the prompts/scripts from the same ref as `uses:`.
+      workflows_ref: 047ca48febe3a6647608ed2e0c4331b491cb9d6a
+    secrets:
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      # Optional — enables start/complete Slack DMs to the triggerer.
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Adds the `cursor-review` label-triggered review workflow — a thin caller for the shared reusable workflow in `Comfy-Org/github-workflows` (single source of truth for the panel/judge/prompts), matching the setup in our other repos. Public-repo shape (same as ComfyUI_frontend): triage-gated label trigger, secret-bearing jobs skip fork PRs, SHA-pinned.

Repo-specific `diff_excludes`: `uv.lock`, `assets/**` (demo gif/mp4), `tests/uv/**`.

Note: requires the `CURSOR_API_KEY` (and optional `SLACK_BOT_TOKEN`) repo secrets for reviews to run — the `cursor-review` label already exists on this repo.