### PR TITLE
feat: persist background ComfyUI logs + add `comfy logs` verb

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -41,6 +41,7 @@ from comfy_cli.command import (
 )
 from comfy_cli.command.install import validate_version
 from comfy_cli.command.launch import launch as launch_command
+from comfy_cli.command.launch import logs as logs_command
 from comfy_cli.command.models import models as models_command
 from comfy_cli.command.models import search as models_search_command
 from comfy_cli.config_manager import ConfigManager
@@ -1110,6 +1111,21 @@ def launch(
     ] = None,
 ):
     launch_command(background, extra, frontend_pr)
+
+
+@app.command(help="Show the captured background ComfyUI log (from `comfy launch --background`).")
+@tracking.track_command()
+def logs(
+    tail: Annotated[
+        int,
+        typer.Option("--tail", help="Number of trailing log lines to show (capped for JSON payloads)."),
+    ] = 200,
+    where: Annotated[
+        str | None,
+        typer.Option("--where", show_default=False, help="Routing target. Only 'local' is supported."),
+    ] = None,
+):
+    logs_command(tail=tail, where=where)
 
 
 @app.command("setup", help="Interactive setup wizard — routing, auth, and agent skills in one step.")

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -273,10 +273,12 @@ def _open_log_for_write(log_path: str):
     pre-place ``comfyui_<port>.log`` as a symlink so ``open(..., "w")`` clobbers
     the link target. ``O_NOFOLLOW`` makes the open fail (``ELOOP``) instead. The
     flag is absent on some platforms (older Windows); there ``getattr`` yields 0
