### PR TITLE
refactor: remove 8 dead symbols + vestigial where.py re-export (BE-3268)

### DIFF
--- a/comfy_cli/auth/store.py
+++ b/comfy_cli/auth/store.py
@@ -17,7 +17,6 @@ import json
 import os
 import re
 import secrets
-from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -209,10 +208,6 @@ def remove(provider: str) -> bool:
         del data["providers"][provider]
         _write_all(path, data)
     return True
-
-
-def known_providers() -> Iterable[str]:
-    return SUPPORTED_PROVIDERS
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/cloud/oauth.py
+++ b/comfy_cli/cloud/oauth.py
@@ -86,10 +86,6 @@ class OAuthRefreshError(OAuthError):
     code = "oauth_refresh_failed"
 
 
-class OAuthCancelled(OAuthError):
-    code = "oauth_cancelled"
-
-
 class OAuthTimeout(OAuthError):
     code = "oauth_timeout"
 

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1103,12 +1103,6 @@ def run_cli(
     )
 
 
-def validate_comfyui(_env_checker):
-    if _env_checker.comfy_repo is None:
-        rprint("[bold red]If ComfyUI is not installed, this feature cannot be used.[/bold red]")
-        raise typer.Exit(code=1)
-
-
 @app.command(help="Stop background ComfyUI")
 @tracking.track_command()
 def stop():

--- a/comfy_cli/command/generate/spec.py
+++ b/comfy_cli/command/generate/spec.py
@@ -420,7 +420,3 @@ def write_cache(yaml_text: str) -> Path:
     load_raw_spec.cache_clear()
     _registry.cache_clear()
     return _USER_CACHE
-
-
-def active_spec_path() -> Path:
-    return _select_spec_path()

--- a/comfy_cli/command/generate/spec.py
+++ b/comfy_cli/command/generate/spec.py
@@ -522,3 +522,7 @@ def write_cache(yaml_text: str) -> Path:
     load_raw_spec.cache_clear()
     _registry.cache_clear()
     return _USER_CACHE
+
+
+def active_spec_path() -> Path:
+    return _select_spec_path()

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -29,12 +29,6 @@ workspace_manager = WorkspaceManager()
 console = Console()
 
 
