### PR TITLE
test(e2e): fail-fast + retry comfy install in workspace fixtures (BE-2498)

### DIFF
--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import time
 from datetime import datetime
 from textwrap import dedent
 
@@ -47,14 +48,35 @@ def workspace():
     install_flags = os.getenv("TEST_E2E_COMFY_INSTALL_FLAGS", "--cpu")
     comfy_url = os.getenv("TEST_E2E_COMFY_URL", "")
     url_flag = f"--url {comfy_url}" if comfy_url else ""
-    proc = exec(
-        f"""
-            comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}
-            comfy --skip-prompt set-default {ws}
-            comfy --skip-prompt --no-enable-telemetry env
-        """
-    )
-    assert proc.returncode == 0
+    # Run `comfy install` as its OWN command (not chained via a shell string) so
+    # its exit code is actually checked. When several commands are joined in one
+    # `shell=True` string, `/bin/sh -c` returns only the LAST command's status, so
+    # a failed install (e.g. `sys.exit(1)` on a PyTorch wheel-CDN TLS handshake
+    # failure) used to be masked by a later `comfy env` succeeding — the fixture
+    # limped on to `node update-cache` and reported a misleading
+    # "ComfyUI-Manager not found" instead of the real network error.
+    #
+    # Wrap the network-bound install in a bounded retry (mirrors the node-install
+    # retry below) so a single transient blip is absorbed rather than nuking the
+    # whole matrix; a sustained CDN outage still fails fast with the true cause.
+    install_cmd = f"comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}"
+    attempts = 3
+    for attempt in range(1, attempts + 1):
+        proc = exec(install_cmd)
+        if proc.returncode == 0:
+            break
+        print(f"[workspace] comfy install attempt {attempt}/{attempts} failed (rc={proc.returncode})")
+        if attempt < attempts:
+            backoff = 5 * attempt
+            print(f"[workspace] retrying comfy install after {backoff}s backoff")
+            time.sleep(backoff)
+    assert proc.returncode == 0, f"comfy install failed after {attempts} attempts:\n{proc.stdout}\n{proc.stderr}"
+
+    proc = exec(f"comfy --skip-prompt set-default {ws}")
+    assert proc.returncode == 0, f"set-default failed:\n{proc.stdout}\n{proc.stderr}"
+
+    proc = exec("comfy --skip-prompt --no-enable-telemetry env")
+    assert proc.returncode == 0, f"env failed:\n{proc.stdout}\n{proc.stderr}"
 
     # Populate Manager cache before any node operations (blocking fetch).
     proc = exec(f"comfy --workspace {ws} node update-cache")

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import time
 from datetime import datetime
@@ -59,9 +60,16 @@ def workspace():
     # Wrap the network-bound install in a bounded retry (mirrors the node-install
     # retry below) so a single transient blip is absorbed rather than nuking the
     # whole matrix; a sustained CDN outage still fails fast with the true cause.
+    # Each attempt starts from a clean `ws`: a failed install can partially mutate
+    # the workspace (e.g. ComfyUI already cloned), and without a reset a later
+    # attempt could short-circuit to success and mask a *deterministic* install
+    # regression. The retry is only meant to absorb transient failures, so we wipe
+    # the workspace between attempts to keep each one a true from-scratch install.
     install_cmd = f"comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}"
     attempts = 3
     for attempt in range(1, attempts + 1):
+        if os.path.isdir(ws):
+            shutil.rmtree(ws, ignore_errors=True)
         proc = exec(install_cmd)
         if proc.returncode == 0:
             break

--- a/tests/e2e/test_e2e_uv_compile.py
+++ b/tests/e2e/test_e2e_uv_compile.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime
 from textwrap import dedent
 
@@ -112,14 +113,35 @@ def workspace():
     comfy_url = os.getenv("TEST_E2E_COMFY_URL", "")
     url_flag = f"--url {comfy_url}" if comfy_url else ""
 
