### PR TITLE
refactor: extract module-local _emit_http_error helper in models/search.py (BE-2143)

### DIFF
--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -29,7 +29,7 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Annotated, Any
+from typing import Annotated, Any, NoReturn
 
 import typer
 
@@ -124,6 +124,25 @@ def _http_get_json(url: str, target, timeout: float = 30.0) -> Any:
         return json.loads(body)
 
 
+def _emit_http_error(e: urllib.error.HTTPError, *, renderer, target, message: str, hint: str) -> NoReturn:
+    """Emit a renderer error for an ``HTTPError`` and exit with code 1.
+
+    Shared by the ``list-folders`` and ``search`` handlers, whose HTTPError
+    branches are identical: the error ``code`` is cloud/local-routed, and the
+    response body is truncated to 1 KiB and decoded (lossily) into ``details``
+    for debugging. Only ``message`` and ``hint`` differ per caller. The
+    single-hint ``show`` handler and the 404-special-casing ``list-folder``
+    handler deliberately do NOT use this — their shapes differ.
+    """
+    renderer.error(
+        code="cloud_http_error" if target.is_cloud else "server_not_running",
+        message=message,
+        hint=hint,
+        details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8", "replace")},
+    )
+    raise typer.Exit(code=1) from e
+
+
 # ---------------------------------------------------------------------------
 # list-folders / list-folder — runtime introspection
 # ---------------------------------------------------------------------------
@@ -149,15 +168,15 @@ def list_folders_cmd(
     try:
         data = _http_get_json(url, target)
     except urllib.error.HTTPError as e:
-        renderer.error(
-            code="cloud_http_error" if target.is_cloud else "server_not_running",
+        _emit_http_error(
+            e,
+            renderer=renderer,
+            target=target,
             message=f"HTTP {e.code} from {url}",
             hint="run `comfy auth whoami` to verify auth"
             if target.is_cloud
             else "run `comfy launch` to start a local server",
-            details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8", "replace")},
         )
-        raise typer.Exit(code=1) from e
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
         renderer.error(
             code="server_not_running" if not target.is_cloud else "cloud_http_error",
@@ -459,13 +478,13 @@ def search_cmd(
         else:
             rows, total = _local_search(target, text=text, type_=type_, limit=limit)
     except urllib.error.HTTPError as e:
-        renderer.error(
-            code="cloud_http_error" if target.is_cloud else "server_not_running",
+        _emit_http_error(
+            e,
+            renderer=renderer,
+            target=target,
             message=f"HTTP {e.code} during models search",
             hint="check auth (`comfy auth whoami`) or network",
-            details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8", "replace")},
         )
-        raise typer.Exit(code=1) from e
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
         renderer.error(
             code="cloud_http_error" if target.is_cloud else "server_not_running",

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -219,6 +219,26 @@ class TestListFolders:
         # The string-list shape normalizes to [{name, subfolders=[]}].
         assert env["data"]["folders"][0] == {"name": "checkpoints", "subfolders": []}
 
+    def test_cloud_http_error_decodes_body(self, cloud_target, monkeypatch, capsys):
+        # Shared `_emit_http_error` path: cloud code + truncated/decoded body in details.
+        err = urllib.error.HTTPError("https://x", 502, "Bad Gateway", {}, io.BytesIO(b'{"error": "upstream"}'))
+        _patch_urlopen(monkeypatch, {"/api/experiment/models": err})
+        env = _run(["list-folders", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert env["error"]["details"]["status"] == 502
+        assert env["error"]["details"]["body"] == '{"error": "upstream"}'
+
+    def test_local_http_error_uses_server_not_running(self, local_target, monkeypatch, capsys):
+        # Same shared path, local branch: code flips to server_not_running.
+        err = urllib.error.HTTPError("http://x", 500, "Server Error", {}, io.BytesIO(b"boom"))
+        _patch_urlopen(monkeypatch, {"127.0.0.1:8188/models": err})
+        env = _run(["list-folders", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_not_running"
+        assert env["error"]["details"]["status"] == 500
+        assert env["error"]["details"]["body"] == "boom"
+
 
 # ---------------------------------------------------------------------------
 # list-folder
@@ -315,6 +335,16 @@ class TestSearch:
         env = _run(["search", "--text", "flux", "--where", "local"], capsys)
         names = [r["name"] for r in env["data"]["rows"]]
         assert names == ["flux1-dev.safetensors"]
+
+    def test_cloud_http_error_decodes_body(self, cloud_target, monkeypatch, capsys):
+        # Shared `_emit_http_error` path via the search handler.
+        err = urllib.error.HTTPError("https://x", 400, "Bad Request", {}, io.BytesIO(b'{"detail": "bad tag"}'))
+        _patch_urlopen(monkeypatch, {"/api/assets": err})
+        env = _run(["search", "--text", "flux", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert env["error"]["details"]["status"] == 400
+        assert env["error"]["details"]["body"] == '{"detail": "bad tag"}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

Two spots in `comfy models` (the `list-folders` and `search` commands) had the
*exact same* copy-pasted block for turning an HTTP failure into a nice error:
pick a cloud-vs-local error code, and stuff a truncated, decoded copy of the
server's response body into the error details. This PR lifts that duplicated
block into one small helper next to them, so the idiom lives in one place.

## What changed

- New module-local helper `_emit_http_error(e, *, renderer, target, message, hint)`
  in `comfy_cli/command/models/search.py`. It reproduces the shared idiom
  verbatim: `code = cloud_http_error if target.is_cloud else server_not_running`,
  and `details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8","replace")}`.
  It's annotated `-> NoReturn` (it always ends in `raise typer.Exit(code=1) from e`).
- `list_folders_cmd` and `search_cmd` HTTPError handlers now call the helper.
  `message`/`hint` are the only per-caller differences, so they stay at the call
  sites.
- Added regression tests covering both extracted paths — cloud and local
  branches for `list-folders`, plus the `search` cloud path — asserting the
  error code and the truncated/decoded `details.body`. No such tests existed
  before.

## Scope (deliberately narrow)

Per the ticket's corrected recommendation (downgraded from the original,
overstated finding), this is a **module-local** extraction shared by the **two**
sites that actually share the body-decode idiom. The other HTTPError handlers do
NOT share it and are intentionally left untouched:

- `list-folder` (404-special-cased, `details={status, folder}`, no body decode)
- `show` (fixed `cloud_http_error`, `details={status}`, no body decode)
- the sibling `URLError`/`OSError`/`JSONDecodeError` handlers (no body decode)

No cross-module `emit_http_error` was built — the `transfer.py` / `project.py` /
`run/execution.py` sites cited in the original finding don't share the idiom and
would be forced through parameters they don't want.

## Verification

- `pytest tests/comfy_cli` — 2218 passed, 12 skipped.
- `ruff check` + `ruff format --check` clean on both changed files.

## Judgment call

- Pure refactor, behavior-preserving; no functional change to emitted errors.
- Followed the repo's own PR/commit convention of the `(BE-####)` suffix
  (matches recent history, e.g. `(BE-2142)`, `(BE-992)`).
