### PR TITLE
refactor: extract shared Live+Progress scaffold for tarball helpers (BE-2837)

### DIFF
--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import subprocess
 import tarfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO, cast
 
@@ -139,6 +140,29 @@ def download_url(
     return fpath
 
 
+@contextmanager
+def _tarball_progress(description: str, total: int):
+    """Yield the shared two-row Live progress scaffold used by
+    extract_tarball/create_tarball.
+
+    Builds a byte-progress bar plus a current-path line inside a single
+    ``Live`` display and yields the wired-up
+    ``(barProg, barTask, pathProg, pathTask)`` so each caller can supply its
+    own ``filter`` body and label.
+    """
+    barProg = progress.Progress()
+    barTask = barProg.add_task(f"[cyan]{description}", total=total)
+    pathProg = progress.Progress(progress.TextColumn("{task.description}"))
+    pathTask = pathProg.add_task("")
+
+    progress_table = Table.grid()
+    progress_table.add_row(barProg)
+    progress_table.add_row(pathProg)
+
+    with Live(progress_table, refresh_per_second=10):
+        yield barProg, barTask, pathProg, pathTask
+
+
 def extract_tarball(
     inPath: PathLike,
     outPath: PathLike | None = None,
@@ -167,28 +191,20 @@ def extract_tarball(
 
     fileSize = inPath.stat().st_size
 
-    barProg = progress.Progress()
-    barTask = barProg.add_task("[cyan]extracting tarball...", total=fileSize)
-    pathProg = progress.Progress(progress.TextColumn("{task.description}"))
-    pathTask = pathProg.add_task("")
-
-    progress_table = Table.grid()
-    progress_table.add_row(barProg)
-    progress_table.add_row(pathProg)
-
     _size = 0
 
-    def _filter(tinfo: tarfile.TarInfo, _path: PathLike):
-        nonlocal _size
-        pathProg.update(pathTask, description=tinfo.path)
-        barProg.advance(barTask, _size)
-        _size = tinfo.size
+    with _tarball_progress("extracting tarball...", fileSize) as (barProg, barTask, pathProg, pathTask):
 
-        # TODO: ideally we'd use data_filter here, but it's busted: https://github.com/python/cpython/issues/107845
-        # return tarfile.data_filter(tinfo, _path)
-        return tinfo
+        def _filter(tinfo: tarfile.TarInfo, _path: PathLike):
+            nonlocal _size
+            pathProg.update(pathTask, description=tinfo.path)
+            barProg.advance(barTask, _size)
+            _size = tinfo.size
 
-    with Live(progress_table, refresh_per_second=10):
+            # TODO: ideally we'd use data_filter here, but it's busted: https://github.com/python/cpython/issues/107845
+            # return tarfile.data_filter(tinfo, _path)
+            return tinfo
+
         with tarfile.open(inPath) as tar:
             tar.extractall(filter=_filter)
         barProg.advance(barTask, _size)
@@ -218,26 +234,18 @@ def create_tarball(
 
     fileSize = sum(f.stat().st_size for f in inPath.glob("**/*"))
 
-    barProg = progress.Progress()
-    barTask = barProg.add_task("[cyan]creating tarball...", total=fileSize)
-    pathProg = progress.Progress(progress.TextColumn("{task.description}"))
-    pathTask = pathProg.add_task("")
-
-    progress_table = Table.grid()
-    progress_table.add_row(barProg)
-    progress_table.add_row(pathProg)
-
     _size = 0
 
-    def _filter(tinfo: tarfile.TarInfo):
-        nonlocal _size
-        pathProg.update(pathTask, description=tinfo.path)
-        barProg.advance(barTask, _size)
-        _size = Path(tinfo.path).stat().st_size
+    with _tarball_progress("creating tarball...", fileSize) as (barProg, barTask, pathProg, pathTask):
 
-        return tinfo
+        def _filter(tinfo: tarfile.TarInfo):
+            nonlocal _size
+            pathProg.update(pathTask, description=tinfo.path)
+            barProg.advance(barTask, _size)
+            _size = Path(tinfo.path).stat().st_size
 
-    with Live(progress_table, refresh_per_second=10):
+            return tinfo
+
         with tarfile.open(outPath, "w:gz") as tar:
             # don't include parent paths in archive
             tar.add(inPath.relative_to(cwd), filter=_filter)


### PR DESCRIPTION
## ELI-5

`extract_tarball` and `create_tarball` each hand-built the exact same ~18-line
progress display — a byte bar, a "current file" line, a two-row table, and a
`Live` wrapper — before running their own copy loop. This PR moves that shared
scaffolding into one small helper so each function only keeps the parts that are
actually different (its own `filter` body and its label). Same on-screen
behavior; just less duplication.

## What changed

- New `_tarball_progress(description, total)` `@contextmanager` in
  `comfy_cli/utils.py`: builds the `barProg`/`barTask` + `pathProg`/`pathTask`
  two-row `Table.grid()` inside a single `Live(..., refresh_per_second=10)` and
  `yield`s `(barProg, barTask, pathProg, pathTask)`.
- `extract_tarball` and `create_tarball` now `with _tarball_progress(...) as
  (barProg, barTask, pathProg, pathTask):` and supply only their own `_filter`
  body + label string. The `[cyan]` styling prefix moved into the helper, so the
  rendered task descriptions are byte-identical to before.

## Why

Per BE-2837 (groom finder + adversarial verifier, DOWNGRADE verdict): both
functions duplicated the identical progress scaffold. This is the recommended
minimal shape — a yield-based helper that parametrizes only the differing bits.
Nice-to-have cleanup, not a defect fix.

## Behavior

Unchanged. The differing pieces stay in each function:
- tar open mode (`'r'` implicit vs `'w:gz'`)
- the `_filter` signature (`(tinfo, path)` for extract vs `(tinfo)` for create)
  and how it computes the next `_size`
- the label (`extracting tarball...` vs `creating tarball...`)
The `show_progress=False` fast paths, `shutil.move`, and cleanup logic are
untouched (the helper wraps only the progress-rendering block).

## Testing

- `pytest tests/comfy_cli/test_utils.py` — the create→extract round-trip
  (`TestTarballRoundTrip`, which patches `comfy_cli.utils.Live`) passes; the
  helper still references module-scope `Live`, so the patch continues to apply.
- Full suite: `2455 passed, 36 skipped`.
- `ruff format` (no changes) + `ruff check` clean.

## Notes / judgment calls

- Net line delta is small (+42/-34) — expected for this ticket: a shared helper
  must re-yield the four wired-up handles the differing filters need, so most of
  the savings is the eliminated `Table.grid()`/`Live` boilerplate rather than raw
  line count. This matches the ticket's "modest, do it as a small helper" scope.
- No capability-denial / dead-end paths added (falsification clause N/A — pure
  refactor).
