### PR TITLE
fix: escape square brackets in Typer help strings so choice lists render

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -613,7 +613,7 @@ def install(
 def update(
     target: str = typer.Argument(
         "comfy",
-        help="[all|comfy|cli]",
+        help="\\[all|comfy|cli]",
         autocompletion=utils.create_choice_completer(["all", "comfy", "cli"]),
     ),
 ):

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -515,7 +515,7 @@ def show(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -540,7 +540,7 @@ def simple_show(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -595,7 +595,7 @@ def install(
     ] = False,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -664,7 +664,7 @@ def reinstall(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -709,7 +709,7 @@ def uninstall(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -748,7 +748,7 @@ def update_node_id_cache():
 def update(
     nodes: list[str] = typer.Argument(
         ...,
-        help="[all|List of custom nodes to update]",
+        help="\\[all|List of custom nodes to update]",
         autocompletion=node_or_all_completer,
     ),
     channel: Annotated[
@@ -769,7 +769,7 @@ def update(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -785,7 +785,7 @@ def update(
 def disable(
     nodes: list[str] = typer.Argument(
         ...,
-        help="[all|List of custom nodes to disable]",
+        help="\\[all|List of custom nodes to disable]",
         autocompletion=node_or_all_completer,
     ),
     channel: Annotated[
@@ -798,7 +798,7 @@ def disable(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -812,7 +812,7 @@ def disable(
 def enable(
     nodes: list[str] = typer.Argument(
         ...,
-        help="[all|List of custom nodes to enable]",
+        help="\\[all|List of custom nodes to enable]",
         autocompletion=node_or_all_completer,
     ),
     channel: Annotated[
@@ -825,7 +825,7 @@ def enable(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -839,7 +839,7 @@ def enable(
 def fix(
     nodes: list[str] = typer.Argument(
         ...,
-        help="[all|List of custom nodes to fix]",
+        help="\\[all|List of custom nodes to fix]",
         autocompletion=node_or_all_completer,
     ),
     channel: Annotated[
@@ -860,7 +860,7 @@ def fix(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -901,7 +901,7 @@ def install_deps(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):
@@ -951,7 +951,7 @@ def deps_in_workflow(
     ] = None,
     mode: str = typer.Option(
         None,
-        help="[remote|local|cache]",
+        help="\\[remote|local|cache]",
         autocompletion=mode_completer,
     ),
 ):


### PR DESCRIPTION
## ELI-5

The CLI's `--help` was supposed to tell you which values an option accepts — `[remote|local|cache]`, `[all|comfy|cli]`. It didn't. Rich (the library that draws those pretty help panels) reads square brackets as *styling markup*, the same way `[bold]` means "make this bold". So it looked at `[remote|local|cache]`, decided `remote|local|cache` must be a style name, and quietly deleted the whole thing. You got an empty cell.

This escapes the opening bracket at the 16 places it happened, so Rich prints the brackets instead of eating them.

## What changed

One character per site — `help="[a|b|c]"` → `help="\\[a|b|c]"` — across 16 argument/option help strings:

- `comfy_cli/command/custom_nodes/command.py` (15): the `--mode` `[remote|local|cache]` help on 11 `node` subcommands, plus the `nodes` argument help on `update` / `disable` / `enable` / `fix`.
- `comfy_cli/cmdline.py` (1): the `target` argument help on `comfy update`.

No runtime behavior changes — these are help strings only. Only the opening `[` needs escaping; the closing `]` is already literal.

## Verification

Since no test asserts on these strings, the real check is rendering the actual help. **All 16 sites confirmed rendering**, not just the 3 named in the issue:

```
$ comfy node show --help
│ --mode           TEXT  [remote|local|cache]          │   # was: empty cell

$ comfy node update --help
│ *  nodes  NODES...  [all|List of custom nodes to update] [required]

$ comfy update --help
│    target  [TARGET]  [all|comfy|cli] [default: comfy]
```

All 11 `[remote|local|cache]` sites verified by rendering each owning command (`show`, `simple-show`, `install`, `reinstall`, `uninstall`, `update`, `disable`, `enable`, `fix`, `install-deps`, `deps-in-workflow`) — 11/11 render.

- `pytest tests/comfy_cli -q` → **2471 passed, 13 skipped** (matches baseline exactly)
- `ruff format` → clean; `ruff check` → **14 errors, identical to the pre-change baseline on `main`** (all pre-existing, none in touched lines)

## Judgment calls / notes

**1. Two additional bracket sites exist that the issue's grep (`help="\[`) can't see — both deliberately left alone.** That pattern anchors to a *leading* bracket; a broader `help=("|')[^"']*\[` sweep found two more:

- `cmdline.py:1133` — `help="Launch ComfyUI: ?[--background] ?[-- <extra args ...>]"`. **Not a bug — verified by rendering.** `comfy launch --help` prints its brackets intact, because Rich only treats `[...]` as a tag when the contents can parse as a style name; `--background` starts with `-`, so Rich leaves it literal. This is also *why* the 16 sites in this PR do break: `[remote|...]`, `[all|...]` start with a letter. I nearly "fixed" this one before checking.
- `cmdline.py:611` — `@app.command(help="Update ComfyUI Environment [all|comfy|cli]")`. This one **is** genuinely stripped on `main` today (renders as `Update ComfyUI Environment`), but it is the exact site #520 already fixes, so touching it here would collide. Left to #520.

**2. Verified this does not conflict with #520**, which is open and touches both of these files with hunks landing within a few lines of two of mine. Test-merged #520 into this branch locally: **merges cleanly, no conflicts**, and both fixes render correctly side by side (`update` panel help *and* `--mode` both show their choice lists). No coordination needed on merge order.

**3. Escape spelling.** Written `"\\[..."` (normal string → the string holds a literal `\[`), not `"\["`. The latter renders identically but is an invalid escape sequence — it trips ruff `W605` (+16 errors over baseline) and is a future `SyntaxError`. Worth noting since `"\["` is the tempting shorter form.

**4. No Linear ref in this title/body**, per the public-repo convention for this repo; the ticket autolinks via the branch name. Flagging because sibling PRs (#490, #520) do carry `(BE-…)` suffixes, so this is an inconsistency someone may want to settle either way.

**5. Not done (explicitly out of scope per the issue):** converting these to a real `enum` / `click.Choice` so Typer renders the values itself. Several duplicate an existing `autocompletion=` choice list, so that dedup is real — but it's a behavior change and should be decided separately.
