### PR TITLE
refactor: remove dead/vestigial helpers with zero prod usage

### DIFF
--- a/comfy_cli/output/branding.py
+++ b/comfy_cli/output/branding.py
@@ -78,17 +78,6 @@ def branded_panel(
     )
 
 
-def cli_footer(*, version: str, where: str | None = None) -> Text:
-    """Right-aligned, dim subtitle used as the pretty-mode brand signature.
-
-    Every pretty rendering that *isn't* already a Panel should print this
-    after its primary output so the human always knows which tool / version /
-    routing target produced what they're looking at.
-    """
-    suffix = f"  ·  {where}" if where else ""
-    return Text(f"comfy CLI v{version}{suffix}", style="dim", justify="right")
-
-
 # ---------------------------------------------------------------------------
 # Wordmark — handcrafted 5-row block art, kept narrow enough for an 80-col tty
 # ---------------------------------------------------------------------------

--- a/comfy_cli/output/glyphs.py
+++ b/comfy_cli/output/glyphs.py
@@ -49,10 +49,3 @@ def status_glyph(status: str | None) -> str:
     canonical = _canonical(status)
     glyph, style = STATUS_STYLE.get(canonical, DEFAULT_STYLE)
     return f"[{style}]{glyph} {canonical or 'unknown'}[/{style}]"
-
-
-def glyph_only(status: str | None) -> str:
-    """Return just the colored glyph, no label — handy for tight tables."""
-    canonical = _canonical(status)
-    glyph, style = STATUS_STYLE.get(canonical, DEFAULT_STYLE)
-    return f"[{style}]{glyph}[/{style}]"

--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -317,13 +317,6 @@ class Renderer:
         self.event(type, **fields)
         return True
 
-    def flush_throttled(self, token: str, type: str, **fields: Any) -> None:
-        """Force-emit one final event for a throttle token (e.g., on completion)."""
-        if not self.is_stream():
-            return
-        self._throttle[token] = time.monotonic()
-        self.event(type, **fields)
-
     # ----- internals -----
 
     def _envelope(

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -1,9 +1,7 @@
-import concurrent.futures
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 
 import git
 import typer
@@ -121,31 +119,6 @@ def check_comfy_repo(path) -> tuple[bool, str | None]:
 
 
 # Generate and update this following method using chatGPT
-# def load_yaml(file_path: str) -> ComfyLockYAMLStruct:
-#     with open(file_path, "r", encoding="utf-8") as file:
-#         data = yaml.safe_load(file)
-#         basics = Basics(
-#             name=data.get("basics", {}).get("name"),
-#             updated_at=(
-#                 datetime.fromisoformat(data.get("basics", {}).get("updated_at"))
-#                 if data.get("basics", {}).get("updated_at")
-#                 else None
-#             ),
-#         )
-#         models = [
-#             Model(
-#                 name=m.get("model"),
-#                 url=m.get("url"),
-#                 paths=[ModelPath(path=p.get("path")) for p in m.get("paths", [])],
-#                 hash=m.get("hash"),
-#                 type=m.get("type"),
-#             )
-#             for m in data.get("models", [])
-#         ]
-#         custom_nodes = []
-
-
-# Generate and update this following method using chatGPT
 def save_yaml(file_path: str, metadata: ComfyLockYAMLStruct):
     data = {
         "basics": {
@@ -166,12 +139,6 @@ def save_yaml(file_path: str, metadata: ComfyLockYAMLStruct):
     }
     with open(file_path, "w", encoding="utf-8") as file:
         yaml.safe_dump(data, file, default_flow_style=False, allow_unicode=True)
-
-
-# Function to check if the file is config.json
-def check_file_is_model(path):
-    if path.name.endswith(constants.SUPPORTED_PT_EXTENSIONS):
-        return str(path)
 
 
 class WorkspaceType(Enum):
@@ -316,19 +283,6 @@ class WorkspaceManager:
             for file in files:
                 if file.endswith(constants.SUPPORTED_PT_EXTENSIONS):
                     model_files.append(os.path.join(root, file))
-        return model_files
-
-    def scan_dir_concur(self):
-        base_path = Path(".")
-        model_files = []
-
-        # Use ThreadPoolExecutor to manage concurrency
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [executor.submit(check_file_is_model, p) for p in base_path.rglob("*")]
-            for future in concurrent.futures.as_completed(futures):
-                if future.result():
-                    model_files.append(future.result())
-
         return model_files
 
     def load_metadata(self):


### PR DESCRIPTION
## ELI-5

We had six little helper functions (and one big commented-out block of old code) that nothing in the project actually uses anymore — leftover scaffolding. This PR just deletes them. Nothing that runs changes; there's simply less dead code to trip over.

## What & why

Pure removal of dead/vestigial code — every item below was verified to have **zero callers** across both `comfy_cli/` and `tests/` (grep is authoritative here: none of these are reached via `getattr`/`globals` dynamic dispatch, and none are re-exported via any module `__all__`):

- **`workspace_manager.scan_dir_concur`** — 0 callers. Also latently buggy: it hardcoded `base_path = Path(".")`, ignoring `self.workspace_path`, so it would have scanned the wrong directory if ever wired up.
- **`workspace_manager.check_file_is_model`** — referenced only by `scan_dir_concur`; dead as a pair once that goes.
- **Commented-out `load_yaml` block** in `workspace_manager.py` (~23 lines) — pure noise. The live `save_yaml` immediately below it (which shares a similar header comment) is real and is left untouched.
- **`renderer.Renderer.flush_throttled`** — 0 callers (its sibling `throttled_event` has real callers and stays).
- **`glyphs.glyph_only`** — 0 callers (only `status_glyph` is used).
- **`branding.cli_footer`** — 0 callers (the sole reference is a doc-comment in `test_panels.py` noting "no separate `cli_footer`").

## Judgment call

Removing `scan_dir_concur` orphaned two imports that were used **only** by it — `import concurrent.futures` and `from pathlib import Path`. I removed those too (verified via grep they had no other use in the file), otherwise the linter would flag them as unused. This keeps the change to a clean, lint-green removal.

## Testing

- `ruff check comfy_cli/` — clean
- `ruff format --check` on all touched files — already formatted
- Full `pytest` suite — **2455 passed, 36 skipped**

No behavior change.
