### PR TITLE
fix(registry): exit non-zero on non-RegistryAPIError registry-install failures

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -1219,11 +1219,6 @@ def registry_install(
     try:
         # Call the API to install the node
         node_version = registry_api.install_node(node_id, version)
-        if not node_version.download_url:
-            logging.error("Download URL not provided from the registry.")
-            ui.display_error_message(f"Failed to download the custom node {node_id}.")
-            return
-
     except RegistryAPIError as e:
         logging.error(f"Encountered an error while installing the node. error: {str(e)}")
         get_renderer().error(
@@ -1234,8 +1229,23 @@ def registry_install(
         raise typer.Exit(code=1) from e
     except Exception as e:
         logging.error(f"Encountered an error while installing the node. error: {str(e)}")
-        ui.display_error_message(f"Failed to download the custom node {node_id}.")
-        return
+        get_renderer().error(
+            code="node_install_failed",
+            message=f"Failed to download the custom node {node_id}.",
+            details={"node_id": node_id},
+        )
+        raise typer.Exit(code=1) from e
+
+    # Checked outside the try: typer.Exit subclasses Exception, so raising it
+    # above would be swallowed by the broad handler and emit a second envelope.
+    if not node_version.download_url:
+        logging.error("Download URL not provided from the registry.")
+        get_renderer().error(
+            code="node_install_failed",
+            message=f"Failed to download the custom node {node_id}.",
+            details={"node_id": node_id},
+        )
+        raise typer.Exit(code=1)
 
     # Download the node archive
     custom_nodes_path = pathlib.Path(workspace_manager.workspace_path) / "custom_nodes"

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -2,6 +2,7 @@ import re
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import requests
 from typer.testing import CliRunner
 
 from comfy_cli.command.custom_nodes.command import app
@@ -410,3 +411,53 @@ class TestRegistryInstallApiError:
         _, kwargs = mock_get_renderer.return_value.error.call_args
         assert kwargs["code"] == "node_install_failed"
         assert kwargs["details"] == {"node_id": "test-node", "status": 404, "body": "Not Found"}
+
+
+class TestRegistryInstallNonApiFailure:
+    """Failures that aren't RegistryAPIError — a connection error, a DNS failure,
+    a timeout, a JSON decode error, or a registry response carrying no download
+    URL — must also emit the node_install_failed envelope and exit non-zero.
+    Exiting 0 here reports a network outage to automation / CI as success."""
+
+    def _invoke(self, tmp_path, *, install_node_side_effect=None, install_node_return=None):
+        with (
+            patch("comfy_cli.command.custom_nodes.command.registry_api") as mock_api,
+            patch("comfy_cli.command.custom_nodes.command.workspace_manager") as mock_ws,
+            patch("comfy_cli.command.custom_nodes.command.get_renderer") as mock_get_renderer,
+            patch("comfy_cli.command.custom_nodes.command.download_file") as mock_dl,
+        ):
+            mock_ws.workspace_path = str(tmp_path)
+            if install_node_side_effect is not None:
+                mock_api.install_node.side_effect = install_node_side_effect
+            else:
+                mock_api.install_node.return_value = install_node_return
+
+            result = runner.invoke(app, ["registry-install", "test-node"])
+            return result, mock_get_renderer, mock_dl
+
+    def test_connection_error_exits_1_with_envelope(self, tmp_path):
+        result, mock_get_renderer, mock_dl = self._invoke(
+            tmp_path, install_node_side_effect=requests.ConnectionError("Name or service not known")
+        )
+
+        # Must exit non-zero so automation / CI can detect the failure.
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        mock_dl.assert_not_called()
+        mock_get_renderer.return_value.error.assert_called_once()
+        _, kwargs = mock_get_renderer.return_value.error.call_args
+        assert kwargs["code"] == "node_install_failed"
+        assert kwargs["details"] == {"node_id": "test-node"}
+
+    def test_missing_download_url_exits_1_with_envelope(self, tmp_path):
+        result, mock_get_renderer, mock_dl = self._invoke(
+            tmp_path, install_node_return=MagicMock(download_url="", version="1.0.0")
+        )
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        mock_dl.assert_not_called()
+        mock_get_renderer.return_value.error.assert_called_once()
+        _, kwargs = mock_get_renderer.return_value.error.call_args
+        assert kwargs["code"] == "node_install_failed"
+        assert kwargs["details"] == {"node_id": "test-node"}


### PR DESCRIPTION
## ELI-5

If your wifi dropped in the middle of `comfy node registry-install`, the command printed a friendly "Failed to download..." message and then told your shell **everything was fine** (exit code 0). A CI job or an agent watching the exit code would happily carry on as if the node had installed. This makes the command admit it failed.

## What this changes

`registry_install` had two silent-success paths:

1. The broad `except Exception` — every non-`RegistryAPIError` failure (connection error, DNS failure, timeout, JSON decode error) logged, printed a message, and `return`ed → **exit 0**, with no error output at all in JSON mode.
2. The `if not node_version.download_url:` branch — same shape, same silent exit 0.

Both now emit the `node_install_failed` structured envelope and `raise typer.Exit(code=1)`, mirroring the existing `RegistryAPIError` branch. `node_install_failed` was already registered, so no new error code.

This is a deliberate, behavioral change: connection errors and other non-registry failures now exit 1 where they previously exited 0. That is the point of the change.

## Stacked PR

Based on `matt/be-3271-registry-api-typed-errors` (#528), **not** `main` — the `RegistryAPIError` branch, `get_renderer()` in this module, and the `node_install_failed` error code all come from that PR and are not on `main` yet. GitHub will retarget this to `main` once #528 merges. Review only the net diff (one commit).

## The one non-obvious line

The `download_url` check **moves below** the `try` block. `typer.Exit` subclasses `Exception`, so raising it inside the `try` would be caught by the broad `except Exception` — logging a nonsense `error: 1` and emitting a **second** envelope. Moving the check out is safe because `install_node` either returns a `NodeVersion` or raises, and both `except` branches now raise, so the check is only reached on the success path with a non-`None` `node_version`. (Response-mapping errors like a missing `id`/`version` still raise inside `install_node`, i.e. still inside the `try`.)

## Testing

New `TestRegistryInstallNonApiFailure` covers the two cases the ticket asked for — a `requests.ConnectionError` from `install_node`, and a response with no `download_url` — each asserting exit 1 plus the `node_install_failed` envelope with `details={"node_id": ...}`.

Beyond the mocked tests, I drove the real CLI with the **real** renderer in JSON mode (the unit tests mock `get_renderer`, so they can't prove the envelope is well-formed). Both paths produce exit 1 and exactly one valid envelope, confirming there's no double-emit:

```json
{"schema": "envelope/1", "ok": false, "command": "node registry-install",
 "error": {"code": "node_install_failed", "message": "Failed to download the custom node test-node.",
           "details": {"node_id": "test-node"}}}
```

Full suite green: **2584 passed, 37 skipped**. `ruff format --check` clean; `ruff check` clean on both touched files.

## Judgment calls

- **Audited the pre-existing `assert result.exit_code == 0` cases** in `test_node_install.py`, per the ticket's guardrail. All of them exercise other commands (`install`, `uv-sync`, `show`, …) against a mocked `execute_cm_cli` success — none were asserting the silent-success bug fixed here, so none needed changing.
- **`ruff check .` reports 14 pre-existing `UP038` errors** in files this PR doesn't touch. They reproduce with my changes stashed (a local ruff newer than the pinned one), so I left them alone rather than take a drive-by refactor into this diff.
- **The registered hint for `node_install_failed` ends with "check `details.body`"**, but the two new non-API paths have no `body` in `details`. The hint comes from #528's registry and is shared with the API path, so retuning it is out of scope here — flagging it as a cosmetic wart rather than silently widening this PR.
- **Not a capability denial.** This diff adds `raise`/exit-1 paths, but nothing that previously worked now fails: it only changes how already-failed installs report themselves. There's no working alternate path a user should be redirected to instead.
