### PR TITLE
refactor: consolidate refuse-redirect handlers into shared comfy_cli/http.py (BE-2152)

### DIFF
--- a/comfy_cli/cloud/oauth.py
+++ b/comfy_cli/cloud/oauth.py
@@ -52,6 +52,7 @@ from comfy_cli.cloud import (
     CLIENT_NAME,
     get_base_url,
 )
+from comfy_cli.http import NoRedirectHandler
 
 # ---------------------------------------------------------------------------
 # Error types — caller maps these to renderer.error(code=...) codes.
@@ -881,16 +882,7 @@ def _assert_https_or_loopback(url: str) -> None:
     raise _HTTPFail(0, f"refusing plaintext HTTP for OAuth endpoint: {url}")
 
 
-# Refuse redirects: an evil 302 from the token endpoint to attacker.example
-# would replay the verifier + code at the redirect target.
-class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    def http_error_301(self, req, fp, code, msg, headers):
-        raise HTTPError(req.full_url, code, "redirect refused", headers, fp)
-
-    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
-
-
-_OAUTH_OPENER = urllib.request.build_opener(_NoRedirect())
+_OAUTH_OPENER = urllib.request.build_opener(NoRedirectHandler())
 
 
 def _send_and_parse(req: urllib.request.Request) -> dict:

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from comfy_cli.http import NoRedirectHandler
 from comfy_cli.target import Target
 
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
@@ -94,22 +95,7 @@ class Unauthenticated(Exception):
     """Target needs auth but no valid session is present."""
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Refuse to follow redirects.
-
-    Following redirects with `Authorization: Bearer …` in flight risks
-    replaying the token at the redirect target. ComfyUI gateways don't issue
-    redirects under normal operation; if we ever see one it's almost certainly
-    a misconfiguration or attack. Surface as a clear HTTPError instead.
-    """
-
-    def http_error_301(self, req, fp, code, msg, headers):
-        raise urllib.error.HTTPError(req.full_url, code, "redirect refused", headers, fp)
-
-    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
-
-
-_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+_OPENER = urllib.request.build_opener(NoRedirectHandler())
 
 
 def _assert_safe_url(url: str) -> None:

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -24,6 +24,7 @@ import typer
 
 from comfy_cli import jobs_state
 from comfy_cli.comfy_client import Client, Unauthenticated, extract_output_entries
+from comfy_cli.http import NoRedirectHandler
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
 from comfy_cli.target import resolve_target
@@ -74,14 +75,6 @@ def _auth_headers(target: Any) -> dict[str, str]:
     return headers
 
 
-# Refuse redirects on upload — a 30x from an authenticated POST is suspicious.
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def http_error_301(self, req, fp, code, msg, headers):
-        raise urllib.error.HTTPError(req.full_url, code, "redirect refused (auth leak prevention)", headers, fp)
-
-    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
-
-
 # Stripped on every download redirect so auth never crosses origins.
 _AUTH_HEADERS_TO_STRIP = frozenset({"authorization", "x-api-key", "x-comfy-api-key", "cookie"})
 _MAX_REDIRECTS = 5
@@ -109,7 +102,7 @@ class _DownloadRedirectHandler(urllib.request.HTTPRedirectHandler):
         return new_req
 
 
-_TRANSFER_OPENER = urllib.request.build_opener(_NoRedirectHandler())
+_TRANSFER_OPENER = urllib.request.build_opener(NoRedirectHandler("redirect refused (auth leak prevention)"))
 _DOWNLOAD_OPENER = urllib.request.build_opener(_DownloadRedirectHandler())
 
 

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from comfy_cli.cql._net import is_loopback_host
+from comfy_cli.http import NoRedirectHandler
 
 # ---------------------------------------------------------------------------
 # Types — mirrors nodegraph/types.go
@@ -1048,16 +1049,7 @@ _logger = logging.getLogger(__name__)
 _MAX_OBJECT_INFO_BYTES = 64 * 1024 * 1024
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Refuse redirects — a 302 from /object_info is suspicious."""
-
-    def http_error_301(self, req, fp, code, msg, headers):
-        raise urllib.error.HTTPError(req.full_url, code, "redirect refused", headers, fp)
-
-    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
-
-
-_opener = urllib.request.build_opener(_NoRedirectHandler())
+_opener = urllib.request.build_opener(NoRedirectHandler())
 
 
 class LoadError(Exception):

--- a/comfy_cli/cql/loader.py
+++ b/comfy_cli/cql/loader.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from comfy_cli.cql._net import is_loopback_host
 from comfy_cli.cql.errors import CQLRuntimeError
+from comfy_cli.http import NoRedirectHandler
 
 # Cap raw bytes read from disk or the network. Real `object_info` dumps are a
 # few MB; anything past 256 MiB is almost certainly a wrong path or a hostile
@@ -37,17 +38,7 @@ from comfy_cli.cql.errors import CQLRuntimeError
 MAX_INPUT_BYTES = 256 * 1024 * 1024
 
 
