### PR TITLE
fix: comfy download copies on-disk local outputs instead of refusing them (BE-2190)

### DIFF
--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import mimetypes
 import re
+import shutil
 import sys
 import urllib.error
 import urllib.parse
@@ -127,6 +128,32 @@ def _assert_download_url(url: str) -> None:
     parsed = urllib.parse.urlsplit(url)
     if parsed.scheme not in ("http", "https"):
         raise ValueError(f"refusing to download from non-HTTP URL: {url}")
+
+
+def _local_source_path(url: str) -> Path | None:
+    """Return the on-disk source for a LOCAL output reference, else ``None``.
+
+    A ``comfy run --where local`` job emits bare absolute output paths (see
+    ``run.execution.format_image_path``) rather than ``/view`` URLs, so
+    ``download`` must copy the file off disk instead of fetching it over HTTP.
+    Only a bare absolute filesystem path or a ``file://`` URL with no remote
+    host counts as local; anything carrying a network scheme
+    (``http``/``https``/``ftp``/…) returns ``None`` so the SSRF guard
+    (``_assert_download_url``) still governs it — this branch is purely
+    additive and never weakens that guard for real URLs.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme == "file":
+        # file://host/path with a real host is NOT a local file — leave it to
+        # the SSRF guard rather than reading an attacker-chosen path.
+        if parsed.netloc and parsed.netloc.lower() not in ("localhost", "127.0.0.1"):
+            return None
+        return Path(urllib.request.url2pathname(parsed.path))
+    # A bare absolute filesystem path (POSIX `/…`, Windows `C:\…`). Network
+    # URLs are never absolute paths, so they fall through to the SSRF guard.
+    if Path(url).is_absolute():
+        return Path(url)
+    return None
 
 
 def _sanitize_item_name(item: str) -> str:
@@ -461,11 +488,20 @@ def execute_download(
     item_counters: dict[str, int] = {}
 
     for idx, url in enumerate(output_urls):
-        # Derive extension from the URL's filename query param
-        parsed = urllib.parse.urlparse(url)
-        qs = urllib.parse.parse_qs(parsed.query)
-        remote_name = qs.get("filename", ["output.png"])[0]
-        ext = Path(remote_name).suffix or ".png"
+        # A LOCAL run emits a bare on-disk path / file:// URL for an output
+        # that already exists — copy it instead of HTTP-fetching it.
+        local_source = _local_source_path(url)
+        # Derive the extension from the source. A bare path has no
+        # `?filename=` query param, so read the real suffix off the on-disk
+        # file rather than mislabeling everything `.png`; real URLs carry the
+        # name in the query param.
+        if local_source is not None:
+            ext = local_source.suffix or ".png"
+        else:
+            parsed = urllib.parse.urlparse(url)
+            qs = urllib.parse.parse_qs(parsed.query)
+            remote_name = qs.get("filename", ["output.png"])[0]
+            ext = Path(remote_name).suffix or ".png"
         node_id, item = annotations[idx]
         if item is not None:
             safe_item = _sanitize_item_name(item)
@@ -477,17 +513,6 @@ def execute_download(
         # Suffix deterministically instead of overwriting a prior attempt.
         local_path = _collision_safe_path(dest / local_name)
 
-        try:
-            _assert_download_url(url)
-        except ValueError as e:
-            renderer.error(
-                code="download_failed",
-                message=str(e),
-                hint="output URLs should be http or https",
-                details={"url": url, "index": idx},
-            )
-            raise typer.Exit(code=1)
-
         # Refuse to overwrite symlinks (could be pointed at arbitrary files).
         if local_path.is_symlink():
             renderer.error(
@@ -498,31 +523,58 @@ def execute_download(
             )
             raise typer.Exit(code=1)
 
-        req = urllib.request.Request(url)
-        for hdr, val in auth_hdrs.items():
-            req.add_header(hdr, val)
+        if local_source is not None:
+            # On-disk output (local run): copy it in. No HTTP fetch, so the
+            # SSRF guard doesn't apply — a bare path/file:// URL has no host to
+            # forge a request to. `copyfile` follows a symlinked SOURCE but
+            # writes a plain file at `local_path` (the dest-symlink guard above
+            # already refused a symlinked destination).
+            if not local_source.is_file():
+                renderer.error(
+                    code="download_failed",
+                    message=f"Local output not found on disk: {local_source}",
+                    hint="ensure the job completed and its output files still exist",
+                    details={"url": url, "path": str(local_source), "index": idx},
+                )
+                raise typer.Exit(code=1)
+            shutil.copyfile(local_source, local_path)
+        else:
+            try:
+                _assert_download_url(url)
+            except ValueError as e:
+                renderer.error(
+                    code="download_failed",
+                    message=str(e),
+                    hint="output URLs should be http or https",
+                    details={"url": url, "index": idx},
+                )
+                raise typer.Exit(code=1)
 
-        max_download = 10 * 1024 * 1024 * 1024  # 10 GB safety cap
-        try:
-            with _DOWNLOAD_OPENER.open(req) as resp:
-                total = 0
-                with open(local_path, "wb") as fp:
-                    while True:
-                        chunk = resp.read(65536)
-                        if not chunk:
-                            break
-                        total += len(chunk)
-                        if total > max_download:
-                            raise ValueError(f"download exceeds {max_download} byte safety limit")
-                        fp.write(chunk)
-        except urllib.error.HTTPError as e:
-            renderer.error(
-                code="download_failed",
-                message=f"Failed to download output {idx}: HTTP {e.code}",
-                hint="check that the job completed successfully and the server is reachable",
-                details={"status": e.code, "url": url, "index": idx},
-            )
-            raise typer.Exit(code=1)
+            req = urllib.request.Request(url)
+            for hdr, val in auth_hdrs.items():
+                req.add_header(hdr, val)
+
+            max_download = 10 * 1024 * 1024 * 1024  # 10 GB safety cap
+            try:
+                with _DOWNLOAD_OPENER.open(req) as resp:
+                    total = 0
+                    with open(local_path, "wb") as fp:
+                        while True:
+                            chunk = resp.read(65536)
+                            if not chunk:
+                                break
+                            total += len(chunk)
+                            if total > max_download:
+                                raise ValueError(f"download exceeds {max_download} byte safety limit")
+                            fp.write(chunk)
+            except urllib.error.HTTPError as e:
+                renderer.error(
+                    code="download_failed",
+                    message=f"Failed to download output {idx}: HTTP {e.code}",
+                    hint="check that the job completed successfully and the server is reachable",
+                    details={"status": e.code, "url": url, "index": idx},
+                )
+                raise typer.Exit(code=1)
 
         file_size = local_path.stat().st_size
         entry: dict[str, Any] = {

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -142,13 +142,27 @@ def _local_source_path(url: str) -> Path | None:
     (``_assert_download_url``) still governs it — this branch is purely
     additive and never weakens that guard for real URLs.
     """