-    proc = exec(
-        f"""
-            comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}
-            comfy --skip-prompt set-default {ws}
-            comfy --skip-prompt --no-enable-telemetry env
-        """
-    )
-    assert proc.returncode == 0
+    # Run `comfy install` as its OWN command (not chained via a shell string) so
+    # its exit code is actually checked. When several commands are joined in one
+    # `shell=True` string, `/bin/sh -c` returns only the LAST command's status, so
+    # a failed install (e.g. `sys.exit(1)` on a PyTorch wheel-CDN TLS handshake
+    # failure) used to be masked by a later `comfy env` succeeding — the fixture
+    # limped on to `node update-cache` and reported a misleading
+    # "ComfyUI-Manager not found" instead of the real network error.
+    #
+    # Wrap the network-bound install in a bounded retry so a single transient blip
+    # is absorbed rather than nuking the whole matrix; a sustained CDN outage still
+    # fails fast with the true cause.
+    install_cmd = f"comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}"
+    attempts = 3
+    for attempt in range(1, attempts + 1):
+        proc = exec(install_cmd)
+        if proc.returncode == 0:
+            break
+        print(f"[workspace] comfy install attempt {attempt}/{attempts} failed (rc={proc.returncode})")
+        if attempt < attempts:
+            backoff = 5 * attempt
+            print(f"[workspace] retrying comfy install after {backoff}s backoff")
+            time.sleep(backoff)
+    assert proc.returncode == 0, f"comfy install failed after {attempts} attempts:\n{proc.stdout}\n{proc.stderr}"
+
+    proc = exec(f"comfy --skip-prompt set-default {ws}")
+    assert proc.returncode == 0, f"set-default failed:\n{proc.stdout}\n{proc.stderr}"
+
+    proc = exec("comfy --skip-prompt --no-enable-telemetry env")
+    assert proc.returncode == 0, f"env failed:\n{proc.stdout}\n{proc.stderr}"
 
     # Override Manager if MANAGER_OVERRIDE is set (skip PyPI/Core PR cycle).
     # Accepts:  "4.1b7" (PyPI)  or  "Comfy-Org/ComfyUI-Manager@branch" (git clone + uv)

--- a/tests/e2e/test_e2e_uv_compile.py
+++ b/tests/e2e/test_e2e_uv_compile.py
@@ -123,10 +123,17 @@ def workspace():
     #
     # Wrap the network-bound install in a bounded retry so a single transient blip
     # is absorbed rather than nuking the whole matrix; a sustained CDN outage still
-    # fails fast with the true cause.
+    # fails fast with the true cause. Each attempt starts from a clean `ws`: a
+    # failed install can partially mutate the workspace (e.g. ComfyUI already
+    # cloned), and without a reset a later attempt could short-circuit to success
+    # and mask a *deterministic* install regression. The retry is only meant to
+    # absorb transient failures, so we wipe the workspace between attempts to keep
+    # each one a true from-scratch install.
     install_cmd = f"comfy --skip-prompt --workspace {ws} install {url_flag} {install_flags}"
     attempts = 3
     for attempt in range(1, attempts + 1):
+        if os.path.isdir(ws):
+            shutil.rmtree(ws, ignore_errors=True)
         proc = exec(install_cmd)
         if proc.returncode == 0:
             break


### PR DESCRIPTION
## ELI-5

The end-to-end tests set up a workspace by running three `comfy` commands squished into **one** shell string: `install`, then `set-default`, then `env`. The problem: `/bin/sh -c "a; b; c"` only reports whether the **last** command (`c`) succeeded. So when `comfy install` blew up (e.g. PyTorch's wheel CDN rejected the TLS handshake and install `sys.exit(1)`-ed), the shell still returned success because `comfy env` at the end was fine. The test happily marched on for ~70 seconds until `node update-cache` finally failed with a **misleading** `ComfyUI-Manager not found` — burying the real network/torch error under 18 identical, unhelpful red X's per platform.

This PR unchains those commands so each one's exit code is actually checked, and wraps the network-bound `comfy install` in a small retry so a one-off blip doesn't nuke the whole matrix.

## What changed

Test-harness only (`tests/e2e/**`) — **no product-code behavior change**. In both `workspace` fixtures (`test_e2e.py` and `test_e2e_uv_compile.py`):

1. **Fail fast on the real error.** `comfy install` runs as its own `exec(...)` with its **own** `assert proc.returncode == 0`, surfacing `stdout` + `stderr` so the actual torch/TLS message lands in the CI log. `set-default` and `env` are now separate `exec` calls with their own asserts, so a failed install can no longer be masked by a later command's exit code.
2. **Tolerate transient blips.** `comfy install` is wrapped in a bounded 3-attempt retry with a short incremental backoff (5s, 10s), mirroring the existing `node install` retry in `test_e2e.py`. Attempt count and backoff are logged. This absorbs a one-off handshake/DNS blip; a sustained CDN outage still fails fast with the true cause.

## Acceptance criteria

- [x] Non-zero `comfy install` fails the fixture **immediately** with an assertion including install's stdout/stderr — no longer proceeds to `update-cache`, no longer reports the misleading `ComfyUI-Manager not found`.
- [x] install/set-default/env are no longer chained such that a failed install is masked; the install step's own returncode is asserted.
- [x] Both fixtures (`test_e2e.py::workspace`, `test_e2e_uv_compile.py::workspace`) get the same treatment.
- [x] A bounded retry wraps `comfy install`; attempt count + backoff are logged.

## Out of scope

Does **not** attempt to fix the upstream PyTorch wheel-CDN TLS failure (external; `download.pytorch.org` redirects to `download-r2.pytorch.org`, not ours to choose). This change makes CI fail with the *true* cause and shrug off transient blips.

## Testing

`ruff format --check` and `ruff check` pass on both files; `pytest --co` collects all 19 e2e tests cleanly. The e2e tests themselves are gated behind `TEST_E2E=true` and require a live install/network, so they run in CI, not locally.