-class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    """Refuse redirects — a 302 from /object_info to elsewhere is suspicious
-    and would expose us to a different server than the user asked to query."""
-
-    def http_error_301(self, req, fp, code, msg, headers):
-        raise urllib.error.HTTPError(req.full_url, code, "redirect refused", headers, fp)
-
-    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
-
-
-_LOADER_OPENER = urllib.request.build_opener(_NoRedirect())
+_LOADER_OPENER = urllib.request.build_opener(NoRedirectHandler())
 
 
 def load_graph(

--- a/comfy_cli/http.py
+++ b/comfy_cli/http.py
@@ -1,0 +1,26 @@
+"""Shared HTTP helpers with an auth-leak-safe redirect policy."""
+
+import urllib.error
+import urllib.request
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse to follow HTTP redirects.
+
+    Following a redirect with ``Authorization: Bearer …`` / ``X-API-Key`` in
+    flight risks replaying the credential at the redirect target (auth leak /
+    SSRF). None of our authenticated endpoints redirect under normal
+    operation; a 30x is almost certainly a misconfiguration or an attack, so
+    we surface it as a clear ``HTTPError`` instead of following it.
+
+    ``message`` is parameterizable so call sites can keep their own wording.
+    """
+
+    def __init__(self, message: str = "redirect refused"):
+        super().__init__()
+        self._message = message
+
+    def http_error_301(self, req, fp, code, msg, headers):
+        raise urllib.error.HTTPError(req.full_url, code, self._message, headers, fp)
+
+    http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301

--- a/tests/comfy_cli/test_http.py
+++ b/tests/comfy_cli/test_http.py
@@ -1,0 +1,44 @@
+import http.client
+import urllib.error
+import urllib.request
+
+import pytest
+
+from comfy_cli.http import NoRedirectHandler
+
+
+def _call(handler, method_name, code=302):
+    req = urllib.request.Request("https://example.com/thing")
+    headers = http.client.HTTPMessage()
+    method = getattr(handler, method_name)
+    method(req, None, code, "Found", headers)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["http_error_301", "http_error_302", "http_error_303", "http_error_307", "http_error_308"],
+)
+def test_refuses_every_redirect_status(method_name):
+    handler = NoRedirectHandler()
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _call(handler, method_name, code=308)
+    err = exc_info.value
+    assert err.code == 308  # status code is preserved
+    assert str(err.reason) == "redirect refused"  # default message
+    assert err.url == "https://example.com/thing"
+
+
+def test_default_message():
+    handler = NoRedirectHandler()
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _call(handler, "http_error_301", code=301)
+    assert exc_info.value.code == 301
+    assert str(exc_info.value.reason) == "redirect refused"
+
+
+def test_custom_message_passthrough():
+    handler = NoRedirectHandler("redirect refused (auth leak prevention)")
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _call(handler, "http_error_302", code=302)
+    assert str(exc_info.value.reason) == "redirect refused (auth leak prevention)"
+    assert exc_info.value.code == 302


### PR DESCRIPTION
## ELI-5

Five different files each had their own private copy of the same little safety class that says *"if a server tries to redirect this authenticated request somewhere else, refuse — don't hand over the `Bearer` token / `X-API-Key` to wherever it points."* Five identical copies means a future security fix could land in one and be forgotten in the other four. This PR replaces all five with **one** audited definition in a new `comfy_cli/http.py`, so there's a single source of truth.

## What changed

- **New module `comfy_cli/http.py`** — one `NoRedirectHandler` (stdlib-only, so no import cycles). It refuses to follow any 30x redirect and raises a clear `HTTPError` instead. The refusal `message` is a constructor arg so call sites keep their own wording.
- **Swapped in at all 5 sites**, deleting each local copy:
  - `comfy_client.py` (`_NoRedirectHandler`)
  - `cql/engine.py` (`_NoRedirectHandler`)
  - `cql/loader.py` (`_NoRedirect`)
  - `cloud/oauth.py` (`_NoRedirect`)
  - `command/transfer.py` (`_NoRedirectHandler`) — passes `"redirect refused (auth leak prevention)"` to preserve its original message byte-for-byte.
- **New tests** `tests/comfy_cli/test_http.py` — assert every redirect status (301/302/303/307/308) raises `HTTPError` with the code preserved, the default `"redirect refused"` message, and a custom message passed through.

## Deliberately NOT touched

- `command/transfer.py`'s `_DownloadRedirectHandler` / `_DOWNLOAD_OPENER` — that one *intentionally follows* redirects while stripping auth headers (for cloud `/api/view` → signed-GCS 302s). It is a distinct handler, not a duplicate. Left entirely alone.
- Did not consolidate the separate `_LOOPBACK_HOSTS` duplication — out of scope for this ticket.

## Behavior

Pure refactor — no behavior change. All four non-transfer sites already used the message `"redirect refused"` (now the default); transfer's longer message is preserved via the constructor arg. No import removals were needed (every file that kept `import urllib.error` still uses it elsewhere).

## Verification

- `ruff check` + `ruff format --check` clean (ruff v0.15.15, matching the repo's pre-commit pin).
- Full `pytest` suite: **2324 passed, 36 skipped**.

## Judgment calls

- Dropped the per-site rationale comments/docstrings in favor of the one consolidated docstring in `http.py` (the ticket calls for deleting the local classes; the shared docstring captures the auth-leak/SSRF reasoning).