### PR TITLE
refactor: remove dead _cloud_ls + install.execute cruft (BE-2838)

### DIFF
--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -159,17 +159,13 @@ def execute(
     skip_requirement: bool = False,
     fast_deps: bool = False,
     pr: str | None = None,
-    *args,
-    **kwargs,
 ):
+    """Install ComfyUI from a given URL."""
     # Install ComfyUI from a given PR reference.
     if pr:
         url = handle_pr_checkout(pr, comfy_path)
         version = "nightly"
 
-    """
-    Install ComfyUI from a given URL.
-    """
     if not workspace_manager.skip_prompting:
         res = ui.prompt_confirm_action(f"Install from {url} to {comfy_path}?", True)
 

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -1389,36 +1389,6 @@ def _cloud_client():
         raise typer.Exit(code=1) from e
 
 
-def _cloud_ls(*, limit: int) -> None:
-    from comfy_cli.comfy_client import HTTPError
-
-    cloud_preflight_or_exit()
-    renderer = get_renderer()
-    client = _cloud_client()
-    try:
-        jobs = client.list_jobs(limit=limit)
-    except HTTPError as e:
-        renderer.error(
-            code="cloud_http_error",
-            message=f"Cloud /api/jobs failed (HTTP {e.status}): {e.message}",
-            details={"status": e.status, "body": e.body[:1000]},
-        )
-        raise typer.Exit(code=1)
-
-    rows = [_cloud_job_to_row(j) for j in jobs[:limit]]
-    if renderer.is_pretty():
-        _render_jobs_pretty(rows, host=client.target.base_url, port=0)
-    renderer.emit(
-        {
-            "base_url": client.target.base_url,
-            "count": len(rows),
-            "jobs": [_row_to_dict(r) for r in rows],
-        },
-        command="jobs ls",
-        where="cloud",
-    )
-
-
 def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     """Compose a cloud snapshot from /api/jobs/<id> + /api/history_v2/<id>."""
     from comfy_cli import jobs_state

--- a/tests/comfy_cli/test_install_python_resolution.py
+++ b/tests/comfy_cli/test_install_python_resolution.py
@@ -122,7 +122,6 @@ class TestExecute:
 
             install.execute(
                 url="https://github.com/test/test.git",
-                manager_url="https://github.com/test/manager.git",
                 comfy_path=repo_dir,
                 restore=False,
                 skip_manager=True,


### PR DESCRIPTION
## ELI-5

We had some code lying around that nothing ever calls, plus a couple of tidiness bugs in the installer. This PR sweeps up the guaranteed-safe parts:

- **`_cloud_ls`** — a whole function for listing cloud jobs that no longer had any callers. The live `jobs ls` command already does this inline; this was a leftover parallel copy. Deleted.
- **`install.execute` cruft** — a docstring that had drifted *below* real code (so it was a no-op string, not a docstring), plus a trailing `*args, **kwargs` that nothing referenced. Docstring moved back to the top; the catch-all args removed.

## What changed

1. **Delete `jobs._cloud_ls`** (`comfy_cli/command/jobs.py`). Verified 0 callers repo-wide (`comfy_cli/` + `tests/`). It was a superseded parallel implementation of the cloud-branch listing that `jobs ls` (`_ls`/`ls_cmd`) now inlines. Every helper it used (`_cloud_preflight_or_exit`, `_cloud_client`, `_cloud_job_to_row`, `_render_jobs_pretty`, `_row_to_dict`) is still used by the live path, so no new dead code is left behind. Pure removal — denies no capability.

2. **`install.execute` docstring + `*args/**kwargs`** (`comfy_cli/command/install.py`). A bare `"""Install ComfyUI from a given URL."""` string sat *after* the `if pr:` block as a no-op expression statement (a misplaced docstring). Moved it to the top of the function. Dropped the never-referenced trailing `*args, **kwargs`.

3. **Test fix exposed by (2)** (`tests/comfy_cli/test_install_python_resolution.py`). Removing `**kwargs` surfaced a bogus `manager_url=` kwarg in one test — `execute()` never had a `manager_url` parameter; `**kwargs` was silently swallowing it (`manager_url` appears literally nowhere else in the codebase). Removed the bogus arg; the test's actual assertion (`skip_torch` forwarding) is unchanged.

## Judgment calls / deliberately NOT done

- **`restore: bool` left in `execute`'s signature (unused, but kept).** The ticket noted `restore` is read only in the signature and offered two paths: drop it (a required-positional change) *or* leave it for zero call-site churn. The ticket estimated "both callers pass it positionally," but the real blast radius is **14 call sites** — 2 production callers (`cmdline.py`) plus **12 test call sites** that pass `restore=False` as a keyword. Turning a tidy dead-code cleanup into a signature change touching a dozen tests runs against the small-scoped-PR guardrail, so I took the ticket's blessed zero-churn option. Easy focused follow-up if a maintainer wants it gone.

- **The 8 Graph query methods (`engine.py:530-562`) are intentionally NOT touched.** The ticket flagged these (`pack_nodes`, `label_nodes`, `cloud_disabled_nodes`, `cloud_enabled_nodes`, `api_nodes`, `output_nodes`, `packs`, `known_labels`) as a judgment call — verified 0 callers, but a coherent, deliberately-designed query surface plausibly intended for a future `comfy nodes ls --pack/--label/--api`. Per the ticket, deleting them is a commitment that needs owner sign-off; a maintainer may prefer to KEEP and wire them into `nodes` filters + tests. Left for that decision.

## Testing

- `ruff check` + `ruff format --diff` (ruff 0.15.15, as CI): clean.
- Full `pytest` suite: **2455 passed, 36 skipped**.
