### PR TITLE
fix: migrate get_job_status off deprecated /api/job/<id>/status to /api/jobs/<id>

### DIFF
--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -404,9 +404,15 @@ class Client:
         raise NotImplementedError("local list_jobs uses /queue + /history merge — call jobs._gather_jobs")
 
     def get_job_status(self, prompt_id: str, *, timeout: float | None = None) -> dict | None:
-        """Cloud-only: GET {prefix}/job/<id>/status."""
+        """Cloud-only: GET {prefix}/jobs/<id>.
+
+        Hits the canonical plural jobs-detail endpoint (``JobDetailResponse``,
+        a superset of the deprecated ``/api/job/<id>/status``). Mirrors
+        ``list_jobs`` by routing through ``self.target.jobs_path`` so cloud vs
+        local prefixing stays correct.
+        """
         try:
-            return self._request("GET", ("job", prompt_id, "status"), timeout=timeout)
+            return self._request("GET", (self.target.jobs_path, prompt_id), timeout=timeout)
         except HTTPError as e:
             if e.status == 404:
                 return None

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -411,8 +411,22 @@ class Client:
         ``list_jobs`` by routing through ``self.target.jobs_path`` so cloud vs
         local prefixing stays correct.
         """
+        # Guard like ``list_jobs``: a local target has no ``jobs_path``, and
+        # ``Target.url`` would drop the ``None`` segment and silently issue
+        # ``GET {base}/<id>`` instead of failing loudly.
+        if not self.target.jobs_path:
+            raise NotImplementedError("get_job_status requires a cloud target with a jobs endpoint")
+        # Validate + encode the id so it stays a single terminal path segment.
+        # An empty id would collapse to the plural LIST endpoint (200 with a
+        # ``{"jobs": [...]}`` payload); an id with ``/``, ``?``, ``#`` or ``..``
+        # would inject extra segments / query params (``Target.url`` only
+        # ``strip('/')``s each part, it does not percent-encode).
+        prompt_id = (prompt_id or "").strip()
+        if not prompt_id:
+            raise ValueError("prompt_id must be a non-empty string")
+        encoded_id = urllib.parse.quote(prompt_id, safe="")
         try:
-            return self._request("GET", (self.target.jobs_path, prompt_id), timeout=timeout)
+            return self._request("GET", (self.target.jobs_path, encoded_id), timeout=timeout)
         except HTTPError as e:
             if e.status == 404:
                 return None

--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -214,7 +214,7 @@ def _poll_cloud_once(state: jobs_state.JobState, *, client: Any = None) -> bool:
     state.status = _CLOUD_STATUS_MAP.get(raw, raw)
 
     if state.status == "completed":
-        # Cloud's /api/job/<id>/status sometimes includes outputs directly;
+        # Cloud's /api/jobs/<id> detail response sometimes includes outputs directly;
         # if not, fetch from history. Match the snapshot logic in jobs.py.
         outputs = record.get("outputs")
         if isinstance(outputs, list) and outputs:

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -738,7 +738,7 @@ def _wait_fetch_snapshot(
 ) -> dict | None:
     """Best-effort single-job status snapshot for the wait loop.
 
-    cloud -> /api/job status; local -> live /history when the server is up,
+    cloud -> /api/jobs/<id>; local -> live /history when the server is up,
     else fall back to the on-disk state file the async watcher maintains.
     """
     if cloud:
@@ -1431,7 +1431,7 @@ def _cloud_ls(*, limit: int) -> None:
 
 
 def _cloud_status_snapshot(prompt_id: str) -> dict | None:
-    """Compose a cloud snapshot from /api/job/<id>/status + /api/history_v2/<id>."""
+    """Compose a cloud snapshot from /api/jobs/<id> + /api/history_v2/<id>."""
     from comfy_cli import jobs_state
     from comfy_cli.comfy_client import _group_outputs
 

--- a/comfy_cli/execution_errors.py
+++ b/comfy_cli/execution_errors.py
@@ -1,6 +1,6 @@
 """Parse and classify ComfyUI execution failures into envelope-ready fields.
 
-The cloud's ``/api/job/<id>/status`` carries a failed job's cause as
+The cloud's ``/api/jobs/<id>`` detail response carries a failed job's cause as
 ``error_message`` — a JSON-encoded string holding ``exception_message``,
 ``exception_type``, ``node_id``, ``node_type`` and a full Python traceback.
 Embedding that string verbatim in an error envelope buries the one line a

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -929,7 +929,7 @@ Hard-won lessons per domain. Not a tutorial — a reference card.
 - CLI auto-injects API keys for partner nodes — never extract manually
 - Session tokens are short-lived (~1h); CLI auto-refreshes on 401
 - HTTP 401 with XML body = CDN catch-all, not ComfyUI — endpoints are under `/api/*`
