### PR TITLE
refactor: route comfy run host:port through shared IPv6-aware resolver (BE-2155)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -812,23 +812,14 @@ def run(
             )
             return
 
+        from comfy_cli.host_port import parse_host_port_arg, resolve_host_port
+
         if host:
-            s = host.split(":")
-            host = s[0]
-            if not port and len(s) == 2:
-                port = int(s[1])
+            host, parsed_port = parse_host_port_arg(host)
+            if not port and parsed_port is not None:
+                port = parsed_port
 
-        if config.background:
-            bg_host, bg_port = config.background[0], config.background[1]
-            if not host:
-                host = bg_host
-            if not port:
-                port = bg_port
-
-        if not host:
-            host = "127.0.0.1"
-        if not port:
-            port = 8188
+        host, port = resolve_host_port(host, port)
 
         run_inner.execute(
             workflow,

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -34,15 +34,11 @@ import typer
 from websocket import WebSocket, WebSocketException, WebSocketTimeoutException
 
 from comfy_cli import cancellation, execution_errors, tracking
-from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import check_comfy_server_running
+from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.output import get_renderer
 
 app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch ComfyUI prompts.")
-
-
-DEFAULT_HOST = "127.0.0.1"
-DEFAULT_PORT = 8188
 
 
 def _is_pid_alive(pid: int) -> bool:
@@ -59,34 +55,9 @@ def _is_pid_alive(pid: int) -> bool:
         return True
 
 
-# ---------------------------------------------------------------------------
-# Host/port resolution (reuse the same precedence as `comfy run`)
-# ---------------------------------------------------------------------------
-
-
-_UNSAFE_HOST_CHARS = frozenset("/@?#")
-
-
-def _validate_host(host: str) -> str:
-    """Reject host values that could cause URL injection."""
-    if any(c in host for c in _UNSAFE_HOST_CHARS):
-        raise typer.BadParameter(f"invalid host: {host!r} (contains URL-special characters)")
-    return host
-
-
-def _resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
-    cfg = ConfigManager()
-    bg = cfg.background
-    if not host and bg is not None:
-        host = bg[0]
-    if not port and bg is not None:
-        port = bg[1]
-    h = _validate_host(host or DEFAULT_HOST)
-    # Bracket IPv6 literals so callers building "http://{host}:{port}" /
-    # "ws://{host}:{port}" produce valid URLs (e.g. "::1" -> "[::1]").
-    if ":" in h and not h.startswith("["):
-        h = f"[{h}]"
-    return (h, int(port or DEFAULT_PORT))
+# Host/port resolution (`resolve_host_port`) is shared with `comfy run` via
+# `comfy_cli.host_port`; imported above as `_resolve_host_port` to preserve the
+# call sites in this module unchanged.
 
 
 def _server_or_error(host: str, port: int, *, raise_on_missing: bool = True) -> bool:

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -1,9 +1,11 @@
 """Shared host/port parsing + resolution for local ComfyUI commands.
 
 Both ``comfy run`` and every ``comfy jobs`` subcommand accept a ``--host`` /
-``--port`` pair (and a combined ``host[:port]`` string), fall back to the
-persisted ``config.background`` server, then to ``DEFAULT_HOST`` /
-``DEFAULT_PORT``. They also feed the resolved host straight into URLs like
+``--port`` pair, fall back to the persisted ``config.background`` server, then
+to ``DEFAULT_HOST`` / ``DEFAULT_PORT``. In addition, ``comfy run`` accepts a
+combined ``host[:port]`` string (parsed via ``parse_host_port_arg``); the
+``comfy jobs`` subcommands only take the separate ``--host`` / ``--port``
+options. They all feed the resolved host straight into URLs like
 ``http://{host}:{port}/prompt`` / ``ws://{host}:{port}/ws``, so the value must
 be validated (no URL-injection characters) and IPv6 literals bracketed. This
 module is the single home for that logic; callers should not re-implement it.
@@ -24,6 +26,10 @@ def validate_host(host: str) -> str:
     """Reject host values that could cause URL injection."""
     if any(c in host for c in _UNSAFE_HOST_CHARS):
         raise typer.BadParameter(f"invalid host: {host!r} (contains URL-special characters)")
+    # Whitespace/control chars (notably CR/LF) never appear in a real host and
+    # are the canonical header/URL-injection vectors, so reject them too.
+    if any(c.isspace() or ord(c) < 0x20 or ord(c) == 0x7F for c in host):
+        raise typer.BadParameter(f"invalid host: {host!r} (contains whitespace or control characters)")
     return host
 
 
@@ -41,21 +47,37 @@ def parse_host_port_arg(value: str) -> tuple[str, int | None]:
             raise typer.BadParameter(f"invalid host: {value!r} (unterminated '[')")
         host = v[1:end]
         rest = v[end + 1 :]
-        if rest.startswith(":") and rest[1:]:
-            return host, _to_port(rest[1:], value)
-        return host, None
+        if rest:
+            # Only a ``:port`` suffix is allowed after the bracket; anything
+            # else (e.g. ``[::1]8188``) is a typo we must not silently drop.
+            if not rest.startswith(":"):
+                raise typer.BadParameter(f"invalid host: {value!r} (unexpected text after ']')")
+            if rest[1:]:
+                return _require_host(host, value), _to_port(rest[1:], value)
+        return _require_host(host, value), None
     if v.count(":") == 1:  # exactly one colon -> host:port
         h, p = v.split(":")
-        return h, (_to_port(p, value) if p else None)
+        return _require_host(h, value), (_to_port(p, value) if p else None)
     # zero colons -> hostname only; 2+ colons -> bare IPv6 literal (no port)
-    return v, None
+    return _require_host(v, value), None
+
+
+def _require_host(host: str, original: str) -> str:
+    """Reject an empty host so ``:8188`` / ``[]:8188`` error instead of
+    silently retargeting the request to the default/background server."""
+    if not host:
+        raise typer.BadParameter(f"invalid host: {original!r} (empty host)")
+    return host
 
 
 def _to_port(s: str, original: str) -> int:
     try:
-        return int(s)
+        port = int(s)
     except ValueError:
         raise typer.BadParameter(f"invalid port in {original!r}: {s!r} is not a number")
+    if not (1 <= port <= 65535):
+        raise typer.BadParameter(f"invalid port in {original!r}: {port} is out of range (1-65535)")
+    return port
 
 
 def resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -1,0 +1,74 @@
+"""Shared host/port parsing + resolution for local ComfyUI commands.
+
+Both ``comfy run`` and every ``comfy jobs`` subcommand accept a ``--host`` /
+``--port`` pair (and a combined ``host[:port]`` string), fall back to the
+persisted ``config.background`` server, then to ``DEFAULT_HOST`` /
+``DEFAULT_PORT``. They also feed the resolved host straight into URLs like
+``http://{host}:{port}/prompt`` / ``ws://{host}:{port}/ws``, so the value must
+be validated (no URL-injection characters) and IPv6 literals bracketed. This
+module is the single home for that logic; callers should not re-implement it.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from comfy_cli.config_manager import ConfigManager
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8188
+_UNSAFE_HOST_CHARS = frozenset("/@?#")
+
+
+def validate_host(host: str) -> str:
+    """Reject host values that could cause URL injection."""
+    if any(c in host for c in _UNSAFE_HOST_CHARS):
+        raise typer.BadParameter(f"invalid host: {host!r} (contains URL-special characters)")
+    return host
+
+
+def parse_host_port_arg(value: str) -> tuple[str, int | None]:
+    """Split a user-typed combined ``host[:port]`` string, IPv6-aware.
+
+    Accepts: ``'host'``, ``'host:port'``, ``'[::1]'``, ``'[::1]:8188'``, bare
+    ``'::1'``. Returns ``(host, port_or_None)``. Raises ``typer.BadParameter``
+    on a non-numeric port or an unterminated bracket.
+    """
+    v = value.strip()
+    if v.startswith("["):
+        end = v.find("]")
+        if end == -1:
+            raise typer.BadParameter(f"invalid host: {value!r} (unterminated '[')")
+        host = v[1:end]
+        rest = v[end + 1 :]
+        if rest.startswith(":") and rest[1:]:
+            return host, _to_port(rest[1:], value)
+        return host, None
+    if v.count(":") == 1:  # exactly one colon -> host:port
+        h, p = v.split(":")
+        return h, (_to_port(p, value) if p else None)
+    # zero colons -> hostname only; 2+ colons -> bare IPv6 literal (no port)
+    return v, None
+
+
+def _to_port(s: str, original: str) -> int:
+    try:
+        return int(s)
+    except ValueError:
+        raise typer.BadParameter(f"invalid port in {original!r}: {s!r} is not a number")
+
+
+def resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
+    """Fill host/port from ``config.background`` then defaults; validate and
+    bracket IPv6 literals so callers building ``'http://{host}:{port}'`` get a
+    well-formed URL (e.g. ``'::1'`` -> ``'[::1]'``)."""
+    cfg = ConfigManager()
+    bg = cfg.background
+    if not host and bg is not None:
+        host = bg[0]
+    if not port and bg is not None:
+        port = bg[1]
+    h = validate_host(host or DEFAULT_HOST)
+    if ":" in h and not h.startswith("["):
+        h = f"[{h}]"
+    return (h, int(port or DEFAULT_PORT))

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -1,0 +1,156 @@
+"""Tests for the shared host/port resolver (`comfy_cli.host_port`) and its use
+by the `comfy run` command path."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from comfy_cli.host_port import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    parse_host_port_arg,
+    resolve_host_port,
+    validate_host,
+)
+
+# ---------------------------------------------------------------------------
+# parse_host_port_arg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("localhost", ("localhost", None)),
+        ("127.0.0.1:9000", ("127.0.0.1", 9000)),
+        ("[::1]:8188", ("::1", 8188)),
+        ("[::1]", ("::1", None)),
+        ("::1", ("::1", None)),  # bare IPv6 literal (2+ colons) -> no port
+        ("127.0.0.1", ("127.0.0.1", None)),
+        ("  localhost:8080  ", ("localhost", 8080)),  # whitespace is stripped
+        ("localhost:", ("localhost", None)),  # trailing colon, empty port
+    ],
+)
+def test_parse_host_port_arg(value, expected):
+    assert parse_host_port_arg(value) == expected
+
+
+def test_parse_host_port_arg_non_numeric_port_raises():
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg("localhost:notaport")
+
+
+def test_parse_host_port_arg_non_numeric_bracketed_port_raises():
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg("[::1]:notaport")
+
+
+def test_parse_host_port_arg_unterminated_bracket_raises():
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg("[::1")
+
+
+# ---------------------------------------------------------------------------
+# validate_host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "example.com"])
+def test_validate_host_allows_safe(host):
+    assert validate_host(host) == host
+
+
+@pytest.mark.parametrize("host", ["evil.com/@x", "a/b", "h@ost", "h?ost", "h#ost"])
+def test_validate_host_rejects_url_special_chars(host):
+    with pytest.raises(typer.BadParameter):
+        validate_host(host)
+
+
+# ---------------------------------------------------------------------------
+# resolve_host_port
+# ---------------------------------------------------------------------------
+
+
+def _patch_background(bg):
+    """Patch ConfigManager as seen by resolve_host_port so `.background` == bg."""
+    cfg = MagicMock()
+    cfg.background = bg
+    return patch("comfy_cli.host_port.ConfigManager", return_value=cfg)
+
+
+def test_resolve_host_port_brackets_ipv6():
+    with _patch_background(None):
+        assert resolve_host_port("::1", None) == ("[::1]", DEFAULT_PORT)
+
+
+def test_resolve_host_port_does_not_double_bracket():
+    with _patch_background(None):
+        assert resolve_host_port("[::1]", 8188) == ("[::1]", 8188)
+
+
+def test_resolve_host_port_rejects_unsafe_host():
+    with _patch_background(None), pytest.raises(typer.BadParameter):
+        resolve_host_port("evil.com/@x", None)
+
+
+def test_resolve_host_port_applies_defaults():
+    with _patch_background(None):
+        assert resolve_host_port(None, None) == (DEFAULT_HOST, DEFAULT_PORT)
+
+
+def test_resolve_host_port_falls_back_to_background():
+    # config.background is a (host, port, pid) tuple.
+    with _patch_background(("10.0.0.5", 9001, 4242)):
+        assert resolve_host_port(None, None) == ("10.0.0.5", 9001)
+
+
+def test_resolve_host_port_explicit_overrides_background():
+    with _patch_background(("10.0.0.5", 9001, 4242)):
+        assert resolve_host_port("localhost", 7000) == ("localhost", 7000)
+
+
+# ---------------------------------------------------------------------------
+# `comfy run` integration — host flows through the resolver
+# ---------------------------------------------------------------------------
+
+
+def _write_workflow(tmp_path):
+    wf = tmp_path / "wf.json"
+    wf.write_text('{"1": {"class_type": "X", "inputs": {}}}')
+    return str(wf)
+
+
+def test_run_ipv6_host_port_reaches_execute(tmp_path):
+    from typer.testing import CliRunner
+
+    from comfy_cli.cmdline import app
+
+    with patch("comfy_cli.command.run.execute") as mock_execute:
+        result = CliRunner().invoke(
+            app,
+            ["run", "--workflow", _write_workflow(tmp_path), "--host", "[::1]:8188"],
+            env={"COMFY_WHERE": "local"},
+        )
+    assert result.exit_code == 0, result.output
+    args, _ = mock_execute.call_args
+    # execute(workflow, host, port, ...)
+    assert args[1] == "[::1]"
+    assert args[2] == 8188
+
+
+def test_run_unsafe_host_exits_before_execute(tmp_path):
+    from typer.testing import CliRunner
+
+    from comfy_cli.cmdline import app
+
+    with patch("comfy_cli.command.run.execute") as mock_execute:
+        result = CliRunner().invoke(
+            app,
+            ["run", "--workflow", _write_workflow(tmp_path), "--host", "x/@y"],
+            env={"COMFY_WHERE": "local"},
+        )
+    assert result.exit_code != 0
+    mock_execute.assert_not_called()

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -53,6 +53,25 @@ def test_parse_host_port_arg_unterminated_bracket_raises():
         parse_host_port_arg("[::1")
 
 
+@pytest.mark.parametrize("value", ["[::1]8188", "[::1]junk"])
+def test_parse_host_port_arg_trailing_text_after_bracket_raises(value):
+    # A missing/garbled ':' after ']' must error, not silently drop the port.
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg(value)
+
+
+@pytest.mark.parametrize("value", ["host:0", "host:-1", "host:99999", "[::1]:0", "[::1]:70000"])
+def test_parse_host_port_arg_out_of_range_port_raises(value):
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg(value)
+
+
+@pytest.mark.parametrize("value", [":8188", "[]:8188"])
+def test_parse_host_port_arg_empty_host_raises(value):
+    with pytest.raises(typer.BadParameter):
+        parse_host_port_arg(value)
+
+
 # ---------------------------------------------------------------------------
 # validate_host
 # ---------------------------------------------------------------------------
@@ -65,6 +84,12 @@ def test_validate_host_allows_safe(host):
 
 @pytest.mark.parametrize("host", ["evil.com/@x", "a/b", "h@ost", "h?ost", "h#ost"])
 def test_validate_host_rejects_url_special_chars(host):
+    with pytest.raises(typer.BadParameter):
+        validate_host(host)
+
+
+@pytest.mark.parametrize("host", ["host\r\nX", "ho st", "host\t", "host\x00"])
+def test_validate_host_rejects_whitespace_and_control_chars(host):
     with pytest.raises(typer.BadParameter):
         validate_host(host)
 


### PR DESCRIPTION
## ELI-5

When you run `comfy run --host ...`, the code used to chop the host apart with a
plain `host.split(":")`. That works for `1.2.3.4:9000` but breaks on IPv6
addresses (which are full of colons, like `::1`), skipped the safety check that
blocks sneaky URL characters, and hardcoded `127.0.0.1`/`8188` instead of the
shared constants. Meanwhile the `comfy jobs` commands already had a careful,
IPv6-aware helper doing this right.

This PR pulls that careful helper into one shared home (`comfy_cli/host_port.py`)
and points `comfy run` at it. Now `comfy run` validates the host, brackets IPv6
literals (`::1` → `[::1]`) so the resulting `http://.../prompt` URL is valid, and
uses the same defaults as everything else. `comfy jobs` behavior is unchanged.

## What changed

- **New module `comfy_cli/host_port.py`** — the shared host/port logic, moved out
  of `jobs.py` with public (no-underscore) names:
  - `validate_host` — rejects URL-injection chars (`/@?#`).
  - `parse_host_port_arg` — IPv6-aware split of a combined `host[:port]` string
    (`[::1]:8188`, bare `::1`, `host:port`, `host`), raising `typer.BadParameter`
    on a non-numeric port or unterminated bracket.
  - `resolve_host_port` — folds in the `config.background` fallback, `DEFAULT_HOST`/
    `DEFAULT_PORT` defaults, host validation, and IPv6 bracketing.
- **`comfy_cli/command/jobs.py`** — deleted the local copies of these helpers and
  imports `resolve_host_port as _resolve_host_port` so its ~6 call sites are
  untouched. Behavior is byte-identical (verified by the existing jobs suite).
- **`comfy_cli/cmdline.py` `run()`** — replaced the hand-rolled `host.split(":")`
  block (which also duplicated the `config.background` fallback and hardcoded
  defaults) with `parse_host_port_arg` + `resolve_host_port`. The `run` path now
  gets host validation, IPv6 bracketing, and the shared constants — matching the
  `jobs` path.
- **`tests/comfy_cli/test_host_port.py`** — unit tests for all three helpers plus
  two `comfy run` integration tests (`--host [::1]:8188` reaches `execute` with
  host `[::1]` port `8188`; `--host x/@y` exits before any network call).

## Scope

Deliberately narrow per the ticket: this fixes the `run` path and extracts the
shared helper only. It does **not** sweep the other hardcoded `127.0.0.1/8188`
sites (`target.py`, `cmdline.py` `validate`/`which`, cql loaders) — the spike
flagged that as an over-broad refactor for a separate cleanup ticket.

## Testing

- `pytest tests/comfy_cli` — 2243 passed, 12 skipped.
- `ruff check` + `ruff format --check` — clean.
