### PR TITLE
feat(workflow): local (--where local) support for saved-workflow verbs via ComfyUI /userdata (BE-2222)

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -407,29 +407,127 @@ def vary_cmd(
 
 
 # ---------------------------------------------------------------------------
-# Cloud-saved workflows — list, get, save, delete via /api/workflows
+# Saved workflows — list, get, save, delete.
 # ---------------------------------------------------------------------------
 #
-# These four subcommands are cloud-only. ComfyUI's local server has no
-# /api/workflows surface; users on local manage workflows as JSON files
-# on disk via the slot-editing commands above. With ``--where local`` or
-# no cloud session configured, we surface ``workflow_saved_local_unsupported``
-# with a hint pointing at the local file-based flow.
+# These four subcommands route through ``--where``:
+#
+#   cloud  → Comfy Cloud's ``/api/workflows`` store (UUID-keyed, versioned).
+#   local  → the running ComfyUI's ``/userdata`` file store, under the same
+#            ``workflows/`` dir the ComfyUI frontend uses. A workflow's id on
+#            the local path is its path *relative to* ``workflows/`` (e.g.
+#            ``flux.json`` or ``sub/dir/flux.json``) — that same string is what
+#            ``get``/``delete`` take and what ``save`` returns.
+#
+# The two paths share the ``--json`` envelope shape as far as feasible; the
+# per-verb docstrings + PR note the deltas (local has no versioning, no
+# server-side description, and reports raw file ``size``/``modified``/``created``
+# epoch-ms timestamps instead of cloud's ISO ``created_at``/``updated_at``).
 
 
-def _cloud_target_or_local_error(where: str | None, renderer):
-    """Resolve a cloud Target or emit ``workflow_saved_local_unsupported``."""
+# The userdata subdirectory the ComfyUI frontend stores saved workflows in.
+_WORKFLOWS_DIR = "workflows"
+
+# Map the cloud ``--sort`` fields onto local FileInfo keys (client-side sort;
+# ComfyUI's /userdata listing has no server-side sort/limit/filter).
+_LOCAL_SORT_KEYS = {"create_time": "created", "update_time": "modified", "name": "path"}
+
+
+def _resolve_where_target(where: str | None):
+    """Resolve the routing Target for a saved-workflow verb (cloud or local)."""
     from comfy_cli.target import resolve_target
 
-    target = resolve_target(where=where)
-    if not target.is_cloud:
+    return resolve_target(where=where)
+
+
+def _reject_unsafe_workflow_key(renderer, key: str) -> str:
+    """Validate a local workflow id/name as a safe relative path under ``workflows/``.
+
+    Subdirectories are allowed (``sub/flux.json``), but traversal
+    (``..``), absolute paths, home refs, and backslashes are rejected so a
+    hostile id can't escape the userdata dir. Returns the cleaned key.
+    """
+    cleaned = key.strip()
+    parts = cleaned.split("/")
+    if (
+        not cleaned
+        or cleaned.startswith("/")
+        or cleaned.startswith("~")
+        or "\\" in cleaned
+        or ".." in parts
+        or "" in parts  # empty component: leading/trailing/double slash
+    ):
         renderer.error(
-            code="workflow_saved_local_unsupported",
-            message="Saved-workflow management requires Comfy Cloud; local ComfyUI has no /api/workflows surface.",
-            hint="for local workflows, manage JSON files on disk via `comfy workflow slots/set-slot/vary`",
+            code="invalid_argument",
+            message=f"workflow id {key!r} is not a valid path under the local workflows/ dir",
+            hint="use a relative name like `flux.json` or `sub/flux.json` (no `..`, no leading `/`)",
         )
         raise typer.Exit(code=1)
-    return target
+    return cleaned
+
+
+def _userdata_request(
+    url: str,
+    target,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    content_type: str | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, bytes]:
+    """Authed HTTP call to a ComfyUI ``/userdata`` endpoint returning (status, raw_bytes).
+
+    Raises urllib errors verbatim so callers can map them to envelope codes.
+    Local ComfyUI needs no auth; ``_authed_request`` is a no-op on the headers
+    when the Target carries no credential.
+    """
+    import urllib.request
+
+    req = _authed_request(url, target, method=method, data=data, content_type=content_type)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read(64 * 1024 * 1024)  # 64 MiB cap
+
+
+def _handle_local_http_error(renderer, e, *, operation: str, workflow_id: str | None = None) -> typer.Exit:
+    """Map local ``/userdata`` failures to envelope codes. Returns an Exit to ``raise from``."""
+    import urllib.error
+
+    if isinstance(e, urllib.error.HTTPError) and e.code == 404:
+        renderer.error(
+            code="workflow_not_found",
+            message=f"no saved workflow with id {workflow_id!r}"
+            if workflow_id
+            else f"workflow not found ({operation})",
+            hint="list available workflows via `comfy --json --where local workflow list`",
+            details={"workflow_id": workflow_id, "operation": operation},
+        )
+    elif isinstance(e, urllib.error.HTTPError):
+        renderer.error(
+            code="server_not_running",
+            message=f"HTTP {e.code} during {operation} against local ComfyUI /userdata",
+            hint="run `comfy launch` to start a local server",
+            details={"status": e.code, "operation": operation},
+        )
+    else:
+        renderer.error(
+            code="server_not_running",
+            message=f"could not reach local ComfyUI during {operation}: {e}",
+            hint="run `comfy launch` to start a local server",
+        )
+    return typer.Exit(code=1)
+
+
+def _userdata_file_url(target, key: str, query: dict | None = None) -> str:
+    """Build the ``/userdata/<encoded workflows/key>`` URL. The whole relative
+    path is percent-encoded into a single segment (``/`` → ``%2F``), exactly as
+    the ComfyUI frontend does, so subdir keys survive aiohttp's ``{file}`` route."""
+    import urllib.parse
+
+    encoded = urllib.parse.quote(f"{_WORKFLOWS_DIR}/{key}", safe="")
+    url = target.url("userdata", encoded)
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    return url
 
 
 def _authed_request(
@@ -508,7 +606,196 @@ def _handle_cloud_http_error(renderer, e, *, operation: str, workflow_id: str | 
     return typer.Exit(code=1)
 
 
-@app.command("list", help="List your saved workflows on Comfy Cloud.")
+# ---------------------------------------------------------------------------
+# Local ``/userdata`` implementations of the four saved-workflow verbs.
+# ---------------------------------------------------------------------------
+
+
+def _local_list(renderer, target, *, name: str | None, limit: int, sort: str, order: str) -> None:
+    import urllib.error
+    import urllib.parse
+
+    params = {"dir": _WORKFLOWS_DIR, "recurse": "true", "split": "false", "full_info": "true"}
+    url = target.url("userdata") + "?" + urllib.parse.urlencode(params)
+    try:
+        _, raw = _userdata_request(url, target)
+        rows = json.loads(raw) if raw else []
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            rows = []  # the workflows/ dir doesn't exist yet → no saved workflows
+        else:
+            raise _handle_local_http_error(renderer, e, operation="list") from e
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        raise _handle_local_http_error(renderer, e, operation="list") from e
+
+    rows = [r for r in rows if isinstance(r, dict) and isinstance(r.get("path"), str)]
+    if name:
+        needle = name.lower()
+        rows = [r for r in rows if needle in r["path"].lower()]
+
+    sort_key = _LOCAL_SORT_KEYS.get(sort, "created")
+    reverse = order != "asc"
+    if sort_key == "path":
+        rows.sort(key=lambda r: r["path"].lower(), reverse=reverse)
+    else:
+        rows.sort(key=lambda r: r.get(sort_key) or 0, reverse=reverse)
+    rows = rows[: min(max(limit, 1), 100)]
+
+    workflows = [
+        {
+            "id": r["path"],
+            "name": r["path"],
+            "size": r.get("size"),
+            "modified": r.get("modified"),
+            "created": r.get("created"),
+        }
+        for r in rows
+    ]
+    payload = {"count": len(workflows), "workflows": workflows}
+    if renderer.is_pretty():
+        from rich.table import Table
+
+        tbl = Table(show_header=True, header_style="bold")
+        tbl.add_column("id")
+        tbl.add_column("size", justify="right", style="dim")
+        for r in workflows[:50]:
+            tbl.add_row(r["id"], str(r["size"]) if r["size"] is not None else "")
+        renderer.console().print(tbl)
+        rprint(f"[dim]{len(workflows)} workflow(s) (local)[/dim]")
+    renderer.emit(payload, command="workflow list", where="local")
+
+
+def _local_get(renderer, target, workflow_id: str, out: str | None) -> None:
+    import urllib.error
+
+    key = _reject_unsafe_workflow_key(renderer, workflow_id)
+    url = _userdata_file_url(target, key)
+    try:
+        _, raw = _userdata_request(url, target)
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        raise _handle_local_http_error(renderer, e, operation="get", workflow_id=workflow_id) from e
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        data = None
+    if _is_frontend_format(data):
+        node_count = len(data["nodes"])
+    elif isinstance(data, dict):
+        node_count = len(data)
+    else:
+        node_count = None
+
+    if out:
+        out_path = Path(out).expanduser()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(raw)
+        target_repr = str(out_path)
+    else:
+        if renderer.is_pretty():
+            import sys
+
+            sys.stdout.write(raw.decode("utf-8", "replace"))
+            sys.stdout.write("\n")
+        target_repr = "stdout"
+
+    payload = {
+        "workflow_id": key,
+        "out": target_repr,
+        "bytes": len(raw),
+        "node_count": node_count,
+    }
+    if renderer.is_pretty() and out:
+        rprint(f"[green]✓[/green] wrote {len(raw):,} bytes to {target_repr}")
+    renderer.emit(payload, command="workflow get", where="local")
+
+
+def _local_save(renderer, target, workflow_file: str, name: str, description: str | None) -> None:
+    import urllib.error
+
+    path = Path(workflow_file).expanduser()
+    if not path.is_file():
+        renderer.error(
+            code="workflow_not_found",
+            message=f"local workflow file not found: {path}",
+            hint="check the path",
+        )
+        raise typer.Exit(code=1)
+    try:
+        text = path.read_text(encoding="utf-8")
+        workflow_json = json.loads(text)
+    except json.JSONDecodeError as e:
+        renderer.error(
+            code="workflow_invalid_json",
+            message=f"{path} is not valid JSON: {e}",
+            hint="re-export the workflow from ComfyUI",
+        )
+        raise typer.Exit(code=1) from e
+    if not isinstance(workflow_json, dict):
+        renderer.error(
+            code="workflow_not_api_format",
+            message="workflow_json must be a JSON object",
+            hint="use ComfyUI's `File > Save` to export",
+        )
+        raise typer.Exit(code=1)
+
+    key = name if name.endswith(".json") else f"{name}.json"
+    key = _reject_unsafe_workflow_key(renderer, key)
+    url = _userdata_file_url(target, key, query={"overwrite": "true", "full_info": "true"})
+    try:
+        _, raw = _userdata_request(
+            url, target, method="POST", data=text.encode("utf-8"), content_type="application/json"
+        )
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        raise _handle_local_http_error(renderer, e, operation="save", workflow_id=key) from e
+
+    info = None
+    try:
+        info = json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    # ComfyUI returns FileInfo.path as "workflows/<key>"; strip the prefix back
+    # to the id the other verbs use. Fall back to the key we sent.
+    stored_id = key
+    if isinstance(info, dict) and isinstance(info.get("path"), str):
+        stored = info["path"]
+        prefix = f"{_WORKFLOWS_DIR}/"
+        stored_id = stored[len(prefix) :] if stored.startswith(prefix) else stored
+
+    payload: dict[str, Any] = {
+        "workflow_id": stored_id,
+        "name": stored_id,
+        "source": str(path),
+        "size": info.get("size") if isinstance(info, dict) else None,
+        "modified": info.get("modified") if isinstance(info, dict) else None,
+    }
+    if description:
+        # Local file-backed userdata has no metadata store for a description.
+        payload["warnings"] = [
+            {"code": "description_ignored", "message": "--description is ignored on the local path (no metadata store)"}
+        ]
+    if renderer.is_pretty():
+        rprint(f"[green]✓[/green] saved [dim]{stored_id}[/dim]")
+    renderer.emit(payload, command="workflow save", where="local", changed=True)
+
+
+def _local_delete(renderer, target, workflow_id: str) -> None:
+    import urllib.error
+
+    key = _reject_unsafe_workflow_key(renderer, workflow_id)
+    url = _userdata_file_url(target, key)
+    try:
+        _userdata_request(url, target, method="DELETE")
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        raise _handle_local_http_error(renderer, e, operation="delete", workflow_id=workflow_id) from e
+
+    payload = {"workflow_id": key, "deleted": True}
+    if renderer.is_pretty():
+        rprint(f"[green]✓[/green] deleted [dim]{key}[/dim]")
+    renderer.emit(payload, command="workflow delete", where="local", changed=True)
+
+
+@app.command("list", help="List saved workflows (cloud store, or local ComfyUI /userdata with --where local).")
 @tracking.track_command("workflow")
 def list_cmd(
     name: Annotated[
@@ -530,7 +817,9 @@ def list_cmd(
     import urllib.parse
 
     renderer = get_renderer()
-    target = _cloud_target_or_local_error(where, renderer)
+    target = _resolve_where_target(where)
+    if not target.is_cloud:
+        return _local_list(renderer, target, name=name, limit=limit, sort=sort, order=order)
 
     params: dict[str, Any] = {"limit": min(max(limit, 1), 100), "sort": sort, "order": order}
     if name:
@@ -579,10 +868,16 @@ def list_cmd(
     renderer.emit(payload, command="workflow list", where="cloud")
 
 
-@app.command("get", help="Fetch a saved workflow's content from Comfy Cloud (writes JSON to --out or stdout).")
+@app.command(
+    "get",
+    help="Fetch a saved workflow's content (cloud, or local with --where local); writes JSON to --out or stdout.",
+)
 @tracking.track_command("workflow")
 def get_cmd(
-    workflow_id: Annotated[str, typer.Argument(help="The workflow UUID.")],
+    workflow_id: Annotated[
+        str,
+        typer.Argument(help="Workflow id: cloud UUID, or local path under workflows/ (e.g. flux.json)."),
+    ],
     out: Annotated[
         str | None,
         typer.Option("--out", "-o", show_default=False, help="Write JSON to this file instead of stdout."),
@@ -592,7 +887,9 @@ def get_cmd(
     import urllib.error
 
     renderer = get_renderer()
-    target = _cloud_target_or_local_error(where, renderer)
+    target = _resolve_where_target(where)
+    if not target.is_cloud:
+        return _local_get(renderer, target, workflow_id, out)
 
     import urllib.parse as _up
 
@@ -640,21 +937,31 @@ def get_cmd(
     renderer.emit(payload, command="workflow get", where="cloud")
 
 
-@app.command("save", help="Save a local workflow JSON to Comfy Cloud as a new saved workflow.")
+@app.command(
+    "save",
+    help="Save a workflow JSON to the saved-workflow store (cloud, or local ComfyUI /userdata with --where local).",
+)
 @tracking.track_command("workflow")
 def save_cmd(
     workflow_file: Annotated[str, typer.Argument(help="Path to a workflow JSON file.")],
-    name: Annotated[str, typer.Option("--name", help="Display name for the workflow.")],
+    name: Annotated[
+        str,
+        typer.Option(
+            "--name", help="Cloud: display name. Local: filename under workflows/ ('.json' appended if absent)."
+        ),
+    ],
     description: Annotated[
         str | None,
-        typer.Option("--description", show_default=False, help="Optional description."),
+        typer.Option("--description", show_default=False, help="Optional description (cloud only; ignored on local)."),
     ] = None,
     where: Annotated[str | None, typer.Option("--where", show_default=False)] = None,
 ):
     import urllib.error
 
     renderer = get_renderer()
-    target = _cloud_target_or_local_error(where, renderer)
+    target = _resolve_where_target(where)
+    if not target.is_cloud:
+        return _local_save(renderer, target, workflow_file, name, description)
 
     path = Path(workflow_file).expanduser()
     if not path.is_file():
@@ -702,16 +1009,21 @@ def save_cmd(
     renderer.emit(payload, command="workflow save", where="cloud", changed=True)
 
 
-@app.command("delete", help="Delete a saved workflow from Comfy Cloud.")
+@app.command("delete", help="Delete a saved workflow (cloud, or local ComfyUI /userdata with --where local).")
 @tracking.track_command("workflow")
 def delete_cmd(
-    workflow_id: Annotated[str, typer.Argument(help="The workflow UUID to delete.")],
+    workflow_id: Annotated[
+        str,
+        typer.Argument(help="Workflow id to delete: cloud UUID, or local path under workflows/ (e.g. flux.json)."),
+    ],
     where: Annotated[str | None, typer.Option("--where", show_default=False)] = None,
 ):
     import urllib.error
 
     renderer = get_renderer()
-    target = _cloud_target_or_local_error(where, renderer)
+    target = _resolve_where_target(where)
+    if not target.is_cloud:
+        return _local_delete(renderer, target, workflow_id)
 
     import urllib.parse as _up
 

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -428,6 +428,16 @@ def vary_cmd(
 # The userdata subdirectory the ComfyUI frontend stores saved workflows in.
 _WORKFLOWS_DIR = "workflows"
 
+# Cap on a single ``/userdata`` response we buffer into memory. We read one byte
+# past the cap so we can *detect* truncation and fail loudly, rather than
+# silently writing a partial workflow and reporting success.
+_USERDATA_MAX_BYTES = 64 * 1024 * 1024
+
+
+class _ResponseTooLarge(Exception):
+    """A ``/userdata`` response exceeded ``_USERDATA_MAX_BYTES`` — refuse to truncate."""
+
+
 # Map the cloud ``--sort`` fields onto local FileInfo keys (client-side sort;
 # ComfyUI's /userdata listing has no server-side sort/limit/filter).
 _LOCAL_SORT_KEYS = {"create_time": "created", "update_time": "modified", "name": "path"}
@@ -440,12 +450,24 @@ def _resolve_where_target(where: str | None):
     return resolve_target(where=where)
 
 
+def _strip_terminal_controls(text: str) -> str:
+    """Drop C0/C1 control chars (keeping tab / newline / carriage return) so
+    untrusted workflow content printed to a TTY can't emit ANSI/OSC escape
+    sequences that spoof output or manipulate the terminal."""
+    return "".join(ch for ch in text if ch in "\t\n\r" or (0x20 <= ord(ch) < 0x7F) or ord(ch) >= 0xA0)
+
+
 def _reject_unsafe_workflow_key(renderer, key: str) -> str:
     """Validate a local workflow id/name as a safe relative path under ``workflows/``.
 
     Subdirectories are allowed (``sub/flux.json``), but traversal
     (``..``), absolute paths, home refs, and backslashes are rejected so a
     hostile id can't escape the userdata dir. Returns the cleaned key.
+
+    Components are checked after stripping trailing dots and spaces, because a
+    Windows ComfyUI server strips those from filenames — so ``.. `` or ``...``
+    would collapse to ``..`` and escape ``workflows/`` if we only matched the
+    literal ``..``.
     """
     cleaned = key.strip()
     parts = cleaned.split("/")
@@ -454,8 +476,8 @@ def _reject_unsafe_workflow_key(renderer, key: str) -> str:
         or cleaned.startswith("/")
         or cleaned.startswith("~")
         or "\\" in cleaned
-        or ".." in parts
-        or "" in parts  # empty component: leading/trailing/double slash
+        # Catches "" (leading/trailing/double slash), ".", "..", "...", ".. ", etc.
+        or any(p.rstrip(" .") in ("", "..") for p in parts)
     ):
         renderer.error(
             code="invalid_argument",
@@ -485,14 +507,33 @@ def _userdata_request(
 
     req = _authed_request(url, target, method=method, data=data, content_type=content_type)
     with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.status, resp.read(64 * 1024 * 1024)  # 64 MiB cap
+        status = resp.status
+        # Read one byte past the cap so we can tell a full body from a truncated one.
+        raw = resp.read(_USERDATA_MAX_BYTES + 1)
+    if len(raw) > _USERDATA_MAX_BYTES:
+        raise _ResponseTooLarge()
+    return status, raw
 
 
 def _handle_local_http_error(renderer, e, *, operation: str, workflow_id: str | None = None) -> typer.Exit:
-    """Map local ``/userdata`` failures to envelope codes. Returns an Exit to ``raise from``."""
+    """Map local ``/userdata`` failures to envelope codes. Returns an Exit to ``raise from``.
+
+    A *reachable* server that answers with an HTTP error or an unparseable body
+    gets a distinct code (``server_error`` / ``client_error`` / ``invalid_response``)
+    so the user isn't wrongly told to `comfy launch` — that hint is reserved for a
+    genuinely unreachable server (URLError / OSError).
+    """
     import urllib.error
 
-    if isinstance(e, urllib.error.HTTPError) and e.code == 404:
+    if isinstance(e, _ResponseTooLarge):
+        renderer.error(
+            code="workflow_too_large",
+            message=f"local ComfyUI /userdata response during {operation} exceeded the "
+            f"{_USERDATA_MAX_BYTES // (1024 * 1024)} MiB cap",
+            hint="the saved workflow is unexpectedly large; inspect it directly on the server",
+            details={"operation": operation, "limit_bytes": _USERDATA_MAX_BYTES},
+        )
+    elif isinstance(e, urllib.error.HTTPError) and e.code == 404:
         renderer.error(
             code="workflow_not_found",
             message=f"no saved workflow with id {workflow_id!r}"
@@ -501,12 +542,26 @@ def _handle_local_http_error(renderer, e, *, operation: str, workflow_id: str | 
             hint="list available workflows via `comfy --json --where local workflow list`",
             details={"workflow_id": workflow_id, "operation": operation},
         )
+    elif isinstance(e, urllib.error.HTTPError) and 500 <= e.code < 600:
+        renderer.error(
+            code="server_error",
+            message=f"HTTP {e.code} during {operation} against local ComfyUI /userdata",
+            hint="check the ComfyUI server logs",
+            details={"status": e.code, "operation": operation},
+        )
     elif isinstance(e, urllib.error.HTTPError):
         renderer.error(
-            code="server_not_running",
+            code="client_error",
             message=f"HTTP {e.code} during {operation} against local ComfyUI /userdata",
-            hint="run `comfy launch` to start a local server",
+            hint="the server rejected the request; check the workflow id and the server version",
             details={"status": e.code, "operation": operation},
+        )
+    elif isinstance(e, json.JSONDecodeError):
+        renderer.error(
+            code="invalid_response",
+            message=f"local ComfyUI returned an unparseable body during {operation}",
+            hint="check that the host:port really is a ComfyUI server",
+            details={"operation": operation},
         )
     else:
         renderer.error(
@@ -625,7 +680,7 @@ def _local_list(renderer, target, *, name: str | None, limit: int, sort: str, or
             rows = []  # the workflows/ dir doesn't exist yet → no saved workflows
         else:
             raise _handle_local_http_error(renderer, e, operation="list") from e
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, _ResponseTooLarge) as e:
         raise _handle_local_http_error(renderer, e, operation="list") from e
 
     rows = [r for r in rows if isinstance(r, dict) and isinstance(r.get("path"), str)]
@@ -672,12 +727,14 @@ def _local_get(renderer, target, workflow_id: str, out: str | None) -> None:
     url = _userdata_file_url(target, key)
     try:
         _, raw = _userdata_request(url, target)
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, _ResponseTooLarge) as e:
         raise _handle_local_http_error(renderer, e, operation="get", workflow_id=workflow_id) from e
 
     try:
+        # ``json.loads`` decodes bytes itself and raises ``UnicodeDecodeError`` (not a
+        # ``JSONDecodeError``) on non-UTF-8 input, so catch both.
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         data = None
     if _is_frontend_format(data):
         node_count = len(data["nodes"])
@@ -686,25 +743,48 @@ def _local_get(renderer, target, workflow_id: str, out: str | None) -> None:
     else:
         node_count = None
 
+    # A valid-UTF-8-but-not-JSON body (e.g. an HTML proxy/error page returned 200) or
+    # non-UTF-8 bytes still get written verbatim; warn so a corrupt fetch isn't silent.
+    warnings: list[dict[str, str]] = []
+    if data is None:
+        warnings.append(
+            {
+                "code": "workflow_content_not_json",
+                "message": "fetched content is not parseable JSON; wrote the raw bytes unchanged",
+            }
+        )
+
     if out:
         out_path = Path(out).expanduser()
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        out_path.write_bytes(raw)
+        try:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_bytes(raw)
+        except OSError as e:
+            renderer.error(
+                code="workflow_write_error",
+                message=f"could not write workflow to {out_path}: {e}",
+                hint="check the --out path is writable and the disk has space",
+            )
+            raise typer.Exit(code=1) from e
         target_repr = str(out_path)
     else:
         if renderer.is_pretty():
             import sys
 
-            sys.stdout.write(raw.decode("utf-8", "replace"))
+            # Strip control chars so untrusted content can't emit ANSI/OSC escapes
+            # that spoof or manipulate the terminal.
+            sys.stdout.write(_strip_terminal_controls(raw.decode("utf-8", "replace")))
             sys.stdout.write("\n")
         target_repr = "stdout"
 
-    payload = {
+    payload: dict[str, Any] = {
         "workflow_id": key,
         "out": target_repr,
         "bytes": len(raw),
         "node_count": node_count,
     }
+    if warnings:
+        payload["warnings"] = warnings
     if renderer.is_pretty() and out:
         rprint(f"[green]✓[/green] wrote {len(raw):,} bytes to {target_repr}")
     renderer.emit(payload, command="workflow get", where="local")
@@ -723,6 +803,14 @@ def _local_save(renderer, target, workflow_file: str, name: str, description: st
         raise typer.Exit(code=1)
     try:
         text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        renderer.error(
+            code="workflow_read_error",
+            message=f"could not read {path}: {e}",
+            hint="check file permissions and encoding",
+        )
+        raise typer.Exit(code=1) from e
+    try:
         workflow_json = json.loads(text)
     except json.JSONDecodeError as e:
         renderer.error(
@@ -739,14 +827,14 @@ def _local_save(renderer, target, workflow_file: str, name: str, description: st
         )
         raise typer.Exit(code=1)
 
-    key = name if name.endswith(".json") else f"{name}.json"
+    key = name if name.lower().endswith(".json") else f"{name}.json"
     key = _reject_unsafe_workflow_key(renderer, key)
     url = _userdata_file_url(target, key, query={"overwrite": "true", "full_info": "true"})
     try:
         _, raw = _userdata_request(
             url, target, method="POST", data=text.encode("utf-8"), content_type="application/json"
         )
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, _ResponseTooLarge) as e:
         raise _handle_local_http_error(renderer, e, operation="save", workflow_id=key) from e
 
     info = None
@@ -786,7 +874,7 @@ def _local_delete(renderer, target, workflow_id: str) -> None:
     url = _userdata_file_url(target, key)
     try:
         _userdata_request(url, target, method="DELETE")
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, _ResponseTooLarge) as e:
         raise _handle_local_http_error(renderer, e, operation="delete", workflow_id=workflow_id) from e
 
     payload = {"workflow_id": key, "deleted": True}
@@ -817,11 +905,30 @@ def list_cmd(
     import urllib.parse
 
     renderer = get_renderer()
+
+    # Validate the free-form sort/order options up front (both routes) so a typo like
+    # `--order ASC` errors loudly instead of silently sorting the wrong way.
+    order_norm = order.lower()
+    if order_norm not in ("asc", "desc"):
+        renderer.error(
+            code="invalid_argument",
+            message=f"--order must be 'asc' or 'desc', got {order!r}",
+            hint="pass `--order asc` or `--order desc`",
+        )
+        raise typer.Exit(code=1)
+    if sort not in _LOCAL_SORT_KEYS:
+        renderer.error(
+            code="invalid_argument",
+            message=f"--sort must be one of {', '.join(_LOCAL_SORT_KEYS)}, got {sort!r}",
+            hint="pass `--sort create_time|update_time|name`",
+        )
+        raise typer.Exit(code=1)
+
     target = _resolve_where_target(where)
     if not target.is_cloud:
-        return _local_list(renderer, target, name=name, limit=limit, sort=sort, order=order)
+        return _local_list(renderer, target, name=name, limit=limit, sort=sort, order=order_norm)
 
-    params: dict[str, Any] = {"limit": min(max(limit, 1), 100), "sort": sort, "order": order}
+    params: dict[str, Any] = {"limit": min(max(limit, 1), 100), "sort": sort, "order": order_norm}
     if name:
         params["name"] = name
     url = target.url("workflows") + "?" + urllib.parse.urlencode(params)

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -236,11 +236,6 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy jobs cancel` could not reach the local server to cancel the prompt.",
         "check the server is still running on the host/port",
     ),
-    ErrorCode(
-        "workflow_saved_local_unsupported",
-        "`comfy workflow {list,get,save,delete}` requires Comfy Cloud — local ComfyUI has no /api/workflows.",
-        "for local workflows, manage JSON files on disk via `workflow slots`/`set-slot`/`vary`",
-    ),
     # --- auth (provider keys + cloud session intertwined) --------------------
     ErrorCode(
         "auth_invalid_key",
@@ -457,6 +452,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`details.source` has the host key; `details.reason` has the fetch error. "
         "Surfaced in `data.warnings[]` (not as an error envelope) so the command still succeeds.",
         "re-run once the server/session is reachable to get a fresh schema",
+    ),
+    ErrorCode(
+        "description_ignored",
+        "`comfy workflow save --where local --description` was given a description, but the local "
+        "file-backed `/userdata` store has nowhere to keep it. Surfaced in `data.warnings[]` "
+        "(not as an error envelope) so the save still succeeds.",
+        "descriptions are a Comfy Cloud feature; drop `--description` on the local path",
     ),
     ErrorCode(
         "cql_query_invalid",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -68,6 +68,25 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "Workflow file exists but isn't readable as UTF-8 text (OSError / UnicodeDecodeError).",
         "check file permissions and encoding",
     ),
+    ErrorCode(
+        "workflow_write_error",
+        "`workflow get --out` could not write the fetched workflow to disk (OSError: permissions, "
+        "missing parent dir, full disk, invalid path).",
+        "check the --out path is writable and the disk has space",
+    ),
+    ErrorCode(
+        "workflow_too_large",
+        "A local ComfyUI `/userdata` response exceeded the in-memory read cap, so the CLI refused to "
+        "truncate it into a corrupt/partial file. `details.limit_bytes` carries the cap.",
+        "the saved workflow is unexpectedly large; inspect it directly on the server",
+    ),
+    ErrorCode(
+        "workflow_content_not_json",
+        "`workflow get` fetched content that isn't parseable JSON (non-UTF-8 bytes or a non-JSON body such "
+        "as an HTML error page); the raw bytes were still written. Surfaced in `data.warnings[]`, not as an "
+        "error envelope, so the command still succeeds.",
+        "verify the id points at a real saved workflow, not a stray file, on the local server",
+    ),
     # --- local server / WebSocket --------------------------------------------
     ErrorCode(
         "server_not_running",

--- a/tests/comfy_cli/command/test_workflow_saved.py
+++ b/tests/comfy_cli/command/test_workflow_saved.py
@@ -224,6 +224,36 @@ class TestLocalList:
         assert env["ok"] is False
         assert env["error"]["code"] == "server_not_running"
 
+    def test_reachable_server_error_is_not_server_not_running(self, local_target, monkeypatch, capsys):
+        # A reachable server that 500s must not be mislabeled "run comfy launch".
+        _patch_urlopen(monkeypatch, {"/userdata": _http_error(500)})
+        env = _run(["list", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_error"
+
+    def test_unparseable_body_surfaces_invalid_response(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata": (b"<html>not json</html>", 200)})
+        env = _run(["list", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_response"
+
+    def test_invalid_order_rejected(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {})  # must fail before any HTTP
+        env = _run(["list", "--where", "local", "--order", "sideways"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_argument"
+
+    def test_order_normalized_case_insensitively(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata": _USERDATA_LIST_RESPONSE})
+        env = _run(["list", "--where", "local", "--order", "ASC"], capsys)
+        assert env["ok"] is True
+
+    def test_invalid_sort_rejected(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["list", "--where", "local", "--sort", "bogus"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_argument"
+
 
 class TestLocalGet:
     def test_writes_content_to_file(self, local_target, tmp_path, monkeypatch, capsys):
@@ -252,6 +282,54 @@ class TestLocalGet:
         env = _run(["get", "../../etc/passwd", "--where", "local"], capsys)
         assert env["ok"] is False
         assert env["error"]["code"] == "invalid_argument"
+
+    def test_rejects_windows_trailing_dot_traversal(self, local_target, monkeypatch, capsys):
+        # A Windows server strips trailing dots/spaces, so "sub/.. /x" collapses to
+        # "sub/../x" and escapes workflows/ — reject it before any HTTP.
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["get", "sub/.. /secret", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_argument"
+
+    def test_non_json_body_warns_and_writes_raw(self, local_target, tmp_path, monkeypatch, capsys):
+        # A 200 with a non-JSON body (e.g. an HTML error page) still gets written,
+        # but a warning surfaces so the corrupt fetch isn't silent.
+        _patch_urlopen(monkeypatch, {"/userdata/": (b"<html>nope</html>", 200)})
+        out = tmp_path / "got.json"
+        env = _run(["get", "flux.json", "--out", str(out), "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["node_count"] is None
+        assert any(w["code"] == "workflow_content_not_json" for w in env["data"].get("warnings", []))
+        assert out.read_bytes() == b"<html>nope</html>"
+
+    def test_non_utf8_body_does_not_crash(self, local_target, tmp_path, monkeypatch, capsys):
+        # json.loads on non-UTF-8 bytes raises UnicodeDecodeError, not JSONDecodeError.
+        _patch_urlopen(monkeypatch, {"/userdata/": (b"\xff\xfe\x00bad", 200)})
+        out = tmp_path / "got.json"
+        env = _run(["get", "flux.json", "--out", str(out), "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert any(w["code"] == "workflow_content_not_json" for w in env["data"].get("warnings", []))
+        assert out.read_bytes() == b"\xff\xfe\x00bad"
+
+    def test_write_error_surfaces_envelope(self, local_target, tmp_path, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata/": _LOCAL_WORKFLOW})
+
+        def _boom(self, data):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("pathlib.Path.write_bytes", _boom)
+        env = _run(["get", "flux.json", "--out", str(tmp_path / "o.json"), "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_write_error"
+
+    def test_response_over_cap_refuses_to_truncate(self, local_target, tmp_path, monkeypatch, capsys):
+        # Shrink the cap so the mocked body exceeds it; the CLI must fail loudly
+        # rather than silently writing a truncated file.
+        monkeypatch.setattr(workflow_cmd, "_USERDATA_MAX_BYTES", 4)
+        _patch_urlopen(monkeypatch, {"/userdata/": (b'{"nodes": []}', 200)})
+        env = _run(["get", "flux.json", "--out", str(tmp_path / "o.json"), "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_too_large"
 
 
 class TestLocalSave:
@@ -284,6 +362,24 @@ class TestLocalSave:
         env = _run(["save", str(wf), "--name", "x", "--where", "local"], capsys)
         assert env["ok"] is False
         assert env["error"]["code"] == "workflow_invalid_json"
+
+    def test_non_utf8_file_surfaces_read_error(self, local_target, tmp_path, monkeypatch, capsys):
+        wf = tmp_path / "bin.json"
+        wf.write_bytes(b"\xff\xfe\x00")  # not valid UTF-8 → UnicodeDecodeError on read
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["save", str(wf), "--name", "x", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_read_error"
+
+    def test_json_ext_appended_case_insensitively(self, local_target, tmp_path, monkeypatch, capsys):
+        # `--name flux.JSON` already ends in .json (case-insensitive) → don't double the ext.
+        wf = tmp_path / "src.json"
+        wf.write_text(json.dumps(_LOCAL_WORKFLOW))
+        calls = _patch_urlopen(monkeypatch, {"/userdata/": {"path": "flux.JSON"}})
+        env = _run(["save", str(wf), "--name", "flux.JSON", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert "workflows%2Fflux.JSON" in calls[0]["url"]
+        assert "flux.JSON.json" not in calls[0]["url"]
 
     def test_missing_file(self, local_target, tmp_path, monkeypatch, capsys):
         _patch_urlopen(monkeypatch, {})

--- a/tests/comfy_cli/command/test_workflow_saved.py
+++ b/tests/comfy_cli/command/test_workflow_saved.py
@@ -1,8 +1,10 @@
-"""Tests for `comfy workflow list/get/save/delete` — cloud-saved workflows.
+"""Tests for `comfy workflow list/get/save/delete` — saved workflows.
 
-These commands wrap the `/api/workflows` surface documented at
-docs.comfy.org/api-reference/cloud/workflow. All HTTP is mocked; the
-live round-trip is verified manually.
+The cloud path wraps the `/api/workflows` surface documented at
+docs.comfy.org/api-reference/cloud/workflow. The local path (`--where local`)
+wraps the running ComfyUI's `/userdata` file store under `workflows/`, mirroring
+the ComfyUI frontend's layout. All HTTP is mocked; the live round-trip is
+verified manually.
 """
 
 from __future__ import annotations
@@ -163,33 +165,161 @@ _WORKFLOW_CONTENT_RESPONSE = {
 }
 
 
+# A frontend-format workflow (nodes[] list) — what the local /userdata store holds.
+_LOCAL_WORKFLOW = {
+    "last_node_id": 2,
+    "nodes": [
+        {"id": 1, "type": "KSampler"},
+        {"id": 2, "type": "VAEDecode"},
+    ],
+    "links": [],
+}
+
+# ComfyUI's /userdata?dir=workflows&full_info=true response: FileInfo dicts with
+# `path` relative to the workflows/ dir.
+_USERDATA_LIST_RESPONSE = [
+    {"path": "flux.json", "size": 120, "modified": 1700000002000, "created": 1700000000000},
+    {"path": "sub/wan.json", "size": 340, "modified": 1700000001000, "created": 1700000001000},
+]
+
+
+def _http_error(code: int):
+    return urllib.error.HTTPError("http://127.0.0.1:8188/userdata/x", code, "err", {}, io.BytesIO(b""))
+
+
 # ---------------------------------------------------------------------------
-# Local route — all four subcommands must reject with workflow_saved_local_unsupported
+# Local route — /userdata-backed CRUD
 # ---------------------------------------------------------------------------
 
 
-class TestLocalIsRejectedCleanly:
-    def test_list_local_unsupported(self, local_target, capsys):
+class TestLocalList:
+    def test_lists_userdata_workflows(self, local_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {"/userdata": _USERDATA_LIST_RESPONSE})
+        env = _run(["list", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["count"] == 2
+        # id == name == the path relative to workflows/ (what get/delete take).
+        ids = {r["id"] for r in env["data"]["workflows"]}
+        assert ids == {"flux.json", "sub/wan.json"}
+        # Requests the recursive full-info listing of the workflows/ dir.
+        assert "dir=workflows" in calls[0]["url"]
+        assert "full_info=true" in calls[0]["url"]
+
+    def test_name_filter_and_limit(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata": _USERDATA_LIST_RESPONSE})
+        env = _run(["list", "--where", "local", "--name", "wan", "--limit", "10"], capsys)
+        assert env["data"]["count"] == 1
+        assert env["data"]["workflows"][0]["id"] == "sub/wan.json"
+
+    def test_missing_workflows_dir_is_empty_not_error(self, local_target, monkeypatch, capsys):
+        # ComfyUI 404s when the workflows/ dir doesn't exist yet — that's "none saved".
+        _patch_urlopen(monkeypatch, {"/userdata": _http_error(404)})
+        env = _run(["list", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["count"] == 0
+
+    def test_server_not_running_envelope(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata": urllib.error.URLError("Connection refused")})
         env = _run(["list", "--where", "local"], capsys)
         assert env["ok"] is False
-        assert env["error"]["code"] == "workflow_saved_local_unsupported"
+        assert env["error"]["code"] == "server_not_running"
 
-    def test_get_local_unsupported(self, local_target, capsys):
-        env = _run(["get", "any-id", "--where", "local"], capsys)
-        assert env["ok"] is False
-        assert env["error"]["code"] == "workflow_saved_local_unsupported"
 
-    def test_delete_local_unsupported(self, local_target, capsys):
-        env = _run(["delete", "any-id", "--where", "local"], capsys)
-        assert env["ok"] is False
-        assert env["error"]["code"] == "workflow_saved_local_unsupported"
+class TestLocalGet:
+    def test_writes_content_to_file(self, local_target, tmp_path, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata/": _LOCAL_WORKFLOW})
+        out = tmp_path / "got.json"
+        env = _run(["get", "flux.json", "--out", str(out), "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["workflow_id"] == "flux.json"
+        assert env["data"]["node_count"] == 2  # frontend format → len(nodes)
+        assert json.loads(out.read_text()) == _LOCAL_WORKFLOW
 
-    def test_save_local_unsupported(self, local_target, tmp_path, capsys):
-        wf = tmp_path / "wf.json"
-        wf.write_text(json.dumps({"1": {"class_type": "X"}}))
-        env = _run(["save", str(wf), "--name", "test", "--where", "local"], capsys)
+    def test_encodes_subdir_key_as_single_segment(self, local_target, tmp_path, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {"/userdata/": _LOCAL_WORKFLOW})
+        _run(["get", "sub/wan.json", "--out", str(tmp_path / "o.json"), "--where", "local"], capsys)
+        # workflows/sub/wan.json is percent-encoded whole (slashes → %2F).
+        assert "workflows%2Fsub%2Fwan.json" in calls[0]["url"]
+
+    def test_404_surfaces_workflow_not_found(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata/": _http_error(404)})
+        env = _run(["get", "ghost.json", "--where", "local"], capsys)
         assert env["ok"] is False
-        assert env["error"]["code"] == "workflow_saved_local_unsupported"
+        assert env["error"]["code"] == "workflow_not_found"
+
+    def test_rejects_path_traversal(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {})  # must fail before any HTTP
+        env = _run(["get", "../../etc/passwd", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_argument"
+
+
+class TestLocalSave:
+    def test_posts_file_bytes_and_appends_json_ext(self, local_target, tmp_path, monkeypatch, capsys):
+        wf = tmp_path / "src.json"
+        wf.write_text(json.dumps(_LOCAL_WORKFLOW))
+        stored = {"path": "flux.json", "size": 120, "modified": 1700000002000, "created": 1700000000000}
+        calls = _patch_urlopen(monkeypatch, {"/userdata/": stored})
+        env = _run(["save", str(wf), "--name", "flux", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["workflow_id"] == "flux.json"
+        assert calls[0]["method"] == "POST"
+        # '.json' appended to the bare --name; encoded into the userdata path.
+        assert "workflows%2Fflux.json" in calls[0]["url"]
+        assert "overwrite=true" in calls[0]["url"]
+        assert json.loads(calls[0]["body"]) == _LOCAL_WORKFLOW
+
+    def test_description_ignored_with_warning(self, local_target, tmp_path, monkeypatch, capsys):
+        wf = tmp_path / "src.json"
+        wf.write_text(json.dumps(_LOCAL_WORKFLOW))
+        _patch_urlopen(monkeypatch, {"/userdata/": {"path": "flux.json"}})
+        env = _run(["save", str(wf), "--name", "flux.json", "--description", "hi", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert any(w["code"] == "description_ignored" for w in env["data"].get("warnings", []))
+
+    def test_invalid_json_file(self, local_target, tmp_path, monkeypatch, capsys):
+        wf = tmp_path / "bad.json"
+        wf.write_text("not json")
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["save", str(wf), "--name", "x", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_invalid_json"
+
+    def test_missing_file(self, local_target, tmp_path, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["save", str(tmp_path / "nope.json"), "--name", "x", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_not_found"
+
+    def test_server_not_running_envelope(self, local_target, tmp_path, monkeypatch, capsys):
+        wf = tmp_path / "src.json"
+        wf.write_text(json.dumps(_LOCAL_WORKFLOW))
+        _patch_urlopen(monkeypatch, {"/userdata/": urllib.error.URLError("refused")})
+        env = _run(["save", str(wf), "--name", "flux", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_not_running"
+
+
+class TestLocalDelete:
+    def test_sends_delete(self, local_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {"/userdata/": (b"", 204)})
+        env = _run(["delete", "flux.json", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["deleted"] is True
+        assert calls[0]["method"] == "DELETE"
+        assert "workflows%2Fflux.json" in calls[0]["url"]
+
+    def test_404_surfaces_workflow_not_found(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"/userdata/": _http_error(404)})
+        env = _run(["delete", "ghost.json", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_not_found"
+
+    def test_rejects_absolute_path(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {})
+        env = _run(["delete", "/etc/passwd", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "invalid_argument"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

`comfy workflow list/get/save/delete` could only talk to Comfy Cloud. If you passed `--where local` it refused with `workflow_saved_local_unsupported`. But a running local ComfyUI already stores saved workflows as plain JSON files under its `/userdata` `workflows/` directory — the exact store the ComfyUI web UI uses. This PR points the four verbs at that store when the resolved target is local, so you can save/list/get/delete workflows against your own ComfyUI with no cloud account. Cloud behavior is untouched.

This unblocks saved-workflow parity in the local Comfy MCP (a thin comfy-cli wrapper) as a trivial follow-up.

## What changed

- **Routing:** each of `list/get/save/delete` now resolves the `--where` target and, when local, dispatches to a `/userdata`-backed implementation instead of the cloud `/api/workflows` store. Cloud paths are unchanged (early-return before the cloud code).
- **Local id model:** a workflow's id/name on the local path is its path *relative to* `workflows/` (e.g. `flux.json`, `sub/flux.json`) — the same key the frontend uses. `save` returns it, `list` reports it, `get`/`delete` take it. The whole `workflows/<key>` path is percent-encoded into a single `/userdata/{file}` segment (`/` → `%2F`), exactly as the frontend does, so subdir keys survive aiohttp's single-segment route.
- **Contract (verified against `ComfyUI/app/user_manager.py`):**
  - `list` → `GET /userdata?dir=workflows&recurse=true&split=false&full_info=true`; a 404 (dir doesn't exist yet) is treated as "none saved", not an error. Sort/limit/name-filter are applied client-side (the endpoint has none).
  - `get` → `GET /userdata/<enc>`; writes the raw file bytes to `--out`/stdout (byte-identical round-trip).
  - `save` → `POST /userdata/<enc>?overwrite=true&full_info=true` with the file's bytes; `.json` is appended to a bare `--name`.
  - `delete` → `DELETE /userdata/<enc>`.
- **Errors:** server unreachable / non-404 HTTP → `server_not_running` (hint: `comfy launch`); missing workflow → `workflow_not_found`; unsafe id (traversal / absolute / backslash) → `invalid_argument`.
- **Error registry:** retired the now-unreachable `workflow_saved_local_unsupported`; added a `description_ignored` warning code.

## Documented deltas (local vs cloud `data` shape)

Kept consistent where feasible; local necessarily differs:
- No versioning on local — `get` omits `version`/`version_id`; `list` omits `latest_version`/`description`/`default_view`.
- `list` rows carry `size` + `modified`/`created` (epoch-ms) instead of cloud's ISO `created_at`/`updated_at`.
- `--description` has no home in the file-backed store → ignored on local, surfaced as a `data.warnings[]` entry (`description_ignored`).
- `save` overwrites an existing same-named local file (matches the frontend's save behavior); cloud always creates a new versioned record.

## Acceptance criteria

1. ✅ Round-trips (save → list → get → delete) against local ComfyUI — contract matches `/userdata` exactly. **Note:** the *live* round-trip against a running ComfyUI is a manual check (this env has none), consistent with how the existing cloud tests document their live verification. Automated coverage drives every verb end-to-end through the CLI with mocked HTTP.
2. ✅ Cloud path byte-identical — full suite green (2347 passed, 36 skipped); new unit tests cover local routing incl. the server-not-running envelope.
3. ✅ `--where local` no longer emits `workflow_saved_local_unsupported`; ruff (check + format, pinned 0.15.15) and pytest green.

`comfy discover` exposes `where` support as a global capability (not per-command), so no discovery metadata change was needed.

## Test plan

- `pytest tests/` → 2347 passed, 36 skipped.
- `ruff check` + `ruff format --diff` on touched files → clean.
- Manual (reviewer, optional): `comfy launch`, then `comfy --json --where local workflow save wf.json --name t` → `list` → `get t.json` → `delete t.json`.