+    # UNC / network paths (\\host\share, //host/share) are "absolute" on
+    # Windows but resolve over SMB — treat them as remote so is_file() can't be
+    # coaxed into an outbound NTLM-leaking connection. Reject up front for both
+    # the bare-path and file:// forms.
+    if url.startswith(("//", "\\\\")):
+        return None
     parsed = urllib.parse.urlsplit(url)
     if parsed.scheme == "file":
         # file://host/path with a real host is NOT a local file — leave it to
-        # the SSRF guard rather than reading an attacker-chosen path.
-        if parsed.netloc and parsed.netloc.lower() not in ("localhost", "127.0.0.1"):
+        # the SSRF guard rather than reading an attacker-chosen path. Use
+        # `hostname` (not `netloc`) so the port/IPv6 brackets in
+        # `file://localhost:8080/…` or `file://[::1]/…` don't defeat the check.
+        host = (parsed.hostname or "").lower()
+        if host and host not in ("localhost", "127.0.0.1", "::1"):
             return None
-        return Path(urllib.request.url2pathname(parsed.path))
+        source = Path(urllib.request.url2pathname(parsed.path))
+        # url2pathname can still yield a UNC path on Windows (\\host\share);
+        # reject those too.
+        if str(source).startswith(("//", "\\\\")):
+            return None
+        return source
     # A bare absolute filesystem path (POSIX `/…`, Windows `C:\…`). Network
     # URLs are never absolute paths, so they fall through to the SSRF guard.
     if Path(url).is_absolute():
