### PR TITLE
ci: set UV_LINK_MODE=copy in the Windows workflow

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: windows-latest
     env:
       PYTHONIOENCODING: "utf8"
+      # uv hardlinks by default, which cannot replace a .pyd that is still
+      # loaded by another process on the runner (os error 5). Copy instead.
+      UV_LINK_MODE: copy
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## ELI-5

The Windows CI job installs packages with `uv`, and `uv` saves time by hardlinking files instead of copying them. On Windows it cannot overwrite a `.pyd` that some other process still has open, so the install blows up with "Access is denied" before any test runs. Telling `uv` to just copy the files makes the problem go away.

## What

Adds `UV_LINK_MODE: copy` to `jobs.test.env` in `.github/workflows/test-windows.yml`, alongside the existing `PYTHONIOENCODING`.

## Why

The "Windows Specific Commands" workflow fails on every recent PR across all branches, in the `Install Dependencies` step, before any test runs:

```
error: failed to remove file `...\venv\Lib\site-packages\pydantic_core\_pydantic_core.cp312-win_amd64.pyd`: Access is denied. (os error 5)
```

uv then exits non-zero and the half-removed `.pyd` produces a downstream `ImportError: cannot import name '__version__' from 'pydantic_core'`.

`comfy install --fast-deps` shells out to `python -m uv pip install` (`comfy_cli/uv.py`), and uv's default link mode on Windows is hardlink/clone — it cannot replace a `.pyd` that is loaded/locked by another process on the runner. Copy mode writes a fresh file instead, which is the standard remediation for this error. Setting it at job level (rather than on the step) means it also reaches the uv subprocess that `comfy install` spawns; `comfy_cli/uv.py` never passes an explicit `env=`, so the child inherits it.

## Verification / judgment calls

- **This PR cannot verify itself.** The workflow only triggers on `paths: comfy_cli/**`, so a workflow-only change does not run it. Verify by re-running "Windows Specific Commands" on any open PR that touches `comfy_cli/**` (e.g. #517) once this lands, and confirm `Install Dependencies` and the subsequent `comfy launch --quick-test-for-ci` both pass.
- I deliberately did **not** add `.github/workflows/test-windows.yml` to the `paths` filter (which would make the workflow self-testing) — that is a separate behavior change and out of scope here. Flagging it as a reasonable follow-up.
- No Python source is touched, so there is no test or lint surface for this diff; the YAML was parsed to confirm `jobs.test.env` resolves to `{PYTHONIOENCODING: utf8, UV_LINK_MODE: copy}`.
- Tradeoff: copy mode is marginally slower/more disk than hardlinking. On a fresh CI runner that is negligible next to a job that currently always fails.