### PR TITLE
refactor(cli): remove dead command surface (dup dependency decorator, models typo-stub, no-op nodes refresh)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1435,12 +1435,6 @@ def env():
     renderer.emit(data, command="env")
 
 
-@app.command(hidden=True)
-@tracking.track_command()
-def models():
-    rprint("\n[bold red] No such command, did you mean 'comfy model' instead?[/bold red]\n")
-
-
 _FEEDBACK_DISABLED_NOTICE = (
     "[yellow]Feedback not sent — telemetry is opted out via DO_NOT_TRACK / COMFY_NO_TELEMETRY.[/yellow]\n"
     "Unset that to send, or open an issue: https://github.com/Comfy-Org/comfy-cli/issues/new/choose"
@@ -1544,9 +1538,9 @@ def agent_review(
     )
 
 
-@app.command(hidden=True)
 @app.command(
-    help="Given an existing installation of comfy core and any custom nodes, installs any needed python dependencies"
+    hidden=True,
+    help="Given an existing installation of comfy core and any custom nodes, installs any needed python dependencies",
 )
 @tracking.track_command()
 def dependency():

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -848,25 +848,3 @@ def categories_cmd(
             renderer.console().print(tbl)
             rprint(f"[dim]{len(flat)} categories[/dim]")
     renderer.emit(payload, command="nodes categories")
-
-
-# ---------------------------------------------------------------------------
-# refresh — object_info is fetched live; nothing to cache
-# ---------------------------------------------------------------------------
-
-
-@app.command(
-    "refresh",
-    help="object_info is fetched live from the server on each command — nothing to refresh.",
-)
-@tracking.track_command("nodes")
-def refresh_cmd(
-    where: Annotated[
-        str | None,
-        typer.Option("--where", show_default=False, help="Override the resolved routing mode."),
-    ] = None,
-):
-    """Explain that object_info is fetched live and exit."""
-    renderer = get_renderer()
-    rprint("[dim]object_info is fetched live from the server on each command — nothing to refresh.[/dim]")
-    renderer.emit({"refreshed": False, "reason": "live_fetch"}, command="nodes refresh")

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -531,7 +531,7 @@ def execute_cloud(
             renderer.error(
                 code="cql_no_graph",
                 message=f"could not load cloud object_info for conversion: {e}",
-                hint="run `comfy nodes refresh --where cloud` to populate the cache",
+                hint="object_info is fetched live — check your cloud sign-in and connection then retry, or run against a local server",
             )
             raise typer.Exit(code=1) from e
         try:

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -48,7 +48,6 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy nodes path": "nodes",
     "comfy nodes types": "nodes",
     "comfy nodes categories": "nodes",
-    "comfy nodes refresh": "nodes",
     # workflow editing
     "comfy workflow slots": "workflow",
     "comfy workflow set-slot": "workflow",

--- a/comfy_cli/skills/comfy-debug/SKILL.md
+++ b/comfy_cli/skills/comfy-debug/SKILL.md
@@ -47,7 +47,7 @@ comfy --json run --workflow same_workflow.json --where cloud   # just resubmit �
 If several jobs from one batch died together with this code, resubmit them all; one retry each is normally enough.
 
 ### `workflow_not_api_format`
-UI-format workflows are converted to API format **client-side** using object_info (no server conversion endpoint exists). If conversion fails with `conversion_error`, re-export via `File > Export (API)` in ComfyUI; if object_info can't be fetched (`cql_no_graph`), run `comfy nodes refresh --where cloud` or start a local server.
+UI-format workflows are converted to API format **client-side** using object_info (no server conversion endpoint exists). If conversion fails with `conversion_error`, re-export via `File > Export (API)` in ComfyUI; if object_info can't be fetched (`cql_no_graph`), retry (it's fetched live — check cloud sign-in/connection) or start a local server.
 
 ### `workflow_invalid_json`
 The file isn't valid JSON. Inspect the first/last 100 bytes — often it's an HTML error page that was saved with `.json`.

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -499,7 +499,7 @@ object_info through the routing chain with a cached fallback — cloud-signed-in
 works with no local server. If the live fetch fails, the command still succeeds
 from cache and the envelope carries `data.stale: true` +
 `warnings[] {code: "object_info_stale"}` — treat results as possibly outdated
-and run `comfy nodes refresh --where cloud` to refresh.
+re-run the command once the live fetch recovers to pick up fresh object_info.
 
 Slot addresses are `<instance_id>.<input_name>`. Feed them to
 `workflow set-slot` / `workflow vary` in the Execution half. Works on


### PR DESCRIPTION
## ELI-5

The CLI had three "dead" spots on its command surface. Removing them so every
command name means exactly one real thing, and nothing registered does nothing:

1. `dependency` was registered **twice** (two stacked `@app.command` decorators).
2. A hidden `models` "did you mean `comfy model`?" typo-stub sat in `cmdline.py`,
   but it was **shadowed** by the real `models` sub-app, so it was unreachable dead code.
3. `comfy nodes refresh` was an **honest no-op** — it just printed
   "nothing to refresh" and exited. A registered command that does nothing erodes
   trust in every other command.

## What changed

- **`dependency` — deduplicated.** Collapsed the two stacked `@app.command`
  decorators into a single `@app.command(hidden=True, help=...)`. The name now
  registers exactly one implementation. Behavior is unchanged (it was already
  effectively hidden — the `hidden=True` decorator was the one that won), and the
  function body is untouched.
- **`models` typo-stub — removed.** The hidden `def models()` in `cmdline.py` was
  shadowed by `app.add_typer(..., name="models")` (the real model-discovery
  sub-app), so `comfy models` always resolved to the sub-app and the stub's
  message was never reachable. Pure dead-code removal.
- **`nodes refresh` — removed.** `object_info` is fetched live on every command,
  and the on-disk cache is auto-written on each successful fetch via
  `resilient_load_object_info` (cache + refresh-retry + stale fallback). A manual
  `refresh` therefore has nothing to do — every `comfy nodes <cmd>` already
  refreshes the cache when the server is reachable. Removed rather than
  reimplemented (see note below).

## `--help` before → after

**Top-level `comfy --help` command list** — the only change is that `models`
**relocates** in the list (its help text is unchanged). This is a side effect of
removing the dead stub: the stub registered the `models` key *early* (right after
`env`), and Python dicts keep a key's first-insertion position even when the value
is later overwritten by the real sub-app. With the stub gone, the `models` key is
first inserted where the real sub-app is registered — next to `model` / `node` /
`nodes`, which is where it belongs. No command is added or removed at the top level.

```diff
- models        Discover models — folders, files, and the cloud asset catalog.   # (was up near env/feedback)
  ...
  nodes         Introspect ComfyUI node classes (inputs, outputs, categories).
+ models        Discover models — folders, files, and the cloud asset catalog.   # (now beside the other sub-apps)
```

**`comfy nodes --help` command list:**

```diff
  categories  Browse the category tree.
- refresh     object_info is fetched live from the server on each command — nothing to refresh.
```

(`comfy dependency` remains hidden from the top-level list before and after; the
only difference is `comfy dependency --help` now shows its description, since the
retained decorator carries the `help=` text.)

## Acceptance

1. **Each command name resolves to exactly one implementation** — `dependency`
   (one decorator), `models` (sub-app only), `nodes refresh` (gone). ✓
2. **No registered command is a silent no-op** — the `nodes refresh` no-op is
   removed. ✓
3. **`--help` before/after diffed** — above. ✓

## Judgment calls

- **`dependency` kept hidden, not promoted.** The two decorators disagreed
  (`hidden=True` vs. a visible one with help text); the effective behavior has
  always been *hidden* (the hidden decorator won). I deduplicated to preserve that
  effective behavior — the top-level command list is byte-identical before/after.
  Whether `dependency` *should* be a visible, documented command is a separate
  product call I did not make here.
- **`nodes refresh` removed, not reimplemented.** The ticket allowed "make it
  actually refresh." I verified there is genuinely nothing for a manual refresh to
  do: any `comfy nodes` command that reaches the server already live-fetches and
  overwrites the cache (`resilient_load_object_info`), and the cache is only ever
  read as a fallback when the server is unreachable — a state a manual refresh
  can't fix either. So a real refresh command would still be a no-op. Removal is
  the honest fix. (The genuine "refresh object_info" capability is intact and runs
  automatically on every nodes command — nothing is being denied.)

## Testing

- `ruff check` + `ruff format --check` — clean.
- Full test suite: **2573 passed, 37 skipped**.
- Manually verified: `comfy dependency --help` still works, `comfy models`
  resolves to the sub-app, `comfy nodes refresh` now returns "No such command".
