### PR TITLE
ci: install test deps from uv.lock so upstream releases can't break every PR (BE-3292)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,30 +39,27 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
+      # Install from uv.lock so CI uses the same pinned versions as local dev
+      # (`--frozen` fails loudly if the lockfile drifts from pyproject.toml
+      # instead of silently resolving a new upstream release).
       - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-          pip install -e .
+        run: uv sync --extra dev --frozen --python ${{ matrix.python-version }}
 
       - name: Test CUDA auto-detection (skips if no GPU)
-        run: |
-          pytest tests/comfy_cli/test_cuda_detect_real.py -v
+        run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest tests/comfy_cli/test_cuda_detect_real.py -v
 
       - name: Test e2e
         env:
           PYTHONPATH: ${{ github.workspace }}
           TEST_E2E: true
-        run: |
-          pytest tests/e2e
+        run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest tests/e2e
 
       - name: Test torch backend compilation
         env:
           TEST_TORCH_BACKEND: "true"
-        run: |
-          pytest tests/uv/test_torch_backend_compile.py -xvs
+        run: uv run --frozen --extra dev --python ${{ matrix.python-version }} pytest tests/uv/test_torch_backend_compile.py -xvs

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,22 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.10'  # Follow the min version in pyproject.toml
+          enable-cache: true
 
+      # Install from uv.lock so CI uses the same pinned versions as local dev
+      # (`--frozen` fails loudly if the lockfile drifts from pyproject.toml
+      # instead of silently resolving a new upstream release). `--python 3.10`
+      # follows the min version in pyproject.toml.
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest pytest-cov jsonschema
-          pip install -e .
+        run: uv sync --extra dev --frozen --python 3.10
 
       - name: Run tests
         env:
           PYTHONPATH: ${{ github.workspace }}
-        run: |
-          pytest --cov=comfy_cli --cov-report=xml .
+        run: uv run --frozen --extra dev --python 3.10 pytest --cov=comfy_cli --cov-report=xml .
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2


### PR DESCRIPTION
## ELI-5

Our CI didn't use the versions of test tools we'd locked in `uv.lock`. Every
time it ran, it fetched the *newest* versions of everything from the internet.
So when some unrelated package shipped a new release, CI could suddenly go red
on **every open PR at once** — for reasons that had nothing to do with the PR.
This makes CI install exactly the locked versions instead, so a surprise
upstream release can't ambush everyone.

## What & why

`.github/workflows/pytest.yml` (and `build-and-test.yml`) installed test deps
unpinned:

```yaml
pip install pytest pytest-cov jsonschema
pip install -e .
```

`pip install -e .` re-resolves transitive deps fresh on every run, ignoring the
versions pinned in `uv.lock`. This isn't hypothetical — on **2026-07-17**,
`tomlkit` 0.15.1 shipped and 9 tests began failing
(`tests/comfy_cli/registry/test_config_parser.py` ×8 +
`test_node_init.py::test_node_init_strips_credentials`) with
`ValueError: Comment cannot contain line breaks`, red-ing PRs whose diffs
touched none of that. The tomlkit source fix is handled separately (#533 /
BE-3285); **this PR closes the CI-reproducibility gap** that let it happen.

## Change

Both workflows now install from the lockfile via `uv`:

- `uv sync --extra dev --frozen` — install the exact pinned versions.
- `uv run --frozen --extra dev pytest ...` — run against them.
- `--frozen` makes CI **fail loudly** if `uv.lock` drifts from
  `pyproject.toml`, instead of silently resolving something new.
- `--extra dev` supplies `pytest` / `pytest-cov` / `jsonschema` (the repo's
  existing `optional-dependencies.dev` group), replacing the ad-hoc `pip install`.
- Python stays pinned to the version the jobs already used (`--python 3.10` for
  pytest.yml's min-version job; `--python ${{ matrix.python-version }}` for
  build-and-test.yml's matrix), so `uv` provides the interpreter and
  `actions/setup-python` is no longer needed.

Upgrades now become deliberate: bump `uv.lock` in its own PR where a break is
attributable and reviewable, instead of ambushing whoever opens the next PR.

## Verification (run locally on this branch)

- `uv sync --extra dev --frozen --python 3.10` succeeds — lockfile is in sync
  with `pyproject.toml`; installs `tomlkit==0.13.3`.
- `uv run --frozen --extra dev --python 3.10 pytest --cov=comfy_cli
  --cov-report=xml .` → **2573 passed, 37 skipped** (coverage.xml written, so
  `pytest-cov`/`jsonschema` are present under `--extra dev`).
- **Lockfile-tracking proof:** re-running the affected tests with the pin
  overridden — `uv run ... --with tomlkit==0.15.1 pytest <the 9 tests>` →
  **9 failed** (exactly the ones from the incident); the default lockfile run
  (0.13.3) passes them. Confirms CI now tracks `uv.lock`.
- Both YAML files parse; the `build-and-test.yml` CUDA step runs under `uv run`
  and skips gracefully with no GPU.

## Judgment calls / scope

- **Scope = the two workflows the ticket named** (`pytest.yml`,
  `build-and-test.yml`), both of which run the pytest suites via the unpinned
  pattern.
- **Deliberately left as follow-ups** (noted, not changed here):
  - `run-on-gpu.yml` — same pattern, but runs on a **self-hosted GPU runner**
    I can't verify locally; converting it unverified would be risky.
  - `test-windows.yml` / `test-mac.yml` — these are **CLI integration smoke
    tests** (`comfy install` + `comfy launch` in an explicit venv), not
    pytest-suite runs, so the tomlkit-class break doesn't hit them and the
    conversion is structurally different. (`test-windows` is also a known,
    separate infra flake.)
  - `ruff_check.yml` already pins its tool (`ruff==0.15.15`); `publish_package.yml`
    is release-time, not per-PR.

  A separate PR could extend the lockfile approach to these if desired.