### PR TITLE
refactor: extract shared access-token line helper for banners (BE-2836)

### DIFF
--- a/comfy_cli/output/branding.py
+++ b/comfy_cli/output/branding.py
@@ -203,6 +203,20 @@ def _humanize_seconds(s: int) -> str:
     return f"{h}h {rem // 60}m"
 
 
+def _access_token_line(expires_at: int | None) -> Text:
+    """The "Access token" value cell shared by welcome_banner and whoami_banner.
+
+    Pairs the humanized relative expiry (accented) with the absolute ISO
+    timestamp (dim). Kept as one helper so the two banners never drift in how
+    the token line is formatted.
+    """
+    return Text.assemble(
+        (_humanize_relative(expires_at), f"bold {BRAND_ACCENT}"),
+        ("   ", ""),
+        (_iso(expires_at), "dim"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Welcome banner — the big one, shown after auth login success
 # ---------------------------------------------------------------------------
@@ -241,14 +255,7 @@ def welcome_banner(
     info_tbl.add_column(justify="right", style="dim", no_wrap=True)
     info_tbl.add_column(overflow="fold")
     info_tbl.add_row("Scope", Text(scope, style="white"))
-    info_tbl.add_row(
-        "Access token",
-        Text.assemble(
-            (_humanize_relative(expires_at), f"bold {BRAND_ACCENT}"),
-            ("   ", ""),
-            (_iso(expires_at), "dim"),
-        ),
-    )
+    info_tbl.add_row("Access token", _access_token_line(expires_at))
     info_tbl.add_row("", Text("renews automatically while you keep using the CLI", style="dim"))
     info_tbl.add_row("Client", Text(client_id, style="white"))
 
@@ -311,14 +318,7 @@ def whoami_banner(
     info_tbl.add_column(justify="right", style="dim", no_wrap=True)
     info_tbl.add_column(overflow="fold")
     info_tbl.add_row("Scope", Text(scope, style="white"))
-    info_tbl.add_row(
-        "Access token",
-        Text.assemble(
-            (_humanize_relative(expires_at), f"bold {BRAND_ACCENT}"),
-            ("   ", ""),
-            (_iso(expires_at), "dim"),
-        ),
-    )
+    info_tbl.add_row("Access token", _access_token_line(expires_at))
     if not expired:
         info_tbl.add_row("", Text("renews automatically while you keep using the CLI", style="dim"))
     info_tbl.add_row("Client", Text(client_id, style="white"))


### PR DESCRIPTION
## ELI-5

Two Comfy Cloud banners — the big one you see right after `comfy cloud login`
(`welcome_banner`) and the compact `comfy cloud whoami` card (`whoami_banner`) —
both print an "Access token" line that pairs a human-friendly countdown
("in 59m 58s") with the exact expiry timestamp. Each banner built that line by
hand with the same `Text.assemble(...)`, so a formatting tweak had to be made in
two places or they'd drift apart. This pulls that one line into a tiny shared
helper, `_access_token_line(expires_at)`, that both banners call. Nothing the
user sees changes.

## What & why

Per BE-2836 (a deliberately **narrowed** de-dup): the two banners share a
near-identical session-info `Table.grid`, but they're intentionally different
products (a big post-login moment vs. a compact status card) with differing
label styles and one differing row (`whoami` gates the "renews automatically"
row on `not expired`). Rather than couple them behind a
`_session_info_table(show_renews=...)` or widen `_kv_table`, this extracts only
the **highest-drift-risk** piece — the `_humanize_relative` / `_iso` token-line
assembly — into one helper. The per-banner tables, label styles, and the
`whoami` renews-gate are untouched.

## Changes

- Add `_access_token_line(expires_at) -> Text` next to the other time-format
  helpers in `comfy_cli/output/branding.py`.
- Replace the two inline `Text.assemble(...)` token-line blocks in
  `welcome_banner` and `whoami_banner` with a call to the helper.

## Testing

- `pytest tests/comfy_cli/output/test_branding.py` — 17 passed.
- `ruff check` + `ruff format --check` clean on the changed file.
- Manually rendered all three states (welcome, whoami-active, whoami-expired);
  output is byte-identical to before — the helper reproduces the exact same
  `Text.assemble` structure, so this is a behavior-preserving refactor.

## Notes

- Scoped exactly as the ticket directs: no full `_session_info_table` helper,
  no widening of `_kv_table`. Just the one shared token line.
