### PR TITLE
refactor: promote cloud_preflight_or_exit to where.py, drop re-inlined blocks (BE-2833)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -793,15 +793,7 @@ def run(
         effective_notify = notify if notify is not None else (renderer.is_pretty() and not wait)
 
         if decision.target is where_module.WhereTarget.CLOUD:
-            err = where_module.cloud_preflight()
-            if err is not None:
-                renderer.error(
-                    code=err.code,
-                    message=err.message,
-                    hint=err.hint,
-                    details=err.details,
-                )
-                raise typer.Exit(code=1)
+            where_module.cloud_preflight_or_exit()
             # Cloud path uses HTTPS + Bearer auth; host/port aren't applicable.
             run_inner.execute_cloud(
                 workflow,
@@ -978,10 +970,7 @@ def upload(
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
     if effective_where == "cloud":
-        err = where_module.cloud_preflight()
-        if err is not None:
-            renderer.error(code=err.code, message=err.message, hint=err.hint, details=err.details)
-            raise typer.Exit(code=1)
+        where_module.cloud_preflight_or_exit()
 
     transfer_inner.execute_upload(files, where=effective_where, overwrite=overwrite)
 
@@ -1020,10 +1009,7 @@ def download(
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
     if effective_where == "cloud":
-        err = where_module.cloud_preflight()
-        if err is not None:
-            renderer.error(code=err.code, message=err.message, hint=err.hint, details=err.details)
-            raise typer.Exit(code=1)
+        where_module.cloud_preflight_or_exit()
 
     transfer_inner.execute_download(prompt_id, out_dir=out_dir, where=effective_where, url_only=url_only)
 

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -37,6 +37,7 @@ from comfy_cli import cancellation, execution_errors, tracking
 from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.output import get_renderer
+from comfy_cli.where import cloud_preflight_or_exit
 
 app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch ComfyUI prompts.")
 
@@ -411,7 +412,7 @@ def ls_cmd(
     if not local_only:
         if _is_cloud(where):
             try:
-                _cloud_preflight_or_exit()
+                cloud_preflight_or_exit()
                 client = _cloud_client()
                 server_rows = [_cloud_job_to_row(j) for j in client.list_jobs(limit=limit)]
             except typer.Exit:
@@ -871,7 +872,7 @@ def wait_cmd(
     p: int | None = None
     server_up = False
     if cloud:
-        _cloud_preflight_or_exit()
+        cloud_preflight_or_exit()
     else:
         h, p = _resolve_host_port(host, port)
         server_up = _server_or_error(h, p, raise_on_missing=False)
@@ -1053,7 +1054,7 @@ def _local_cancel(prompt_id: str, host: str, port: int) -> None:
 
 def _cloud_cancel(prompt_id: str) -> None:
     """Cancel a cloud job via ``POST /api/jobs/<id>/cancel`` — idempotent."""
-    _cloud_preflight_or_exit()
+    cloud_preflight_or_exit()
     renderer = get_renderer()
 
     from comfy_cli.target import resolve_target
@@ -1351,18 +1352,6 @@ def _is_cloud(where: str | None) -> bool:
     return decision.target is where_module.WhereTarget.CLOUD
 
 
-def _cloud_preflight_or_exit() -> None:
-    """Surface a clean envelope if the user isn't signed in / is expired."""
-    from comfy_cli.where import cloud_preflight
-
-    err = cloud_preflight()
-    if err is None:
-        return
-    renderer = get_renderer()
-    renderer.error(code=err.code, message=err.message, hint=err.hint, details=err.details)
-    raise typer.Exit(code=1)
-
-
 def _cloud_job_to_row(j: dict) -> JobRow:
     """Map a /api/jobs entry to our JobRow shape."""
     status_map = {"completed": "completed", "success": "completed", "failed": "error", "error": "error"}
@@ -1403,7 +1392,7 @@ def _cloud_client():
 def _cloud_ls(*, limit: int) -> None:
     from comfy_cli.comfy_client import HTTPError
 
-    _cloud_preflight_or_exit()
+    cloud_preflight_or_exit()
     renderer = get_renderer()
     client = _cloud_client()
     try:
@@ -1478,7 +1467,7 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
 
 
 def _cloud_status(prompt_id: str) -> None:
-    _cloud_preflight_or_exit()
+    cloud_preflight_or_exit()
     renderer = get_renderer()
     snap = _cloud_status_snapshot(prompt_id)
     if snap is None:
@@ -1513,7 +1502,7 @@ def _cloud_status(prompt_id: str) -> None:
 
 def _cloud_watch(prompt_id: str, *, poll_interval: float, max_wait: float) -> None:
     """Poll cloud's job status, emit NDJSON events on each transition."""
-    _cloud_preflight_or_exit()
+    cloud_preflight_or_exit()
     renderer = get_renderer()
     base_url = _cloud_client().target.base_url
 

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -190,3 +190,23 @@ def cloud_preflight() -> CloudError | None:
             },
         )
     return None
+
+
+def cloud_preflight_or_exit() -> None:
+    """Run :func:`cloud_preflight`; emit a clean error envelope and exit if the
+    cloud path can't proceed (not signed in / expired session).
+
+    The shared "emit-and-exit" wrapper for every command that routes to cloud —
+    keeps the envelope shape identical across ``jobs``, ``run``, ``upload``, and
+    ``download`` instead of re-inlining the same block at each call site.
+    """
+    import typer
+
+    from comfy_cli.output import get_renderer
+
+    err = cloud_preflight()
+    if err is None:
+        return
+    renderer = get_renderer()
+    renderer.error(code=err.code, message=err.message, hint=err.hint, details=err.details)
+    raise typer.Exit(code=1)

--- a/tests/comfy_cli/auth/test_where.py
+++ b/tests/comfy_cli/auth/test_where.py
@@ -242,3 +242,35 @@ def test_cloud_preflight_refreshes_expired_session(isolated_secrets, monkeypatch
     assert where_module.cloud_preflight() is None
     # The refreshed token was persisted, so subsequent commands use it.
     assert auth_store.get_cloud_session().access_token == "fresh-access-token"
+
+
+def test_cloud_preflight_or_exit_passes_when_configured(isolated_secrets):
+    """The emit-and-exit wrapper returns quietly when preflight clears."""
+    auth_store.save_cloud_session(
+        base_url="https://testcloud.comfy.org",
+        resource="https://testcloud.comfy.org/mcp",
+        client_id="mcp-dyn-test-id",
+        scope="mcp:tools:read mcp:tools:call",
+        access_token="fake-access-token",
+        refresh_token="fake-refresh-token",
+        token_type="Bearer",
+        expires_at=9999999999,
+    )
+    assert where_module.cloud_preflight_or_exit() is None
+
+
+def test_cloud_preflight_or_exit_emits_and_exits_when_not_configured(isolated_secrets, monkeypatch):
+    """No session → the wrapper emits the error envelope and raises Exit(1)."""
+    import typer
+
+    captured = {}
+
+    class _Renderer:
+        def error(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr("comfy_cli.output.get_renderer", lambda: _Renderer())
+    with pytest.raises(typer.Exit) as excinfo:
+        where_module.cloud_preflight_or_exit()
+    assert excinfo.value.exit_code == 1
+    assert captured["code"] == "cloud_not_configured"

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -482,7 +482,7 @@ def test_jobs_cancel_cloud_posts_to_jobs_cancel_endpoint(monkeypatch: pytest.Mon
     )
     monkeypatch.setattr("comfy_cli.target.resolve_target", lambda **kw: fake_target)
     monkeypatch.setattr(jobs_mod, "_is_cloud", lambda w: True)
-    monkeypatch.setattr(jobs_mod, "_cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
 
     calls = _capture_urlopen(
         monkeypatch,
@@ -520,7 +520,7 @@ def test_jobs_cancel_cloud_404_surfaces_prompt_not_found(monkeypatch: pytest.Mon
     )
     monkeypatch.setattr("comfy_cli.target.resolve_target", lambda **kw: fake_target)
     monkeypatch.setattr(jobs_mod, "_is_cloud", lambda w: True)
-    monkeypatch.setattr(jobs_mod, "_cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
 
     err = urllib.error.HTTPError("https://x/cancel", 404, "Not Found", {}, io.BytesIO(b'{"error":"no such job"}'))
     _capture_urlopen(monkeypatch, {"/api/jobs/missing/cancel": err})
@@ -848,7 +848,7 @@ def test_jobs_status_cloud_envelope_carries_grouped_outputs(monkeypatch, capsys)
     from comfy_cli.output import Renderer, set_renderer
     from comfy_cli.output.renderer import OutputMode
 
-    monkeypatch.setattr(jobs_mod, "_cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
     monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _CompletedCloudClient())
     state = jobs_state.new(prompt_id="pid-env", client_id="c", workflow="w", where="cloud")
     state.item_map = {"s1": {"nodes": ["9", "12"], "save_node": "12", "prefix": "outputs/s1"}}
@@ -873,7 +873,7 @@ def test_jobs_watch_cloud_terminal_envelope_carries_grouped_outputs(monkeypatch,
     from comfy_cli.output import Renderer, set_renderer
     from comfy_cli.output.renderer import OutputMode
 
-    monkeypatch.setattr(jobs_mod, "_cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
     monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _CompletedCloudClient())
     state = jobs_state.new(prompt_id="pid-watch", client_id="c", workflow="w", where="cloud")
     state.item_map = {"s1": {"nodes": ["9"], "save_node": "9", "prefix": "outputs/s1"}}


### PR DESCRIPTION
## ELI-5

When a command talks to Comfy Cloud, we first check "are you signed in?" — and if not, print a tidy error and stop. That little check-and-stop snippet was copy-pasted in a few places. This PR moves it into one shared function everybody calls, so there's only one copy to maintain. Nothing about what the user sees changes.

## What & why

`comfy_cli/command/jobs.py` already had a private `_cloud_preflight_or_exit()` — `err = cloud_preflight(); if err: renderer.error(...); raise typer.Exit(1)` — with 6 callers. The **identical** block was re-inlined at three `cmdline.py` sites: `run`, `upload`, and `download`.

This promotes the helper to a public `comfy_cli.where.cloud_preflight_or_exit()`, right next to `cloud_preflight()`, and adopts it everywhere:

- **`comfy_cli/where.py`** — new public `cloud_preflight_or_exit()` (lazy-imports `typer` / `get_renderer` to keep `where.py`'s module-level deps minimal, matching how `cloud_preflight()` lazy-imports `credentials`).
- **`comfy_cli/cmdline.py`** — the 3 re-inlined blocks (`run`, `upload`, `download`) now call `where_module.cloud_preflight_or_exit()`.
- **`comfy_cli/command/jobs.py`** — removed the private duplicate; the 6 call sites now use the shared symbol via a module-level import.

Behavior is unchanged: same error envelope (`code`/`message`/`hint`/`details`), same `Exit(1)`.

## Scope note (deliberately NOT changed)

`comfy_cli/command/setup.py` `_check_existing_auth()` also calls `cloud_preflight()`, but it returns a **bool** for a non-interactive auth check — it never emits an error envelope or exits. It is **not** an adoption target and is left untouched.

## Tests

- Added `cloud_preflight_or_exit` coverage in `tests/comfy_cli/auth/test_where.py` (passes-when-configured; emits-envelope-and-`Exit(1)`-when-not).
- Updated the 4 `test_jobs.py` monkeypatches to the new symbol name.
- Full suite green: **2457 passed, 36 skipped**. `ruff check` + `ruff format --check` clean.

## Notes for review

- Pure refactor — no capability is denied or added; the emit-and-exit path is byte-for-byte equivalent to the previous inline blocks.
- No circular-import risk: `where.py`'s only top-level `comfy_cli` import is `cancellation` (no command modules), and the full suite (which imports `jobs.py` via the CLI app) passes.
