### PR TITLE
feat: add `comfy run --prompt`/`--set` for local text2img via bundled default workflow (BE-2535)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -660,15 +660,40 @@ def update(
 @app.command(help="Run an API workflow. Submits and returns immediately by default; pass --wait to block.")
 def run(
     workflow: Annotated[
-        str,
+        str | None,
         typer.Option(
             help=(
                 "Path to the workflow JSON file. Both ComfyUI API format and "
                 "exported UI format are accepted; UI workflows are converted "
-                "to API format client-side."
+                "to API format client-side. Optional: omit it and pass --prompt "
+                "to run the bundled default text2img workflow."
             )
         ),
-    ],
+    ] = None,
+    prompt: Annotated[
+        str | None,
+        typer.Option(
+            "--prompt",
+            show_default=False,
+            help=(
+                "Positive text prompt for the bundled default text2img workflow "
+                "(used when --workflow is omitted). Cannot be combined with --workflow."
+            ),
+        ),
+    ] = None,
+    set_overrides: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--set",
+            show_default=False,
+            help=(
+                "Override a field in the bundled default workflow, repeatable. "
+                "Form: alias=VALUE (checkpoint/negative/seed/steps/cfg/width/height/…) "
+                "or NODE_ID.field=VALUE (e.g. 4.ckpt_name=model.safetensors). "
+                "Cannot be combined with --workflow."
+            ),
+        ),
+    ] = None,
     wait: Annotated[
         bool,
         typer.Option(
@@ -792,6 +817,36 @@ def run(
         # ask for). The user can override either way with --notify/--no-notify.
         effective_notify = notify if notify is not None else (renderer.is_pretty() and not wait)
 
+        # --prompt/--set build an in-memory API-format graph from the bundled
+        # default text2img workflow (no --workflow file). The aliases resolve
+        # against OUR pinned node ids, so mixing them with a user --workflow —
+        # whose node ids are arbitrary — is rejected rather than silently
+        # misapplied. `preloaded` is handed straight to run's execute path.
+        preloaded: tuple[dict, str, bool] | None = None
+        if prompt is not None or set_overrides:
+            if workflow is not None:
+                renderer.error(
+                    code="prompt_rejected",
+                    message="--prompt/--set apply to the bundled default workflow and cannot be combined with --workflow",
+                    hint="drop --workflow to use the bundled default, or edit the workflow file directly",
+                )
+                raise typer.Exit(code=1)
+            from comfy_cli.cql.default_workflow import PromptInjectionError, build_default_workflow
+
+            try:
+                injected = build_default_workflow(prompt=prompt, overrides=set_overrides)
+            except PromptInjectionError as e:
+                renderer.error(code=e.code, message=str(e), hint=e.hint)
+                raise typer.Exit(code=1) from e
+            preloaded = (injected, "default_text2img", False)
+        elif workflow is None:
+            renderer.error(
+                code="prompt_rejected",
+                message="run requires --workflow, or --prompt (with optional --set) to use the bundled default workflow",
+                hint="e.g. comfy run --prompt 'a red fox in snow' --wait",
+            )
+            raise typer.Exit(code=1)
+
         if decision.target is where_module.WhereTarget.CLOUD:
             err = where_module.cloud_preflight()
             if err is not None:
@@ -810,6 +865,7 @@ def run(
                 timeout=timeout,
                 notify=effective_notify,
                 print_prompt=print_prompt,
+                preloaded=preloaded,
             )
             return
 
@@ -832,6 +888,7 @@ def run(
             notify=effective_notify,
             api_key=api_key,
             print_prompt=print_prompt,
+            preloaded=preloaded,
         )
     except typer.Exit as e:
         if (e.exit_code or 0) == 0:

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -104,6 +104,7 @@ def execute(
     notify: bool = False,
     api_key: str | None = None,
     print_prompt: bool = False,
+    preloaded: tuple[dict, str, bool] | None = None,
 ):
     # `0.0.0.0` is a wildcard bind, not a connect address. macOS / Windows
     # clients can't reach it; on Linux it happens to resolve to a loopback.
@@ -120,11 +121,17 @@ def execute(
 
     renderer = get_renderer()
 
-    try:
-        raw_workflow, workflow_name, is_ui = _load_workflow_file(workflow)
-    except WorkflowLoadError as e:
-        renderer.error(code=e.code, message=str(e), hint=e.hint)
-        raise typer.Exit(code=1) from e
+    # `preloaded` short-circuits file loading: an in-memory API-format graph
+    # (e.g. the `comfy run --prompt` injected default) is handed straight in as
+    # (workflow_dict, display_name, is_ui). Everything downstream is unchanged.
+    if preloaded is not None:
+        raw_workflow, workflow_name, is_ui = preloaded
+    else:
+        try:
+            raw_workflow, workflow_name, is_ui = _load_workflow_file(workflow)
+        except WorkflowLoadError as e:
+            renderer.error(code=e.code, message=str(e), hint=e.hint)
+            raise typer.Exit(code=1) from e
 
     if not print_prompt and not check_comfy_server_running(port, host, timeout=timeout):
         renderer.error(
@@ -486,21 +493,28 @@ def execute_cloud(
     timeout: int = 600,
     notify: bool = False,
     print_prompt: bool = False,
+    preloaded: tuple[dict, str, bool] | None = None,
 ):
     """Run a workflow against Comfy Cloud via the stored OAuth session.
 
     Uses the unified :class:`comfy_cli.comfy_client.Client` — same surface as
     local, just a different :class:`comfy_cli.target.Target`.
+
+    ``preloaded`` short-circuits file loading with an in-memory API-format graph
+    (the ``comfy run --prompt`` injected default), mirroring :func:`execute`.
     """
     from comfy_cli.comfy_client import Client, HTTPError, Unauthenticated, _group_outputs
     from comfy_cli.target import resolve_target
 
     renderer = get_renderer()
-    try:
-        raw_workflow, workflow_name, is_ui = _load_workflow_file(workflow)
-    except WorkflowLoadError as e:
-        renderer.error(code=e.code, message=str(e), hint=e.hint)
-        raise typer.Exit(code=1) from e
+    if preloaded is not None:
+        raw_workflow, workflow_name, is_ui = preloaded
+    else:
+        try:
+            raw_workflow, workflow_name, is_ui = _load_workflow_file(workflow)
+        except WorkflowLoadError as e:
+            renderer.error(code=e.code, message=str(e), hint=e.hint)
+            raise typer.Exit(code=1) from e
 
     if is_ui:
         # Frontend-format workflows (the `nodes`+`links` shape from the canvas

--- a/comfy_cli/cql/data/default_text2img.json
+++ b/comfy_cli/cql/data/default_text2img.json
@@ -1,0 +1,66 @@
+{
+  "3": {
+    "class_type": "KSampler",
+    "inputs": {
+      "seed": 0,
+      "steps": 20,
+      "cfg": 8.0,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1.0,
+      "model": ["4", 0],
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "latent_image": ["5", 0]
+    },
+    "_meta": {"title": "KSampler"}
+  },
+  "4": {
+    "class_type": "CheckpointLoaderSimple",
+    "inputs": {
+      "ckpt_name": "v1-5-pruned-emaonly.ckpt"
+    },
+    "_meta": {"title": "Load Checkpoint"}
+  },
+  "5": {
+    "class_type": "EmptyLatentImage",
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    },
+    "_meta": {"title": "Empty Latent Image"}
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": ["4", 1]
+    },
+    "_meta": {"title": "CLIP Text Encode (Positive)"}
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": ["4", 1]
+    },
+    "_meta": {"title": "CLIP Text Encode (Negative)"}
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": ["3", 0],
+      "vae": ["4", 2]
+    },
+    "_meta": {"title": "VAE Decode"}
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": ["8", 0]
+    },
+    "_meta": {"title": "Save Image"}
+  }
+}