-- Cloud uses HTTP polling (no WebSocket); `jobs watch` polls `/api/job/<id>/status`
+- Cloud uses HTTP polling (no WebSocket); `jobs watch` polls `/api/jobs/<id>`
 
 ---
 

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -314,6 +314,29 @@ class TestGetJobStatus:
         with patch.object(comfy_client._OPENER, "open", side_effect=_http_error(404)):
             assert comfy_client.Client(CLOUD).get_job_status("pid") is None
 
+    def test_local_raises_not_implemented(self):
+        # A local target has no jobs_path — must fail loudly, not fall back to
+        # GET {base}/<id> (mirrors list_jobs).
+        with pytest.raises(NotImplementedError):
+            comfy_client.Client(LOCAL).get_job_status("pid")
+
+    @pytest.mark.parametrize("bad_id", ["", "   "])
+    def test_empty_id_rejected(self, bad_id):
+        # An empty id would collapse to the plural LIST endpoint and misclassify
+        # the job — reject before issuing any request.
+        with patch.object(comfy_client._OPENER, "open") as urlopen:
+            with pytest.raises(ValueError):
+                comfy_client.Client(CLOUD).get_job_status(bad_id)
+        urlopen.assert_not_called()
+
+    def test_id_is_percent_encoded(self):
+        # A raw id with path/query metacharacters must not escape the
+        # /api/jobs/<id> segment.
+        with patch.object(comfy_client._OPENER, "open", return_value=_mock_response({"status": "success"})) as urlopen:
+            comfy_client.Client(CLOUD).get_job_status("../admin?x=1")
+        req = urlopen.call_args.args[0]
+        assert req.full_url == "https://cloud.example.com/api/jobs/..%2Fadmin%3Fx%3D1"
+
 
 class TestWaitForCompletion:
     def test_returns_record_when_status_completed_true(self):

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -304,11 +304,11 @@ class TestListJobs:
 
 
 class TestGetJobStatus:
-    def test_cloud_uses_job_status_endpoint(self):
+    def test_cloud_uses_jobs_detail_endpoint(self):
         with patch.object(comfy_client._OPENER, "open", return_value=_mock_response({"status": "success"})) as urlopen:
             comfy_client.Client(CLOUD).get_job_status("pid-1")
         req = urlopen.call_args.args[0]
-        assert req.full_url == "https://cloud.example.com/api/job/pid-1/status"
+        assert req.full_url == "https://cloud.example.com/api/jobs/pid-1"
 
     def test_404_returns_none(self):
         with patch.object(comfy_client._OPENER, "open", side_effect=_http_error(404)):


### PR DESCRIPTION
## ELI-5

When you run `comfy jobs status` or `comfy jobs watch` against the cloud, the CLI asks the server "how's this job doing?". It was asking through an **old door** (`GET /api/job/<id>/status`) that the cloud has marked deprecated and plans to remove. This PR switches to the **new door** (`GET /api/jobs/<id>`), the plural job-detail endpoint, which returns the same information (and more) under the same field names — so nothing the user sees changes, we just stop knocking on a door that's going away.

## What changed

- `get_job_status()` in `comfy_client.py` now requests the plural job-detail path (`{jobs_path}/<id>`) instead of `job/<id>/status`. It routes through `self.target.jobs_path` exactly like `list_jobs()`, so the cloud `/api` prefix stays correct. The `404 → None` handling is unchanged.
- Updated the docstring plus the stale endpoint references in comments/docs (`jobs.py`, `job_watcher.py`, `execution_errors.py`, `skills/comfy/SKILL.md`).
- Updated the client test that asserted the old URL to expect the new one.

The detail response exposes the same fields the snapshot reader already consumes (`status`, `assigned_inference`, `error_message`, `created_at`, `updated_at`) plus embedded `outputs`, so `comfy jobs status` and `comfy jobs watch` behave identically.

## Testing

- `pytest` over the cloud client, jobs, auth/oauth, and run suites — **241 passed**.
- `ruff check` + `ruff format --check` on the changed files — clean.

## Notes / judgment calls

- **Out of scope (flagged as follow-on):** the completed-job path still calls `get_history` → `/api/history_v2/<id>`, which is also on a deprecation path. Its clean replacement is the outputs already embedded in the plural detail response, but collapsing status+history into one call is a larger refactor left for a follow-up.
- The `comfy run --wait` progress probe reads `progress`/`queue_position` in addition to the five fields above. These are accessed via `.get()` (safely `None` if absent) and only feed the wait loop's silence-deadline reset, which also resets on any status change — so no behavior regression even in the unlikely case the detail response omits them.
