### PR TITLE
docs: document the Comfy Cloud run path in the README + --help epilog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ comfy setup
 
 `comfy setup` walks you through everything — local or cloud routing, authentication, and agent skill installation — in one interactive wizard. Pass `-y` for non-interactive (CI/scripted) installs.
 
+## Run a workflow in the cloud
+
+No local GPU? Route any API-format workflow to [Comfy Cloud](https://www.comfy.org/) with `--where cloud`:
+
+```bash
+comfy cloud login                                        # sign in via your browser (OAuth)
+comfy run --workflow ./workflow.json --where cloud       # submits, prints a prompt_id, returns immediately
+comfy jobs wait <prompt_id> --where cloud                # block until the job finishes (or: jobs status for a one-shot check)
+comfy download <prompt_id> --where cloud -o ./outputs    # save the results locally
+```
+
+`comfy run` submits asynchronously and prints the `prompt_id` you feed to `jobs`/`download`; add `--wait` to block inline instead. Check your sign-in anytime with `comfy cloud whoami`. Export the workflow JSON from ComfyUI via **File → Export (API)** (UI-format JSON is auto-converted). Set cloud as your default target so you can drop the flag: `comfy set-default --where cloud`.
+
+**Credits:** cloud generation (`comfy run --where cloud`, `comfy generate`) consumes Comfy Cloud credits and needs an active subscription. Discovery and inspection commands — `comfy cloud whoami`, `comfy jobs status/ls`, `comfy templates ls`, `comfy generate list` — don't.
+
 ## Installation
 
 1. (Recommended) Activate a virtual environment ([venv](https://docs.python.org/3/library/venv.html) or [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html)).

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -153,7 +153,17 @@ def _maybe_nudge_setup(ctx: typer.Context, renderer) -> None:
         pass
 
 
-@app.callback(invoke_without_command=True)
+@app.callback(
+    invoke_without_command=True,
+    epilog=(
+        "Cloud quickstart (no local GPU required):\n\n"
+        "comfy cloud login  →  comfy run --workflow wf.json --where cloud  "
+        "(prints a prompt_id)  →  comfy jobs wait <prompt_id> --where cloud  →  "
+        "comfy download <prompt_id> --where cloud\n\n"
+        "Cloud generation consumes Comfy Cloud credits (needs an active subscription); "
+        "discovery commands (jobs status, templates ls, generate list) don't. See the README."
+    ),
+)
 def entry(
     ctx: typer.Context,
     workspace: Annotated[


### PR DESCRIPTION
## ELI-5

If you don't have a beefy GPU, comfy-cli can run your workflow on **Comfy Cloud** instead. Until now the README never told you how — it only showed `comfy generate`. This PR adds a short recipe: sign in, submit your workflow to the cloud, wait for it to finish, and download the results. It also drops the same recipe at the bottom of `comfy --help`, and explains that cloud generation costs credits while just looking around (listing jobs/templates) is free.

## What changed

- **README:** new "Run a workflow in the cloud" section right after Quick Start — the full `comfy cloud login` → `comfy run --where cloud` → `comfy jobs wait` → `comfy download` path, how to export the workflow JSON, and a one-line credits/subscription note.
- **`comfy --help` epilog:** the same ~1-line decision path + credits note now renders at the bottom of the root help, via an `epilog` on the existing `@app.callback` (cheap — no new callback needed).

## Command validation

Every command/flag in the new docs was validated against the **actual registered CLI surface** (the ticket flags a prior `comfy auth login` doc bug — a command that didn't exist — as the reason this matters). Installed the package in a clean venv and ran `--help` on each:

- `comfy cloud login`, `comfy cloud whoami` ✓
- `comfy run --workflow <path> --where cloud --wait` ✓ (submits async by default, prints `prompt_id`)
- `comfy jobs wait <prompt_id> --where cloud`, `comfy jobs status`, `comfy jobs ls` ✓
- `comfy download <prompt_id> --where cloud -o <dir>` ✓
- `comfy set-default --where cloud`, `comfy templates ls`, `comfy generate list` ✓

## Notes / judgment calls

- **Epilog formatting:** the Rich help renderer collapses hard newlines within a paragraph, so a 4-line aligned block reflowed into a run-on. I rendered the path as a single arrow-chain (`a → b → c`) split into two paragraphs so it stays legible after reflow. Verified visually with `comfy --help`.
- **Credits wording** mirrors the ticket's own framing (generation consumes credits + needs a subscription; discovery/inspection commands don't). It's user guidance, not a hard technical assertion — no capability is denied by this diff.
- Docs-only + a metadata-only Typer kwarg. Full suite green (2573 passed, 37 skipped); `ruff check` + `ruff format --check` clean on the changed file.
