### PR TITLE
fix(transfer): structured envelope on connection errors (BE-2454)

### DIFF
--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -421,6 +421,20 @@ def execute_upload(
                 details={"status": status, "filename": filename},
             )
             raise typer.Exit(code=1)
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            # A connection-level failure (refused / DNS / timeout / TLS at
+            # connect, or a reset / read-timeout mid-transfer) raises URLError,
+            # a bare TimeoutError, or a bare ConnectionError — never HTTPError.
+            # Surface it as a structured envelope instead of letting an
+            # unhandled traceback break machine/NDJSON consumers.
+            reason = getattr(e, "reason", None) or e
+            renderer.error(
+                code="upload_failed",
+                message=f"Failed to upload {filename}: {reason}",
+                hint="check that the server is reachable",
+                details={"filename": filename, "reason": str(reason)},
+            )
+            raise typer.Exit(code=1)
 
         cloud_name = result.get("name", filename)
         subfolder = result.get("subfolder", "")

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -421,12 +421,14 @@ def execute_upload(
                 details={"status": status, "filename": filename},
             )
             raise typer.Exit(code=1)
-        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
-            # A connection-level failure (refused / DNS / timeout / TLS at
-            # connect, or a reset / read-timeout mid-transfer) raises URLError,
-            # a bare TimeoutError, or a bare ConnectionError — never HTTPError.
-            # Surface it as a structured envelope instead of letting an
-            # unhandled traceback break machine/NDJSON consumers.
+        except (urllib.error.URLError, TimeoutError, ConnectionError, http.client.HTTPException) as e:
+            # A connection- or transfer-level failure — not HTTPError. A
+            # refused/DNS/timeout/TLS failure at connect raises URLError; a read
+            # timeout raises a bare TimeoutError; a reset raises ConnectionError;
+            # a truncated (e.g. chunked) response body raises
+            # http.client.IncompleteRead (an HTTPException). Surface it as a
+            # structured envelope instead of an unhandled traceback that breaks
+            # machine/NDJSON consumers.
             reason = getattr(e, "reason", None) or e
             renderer.error(
                 code="upload_failed",

--- a/tests/comfy_cli/command/test_transfer_upload.py
+++ b/tests/comfy_cli/command/test_transfer_upload.py
@@ -14,6 +14,7 @@ import urllib.error
 from pathlib import Path
 
 import pytest
+import typer
 
 from comfy_cli.command import transfer
 from comfy_cli.target import Target
@@ -145,3 +146,36 @@ class TestUploadMachineModeStdoutPurity:
         assert parsed[-1]["data"]["uploads"][0]["cloud_name"] == "ab12.png"
         assert "uploaded" not in captured.out
         assert "uploaded" not in captured.err
+
+
+class TestUploadConnectionError:
+    """A connection-level failure (``URLError``/``TimeoutError``) on upload must
+    surface as a structured ``upload_failed`` envelope, not an unhandled
+    traceback that breaks ``--json``/NDJSON consumers (BE-2454)."""
+
+    @pytest.fixture(autouse=True)
+    def reset_renderer(self):
+        from comfy_cli.output.renderer import reset_renderer_for_testing
+
+        reset_renderer_for_testing()
+        yield
+        reset_renderer_for_testing()
+
+    def test_urlerror_emits_upload_failed_envelope(self, asset, monkeypatch, capsys):
+        from comfy_cli.output import Renderer, set_renderer
+        from comfy_cli.output.renderer import OutputMode
+
+        err = urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener(error=err))
+        monkeypatch.setattr(transfer, "resolve_target", lambda where=None: _local_target())
+        set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
+
+        with pytest.raises(typer.Exit) as excinfo:
+            transfer.execute_upload([str(asset)], where="local")
+
+        assert excinfo.value.exit_code == 1
+        env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+        assert env["ok"] is False
+        assert env["error"]["code"] == "upload_failed"
+        assert "Connection refused" in env["error"]["message"]
+        assert "Connection refused" in env["error"]["details"]["reason"]

--- a/tests/comfy_cli/command/test_transfer_upload.py
+++ b/tests/comfy_cli/command/test_transfer_upload.py
@@ -8,6 +8,7 @@ endpoint is the only ingestion path.
 
 from __future__ import annotations
 
+import http.client
 import io
 import json
 import urllib.error
@@ -179,3 +180,20 @@ class TestUploadConnectionError:
         assert env["error"]["code"] == "upload_failed"
         assert "Connection refused" in env["error"]["message"]
         assert "Connection refused" in env["error"]["details"]["reason"]
+
+    def test_incomplete_read_emits_upload_failed_envelope(self, asset, monkeypatch, capsys):
+        from comfy_cli.output import Renderer, set_renderer
+        from comfy_cli.output.renderer import OutputMode
+
+        # A truncated response body raises http.client.IncompleteRead — an
+        # HTTPException, not a URLError.
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener(error=http.client.IncompleteRead(b"x", 100)))
+        monkeypatch.setattr(transfer, "resolve_target", lambda where=None: _local_target())
+        set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
+
+        with pytest.raises(typer.Exit) as excinfo:
+            transfer.execute_upload([str(asset)], where="local")
+
+        assert excinfo.value.exit_code == 1
+        env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+        assert env["error"]["code"] == "upload_failed"


### PR DESCRIPTION
- `comfy upload` now emits a structured `upload_failed` envelope on a connection- or transfer-level failure (connection refused, DNS failure, timeout, TLS error, mid-transfer reset, or a truncated / `IncompleteRead` body) instead of raising an unhandled `urllib.error.URLError` / `http.client.IncompleteRead` traceback that broke `--json` / NDJSON consumers.
- Adds an `except (urllib.error.URLError, TimeoutError, ConnectionError, http.client.HTTPException)` arm after the existing `HTTPError` arm in `execute_upload` (`comfy_cli/command/transfer.py`); the underlying reason is surfaced in `error.details.reason`, with `HTTPError` still caught first for its HTTP-status message.
- Download-side handling is intentionally out of scope: #494 (BE-2513) already added equivalent, broader connection-error handling to `execute_download`, so this branch was rebased onto it and now covers upload only.
- Adds `test_transfer_upload.py::TestUploadConnectionError` (URLError and `IncompleteRead` cases), asserting exit code 1 and a pure-JSON `upload_failed` envelope.