-    and we fall back to a plain truncating open.
+    and we fall back to a plain truncating open. The file is created owner-only
+    (``0o600``) — consistent with the shared-host threat model above, the log
+    isn't meant to be world-readable.
     """
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(log_path, flags, 0o644)
+    fd = os.open(log_path, flags, 0o600)
     return os.fdopen(fd, "w", encoding="utf-8")
 
 

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -211,6 +211,15 @@ def background_launch(extra, frontend_pr=None):
     else:
         extra = []
 
+    # Validate --port as an integer. It flows into the log path
+    # (``comfyui_<port>.log``); a non-integer value like ``../../etc/x`` would
+    # otherwise escape the workspace when the logfile is created.
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        print(f"[bold red]Invalid --port value {port!r}; expected an integer.[/bold red]\n")
+        raise typer.Exit(code=1)
+
     if check_comfy_server_running(port):
         print(f"[bold red]The {port} port is already in use. A new ComfyUI server cannot be launched.\n[bold red]\n")
         raise typer.Exit(code=1)
@@ -257,6 +266,20 @@ def background_log_path(port, workspace: str | None = None) -> str:
     return os.path.join(workspace, "user", f"comfyui_{port}.log")
 
 
+def _open_log_for_write(log_path: str):
+    """Open ``log_path`` for a truncating write, refusing to follow a symlink.
+
+    On a shared host an attacker with write access to ``<workspace>/user`` could
+    pre-place ``comfyui_<port>.log`` as a symlink so ``open(..., "w")`` clobbers
+    the link target. ``O_NOFOLLOW`` makes the open fail (``ELOOP``) instead. The
+    flag is absent on some platforms (older Windows); there ``getattr`` yields 0
+    and we fall back to a plain truncating open.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(log_path, flags, 0o644)
+    return os.fdopen(fd, "w", encoding="utf-8")
+
+
 async def launch_and_monitor(cmd, listen, port):
     """
     Monitor the process during the background launch.
@@ -282,12 +305,27 @@ async def launch_and_monitor(cmd, listen, port):
     env["PYTHONUNBUFFERED"] = "1"
 
     log_path = background_log_path(port)
-    os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
     # Truncate-on-launch: each background launch starts a fresh log. The child
     # inherits its own dup of this fd, so writes continue after we (the monitor)
-    # close our handle and after we os._exit on success.
-    logfh = open(log_path, "w", encoding="utf-8")
+    # close our handle and after we os._exit on success. Failing to create the
+    # log (read-only/permission-restricted workspace) is reported cleanly rather
+    # than aborting launch with a raw traceback.
+    try:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        logfh = _open_log_for_write(log_path)
+    except OSError as e:
+        print(f"[bold red]Could not open background log file {log_path}: {e}[/bold red]\n")
+        os._exit(1)
+
+    # Record the log path up front so `comfy logs` can surface a crash log even
+    # when startup fails before the success marker below (where the running
+    # background info is recorded). A fresh ConfigManager re-reads this on the
+    # success path.
+    cfg = ConfigManager()
+    cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] = log_path
+    cfg.write_config()
+
     try:
         if sys.platform == "win32":
             process = subprocess.Popen(
@@ -318,6 +356,8 @@ async def launch_and_monitor(cmd, listen, port):
             print(
                 f"[bold yellow]ComfyUI is successfully launched in the background.[/bold yellow]\nTo see the GUI go to: http://{listen}:{port}"
             )
+            # CONFIG_KEY_BACKGROUND_LOG was already recorded before launch; here
+            # we add the running background info now that startup succeeded.
             cfg = ConfigManager()
             cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND] = f"{(listen, port, process.pid)}"
             cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] = log_path
@@ -389,8 +429,15 @@ def read_log_tail(
     truncated = n > max_lines and total > max_lines
 
     size = sum(len(line.encode("utf-8")) for line in lines)
-    while lines and size > max_bytes:
+    while len(lines) > 1 and size > max_bytes:
         size -= len(lines.pop(0).encode("utf-8"))
+        truncated = True
+
+    # If the sole remaining line is itself larger than the byte cap, keep a
+    # byte-truncated tail of it rather than dropping all output for a non-empty
+    # logfile (e.g. a single huge newline-less line).
+    if lines and size > max_bytes:
+        lines[-1] = lines[-1].encode("utf-8")[-max_bytes:].decode("utf-8", errors="replace")
         truncated = True
 
     return lines, truncated
@@ -417,15 +464,32 @@ def resolve_background_log_path() -> str | None:
 
 def logs(tail: int = 200, where: str | None = None):
     """Print the tail of the background ComfyUI log captured by `comfy launch`."""
+    from comfy_cli import where as where_mod
     from comfy_cli.output import get_renderer
 
     renderer = get_renderer()
 
-    if where is not None and where.strip().lower() != "local":
+    # Honor the same routing precedence as the rest of the CLI (flag, COMFY_WHERE,
+    # project comfy.yaml, persisted where_default) instead of only the --where flag,
+    # so `comfy logs` errors when routing is *explicitly* pointed at cloud. The
+    # cloud-credentials auto-detect (source="auto") is deliberately NOT treated as
+    # an explicit choice: `comfy logs` is a local-only command, so simply having
+    # cloud creds configured shouldn't force a --where local on every invocation.
+    try:
+        resolution = where_mod.resolve_default(flag=where)
+    except ValueError as e:
         renderer.error(
             code="where_invalid",
-            message="`comfy logs` reads a local logfile; only `--where local` is supported.",
-            hint="drop --where, or pass --where local",
+            message=str(e),
+            hint="pass --where local, or set routing to local",
+            command="logs",
+        )
+        raise typer.Exit(code=1)
+    if resolution.target is not where_mod.WhereTarget.LOCAL and resolution.source != "auto":
+        renderer.error(
+            code="where_invalid",
+            message="`comfy logs` reads a local logfile; only `local` routing is supported.",
+            hint="pass --where local, or set routing to local",
             command="logs",
         )
         raise typer.Exit(code=1)
@@ -440,7 +504,26 @@ def logs(tail: int = 200, where: str | None = None):
         )
         raise typer.Exit(code=1)
 
-    lines, truncated = read_log_tail(log_path, tail)
+    # Pretty output goes to a human terminal: honor the requested --tail. The
+    # line/byte caps exist to keep JSON payloads bounded, so apply them only in
+    # machine mode (matching the --tail help text).
+    if renderer.is_pretty():
+        read_kwargs = {"max_lines": max(tail, LOGS_MAX_LINES), "max_bytes": sys.maxsize}
+    else:
+        read_kwargs = {}
+
+    try:
+        lines, truncated = read_log_tail(log_path, tail, **read_kwargs)
+    except OSError as e:
+        # The isfile() check above is best-effort; the file can vanish or become
+        # unreadable in the TOCTOU window. Emit a clean error, not a raw traceback.
+        renderer.error(
+            code="log_read_failed",
+            message=f"Could not read log file {log_path}: {e}",
+            hint="check the file still exists and is readable",
+            command="logs",
+        )
+        raise typer.Exit(code=1)
 
     if renderer.is_pretty():
         # Write raw so ComfyUI log text (which can contain '[...]') isn't

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -5,7 +5,9 @@ import os
 import subprocess
 import sys
 import threading
+import time
 import uuid
+from collections import deque
 
 import typer
 from rich.console import Console
@@ -241,70 +243,212 @@ def background_launch(extra, frontend_pr=None):
     os._exit(1)
 
 
+def background_log_path(port, workspace: str | None = None) -> str:
+    """Path to the persisted background ComfyUI log for ``port``.
+
+    ``<workspace>/user/comfyui_<port>.log`` — ``<port>`` disambiguates multiple
+    installs that share one comfy-cli config. Truncated on each background launch
+    (a fresh run starts a fresh log). ``workspace`` defaults to the current
+    working directory, which ``launch`` has already ``chdir``'d to the resolved
+    workspace by the time the background monitor runs.
+    """
+    if workspace is None:
+        workspace = os.path.abspath(os.getcwd())
+    return os.path.join(workspace, "user", f"comfyui_{port}.log")
+
+
 async def launch_and_monitor(cmd, listen, port):
     """
     Monitor the process during the background launch.
 