--- a/comfy_cli/cql/default_workflow.py
+++ b/comfy_cli/cql/default_workflow.py
@@ -15,6 +15,7 @@ exactly the fragility this pinned graph removes.
 from __future__ import annotations
 
 import json
+import math
 from importlib import resources
 
 # -- Pinned node ids (must match data/default_text2img.json) --
@@ -70,9 +71,21 @@ def load_default_workflow() -> dict:
     Uses the same ``importlib.resources`` package-data loader as
     ``engine._try_default_annotations``; ``data/*.json`` is already declared as
     package data in ``pyproject.toml``.
+
+    A missing or corrupt bundle is a packaging fault, not user input, but it
+    must still exit through the controlled envelope (no stack trace escapes):
+    surface it as ``default_workflow_unavailable`` so ``build_default_workflow``'s
+    caller catches it like any other ``PromptInjectionError``.
     """
-    data = resources.files("comfy_cli.cql.data").joinpath("default_text2img.json").read_bytes()
-    return json.loads(data)
+    try:
+        data = resources.files("comfy_cli.cql.data").joinpath("default_text2img.json").read_bytes()
+        return json.loads(data)
+    except (OSError, ModuleNotFoundError, ValueError) as e:
+        raise PromptInjectionError(
+            f"the bundled default text2img workflow could not be loaded: {e}",
+            code="default_workflow_unavailable",
+            hint="this is a comfy-cli packaging error; try reinstalling comfy-cli",
+        ) from e
 
 
 def _coerce(value: str, existing):
@@ -82,7 +95,16 @@ def _coerce(value: str, existing):
     ``seed=42`` becomes int ``42``, ``cfg=7.5`` becomes float, and a text field
     stays a string). For a brand-new field with no existing scalar, fall back to
     a JSON-scalar parse (``42`` → int) and finally the raw string.
+
+    A list-valued ``existing`` is a graph connection edge (e.g. ``["6", 0]``),
+    not a settable input — overwriting it with a scalar corrupts the topology,
+    so those targets are rejected outright.
     """
+    if isinstance(existing, list):
+        raise PromptInjectionError(
+            f"this field holds a graph connection, not a settable value; refusing to overwrite it with {value!r}",
+            hint="--set only overrides scalar inputs (seed, cfg, text, ckpt_name, …), not wired node connections",
+        )
     if isinstance(existing, bool):
         low = value.strip().lower()
         if low in ("true", "1", "yes"):
@@ -97,9 +119,14 @@ def _coerce(value: str, existing):
             raise PromptInjectionError(f"expected an integer for this field, got {value!r}") from e
     if isinstance(existing, float):
         try:
-            return float(value)
+            result = float(value)
         except ValueError as e:
             raise PromptInjectionError(f"expected a number for this field, got {value!r}") from e
+        # `float("nan"/"inf")` parses, but json.dumps emits non-standard
+        # NaN/Infinity tokens that strict server-side parsers reject.
+        if not math.isfinite(result):
+            raise PromptInjectionError(f"expected a finite number for this field, got {value!r}")
+        return result
     if isinstance(existing, str):
         return value
     # New field (existing is None): best-effort JSON scalar, else raw string.
@@ -107,8 +134,12 @@ def _coerce(value: str, existing):
         parsed = json.loads(value)
     except (ValueError, TypeError):
         return value
-    if isinstance(parsed, (int, float, str, bool)):
+    if isinstance(parsed, bool) or isinstance(parsed, str):
         return parsed
+    if isinstance(parsed, (int, float)):
+        # json.loads accepts NaN/Infinity — fall back to the raw string rather
+        # than inject a non-finite scalar that won't round-trip through JSON.
+        return parsed if math.isfinite(parsed) else value
     return value
 
 
@@ -140,6 +171,19 @@ def _resolve_address(address: str, workflow: dict) -> tuple[str, str]:
         raise PromptInjectionError(
             f"--set address {address!r} targets node {node_id!r}, which is not in the default workflow",
             hint="node ids in the bundled graph: " + ", ".join(sorted(workflow)),
+        )
+    # A raw ``NODE_ID.field`` typo (e.g. ``4.ckpt_naem``) would otherwise write a
+    # junk key while the real input silently keeps its default. Every alias maps
+    # to a real input too, so validating the resolved field against the node's
+    # actual inputs guards both forms. (The bundled API graph carries every
+    # settable input explicitly, so "not present" == "not a real input".)
+    inputs = node.get("inputs")
+    if not isinstance(inputs, dict) or field not in inputs:
+        known = ", ".join(sorted(inputs)) if isinstance(inputs, dict) else "(none)"
+        raise PromptInjectionError(
+            f"--set address {address!r} targets field {field!r}, which node {node_id!r} "
+            f"({node.get('class_type')}) has no such input",
+            hint=f"inputs on this node: {known}",
         )
     return node_id, field
 

--- a/comfy_cli/cql/default_workflow.py
+++ b/comfy_cli/cql/default_workflow.py
@@ -1,0 +1,177 @@
+"""Bundled default text2img workflow + a direct API-format prompt injector.
+
+``comfy run --prompt`` loads a pinned, **non-subgraphed** API-format graph
+(``comfy_cli/cql/data/default_text2img.json``) with STABLE, KNOWN node ids and
+writes a prompt straight into the node ``inputs`` map. This is deliberately NOT
+``Graph.apply_slots`` (that operates on UI-format ``widgets_values`` and needs
+``object_info``): a bundled API graph sets a field by a trivial dict write, so
+no live server, no ``object_info``, and no ``apply_slots`` are involved.
+
+The node ids below are constants because we OWN this graph — the gallery's
+subgraphed template shifts its interior addresses across revisions, which is
+exactly the fragility this pinned graph removes.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+
+# -- Pinned node ids (must match data/default_text2img.json) --
+CHECKPOINT_LOADER_ID = "4"
+POSITIVE_PROMPT_ID = "6"
+NEGATIVE_PROMPT_ID = "7"
+EMPTY_LATENT_ID = "5"
+KSAMPLER_ID = "3"
+VAE_DECODE_ID = "8"
+SAVE_IMAGE_ID = "9"
+
+# Documented convenience aliases → (node id, input field). These resolve
+# against the KNOWN ids above so a caller never has to know the graph layout.
+# The raw form ``NODE_ID.field=VALUE`` is always available too (see
+# ``_resolve_address``), e.g. ``4.ckpt_name=NAME`` is equivalent to
+# ``checkpoint=NAME``.
+ALIASES: dict[str, tuple[str, str]] = {
+    "prompt": (POSITIVE_PROMPT_ID, "text"),
+    "positive": (POSITIVE_PROMPT_ID, "text"),
+    "negative": (NEGATIVE_PROMPT_ID, "text"),
+    "checkpoint": (CHECKPOINT_LOADER_ID, "ckpt_name"),
+    "ckpt": (CHECKPOINT_LOADER_ID, "ckpt_name"),
+    "seed": (KSAMPLER_ID, "seed"),
+    "steps": (KSAMPLER_ID, "steps"),
+    "cfg": (KSAMPLER_ID, "cfg"),
+    "sampler": (KSAMPLER_ID, "sampler_name"),
+    "scheduler": (KSAMPLER_ID, "scheduler"),
+    "denoise": (KSAMPLER_ID, "denoise"),
+    "width": (EMPTY_LATENT_ID, "width"),
+    "height": (EMPTY_LATENT_ID, "height"),
+    "batch_size": (EMPTY_LATENT_ID, "batch_size"),
+    "filename_prefix": (SAVE_IMAGE_ID, "filename_prefix"),
+}
+
+
+class PromptInjectionError(Exception):
+    """Raised for a malformed/unknown ``--prompt``/``--set`` override.
+
+    ``code`` is a registered ``error_codes`` value so callers can forward it
+    straight to ``renderer.error(code=e.code, ...)`` — no stack trace escapes
+    to the user (acceptance criterion 3).
+    """
+
+    def __init__(self, message: str, *, code: str = "prompt_rejected", hint: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
+
+
+def load_default_workflow() -> dict:
+    """Return a fresh deep copy of the bundled default text2img API graph.
+
+    Uses the same ``importlib.resources`` package-data loader as
+    ``engine._try_default_annotations``; ``data/*.json`` is already declared as
+    package data in ``pyproject.toml``.
+    """
+    data = resources.files("comfy_cli.cql.data").joinpath("default_text2img.json").read_bytes()
+    return json.loads(data)
+
+
+def _coerce(value: str, existing):
+    """Coerce a string CLI value to the API-format type it should carry.
+
+    If the address already holds a scalar in the graph, match its type (so
+    ``seed=42`` becomes int ``42``, ``cfg=7.5`` becomes float, and a text field
+    stays a string). For a brand-new field with no existing scalar, fall back to
+    a JSON-scalar parse (``42`` → int) and finally the raw string.
+    """
+    if isinstance(existing, bool):
+        low = value.strip().lower()
+        if low in ("true", "1", "yes"):
+            return True
+        if low in ("false", "0", "no"):
+            return False
+        raise PromptInjectionError(f"expected a boolean for this field, got {value!r}")
+    if isinstance(existing, int) and not isinstance(existing, bool):
+        try:
+            return int(value)
+        except ValueError as e:
+            raise PromptInjectionError(f"expected an integer for this field, got {value!r}") from e
+    if isinstance(existing, float):
+        try:
+            return float(value)
+        except ValueError as e:
+            raise PromptInjectionError(f"expected a number for this field, got {value!r}") from e
+    if isinstance(existing, str):
+        return value
+    # New field (existing is None): best-effort JSON scalar, else raw string.
+    try:
+        parsed = json.loads(value)
+    except (ValueError, TypeError):
+        return value
+    if isinstance(parsed, (int, float, str, bool)):
+        return parsed
+    return value
+
+
+def _resolve_address(address: str, workflow: dict) -> tuple[str, str]:
+    """Resolve a ``--set`` address to a (node id, field) pair in ``workflow``.
+
+    Accepts an alias (``checkpoint``) or the raw ``NODE_ID.field`` form
+    (``4.ckpt_name``). Raises ``PromptInjectionError`` for an unknown alias or a
+    node id / raw form the pinned graph doesn't contain.
+    """
+    if "." in address:
+        node_id, _, field = address.partition(".")
+        if not node_id or not field:
+            raise PromptInjectionError(
+                f"invalid --set address {address!r}",
+                hint="use NODE_ID.field=VALUE (e.g. 4.ckpt_name=model.safetensors) or an alias",
+            )
+    else:
+        alias = ALIASES.get(address)
+        if alias is None:
+            raise PromptInjectionError(
+                f"unknown --set field {address!r}",
+                hint="known aliases: " + ", ".join(sorted(ALIASES)) + "; or use NODE_ID.field=VALUE",
+            )
+        node_id, field = alias
+
+    node = workflow.get(node_id)
+    if not isinstance(node, dict) or "class_type" not in node:
+        raise PromptInjectionError(
+            f"--set address {address!r} targets node {node_id!r}, which is not in the default workflow",
+            hint="node ids in the bundled graph: " + ", ".join(sorted(workflow)),
+        )
+    return node_id, field
+
+
+def _apply_set(workflow: dict, node_id: str, field: str, value: str) -> None:
+    inputs = workflow[node_id].setdefault("inputs", {})
+    inputs[field] = _coerce(value, inputs.get(field))
+
+
+def build_default_workflow(*, prompt: str | None = None, overrides: list[str] | None = None) -> dict:
+    """Build the injected API-format graph for ``comfy run --prompt``/``--set``.
+
+    ``prompt`` writes the positive CLIPTextEncode ``text``; each ``overrides``
+    entry is a ``node.field=VALUE`` / ``alias=VALUE`` string applied in order
+    (later wins). Returns a ready-to-submit API-format workflow dict. Raises
+    ``PromptInjectionError`` on any malformed/unknown override.
+    """
+    workflow = load_default_workflow()
+
+    if prompt is not None:
+        node_id, field = ALIASES["prompt"]
+        _apply_set(workflow, node_id, field, prompt)
+
+    for raw in overrides or []:
+        if "=" not in raw:
+            raise PromptInjectionError(
+                f"invalid --set {raw!r}: expected node.field=VALUE",
+                hint="e.g. --set checkpoint=model.safetensors or --set 3.seed=42",
+            )
+        address, _, value = raw.partition("=")
+        address = address.strip()
+        node_id, field = _resolve_address(address, workflow)
+        _apply_set(workflow, node_id, field, value)
+
+    return workflow

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -155,6 +155,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "add at least one node to the workflow",
     ),
     ErrorCode(
+        "default_workflow_unavailable",
+        "`comfy run --prompt`/`--set` could not load the bundled default text2img graph "
+        "(missing or corrupt package data). A packaging fault, not user input.",
+        "reinstall comfy-cli",
+    ),
+    ErrorCode(
         "conversion_error",
         "UI-format workflow could not be converted to API format.",
         "export your workflow from ComfyUI via 'File > Export (API)' and retry",

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -46,9 +46,12 @@ POSTHOG_EVENT_PREFIX = "cli:"
 _SENSITIVE_SUFFIXES = ("_token", "_api_key", "_secret", "_password")
 # `token` is the publish PAT; `changelog` is bulky free text with no analytics
 # value beyond its presence. `key` is the bare `--key` option carrying the Comfy
-# Cloud API key (e.g. `cloud set-key`, auth store). Sensitive values become
-# "<redacted>" (the key is kept so we can still tell the option was supplied).
-_SENSITIVE_EXACT = frozenset({"api_key", "key", "token", "password", "secret", "changelog"})
+# Cloud API key (e.g. `cloud set-key`, auth store). `prompt` (the `comfy run
+# --prompt` positive prompt) and `set_overrides` (the `--set` field=value list)
+# are verbatim user content — like `changelog`, we keep the presence but never
+# ship the text. Sensitive values become "<redacted>" (the key is kept so we can
+# still tell the option was supplied).
+_SENSITIVE_EXACT = frozenset({"api_key", "key", "token", "password", "secret", "changelog", "prompt", "set_overrides"})
 
 
 def _is_sensitive(name: str) -> bool:

--- a/tests/comfy_cli/command/test_run_prompt.py
+++ b/tests/comfy_cli/command/test_run_prompt.py
@@ -1,0 +1,133 @@
+"""Integration/smoke tests for `comfy run --prompt`/`--set` (BE-2535).
+
+The injector is unit-tested offline in
+``tests/comfy_cli/cql/test_default_workflow.py``. These tests prove the wiring:
+the CLI builds the bundled default graph, injects the prompt/overrides, and
+hands the SAME graph to run's existing execute/submit path (no new
+websocket/HTTP code).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from comfy_cli.cmdline import run as run_command
+from comfy_cli.command.run import execute
+from comfy_cli.cql.default_workflow import POSITIVE_PROMPT_ID
+
+
+class TestExecuteSubmitsPreloadedGraph:
+    """`preloaded` short-circuits file loading; the in-memory graph is what
+    reaches the submit path (WorkflowExecution)."""
+
+    def test_preloaded_graph_is_submitted(self):
+        injected = {
+            "6": {"class_type": "CLIPTextEncode", "inputs": {"text": "a red fox in snow"}},
+            "9": {"class_type": "SaveImage", "inputs": {"images": ["8", 0]}},
+        }
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.command.run.ExecutionProgress"),
+            patch("comfy_cli.command.run.WorkflowExecution") as MockExec,
+        ):
+            mock_exec = MagicMock()
+            MockExec.return_value = mock_exec
+            mock_exec.outputs = []
+
+            execute(
+                None,
+                host="127.0.0.1",
+                port=8188,
+                wait=True,
+                timeout=30,
+                preloaded=(injected, "default_text2img", False),
+            )
+
+            # The exact injected graph is what got handed to the submit path.
+            submitted = MockExec.call_args.args[0]
+            assert submitted["6"]["inputs"]["text"] == "a red fox in snow"
+            mock_exec.queue.assert_called_once()
+
+    def test_preloaded_skips_file_loading(self):
+        """A non-existent path never triggers workflow_not_found when preloaded."""
+        injected = {"9": {"class_type": "SaveImage", "inputs": {}}}
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.command.run.ExecutionProgress"),
+            patch("comfy_cli.command.run.WorkflowExecution") as MockExec,
+        ):
+            MockExec.return_value = MagicMock(outputs=[])
+            # Positional workflow is a bogus path — must be ignored.
+            execute(
+                "/no/such/file.json",
+                host="127.0.0.1",
+                port=8188,
+                wait=True,
+                timeout=30,
+                preloaded=(injected, "default_text2img", False),
+            )
+            MockExec.assert_called_once()
+
+
+class TestRunCliWiring:
+    """The `run` command builds + injects the bundled default and forwards it."""
+
+    def _call_run(self, **kwargs):
+        # tracking is consent-gated (no-op in tests), but patch it to be safe.
+        with (
+            patch("comfy_cli.cmdline.tracking.track_event"),
+            patch("comfy_cli.command.run.execute") as mock_exec,
+            patch("comfy_cli.command.run.execute_cloud") as mock_cloud,
+        ):
+            run_command(where="local", **kwargs)
+            return mock_exec, mock_cloud
+
+    def test_prompt_builds_injected_graph_and_forwards(self):
+        mock_exec, _ = self._call_run(prompt="a red fox in snow")
+        mock_exec.assert_called_once()
+        preloaded = mock_exec.call_args.kwargs["preloaded"]
+        assert preloaded is not None
+        graph, name, is_ui = preloaded
+        assert is_ui is False
+        assert name == "default_text2img"
+        assert graph[POSITIVE_PROMPT_ID]["inputs"]["text"] == "a red fox in snow"
+
+    def test_set_checkpoint_override_forwarded(self):
+        mock_exec, _ = self._call_run(prompt="fox", set_overrides=["checkpoint=sd_xl.safetensors"])
+        graph = mock_exec.call_args.kwargs["preloaded"][0]
+        assert graph["4"]["inputs"]["ckpt_name"] == "sd_xl.safetensors"
+
+    def test_workflow_path_forwards_no_preloaded(self):
+        mock_exec, _ = self._call_run(workflow="wf.json")
+        assert mock_exec.call_args.kwargs["preloaded"] is None
+
+    def test_cloud_path_forwards_injected_graph(self):
+        with (
+            patch("comfy_cli.cmdline.tracking.track_event"),
+            patch("comfy_cli.cmdline.where_module.cloud_preflight", return_value=None),
+            patch("comfy_cli.command.run.execute") as mock_exec,
+            patch("comfy_cli.command.run.execute_cloud") as mock_cloud,
+        ):
+            run_command(where="cloud", prompt="a red fox in snow")
+            mock_exec.assert_not_called()
+            mock_cloud.assert_called_once()
+            graph = mock_cloud.call_args.kwargs["preloaded"][0]
+            assert graph[POSITIVE_PROMPT_ID]["inputs"]["text"] == "a red fox in snow"
+
+    def test_prompt_with_workflow_is_rejected(self):
+        with pytest.raises(typer.Exit) as e:
+            self._call_run(workflow="wf.json", prompt="fox")
+        assert e.value.exit_code == 1
+
+    def test_no_workflow_no_prompt_is_rejected(self):
+        with pytest.raises(typer.Exit) as e:
+            self._call_run()
+        assert e.value.exit_code == 1
+
+    def test_bad_set_address_is_rejected(self):
+        with pytest.raises(typer.Exit) as e:
+            self._call_run(prompt="fox", set_overrides=["bogus=1"])
+        assert e.value.exit_code == 1

--- a/tests/comfy_cli/cql/test_default_workflow.py
+++ b/tests/comfy_cli/cql/test_default_workflow.py
@@ -139,3 +139,46 @@ class TestErrors:
     def test_empty_field_in_raw_form(self):
         with pytest.raises(PromptInjectionError):
             build_default_workflow(overrides=["4.=x"])
+
+    def test_unknown_raw_field_is_rejected(self):
+        # A typo in the raw form must fail fast rather than silently write a junk
+        # key while the real input keeps its default.
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(overrides=["4.ckpt_naem=x"])
+        assert e.value.code == "prompt_rejected"
+
+    def test_connection_edge_target_is_rejected(self):
+        # `3.positive` holds a wired connection (["6", 0]); overwriting it with a
+        # scalar would corrupt the graph topology.
+        with pytest.raises(PromptInjectionError):
+            build_default_workflow(overrides=["3.positive=cat"])
+
+    def test_rewire_attempt_is_rejected(self):
+        with pytest.raises(PromptInjectionError):
+            build_default_workflow(overrides=['9.images=["8", 0]'])
+
+    @pytest.mark.parametrize("bad", ["cfg=nan", "cfg=inf", "cfg=-inf", "cfg=Infinity"])
+    def test_non_finite_float_is_rejected(self, bad):
+        with pytest.raises(PromptInjectionError):
+            build_default_workflow(overrides=[bad])
+
+
+class TestBundleUnavailable:
+    def test_missing_bundle_surfaces_controlled_error(self, monkeypatch):
+        import comfy_cli.cql.default_workflow as mod
+
+        def boom(*_a, **_k):
+            raise FileNotFoundError("no such resource")
+
+        monkeypatch.setattr(mod.resources, "files", boom)
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(prompt="fox")
+        assert e.value.code == "default_workflow_unavailable"
+
+    def test_corrupt_bundle_surfaces_controlled_error(self, monkeypatch):
+        import comfy_cli.cql.default_workflow as mod
+
+        monkeypatch.setattr(mod.json, "loads", lambda *_a, **_k: (_ for _ in ()).throw(ValueError("bad json")))
+        with pytest.raises(PromptInjectionError) as e:
+            load_default_workflow()
+        assert e.value.code == "default_workflow_unavailable"

--- a/tests/comfy_cli/cql/test_default_workflow.py
+++ b/tests/comfy_cli/cql/test_default_workflow.py
@@ -1,0 +1,141 @@
+"""Offline unit tests for the bundled default text2img workflow injector.
+
+No server, no object_info, no apply_slots — the injector is a pure direct
+API-format write over the pinned graph (BE-2535).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_cli.cql.default_workflow import (
+    CHECKPOINT_LOADER_ID,
+    NEGATIVE_PROMPT_ID,
+    POSITIVE_PROMPT_ID,
+    PromptInjectionError,
+    build_default_workflow,
+    load_default_workflow,
+)
+
+
+class TestBundledGraph:
+    def test_loads_expected_seven_nodes(self):
+        wf = load_default_workflow()
+        classes = sorted(n["class_type"] for n in wf.values())
+        assert classes == [
+            "CLIPTextEncode",
+            "CLIPTextEncode",
+            "CheckpointLoaderSimple",
+            "EmptyLatentImage",
+            "KSampler",
+            "SaveImage",
+            "VAEDecode",
+        ]
+
+    def test_is_api_format_not_subgraphed(self):
+        wf = load_default_workflow()
+        # API format: every value is a node dict with class_type + inputs; no
+        # UI-format `nodes`/`links` keys, no subgraph wrappers.
+        assert "nodes" not in wf and "links" not in wf
+        for node in wf.values():
+            assert "class_type" in node
+            assert isinstance(node["inputs"], dict)
+
+    def test_pinned_ids_point_at_expected_classes(self):
+        wf = load_default_workflow()
+        assert wf[CHECKPOINT_LOADER_ID]["class_type"] == "CheckpointLoaderSimple"
+        assert wf[POSITIVE_PROMPT_ID]["class_type"] == "CLIPTextEncode"
+        assert wf[NEGATIVE_PROMPT_ID]["class_type"] == "CLIPTextEncode"
+
+    def test_fresh_copy_each_call(self):
+        a = load_default_workflow()
+        a[POSITIVE_PROMPT_ID]["inputs"]["text"] = "mutated"
+        b = load_default_workflow()
+        assert b[POSITIVE_PROMPT_ID]["inputs"]["text"] == ""
+
+
+class TestPromptInjection:
+    def test_prompt_sets_positive_text_only(self):
+        wf = build_default_workflow(prompt="a red fox in snow")
+        assert wf[POSITIVE_PROMPT_ID]["inputs"]["text"] == "a red fox in snow"
+        # Negative prompt is left untouched.
+        assert wf[NEGATIVE_PROMPT_ID]["inputs"]["text"] == ""
+
+    def test_no_prompt_no_overrides_is_default_graph(self):
+        wf = build_default_workflow()
+        assert wf[POSITIVE_PROMPT_ID]["inputs"]["text"] == ""
+        assert wf[CHECKPOINT_LOADER_ID]["inputs"]["ckpt_name"] == "v1-5-pruned-emaonly.ckpt"
+
+
+class TestSetOverrides:
+    def test_checkpoint_alias(self):
+        wf = build_default_workflow(overrides=["checkpoint=sd_xl.safetensors"])
+        assert wf[CHECKPOINT_LOADER_ID]["inputs"]["ckpt_name"] == "sd_xl.safetensors"
+
+    def test_raw_node_field_form(self):
+        wf = build_default_workflow(overrides=["4.ckpt_name=sd_xl.safetensors"])
+        assert wf[CHECKPOINT_LOADER_ID]["inputs"]["ckpt_name"] == "sd_xl.safetensors"
+
+    def test_alias_and_raw_form_are_equivalent(self):
+        a = build_default_workflow(overrides=["checkpoint=model.ckpt"])
+        b = build_default_workflow(overrides=["4.ckpt_name=model.ckpt"])
+        assert a == b
+
+    def test_negative_alias(self):
+        wf = build_default_workflow(overrides=["negative=blurry, low quality"])
+        assert wf[NEGATIVE_PROMPT_ID]["inputs"]["text"] == "blurry, low quality"
+
+    def test_seed_coerced_to_int(self):
+        wf = build_default_workflow(overrides=["seed=42"])
+        assert wf["3"]["inputs"]["seed"] == 42
+        assert isinstance(wf["3"]["inputs"]["seed"], int)
+
+    def test_cfg_coerced_to_float(self):
+        wf = build_default_workflow(overrides=["cfg=7.5"])
+        assert wf["3"]["inputs"]["cfg"] == 7.5
+        assert isinstance(wf["3"]["inputs"]["cfg"], float)
+
+    def test_width_height_coerced_to_int(self):
+        wf = build_default_workflow(overrides=["width=768", "height=1024"])
+        assert wf["5"]["inputs"]["width"] == 768
+        assert wf["5"]["inputs"]["height"] == 1024
+
+    def test_later_override_wins(self):
+        wf = build_default_workflow(overrides=["seed=1", "seed=2"])
+        assert wf["3"]["inputs"]["seed"] == 2
+
+    def test_prompt_and_set_combine(self):
+        wf = build_default_workflow(prompt="fox", overrides=["negative=blurry", "seed=9"])
+        assert wf[POSITIVE_PROMPT_ID]["inputs"]["text"] == "fox"
+        assert wf[NEGATIVE_PROMPT_ID]["inputs"]["text"] == "blurry"
+        assert wf["3"]["inputs"]["seed"] == 9
+
+    def test_value_containing_equals_sign(self):
+        wf = build_default_workflow(overrides=["negative=a=b"])
+        assert wf[NEGATIVE_PROMPT_ID]["inputs"]["text"] == "a=b"
+
+
+class TestErrors:
+    def test_unknown_alias(self):
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(overrides=["bogus=x"])
+        assert e.value.code == "prompt_rejected"
+
+    def test_unknown_node_id_raw_form(self):
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(overrides=["99.foo=1"])
+        assert e.value.code == "prompt_rejected"
+
+    def test_missing_equals(self):
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(overrides=["seed"])
+        assert e.value.code == "prompt_rejected"
+
+    def test_non_integer_for_int_field(self):
+        with pytest.raises(PromptInjectionError) as e:
+            build_default_workflow(overrides=["seed=notanumber"])
+        assert e.value.code == "prompt_rejected"
+
+    def test_empty_field_in_raw_form(self):
+        with pytest.raises(PromptInjectionError):
+            build_default_workflow(overrides=["4.=x"])

--- a/tests/comfy_cli/output/test_discovery.py
+++ b/tests/comfy_cli/output/test_discovery.py
@@ -80,6 +80,19 @@ def test_discover_annotates_commands_with_schema():
     assert cmds["discover"]["output_schema"] == "discover.json"
 
 
+def test_discover_lists_run_prompt_and_set_options():
+    # BE-2535: `comfy run --prompt`/`--set` must be visible on the agent
+    # surface. The options are auto-introspected into the commands tree.
+    envelope = _run_cli(["--json", "discover"])
+    run_params = envelope["data"]["commands"]["run"]["params"]
+    flags = {flag for p in run_params for flag in (p.get("flags") or [])}
+    assert "--prompt" in flags
+    assert "--set" in flags
+    # --workflow is now optional (omit it to use the bundled default).
+    workflow_param = next(p for p in run_params if "--workflow" in (p.get("flags") or []))
+    assert workflow_param["required"] is False
+
+
 def test_discover_includes_error_codes_from_markdown():
     envelope = _run_cli(["--json", "discover"])
     codes = {row["code"] for row in envelope["data"]["error_codes"]}

--- a/tests/comfy_cli/test_tracking.py
+++ b/tests/comfy_cli/test_tracking.py
@@ -270,6 +270,23 @@ class TestTrackCommandRedaction:
         assert "pat-supersecret" not in str(properties)
         assert "fix things" not in str(properties)
 
+    def test_run_prompt_and_overrides_are_redacted(self, tracking_module):
+        # `comfy run --prompt`/`--set` carry verbatim user content that must not
+        # be shipped to analytics, only the fact that the option was supplied.
+        tracking_module.config_manager.set(constants.CONFIG_KEY_ENABLE_TRACKING, "True")
+
+        @tracking_module.track_command("run")
+        def run(prompt=None, set_overrides=None):
+            return None
+
+        run(prompt="a red fox in snow", set_overrides=["negative=blurry", "cfg=7.5"])
+
+        _, _, properties = _last_track_call(tracking_module.provider)
+        assert properties["prompt"] == "<redacted>"
+        assert properties["set_overrides"] == "<redacted>"
+        assert "red fox" not in str(properties)
+        assert "blurry" not in str(properties)
+
     def test_set_civitai_api_token_is_redacted(self, tracking_module):
         tracking_module.config_manager.set(constants.CONFIG_KEY_ENABLE_TRACKING, "True")
 
@@ -379,6 +396,8 @@ class TestSensitiveNameMatcher:
             "password",
             "secret",
             "changelog",
+            "prompt",
+            "set_overrides",
             "set_civitai_api_token",
             "set_hf_api_token",
             "access_token",


### PR DESCRIPTION
## ELI-5

Today `comfy run` needs a `--workflow` file. This adds a shortcut: `comfy run --prompt "a red fox in snow"` runs a built-in "text → image" recipe with no file needed. It writes your prompt into a small, fixed workflow we ship and hands it to the exact same execution path a normal `comfy run` uses. A wrapper (comfy-local-mcp) can now expose `generate_image(prompt)` as a thin passthrough.

We deliberately did NOT overload the existing `comfy generate` command — that's the shipped partner-API verb (flux-pro / ideogram / dalle / …) and `generate --prompt "…"` would collide with it. Extending `run` is collision-free.

## What changed

- **`comfy run` (`cmdline.py`)**: `--workflow` is now **optional**. New `--prompt TEXT` and repeatable `--set node.field=VALUE`. Omit `--workflow` and pass `--prompt`/`--set` to run a bundled default text2img workflow.
- **Bundled pinned graph** (`comfy_cli/cql/data/default_text2img.json`): a minimal, **non-subgraphed** API-format graph with stable, known node ids — CheckpointLoaderSimple(4) → CLIPTextEncode positive(6) / negative(7) → EmptyLatentImage(5) → KSampler(3) → VAEDecode(8) → SaveImage(9). We own the ids, so no gallery-template address drift. Picked up by the existing `comfy_cli.cql.data` `*.json` package-data glob — no new packaging entry.
- **Direct injector** (`comfy_cli/cql/default_workflow.py`): `--prompt` writes the positive CLIPTextEncode `text`; `--set` writes arbitrary API-format `inputs`. This is a plain dict write — **not** `Graph.apply_slots` (that operates on UI-format `widgets_values` and needs `object_info`). Documented aliases (`checkpoint`, `negative`, `seed`, `steps`, `cfg`, `width`, `height`, …) resolve against the known ids; the raw `NODE_ID.field=VALUE` form (e.g. `4.ckpt_name=…`) is always accepted. Values are type-coerced to the field's existing scalar type (so `seed=42`→int, `cfg=7.5`→float). No `object_info`, no live server.
- **Submit through run's existing path**: the injected graph is handed to `run.execute` / `run.execute_cloud` via a new `preloaded` short-circuit (skips file loading). **No new websocket/HTTP/preflight code.** `--wait`, `--where`, `--json`, `--host`/`--port`/`--timeout`, `--print-prompt` all behave exactly as `run` does today, and the standard `envelope/1` is emitted.
- **Errors**: an unknown/malformed `--set` address, or combining `--workflow` with `--prompt`/`--set`, surfaces the registered `prompt_rejected` code (not a stack trace). A missing/invalid checkpoint surfaces at submit through run's existing `prompt_rejected` node-error path.

## Acceptance criteria

1. ✅ `comfy run --prompt "…" --wait` (no `--workflow`) submits the injected graph via run's execute path; `--json` emits `envelope/1` with `data.prompt_id` + `data.outputs` (reuses run's existing `--wait` envelope). *Live-server run not exercised in CI; the submit path is proven by patched-submit tests, consistent with existing run tests.*
2. ✅ `--set checkpoint=NAME` and the raw `4.ckpt_name=NAME` form override the checkpoint; omitting uses the bundled default. (unit + integration tested)
3. ✅ `--prompt`/`--set` write the API-format graph correctly; an unknown `--set` address → `prompt_rejected`, no stack trace.
4. ✅ Missing/invalid checkpoint → registered error via run's existing submit-time `prompt_rejected` path (inherited; not re-implemented).
5. ✅ `comfy discover` lists `run`'s new `--prompt` / `--set` options (auto-introspected into the commands tree; tested).
6. ✅ No new websocket/HTTP code — reuses run's execute path via `preloaded`.

## Tests

- `tests/comfy_cli/cql/test_default_workflow.py` — offline injector unit tests (no server, no object_info, no apply_slots): prompt/set writes, aliases vs raw form, type coercion, error codes.
- `tests/comfy_cli/command/test_run_prompt.py` — integration/smoke: the injected graph is what reaches the submit path (`WorkflowExecution`), plus CLI wiring for `--prompt`/`--set`, cloud path, and the rejection branches.
- `tests/comfy_cli/output/test_discovery.py` — asserts `discover` lists `--prompt`/`--set` and that `--workflow` is now optional.

Full `tests/comfy_cli` suite: **2384 passed, 12 skipped**. `ruff format --check` + `ruff check` clean.

## Judgment calls

- **`--prompt`/`--set` are scoped to the bundled default only** — combining them with a user `--workflow` is rejected. The aliases resolve against OUR pinned node ids; applying them to an arbitrary user graph (whose node "4" may not be a checkpoint loader) would silently misfire. Tight scope over a footgun. Raw `NODE_ID.field` + aliases both target the bundled graph.
- **`--schemas-only` nuance**: the ticket says `comfy discover --schemas-only` lists the options, but `--schemas-only` deliberately strips the `commands` tree (pre-existing behavior). The CLI option list lives in the **full** `comfy discover` output (the authoritative surface), where the options do appear — the test targets that. I left `--schemas-only`'s shape unchanged (Chesterton's fence on an existing flag).
- **Default checkpoint** is `v1-5-pruned-emaonly.ckpt` (canonical ComfyUI default). If absent locally, acceptance #4's registered-error path applies.

## Out of scope (per ticket forward path)

Universal `comfy generate` auto-routing (partner-alias vs local checkpoint), multi-template `--template` selection, and generic semantic slot roles are deferred — this ships the single bundled default first, purely additively.