@@ -487,10 +501,17 @@ def execute_download(
     annotations = _annotate_output_urls(output_urls, state)
     item_counters: dict[str, int] = {}
 
+    # Copy-from-disk is only valid for an actual LOCAL job. `output_urls` can
+    # arrive from untrusted metadata (a piped stdin envelope's `data.outputs`,
+    # or a cloud/remote API `record`), so a bare path / file:// URL there must
+    # NOT bypass the SSRF guard — gate the local branch on the job's own
+    # `where == "local"` marker from the state file, never on URL shape alone.
+    is_local_job = state is not None and getattr(state, "where", None) == "local"
+
     for idx, url in enumerate(output_urls):
         # A LOCAL run emits a bare on-disk path / file:// URL for an output
         # that already exists — copy it instead of HTTP-fetching it.
-        local_source = _local_source_path(url)
+        local_source = _local_source_path(url) if is_local_job else None
         # Derive the extension from the source. A bare path has no
         # `?filename=` query param, so read the real suffix off the on-disk
         # file rather than mislabeling everything `.png`; real URLs carry the
@@ -537,7 +558,48 @@ def execute_download(
                     details={"url": url, "path": str(local_source), "index": idx},
                 )
                 raise typer.Exit(code=1)
-            shutil.copyfile(local_source, local_path)
+            # Mirror the HTTP branch's 10 GB safety cap so a pathological source
+            # (e.g. an unbounded pseudo-file that still reports as regular) can't
+            # exhaust the disk. stat() follows the symlinked source, matching
+            # what copyfile actually reads.
+            max_download = 10 * 1024 * 1024 * 1024  # 10 GB safety cap
+            try:
+                source_size = local_source.stat().st_size
+            except OSError as e:
+                renderer.error(
+                    code="download_failed",
+                    message=f"Failed to stat local output {idx}: {e}",
+                    hint="ensure the output file is readable",
+                    details={"url": url, "path": str(local_source), "index": idx},
+                )
+                raise typer.Exit(code=1)
+            if source_size > max_download:
+                renderer.error(
+                    code="download_failed",
+                    message=f"Local output {idx} exceeds {max_download} byte safety limit",
+                    hint="the source file is too large to copy",
+                    details={"url": url, "path": str(local_source), "size": source_size, "index": idx},
+                )
+                raise typer.Exit(code=1)
+            # Wrap the copy like the HTTP branch's failure handling: an OSError
+            # (permission denied, full/read-only dest) or SameFileError (source
+            # already equals the collision-safe dest) must surface as a
+            # structured envelope, not an unhandled traceback that breaks
+            # machine-mode/NDJSON consumers.
+            try:
+                shutil.copyfile(local_source, local_path)
+            except shutil.SameFileError:
+                # Source and dest are the same file — nothing to copy; the file
+                # is already at the destination path.
+                pass
+            except OSError as e:
+                renderer.error(
+                    code="download_failed",
+                    message=f"Failed to copy local output {idx}: {e}",
+                    hint="check filesystem permissions and free space in the out-dir",
+                    details={"url": url, "path": str(local_source), "index": idx},
+                )
+                raise typer.Exit(code=1)
         else:
             try:
                 _assert_download_url(url)

--- a/tests/comfy_cli/command/test_transfer_download.py
+++ b/tests/comfy_cli/command/test_transfer_download.py
@@ -378,6 +378,155 @@ class TestMachineModeStdoutPurity:
         assert "downloaded" not in captured.err
 
 
+class TestLocalOutputCopy:
+    """A `comfy run --where local --wait` job records bare on-disk output
+    paths (execution.format_image_path returns an absolute path for loopback
+    hosts), not `/view` URLs. `comfy download` must copy those files into
+    --out-dir instead of tripping the anti-SSRF guard, which rejects any
+    non-http(s) URL — while STILL rejecting real non-http URLs on the fetch
+    path so the SSRF protection stays intact (issue #480)."""
+
+    def _write_local_state(self, outputs: list[str]) -> None:
+        state = jobs_state.JobState(
+            prompt_id=PROMPT_ID,
+            client_id=None,
+            workflow="/abs/composed.json",
+            where="local",
+            base_url="http://127.0.0.1:8188",
+            status="completed",
+            outputs=outputs,
+            record=None,
+            item_map=None,
+        )
+        assert jobs_state.write(state) is not None
+
+    def _run(self, tmp_path, capsys, fake_target) -> tuple[list[str], dict]:
+        set_renderer(Renderer(mode=OutputMode.NDJSON, command="download"))
+        with patch("comfy_cli.command.transfer.resolve_target", return_value=fake_target):
+            paths = transfer.execute_download(PROMPT_ID, out_dir=str(tmp_path / "out"))
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        return paths, json.loads(lines[-1])["data"]
+
+    def test_bare_path_output_is_copied_into_out_dir(self, fake_target, tmp_path, capsys):
+        src_dir = tmp_path / "output"
+        src_dir.mkdir()
+        src = src_dir / "ComfyUI_00001_.png"
+        src.write_bytes(b"\x89PNG-local-bytes")
+        self._write_local_state([str(src)])
+
+        paths, data = self._run(tmp_path, capsys, fake_target)
+
+        assert len(paths) == 1
+        copied = Path(paths[0])
+        assert copied.is_file()
+        assert copied.parent == (tmp_path / "out")
+        # The bytes are the on-disk source, copied verbatim.
+        assert copied.read_bytes() == b"\x89PNG-local-bytes"
+        # Source is left untouched (a copy, not a move).
+        assert src.read_bytes() == b"\x89PNG-local-bytes"
+        assert data["files"][0]["path"] == str(copied.resolve())
+        assert data["files"][0]["size"] == len(b"\x89PNG-local-bytes")
+
+    def test_copied_output_keeps_real_extension_not_png(self, fake_target, tmp_path, capsys):
+        # A bare path carries no `?filename=` param; the extension must come
+        # from the source file, not the hardcoded `.png` default.
+        src = tmp_path / "output" / "clip_out.webp"
+        src.parent.mkdir()
+        src.write_bytes(b"RIFFfake-webp")
+        self._write_local_state([str(src)])
+
+        paths, _ = self._run(tmp_path, capsys, fake_target)
+
+        assert Path(paths[0]).suffix == ".webp"
+
+    def test_file_uri_output_is_copied(self, fake_target, tmp_path, capsys):
+        src = tmp_path / "output" / "vid.mp4"
+        src.parent.mkdir()
+        src.write_bytes(b"fake-mp4")
+        self._write_local_state([src.as_uri()])  # file:///…/vid.mp4
+
+        paths, _ = self._run(tmp_path, capsys, fake_target)
+
+        assert Path(paths[0]).suffix == ".mp4"
+        assert Path(paths[0]).read_bytes() == b"fake-mp4"
+
+    def test_missing_local_source_errors_cleanly(self, fake_target, tmp_path, capsys):
+        self._write_local_state([str(tmp_path / "output" / "gone.png")])
+        set_renderer(Renderer(mode=OutputMode.JSON, command="download"))
+        import typer
+
+        with patch("comfy_cli.command.transfer.resolve_target", return_value=fake_target):
+            with pytest.raises(typer.Exit) as excinfo:
+                transfer.execute_download(PROMPT_ID, out_dir=str(tmp_path / "out"))
+        assert excinfo.value.exit_code == 1
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        envelope = json.loads(lines[-1])
+        assert envelope["ok"] is False
+        assert envelope["error"]["code"] == "download_failed"
+        assert "not found on disk" in envelope["error"]["message"]
+
+
+class TestSSRFGuardIntact:
+    """The local-copy branch is additive: `_assert_download_url` must still
+    reject any non-http(s) URL that isn't a bare local path, and the download
+    loop must surface that rejection (SSRF protection stays intact)."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://evil.example.com/etc/passwd",
+            "file://evil.example.com/etc/passwd",  # file:// with a REMOTE host
+            "gopher://internal:70/x",
+            "data:text/plain,hi",
+        ],
+    )
+    def test_assert_download_url_rejects_non_http(self, url):
+        with pytest.raises(ValueError, match="non-HTTP URL"):
+            transfer._assert_download_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        ["http://x/view?filename=a.png", "https://x/view?filename=a.png"],
+    )
+    def test_assert_download_url_allows_http(self, url):
+        transfer._assert_download_url(url)  # does not raise
+
+    def test_remote_host_file_uri_is_not_treated_as_local(self):
+        # A file:// URL pointing at a non-local host must NOT be copied — it
+        # falls through to the SSRF guard, which rejects it.
+        assert transfer._local_source_path("file://evil.example.com/etc/passwd") is None
+        assert transfer._local_source_path("ftp://evil.example.com/x") is None
+        assert transfer._local_source_path("http://x/view?filename=a.png") is None
+
+    def test_non_http_output_still_rejected_by_download_loop(self, fake_target, tmp_path, capsys):
+        # A non-http, non-local URL flowing through the download loop must
+        # error via the guard rather than being fetched.
+        state = jobs_state.JobState(
+            prompt_id=PROMPT_ID,
+            client_id=None,
+            workflow="/abs/composed.json",
+            where="cloud",
+            base_url="https://cloud.example.com",
+            status="completed",
+            outputs=["ftp://evil.example.com/etc/passwd"],
+            record=None,
+            item_map=None,
+        )
+        assert jobs_state.write(state) is not None
+        set_renderer(Renderer(mode=OutputMode.JSON, command="download"))
+        import typer
+
+        with patch("comfy_cli.command.transfer.resolve_target", return_value=fake_target):
+            with pytest.raises(typer.Exit) as excinfo:
+                transfer.execute_download(PROMPT_ID, out_dir=str(tmp_path / "out"))
+        assert excinfo.value.exit_code == 1
+        lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+        envelope = json.loads(lines[-1])
+        assert envelope["ok"] is False
+        assert envelope["error"]["code"] == "download_failed"
+        assert "non-HTTP URL" in envelope["error"]["message"]
+
+
 # ---------------------------------------------------------------------------
 # _default_out_dir — project/1 root wins over the legacy config key
 # ---------------------------------------------------------------------------

--- a/tests/comfy_cli/command/test_transfer_download.py
+++ b/tests/comfy_cli/command/test_transfer_download.py
@@ -526,6 +526,67 @@ class TestSSRFGuardIntact:
         assert envelope["error"]["code"] == "download_failed"
         assert "non-HTTP URL" in envelope["error"]["message"]
 
+    def test_bare_path_from_non_local_job_is_not_copied(self, fake_target, tmp_path, capsys):
+        # The copy-from-disk branch is gated on `where == "local"`. A cloud/
+        # remote job whose (untrusted) metadata sneaks in a bare absolute path
+        # must NOT be copied off disk — it falls through to the SSRF guard,
+        # which rejects it as a non-HTTP URL. Guards against exfiltration via a
+        # tampered piped envelope or a malicious API record.
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"top-secret")
+        state = jobs_state.JobState(
+            prompt_id=PROMPT_ID,
+            client_id=None,
+            workflow="/abs/composed.json",
+            where="cloud",
+            base_url="https://cloud.example.com",
+            status="completed",
+            outputs=[str(secret)],
+            record=None,
+            item_map=None,
+        )
+        assert jobs_state.write(state) is not None
+        set_renderer(Renderer(mode=OutputMode.JSON, command="download"))
+        import typer
+
+        out = tmp_path / "out"
+        with patch("comfy_cli.command.transfer.resolve_target", return_value=fake_target):
+            with pytest.raises(typer.Exit) as excinfo:
+                transfer.execute_download(PROMPT_ID, out_dir=str(out))
+        assert excinfo.value.exit_code == 1
+        envelope = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+        assert envelope["error"]["code"] == "download_failed"
+        assert "non-HTTP URL" in envelope["error"]["message"]
+        # The secret was never copied out.
+        assert not any(out.glob("*")) if out.exists() else True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "//attacker.com/share/x.png",  # POSIX-style UNC
+            "\\\\attacker.com\\share\\x.png",  # Windows UNC
+        ],
+    )
+    def test_unc_paths_are_not_local(self, url):
+        # UNC/network paths are "absolute" but resolve over SMB (NTLM leak);
+        # they must not be treated as local files.
+        assert transfer._local_source_path(url) is None
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///abs/path.png",  # no host
+            "file://localhost/abs/path.png",  # bare loopback host
+            "file://localhost:8080/abs/path.png",  # loopback host + port (port ignored)
+            "file://[::1]/abs/path.png",  # IPv6 loopback
+        ],
+    )
+    def test_loopback_file_uris_are_local(self, url):
+        # The tightened `hostname`-based check accepts genuine loopback file://
+        # URIs — a port or IPv6 brackets on a loopback host don't defeat it
+        # (that was the whole point of switching off `netloc`).
+        assert transfer._local_source_path(url) == Path("/abs/path.png")
+
 
 # ---------------------------------------------------------------------------
 # _default_out_dir — project/1 root wins over the legacy config key


### PR DESCRIPTION
## ELI-5

If you run a workflow **locally** and then try to `comfy download` its result, ComfyUI already wrote the image to your disk — there's no web address to fetch. But `download` is a web-fetcher with a safety guard that refuses anything that isn't an `http(s)://` link, so it choked on the plain file path with `refusing to download from non-HTTP URL: /…/output/foo.png`. This teaches `download` to notice "hey, that's already a file on disk" and just **copy** it into your output folder instead of trying to fetch it — while keeping the safety guard fully in force for real remote URLs.

## What & why

Fixes [#480](https://github.com/Comfy-Org/comfy-cli/issues/480).

A `comfy run --where local --wait` job records **bare absolute output paths** (`run/execution.py::format_image_path` returns an on-disk path for loopback hosts). `comfy download` fed those through `_assert_download_url`, whose anti-SSRF guard rejects any non-`http(s)` URL → `[download_failed]: refusing to download from non-HTTP URL`.

### The fix (additive — SSRF guard untouched for real URLs)

- New `_local_source_path(url)` returns a `Path` for a **bare absolute filesystem path** or a `file://` URL with no remote host, and `None` for anything carrying a network scheme (`http`/`https`/`ftp`/`gopher`/`data`/…). A `file://` URL pointing at a **remote** host returns `None` too, so it still hits the guard.
- In the download loop: when the source is local, `shutil.copyfile` it into `--out-dir` (no HTTP request, so the SSRF guard is irrelevant — there is no host to forge a request to). Everything else still runs through `_assert_download_url` exactly as before.
- **Extension fix (latent bug called out in #480):** a bare path has no `?filename=` query param, so the old code mislabeled every local output `.png`. The copied file now takes its extension from the real source file.
- The destination-symlink refusal now runs for **both** branches (copy and fetch); a missing local source produces a clean `download_failed` envelope, not a traceback.

## Acceptance criteria

1. ✅ `comfy download <prompt_id> --where local` succeeds for an on-disk output, copying it into `--out-dir` and returning its path.
2. ✅ `_assert_download_url` still rejects non-`http(s)` URLs on the remote/download path — tests cover both the local-copy branch **and** a rejected non-http URL (`ftp://`, remote-host `file://`, `gopher://`, `data:`) end-to-end through the loop.
3. ✅ Copied local outputs keep their real extension (`.webp`, `.mp4`, …), not hardcoded `.png`.

## Testing

- Added `TestLocalOutputCopy` (bare path copy, extension preservation, `file://` URI, missing-source error) and `TestSSRFGuardIntact` (guard still rejects non-http; remote-host `file://` not treated as local; non-http rejected end-to-end through the loop).
- `pytest tests/comfy_cli/command/` → **1066 passed, 1 skipped**.
- `ruff check` + `ruff format --check` clean.

## Judgment calls

- Local detection uses `Path(url).is_absolute()` (platform-aware for POSIX `/…` and Windows `C:\…`) after ruling out the `file://` scheme. Network URLs are never absolute paths, so they always fall through to the SSRF guard. A protocol-relative `//host/path` would be treated as a local read (not a network fetch) and simply fail `is_file()` with a clean error — not an SSRF vector, and not a form the producer emits.
- The emitted `files[].url` for a local output is the bare source path (provenance); the transfer schema types `url` as an unconstrained string, so this validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