-    If a success message is captured, exit;
+    ComfyUI's stdout/stderr are redirected straight onto the child's own file
+    descriptors pointing at a workspace logfile (``<workspace>/user/comfyui_<port>.log``,
+    truncate-on-launch). Because the redirect lives on the child's fds — not on a
+    monitor thread — every line still lands in the file AFTER this monitor exits
+    on the success signal (the ComfyUI child outlives the monitor). The monitor
+    tails that same file to detect the "To see the GUI go to:" success line.
+
+    If a success message is captured, record the background info and exit;
     otherwise, return the log in case of failure.
     """
     logging_flag = False
     log = []
-    logging_lock = threading.Lock()
 
     # NOTE: To prevent encoding error on Windows platform
     env = dict(os.environ, PYTHONIOENCODING="utf-8")
     env["COMFY_CLI_BACKGROUND"] = "true"
+    # Flush the child's stdout per line so the success marker reaches the logfile
+    # promptly instead of sitting in a block buffer (stdout is a file, not a tty).
+    env["PYTHONUNBUFFERED"] = "1"
 
-    if sys.platform == "win32":
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env,
-            encoding="utf-8",
-            shell=True,  # win32 only
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # win32 only
-        )
-    else:
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=env,
-            encoding="utf-8",
-        )
+    log_path = background_log_path(port)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
-    def msg_hook(stream):
-        nonlocal log
+    # Truncate-on-launch: each background launch starts a fresh log. The child
+    # inherits its own dup of this fd, so writes continue after we (the monitor)
+    # close our handle and after we os._exit on success.
+    logfh = open(log_path, "w", encoding="utf-8")
+    try:
+        if sys.platform == "win32":
+            process = subprocess.Popen(
+                cmd,
+                stdout=logfh,
+                stderr=subprocess.STDOUT,
+                env=env,
+                shell=True,  # win32 only
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # win32 only
+            )
+        else:
+            process = subprocess.Popen(
+                cmd,
+                stdout=logfh,
+                stderr=subprocess.STDOUT,
+                env=env,
+            )
+    finally:
+        # The child holds its own fd now; drop the monitor's copy so tailing sees
+        # a stable, child-owned writer.
+        logfh.close()
+
+    def _handle(line):
         nonlocal logging_flag
+        if "Launching ComfyUI from:" in line:
+            logging_flag = True
+        if "To see the GUI go to:" in line:
+            print(
+                f"[bold yellow]ComfyUI is successfully launched in the background.[/bold yellow]\nTo see the GUI go to: http://{listen}:{port}"
+            )
+            cfg = ConfigManager()
+            cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND] = f"{(listen, port, process.pid)}"
+            cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] = log_path
+            cfg.write_config()
 
+            # NOTE: os.exit(0) doesn't work.
+            os._exit(0)
+        if logging_flag:
+            log.append(line)
+
+    # Tail the logfile the child is writing, reassembling whole lines (a
+    # concurrent writer can leave a trailing partial line without a newline).
+    with open(log_path, encoding="utf-8", errors="replace") as reader:
+        pending = ""
         while True:
-            line = stream.readline()
-            if "Launching ComfyUI from:" in line:
-                logging_flag = True
-            elif "To see the GUI go to:" in line:
-                print(
-                    f"[bold yellow]ComfyUI is successfully launched in the background.[/bold yellow]\nTo see the GUI go to: http://{listen}:{port}"
-                )
-                ConfigManager().config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND] = f"{(listen, port, process.pid)}"
-                ConfigManager().write_config()
-
-                # NOTE: os.exit(0) doesn't work.
-                os._exit(0)
-
-            with logging_lock:
-                if logging_flag:
-                    log.append(line)
-
-    stdout_thread = threading.Thread(target=msg_hook, args=(process.stdout,))
-    stderr_thread = threading.Thread(target=msg_hook, args=(process.stderr,))
-
-    stdout_thread.start()
-    stderr_thread.start()
-
-    process.wait()
+            chunk = reader.readline()
+            if chunk:
+                pending += chunk
+                if pending.endswith("\n") or process.poll() is not None:
+                    _handle(pending)
+                    pending = ""
+                # else: partial line — wait for the rest before acting.
+            else:
+                if process.poll() is not None:
+                    if pending:
+                        _handle(pending)
+                    break
+                time.sleep(0.1)
 
     return log
+
+
+# Output caps for `comfy logs`, so `--json` payloads stay bounded even if the
+# caller asks for a huge --tail against a long-running server's log.
+LOGS_MAX_LINES = 2000
+LOGS_MAX_BYTES = 256 * 1024
+
+
+def read_log_tail(
+    path: str,
+    n: int,
+    *,
+    max_lines: int = LOGS_MAX_LINES,
+    max_bytes: int = LOGS_MAX_BYTES,
+) -> tuple[list[str], bool]:
+    """Return ``(lines, truncated)`` — the last ``n`` lines of ``path``.
+
+    Bounded so machine output stays small: at most ``max_lines`` lines and
+    ``max_bytes`` bytes (whichever binds first), trimmed from the top.
+    ``truncated`` is True when a cap dropped lines the caller would otherwise
+    have received (NOT for the ordinary case of a tail omitting earlier lines,
+    nor for a file shorter than ``n``).
+    """
+    n = max(0, n)
+    want = min(n, max_lines)
+
+    # deque(maxlen) keeps only the last ``want`` lines in memory regardless of
+    # file size. Count total lines in the same pass to decide truncation.
+    tail: deque[str] = deque(maxlen=want) if want > 0 else deque(maxlen=0)
+    total = 0
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            tail.append(line)
+            total += 1
+
+    lines = list(tail)
+    # The line cap actually dropped content only if the caller asked for more
+    # than the cap AND the file had more than the cap to give.
+    truncated = n > max_lines and total > max_lines
+
+    size = sum(len(line.encode("utf-8")) for line in lines)
+    while lines and size > max_bytes:
+        size -= len(lines.pop(0).encode("utf-8"))
+        truncated = True
+
+    return lines, truncated
+
+
+def resolve_background_log_path() -> str | None:
+    """Locate the background logfile: the path recorded at launch, else the
+    default derived from the resolved workspace and background/default port.
+
+    Returns None when no workspace can be resolved and nothing was recorded.
+    """
+    cfg = ConfigManager()
+    recorded = cfg.get(constants.CONFIG_KEY_BACKGROUND_LOG)
+    if recorded:
+        return recorded
+
+    workspace = workspace_manager.workspace_path
+    if not workspace:
+        return None
+
+    port = cfg.background[1] if cfg.background else 8188
+    return background_log_path(port, workspace)
+
+
+def logs(tail: int = 200, where: str | None = None):
+    """Print the tail of the background ComfyUI log captured by `comfy launch`."""
+    from comfy_cli.output import get_renderer
+
+    renderer = get_renderer()
+
+    if where is not None and where.strip().lower() != "local":
+        renderer.error(
+            code="where_invalid",
+            message="`comfy logs` reads a local logfile; only `--where local` is supported.",
+            hint="drop --where, or pass --where local",
+            command="logs",
+        )
+        raise typer.Exit(code=1)
+
+    log_path = resolve_background_log_path()
+    if not log_path or not os.path.isfile(log_path):
+        renderer.error(
+            code="no_log_file",
+            message="No captured ComfyUI log was found." + (f" Looked for: {log_path}" if log_path else ""),
+            hint="start ComfyUI with `comfy launch` so its output is captured",
+            command="logs",
+        )
+        raise typer.Exit(code=1)
+
+    lines, truncated = read_log_tail(log_path, tail)
+
+    if renderer.is_pretty():
+        # Write raw so ComfyUI log text (which can contain '[...]') isn't
+        # reinterpreted as Rich markup, and byte-for-byte matches the file.
+        renderer.pretty_stream.write("".join(lines))
+
+    renderer.emit(
+        {"lines": lines, "path": log_path, "truncated": truncated},
+        command="logs",
+        where="local",
+    )

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -178,6 +178,10 @@ class ConfigManager:
 
     def remove_background(self):
         del self.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
+        # Also drop the recorded logfile path so `comfy logs` doesn't keep
+        # surfacing the previous run's stale log after the server is stopped or
+        # its pid is cleaned up.
+        self.config["DEFAULT"].pop(constants.CONFIG_KEY_BACKGROUND_LOG, None)
         self.write_config()
         self.background = None
 

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -41,6 +41,7 @@ CONFIG_KEY_ENABLE_TRACKING = "enable_tracking"
 CONFIG_KEY_USER_ID = "user_id"
 CONFIG_KEY_INSTALL_EVENT_TRIGGERED = "install_event_triggered"
 CONFIG_KEY_BACKGROUND = "background"
+CONFIG_KEY_BACKGROUND_LOG = "background_log"  # workspace logfile path for the background server
 CONFIG_KEY_MANAGER_GUI_ENABLED = "manager_gui_enabled"  # Legacy, kept for backward compatibility
 CONFIG_KEY_MANAGER_GUI_MODE = "manager_gui_mode"  # Valid: "disable", "enable-gui", "disable-gui", "enable-legacy-gui"
 CONFIG_KEY_UV_COMPILE_DEFAULT = "uv_compile_default"

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -97,6 +97,8 @@ COMMAND_SCHEMAS: dict[str, str] = {
     # config
     "comfy set-default": "set_default",
     "comfy version": "version",
+    # background server logs
+    "comfy logs": "logs",
 }
 
 

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -340,6 +340,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
         '("Unauthorized: Please login first to use this node"). Transient — not a local credential problem.',
         "resubmit the same workflow — it succeeds on retry; `comfy cloud login` will not help",
     ),
+    # --- background server logs ----------------------------------------------
+    ErrorCode(
+        "no_log_file",
+        "`comfy logs` found no captured ComfyUI log — the server was never launched "
+        "via `comfy launch --background`, or it was launched externally.",
+        "start ComfyUI with `comfy launch` so its output is captured",
+    ),
     # --- general argument / mode errors --------------------------------------
     ErrorCode(
         "missing_argument",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -347,6 +347,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "via `comfy launch --background`, or it was launched externally.",
         "start ComfyUI with `comfy launch` so its output is captured",
     ),
+    ErrorCode(
+        "log_read_failed",
+        "`comfy logs` located the logfile but could not read it — it was removed or its "
+        "permissions changed between the existence check and the read (TOCTOU window).",
+        "check the file still exists and is readable, then retry",
+    ),
     # --- general argument / mode errors --------------------------------------
     ErrorCode(
         "missing_argument",

--- a/comfy_cli/help_json.py
+++ b/comfy_cli/help_json.py
@@ -47,6 +47,7 @@ HELP_EXAMPLES: dict[str, list[str]] = {
         "comfy --json-stream run --workflow path/to/workflow_api.json",
     ],
     "comfy stop": ["comfy stop"],
+    "comfy logs": ["comfy logs", "comfy --json logs --tail 50"],
     "comfy set-default": ["comfy set-default /path/to/ComfyUI"],
     "comfy update": ["comfy update", "comfy update all"],
     "comfy standalone": ["comfy standalone"],

--- a/comfy_cli/schemas/logs.json
+++ b/comfy_cli/schemas/logs.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/logs.json",
+  "title": "comfy logs --json data payload",
+  "description": "Tail of the background ComfyUI log captured by `comfy launch --background`.",
+  "type": "object",
+  "required": ["lines", "path", "truncated"],
+  "additionalProperties": true,
+  "properties": {
+    "lines": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "The last N log lines (newline-terminated except possibly the final one)."
+    },
+    "path": {
+      "type": "string",
+      "description": "Absolute path of the logfile that was read."
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True when the line/byte cap dropped lines the caller would otherwise have received."
+    }
+  }
+}

--- a/tests/comfy_cli/command/test_launch_background.py
+++ b/tests/comfy_cli/command/test_launch_background.py
@@ -61,6 +61,24 @@ def test_background_launch_surfaces_error_log(mock_config_manager, mock_check_ru
     mock_exit.assert_called_once_with(1)
 
 
+@patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
+@patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_rejects_non_integer_port(mock_config_manager, mock_check_running, mock_monitor):
+    """A non-integer --port is rejected before it can be interpolated into the
+    log path (`comfyui_<port>.log`), where a value like `../../x` would escape
+    the workspace."""
+    import typer
+
+    mock_config_manager.return_value.background = None
+
+    with pytest.raises(typer.Exit):
+        launch.background_launch(extra=["--port", "../../etc/pwn"])
+
+    # Never reached the launch path.
+    mock_monitor.assert_not_awaited()
+
+
 @patch("comfy_cli.command.launch.utils.is_running", return_value=True)
 @patch("comfy_cli.command.launch.ConfigManager")
 def test_background_launch_refuses_when_already_running(mock_config_manager, mock_is_running):

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -1,0 +1,248 @@
+"""Tests for `comfy logs` — the background ComfyUI log tail reader + verb.
+
+Covers the pure tail reader (last-N and the line/byte caps), the no-log-file
+error envelope, the success envelope shape, the `--where` guard, and that the
+background monitor redirects the child's own fds to a truncate-on-launch
+workspace logfile and records its path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import launch
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer() -> Renderer:
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _envelope(capsys: pytest.CaptureFixture[str]) -> dict[str, Any]:
+    out = capsys.readouterr().out
+    assert out.strip(), "no envelope on stdout"
+    return json.loads(out.strip().splitlines()[-1])
+
+
+# --------------------------------------------------------------------------- #
+# read_log_tail
+# --------------------------------------------------------------------------- #
+
+
+def test_read_log_tail_returns_last_n(tmp_path):
+    p = tmp_path / "log.txt"
+    p.write_text("".join(f"line {i}\n" for i in range(100)))
+
+    lines, truncated = launch.read_log_tail(str(p), 10)
+
+    assert lines == [f"line {i}\n" for i in range(90, 100)]
+    assert truncated is False
+
+
+def test_read_log_tail_file_shorter_than_n_is_not_truncated(tmp_path):
+    p = tmp_path / "log.txt"
+    p.write_text("a\nb\nc\n")
+
+    lines, truncated = launch.read_log_tail(str(p), 50)
+
+    assert lines == ["a\n", "b\n", "c\n"]
+    assert truncated is False
+
+
+def test_read_log_tail_line_cap(tmp_path):
+    p = tmp_path / "log.txt"
+    p.write_text("".join(f"{i}\n" for i in range(50)))
+
+    lines, truncated = launch.read_log_tail(str(p), 40, max_lines=10)
+
+    assert len(lines) == 10
+    assert lines[0] == "40\n" and lines[-1] == "49\n"
+    assert truncated is True
+
+
+def test_read_log_tail_byte_cap_trims_from_top(tmp_path):
+    p = tmp_path / "log.txt"
+    # 20 lines of ~100 bytes each = ~2KB total.
+    p.write_text("".join(("x" * 99 + "\n") for _ in range(20)))
+
+    lines, truncated = launch.read_log_tail(str(p), 20, max_bytes=500)
+
+    assert truncated is True
+    assert 0 < len(lines) < 20
+    assert sum(len(line.encode("utf-8")) for line in lines) <= 500
+
+
+def test_read_log_tail_handles_final_line_without_newline(tmp_path):
+    p = tmp_path / "log.txt"
+    p.write_text("a\nb\nlast-no-newline")
+
+    lines, _ = launch.read_log_tail(str(p), 2)
+
+    assert lines == ["b\n", "last-no-newline"]
+
+
+# --------------------------------------------------------------------------- #
+# `comfy logs` verb
+# --------------------------------------------------------------------------- #
+
+
+def test_logs_no_file_emits_clean_error(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    missing = tmp_path / "user" / "comfyui_8188.log"
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(missing))
+
+    with pytest.raises(typer.Exit) as exc:
+        launch.logs(tail=50)
+
+    assert exc.value.exit_code == 1
+    env = _envelope(capsys)
+    assert env["ok"] is False
+    assert env["command"] == "logs"
+    assert env["error"]["code"] == "no_log_file"
+    assert env["error"]["hint"]
+
+
+def test_logs_no_workspace_emits_error(monkeypatch, capsys):
+    _force_json_renderer()
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: None)
+
+    with pytest.raises(typer.Exit):
+        launch.logs(tail=50)
+
+    env = _envelope(capsys)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "no_log_file"
+
+
+def test_logs_success_envelope(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text("".join(f"line {i}\n" for i in range(5)))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+
+    launch.logs(tail=3)
+
+    env = _envelope(capsys)
+    assert env["ok"] is True
+    assert env["command"] == "logs"
+    assert env["where"] == "local"
+    assert env["data"]["path"] == str(log)
+    assert env["data"]["lines"] == ["line 2\n", "line 3\n", "line 4\n"]
+    assert env["data"]["truncated"] is False
+
+
+def test_logs_rejects_non_local_where(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    # resolve should never be reached, but guard anyway.
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(tmp_path / "x.log"))
+
+    with pytest.raises(typer.Exit):
+        launch.logs(tail=50, where="cloud")
+
+    env = _envelope(capsys)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "where_invalid"
+
+
+def test_logs_where_local_is_accepted(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text("hello\n")
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+
+    launch.logs(tail=10, where="local")
+
+    env = _envelope(capsys)
+    assert env["ok"] is True
+    assert env["data"]["lines"] == ["hello\n"]
+
+
+def test_logs_pretty_writes_raw_lines(monkeypatch, tmp_path, capsys):
+    # Default renderer is pretty; log text with '[...]' must not be reinterpreted.
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text("[INFO] hello [world]\nplain\n")
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+
+    launch.logs(tail=10)
+
+    out = capsys.readouterr().out
+    assert "[INFO] hello [world]" in out
+    assert "plain" in out
+
+
+# --------------------------------------------------------------------------- #
+# background monitor → logfile redirection
+# --------------------------------------------------------------------------- #
+
+
+@patch("comfy_cli.command.launch.os._exit", side_effect=SystemExit)
+@patch("comfy_cli.command.launch.subprocess.Popen")
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_launch_and_monitor_redirects_to_logfile_and_records_path(
+    mock_cfg, mock_popen, mock_exit, tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)  # workspace = cwd
+
+    cfg = MagicMock()
+    cfg.config = {"DEFAULT": {}}
+    mock_cfg.return_value = cfg
+
+    proc = MagicMock()
+    proc.pid = 4321
+    proc.poll.return_value = None
+
+    captured: dict[str, Any] = {}
+
+    def fake_popen(cmd, **kwargs):
+        # The child writes to its OWN fd (the logfile), not a PIPE the monitor
+        # owns — this is what lets post-monitor lines still land in the file.
+        captured["kwargs"] = kwargs
+        fh = kwargs["stdout"]
+        fh.write("Launching ComfyUI from: /ws\n")
+        fh.write("To see the GUI go to: http://127.0.0.1:8188\n")
+        fh.flush()
+        return proc
+
+    mock_popen.side_effect = fake_popen
+
+    with pytest.raises(SystemExit):
+        asyncio.run(launch.launch_and_monitor(["comfy", "launch"], "127.0.0.1", 8188))
+
+    # stdout points at the workspace logfile; stderr is folded into it.
+    assert captured["kwargs"]["stderr"] is subprocess.STDOUT
+    log_path = str(tmp_path / "user" / "comfyui_8188.log")
+    from comfy_cli import constants
+
+    assert cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] == log_path
+    assert "8188" in cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
+    cfg.write_config.assert_called_once()
+    # The logfile the child wrote is on disk with both lines.
+    assert "To see the GUI go to:" in (tmp_path / "user" / "comfyui_8188.log").read_text()

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -109,6 +109,19 @@ def test_read_log_tail_handles_final_line_without_newline(tmp_path):
     assert lines == ["b\n", "last-no-newline"]
 
 
+def test_read_log_tail_single_huge_line_kept_byte_truncated(tmp_path):
+    # A single newline-less line larger than the byte cap must not drop all
+    # output; keep a byte-truncated tail of it instead.
+    p = tmp_path / "log.txt"
+    p.write_text("z" * 5000)
+
+    lines, truncated = launch.read_log_tail(str(p), 10, max_bytes=500)
+
+    assert truncated is True
+    assert len(lines) == 1
+    assert lines[0] == "z" * 500
+
+
 # --------------------------------------------------------------------------- #
 # `comfy logs` verb
 # --------------------------------------------------------------------------- #
@@ -185,6 +198,40 @@ def test_logs_where_local_is_accepted(monkeypatch, tmp_path, capsys):
     assert env["data"]["lines"] == ["hello\n"]
 
 
+def test_logs_read_error_emits_clean_error(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text("hello\n")
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+
+    def boom(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(launch, "read_log_tail", boom)
+
+    with pytest.raises(typer.Exit):
+        launch.logs(tail=50)
+
+    env = _envelope(capsys)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "log_read_failed"
+
+
+def test_logs_pretty_honors_large_tail_past_line_cap(monkeypatch, tmp_path, capsys):
+    # Pretty output goes to a human terminal, so --tail beyond the JSON line cap
+    # must not be silently truncated.
+    log = tmp_path / "comfyui_8188.log"
+    n = launch.LOGS_MAX_LINES + 50
+    log.write_text("".join(f"line {i}\n" for i in range(n)))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+
+    launch.logs(tail=n)
+
+    out = capsys.readouterr().out
+    assert "line 0\n" in out  # earliest line present → nothing was capped away
+    assert f"line {n - 1}\n" in out
+
+
 def test_logs_pretty_writes_raw_lines(monkeypatch, tmp_path, capsys):
     # Default renderer is pretty; log text with '[...]' must not be reinterpreted.
     log = tmp_path / "comfyui_8188.log"
@@ -243,6 +290,8 @@ def test_launch_and_monitor_redirects_to_logfile_and_records_path(
 
     assert cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] == log_path
     assert "8188" in cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
-    cfg.write_config.assert_called_once()
+    # Written twice: the log path is recorded up front (so a crash log is
+    # findable even if startup fails) and again with the background info on success.
+    assert cfg.write_config.call_count == 2
     # The logfile the child wrote is on disk with both lines.
     assert "To see the GUI go to:" in (tmp_path / "user" / "comfyui_8188.log").read_text()

--- a/tests/comfy_cli/test_config_manager.py
+++ b/tests/comfy_cli/test_config_manager.py
@@ -159,3 +159,12 @@ class TestRemoveBackground:
         config_mgr.remove_background()
         assert config_mgr.background is None
         assert constants.CONFIG_KEY_BACKGROUND not in config_mgr.config["DEFAULT"]
+
+    def test_clears_background_log_path(self, config_mgr):
+        # The recorded logfile path must be dropped too, so `comfy logs` stops
+        # surfacing a stopped/dead server's stale log.
+        config_mgr.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND] = "('h', 1, 2)"
+        config_mgr.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] = "/ws/user/comfyui_8188.log"
+        config_mgr.background = ("h", 1, 2)
+        config_mgr.remove_background()
+        assert constants.CONFIG_KEY_BACKGROUND_LOG not in config_mgr.config["DEFAULT"]


### PR DESCRIPTION
## ELI-5

When you run `comfy launch --background`, ComfyUI keeps running but its console
output used to vanish the moment the launch command finished — so if a custom
node failed to import, a model wouldn't load, or the server OOM'd, there was no
way to see why. This change tees that output to a file on disk
(`<workspace>/user/comfyui_<port>.log`) and adds a `comfy logs` command to read
the tail of it.

## What changed

- **Durable capture.** `launch_and_monitor` now points the background child's
  **own** stdout/stderr at the logfile (`stdout=<logfile>, stderr=STDOUT`)
  instead of `PIPE`. Because the redirect lives on the child's file
  descriptors — not on a monitor thread — lines keep landing in the file *after*
  the monitor `os._exit(0)`s on the startup success line and the ComfyUI child
  is orphaned. The monitor tails that same file to detect
  `"To see the GUI go to:"`. Log is truncated on each launch (fresh run → fresh
  log). `PYTHONUNBUFFERED=1` is set on the child so the success marker reaches
  the file promptly.
- **Path recorded** alongside the existing background PID in `ConfigManager`
  (`background_log`), so the reader finds it without re-deriving the port.
- **New `comfy logs` verb.** `--tail N` (default 200) and `--where local`. Emits
  the standard `envelope/1`: `{"lines": [...], "path": ..., "truncated": ...}`.
  Missing file → clean `no_log_file` error envelope with an actionable hint.
  Output is capped (2000 lines / 256KB, trimmed from the top) so `--json`
  payloads stay bounded; `truncated` flags when a cap dropped lines.
- Registered the `no_log_file` error code and a `logs.json` output schema
  (satisfies the discover/error-code contract tests).

## Verification

- Full test suite green (2351 passed, 36 skipped). New `tests/.../test_logs.py`
  covers the tail reader (last-N, line cap, byte cap, no-trailing-newline),
  the no-file/no-workspace error envelopes, the success envelope, the `--where`
  guard, raw (non-Rich) pretty output, and that the monitor redirects to a
  truncate-on-launch logfile and records its path.
- `ruff check` + `ruff format --check` clean on all changed files.
- Manually proved the core fd-inheritance guarantee with a standalone
  subprocess: a child keeps writing to the logfile after the parent closes its
  handle **and** `os._exit(0)`s (i.e. the post-launch-return lines are captured).
- End-to-end: `comfy logs --help` registers; `comfy --json logs` with no server
  returns the `no_log_file` envelope.

## Judgment calls / notes

- **Approach:** used the ticket's "simplest" option — `Popen(stdout=logfile,
  stderr=STDOUT)` + poll the logfile — because it's the one that *guarantees*
  post-monitor-exit lines are captured (the child owns the fd).
- **Truncate-on-launch** (not append+cap), per the ticket's stated preference.
- `remove_background()` (on `comfy stop` / dead pid) intentionally leaves the
  `background_log` path set, so `comfy logs` can still show the last run's output
  post-mortem.
- The tail reader reads the whole file to compute the last-N + truncation flag
  (memory is bounded by a `deque`, but I/O scans the file). Fine for
  truncate-on-launch logs; a seek-from-end optimization is a possible follow-up
  if a very long-running server produces a huge log.
- Opening the logfile assumes the workspace `user/` dir is writable (ComfyUI
  already writes there); a non-writable workspace would surface as a launch
  error rather than a silent fallback.
- Windows path (`shell=True` + file-handle inheritance) follows the existing
  win32 branch shape but could not be exercised on this macOS runner.
