### PR TITLE
docs: add AGENTS.md contributor onboarding guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Onboarding notes for anyone (human or automated agent) making changes to
+`comfy-cli` — a Python/[Typer](https://typer.tiangolo.com/) CLI for installing
+and running ComfyUI. This is a quick-start; see [`DEV_README.md`](DEV_README.md)
+for the fuller development guide.
+
+## Setup
+
+Requires Python >= 3.10 (CI targets 3.10, the minimum supported version). Install
+the package with its dev extras in editable mode:
+
+```bash
+pip install -e '.[dev]'
+```
+
+This pulls in the runtime dependencies plus the dev toolchain (`ruff`, `pytest`,
+`pytest-cov`, `pre-commit`, `jsonschema`).
+
+## Verify your changes
+
+Before opening a PR, run the same three checks CI enforces:
+
+```bash
+ruff check .            # lint
+ruff format --check .   # formatting (CI runs `ruff format --diff`)
+pytest                  # unit tests
+```
+
+All three must pass. Keep changes formatted with `ruff format` and imports sorted
+(ruff's isort rules are enabled) so the format check stays green.
+
+### pre-commit
+
+The repo ships a [pre-commit](https://pre-commit.com/) config that runs ruff (lint
++ format) and a few file hygiene hooks on every commit. Install it once so commits
+are auto-checked:
+
+```bash
+pre-commit install
+```
+
+## Branching
+
+The default branch is **`main`** — branch off `main` and open PRs against it.
+
+> **Gotcha:** a local checkout may already sit on a working branch (e.g.
+> `agent-cli`), *not* `main`. Don't assume the current branch is the base. Create
+> your branch (or worktree) off `origin/main` explicitly:
+>
+> ```bash
+> git fetch origin
+> git switch -c my-feature origin/main
+> # or, without disturbing the current checkout:
+> git worktree add ../comfy-cli-my-feature -b my-feature origin/main
+> ```
+
+## Conventions
+
+- Use `typer` for command/argument handling and `rich` for console output.
+- New commands are registered in `comfy_cli/cmdline.py`; subcommands live under
+  `comfy_cli/command/<name>/`. See [`DEV_README.md`](DEV_README.md#adding-a-new-command)
+  for the boilerplate.
+- End-to-end tests are disabled by default; enable them with `TEST_E2E=true pytest
+  tests/e2e/` (see [`docs/TESTING-e2e.md`](docs/TESTING-e2e.md)).


### PR DESCRIPTION
## ELI-5

Newcomers (and coding agents) landing in this repo have to reverse-engineer how
to build, test, and lint it. This adds a short `AGENTS.md` at the root with the
standard onboarding facts — install with dev extras, verify with ruff + pytest,
use pre-commit — plus one branching gotcha (a local checkout may sit on a
working branch, so branch off `origin/main`, not the current branch). One new
file; no code changes.

## What

New root `AGENTS.md` covering:

- **Setup** — `pip install -e '.[dev]'` (Python >= 3.10).
- **Verify** — the three checks CI enforces: `ruff check .`,
  `ruff format --check .`, `pytest`.
- **pre-commit** — `pre-commit install` for auto lint/format on commit.
- **Branching** — default branch is `main`; explicit worktree/branch off
  `origin/main` because a checkout may already sit on a working branch.
- **Conventions** — pointers to `DEV_README.md` and `docs/TESTING-e2e.md`
  (Typer/rich, adding commands, opt-in e2e tests).

It intentionally stays minimal and points at the existing `DEV_README.md` for
depth rather than duplicating it — the AGENTS.md convention is a well-known
entry point that many contributors and tools look for first.

## Why

The repo had no top-level agent/contributor quick-start. `AGENTS.md` is the
widely-adopted convention for exactly this.

## Testing

Docs-only change (no Python touched).

- `ruff format --check .` → clean (228 files already formatted).
- Markdown verified: no trailing whitespace, final newline present (satisfies
  the pre-commit hygiene hooks).
- All in-repo paths/anchors referenced by the doc were confirmed to exist
  (`DEV_README.md`, `docs/TESTING-e2e.md`, `comfy_cli/cmdline.py`,
  `comfy_cli/command/`, `tests/e2e/`).

## Notes / judgment calls

- **Python version:** used **3.10** (from `pyproject.toml` `requires-python`
  and the CI matrix). Flagging that `DEV_README.md` still says "3.9 minimum" —
  that line appears stale relative to `pyproject.toml`; not changed here to keep
  this PR to a single file, but worth a follow-up.
- **`ruff format --check` vs `--diff`:** the doc uses `--check` (the canonical
  pass/fail verify flag) and notes parenthetically that CI runs
  `ruff format --diff`; both exit non-zero on unformatted code.
- **Heads-up for maintainers:** this adds a new top-level doc, so a courtesy
  ping to a `comfy-cli` maintainer is warranted — flagging here for visibility
  rather than assigning a reviewer. Happy to adjust tone/scope to match repo
  preference.