-def get_os_details():
-    os_name = platform.system()  # e.g., Linux, Darwin (macOS), Windows
-    os_version = platform.release()
-    return os_name, os_version
-
-
 def _pip_install_torch(python: str, index_args: list[str]) -> subprocess.CompletedProcess:
     """Install torch, torchvision, and torchaudio with the given index arguments."""
     return subprocess.run(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -309,11 +309,6 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "run `comfy cloud login` to sign in again",
     ),
     ErrorCode(
-        "oauth_cancelled",
-        "OAuth flow was cancelled by the user.",
-        "re-run `comfy cloud login` to retry sign-in",
-    ),
-    ErrorCode(
         "oauth_timeout",
         "Timed out waiting for browser callback during OAuth login.",
         "re-run `comfy cloud login` and complete the sign-in in your browser",

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -38,26 +38,6 @@ def show_progress(iterable, total, description="Downloading..."):
 ChoiceType = str | Choice | dict[str, Any]
 
 
-def prompt_autocomplete(
-    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
-) -> ChoiceType | None:
-    """
-    Asks a single select question using questionary and returns the selected response.
-
-    Args:
-        question (str): The question to display to the user.
-        choices (List[ChoiceType]): A list of choices the user can autocomplete from.
-        default (ChoiceType): Default choice.
-        force_prompting (bool): Whether to force prompting even if skip_prompting is set.
-
-    Returns:
-        Optional[ChoiceType]: The selected choice from the user, or None if skipping prompts.
-    """
-    if workspace_manager.skip_prompting and not force_prompting:
-        return None
-    return questionary.autocomplete(question, choices=choices, default=default).ask()
-
-
 def prompt_select(
     question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
 ) -> ChoiceType | None:

--- a/comfy_cli/update.py
+++ b/comfy_cli/update.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import time
-from importlib.metadata import metadata
 from pathlib import Path
 
 import requests
@@ -38,11 +37,6 @@ def check_for_newer_pypi_version(package_name, current_version):
     except requests.RequestException as e:
         logger.warning(f"Failed to check for updates: {e}")
         return False, current_version
-
-
-def get_version_from_pyproject():
-    package_metadata = metadata("comfy-cli")
-    return package_metadata["Version"]
 
 
 def upgrade_cli():

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -5,7 +5,6 @@ Module for utility functions.
 import functools
 import platform
 import shutil
-import subprocess
 import tarfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -13,16 +12,11 @@ from typing import BinaryIO, cast
 
 import psutil
 import requests
-import typer
 from rich import progress
 from rich.live import Live
 from rich.table import Table
 
 from comfy_cli.constants import DEFAULT_COMFY_WORKSPACE, OS, PROC
-
-# Use the output shim so prints go to stderr (not stdout) in JSON mode,
-# preserving the one-envelope-on-stdout contract.
-from comfy_cli.output import rprint as print  # noqa: A001 - intentional shadowing
 from comfy_cli.typing import PathLike
 
 
@@ -68,15 +62,6 @@ def get_proc():
         return PROC.ARM
     else:
         raise ValueError
-
-
-def install_conda_package(package_name):
-    try:
-        subprocess.check_call(["conda", "install", "-y", package_name])
-        print(f"[bold green] Successfully installed {package_name} [/bold green]")
-    except subprocess.CalledProcessError as e:
-        print(f"[bold red] Failed to install {package_name}. Error: {e} [/bold red]")
-        raise typer.Exit(code=1)
 
 
 def get_not_user_set_default_workspace():

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -24,8 +24,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from comfy_cli.cancellation import get_token  # noqa: F401  — re-exported indirectly
-
 
 class WhereTarget(str, Enum):
     LOCAL = "local"


### PR DESCRIPTION
## ELI-5

There were 8 functions/classes in the codebase that nothing ever called, plus one leftover "re-export" line — like a light switch wired to nothing. This PR deletes them. Because nothing referenced them, nothing changes at runtime; the code just gets smaller and less confusing. Matches the merged precedent of #499/#504.

## What & why

Deletes 8 zero-reference symbols plus a vestigial `where.py` re-export line. Each was verified dead by full-repo grep (definition-only hits — no decorators, no string/dynamic references, no `__all__` exports):

| Symbol | File |
|---|---|
| `get_version_from_pyproject` | `comfy_cli/update.py` |
| `install_conda_package` | `comfy_cli/utils.py` |
| `known_providers` | `comfy_cli/auth/store.py` (1-line wrapper; real callers use `SUPPORTED_PROVIDERS` directly) |
| `get_os_details` | `comfy_cli/command/install.py` |
| `prompt_autocomplete` | `comfy_cli/ui.py` |
| `active_spec_path` | `comfy_cli/command/generate/spec.py` (unused wrapper over `_select_spec_path`) |
| `validate_comfyui` | `comfy_cli/cmdline.py` (undecorated — not a typer callback; distinct from `custom_nodes` `validate_comfyui_manager`) |
| `OAuthCancelled` | `comfy_cli/cloud/oauth.py` (never raised or caught anywhere) |
| `get_token` re-export | `comfy_cli/where.py:27` (all callers use `comfy_cli.cancellation` directly) |

## Coupled cleanups (kept the tree honest / green)

- **Orphaned imports** removed as a direct consequence of the deletions (ruff-enforced): `metadata` (update.py), `Iterable` (store.py), and `subprocess` / `typer` / the `rprint as print` shim (utils.py — all three were used only by `install_conda_package`).
- **`oauth_cancelled` registry entry** removed from `comfy_cli/error_codes.py`. The `OAuthCancelled` class attribute `code = "oauth_cancelled"` was the *only* source that made that code count as "raised"; deleting the class left it dead, and the repo's own `test_every_registered_code_is_raised` requires dead entries be deleted. This also drops it from the `comfy --json discover` contract — safe, because the code was never actually raised, so no consumer could ever have received it.

## Judgment calls / flags

- **`OAuthCancelled` (flagged per ticket):** never raised or caught today. If a branch in flight plans to use it for user-abort during login, it (and the `oauth_cancelled` error code) can be re-added at that point.
- Two deleted symbols live in auth modules (`known_providers`, `OAuthCancelled`), but deleting unreferenced code changes no auth behavior.

## Testing

- `ruff check` + `ruff format --check`: clean.
- Full `pytest` suite: **2573 passed, 37 skipped**.
- Zero behavioral risk by construction (no references).
