### PR TITLE
fix(deps): pin mixpanel<5 so comfy install can't wedge pydantic-core on Windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -5,6 +5,11 @@ on:
       - main
     paths:
       - comfy_cli/**
+      # The smoke test below pip-installs comfy-cli, so dependency changes must
+      # run it too — an unpinned transitive dep (mixpanel 5.x -> pydantic-core)
+      # is exactly what broke `comfy install` on Windows.
+      - pyproject.toml
+      - .github/workflows/test-windows.yml
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,11 @@ dependencies = [
   "cookiecutter",
   "gitpython>=3.1.50",
   "httpx",
-  "mixpanel",
+  # mixpanel 5.x pulls in pydantic/pydantic-core; the compiled pydantic_core DLL
+  # gets loaded by `comfy install` and then cannot be replaced when ComfyUI's
+  # requirements resolve a different version on Windows (os error 5). 4.x has no
+  # pydantic dependency.
+  "mixpanel<5",
   "packaging",
   "pathspec",
   "posthog>=6,<8",

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ requires-dist = [
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "httpx" },
     { name = "jsonschema", marker = "extra == 'dev'" },
-    { name = "mixpanel" },
+    { name = "mixpanel", specifier = "<5" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "posthog", specifier = ">=6,<8" },


### PR DESCRIPTION
## ELI-5

Installing comfy-cli fresh started pulling in a new version of an analytics library (mixpanel 5.x) that drags along `pydantic` and its compiled `pydantic-core` DLL. On Windows, `comfy install` loads that DLL into the running process, and when ComfyUI's own requirements then want a *different* pydantic-core in the same venv, uv can't replace a DLL the calling process has loaded — the install dies with `Access is denied (os error 5)` and leaves the venv half-broken. Pinning mixpanel back to 4.x removes pydantic from comfy-cli's dependency set entirely, so there's nothing to collide with.

## What broke

The "Windows Specific Commands" smoke workflow has failed on every PR since ~Jul 17 ([example run](https://github.com/Comfy-Org/comfy-cli/actions/runs/29931618838/job/88962520629)):

1. `pip install -e .` resolves the unpinned `mixpanel` to 5.2.0 → `pydantic<2.12` → `pydantic 2.11.10` + `pydantic-core 2.33.2` land in the venv.
2. `comfy install` imports `mixpanel` at startup (`comfy_cli/tracking.py`), which loads `_pydantic_core.cp312-win_amd64.pyd` into the running `comfy.exe`.
3. `install_deps` then runs `uv pip install --requirement requirements.compiled` in the same venv; ComfyUI's requirements resolve a different pydantic-core, and on Windows uv cannot remove a DLL loaded by the calling process: `error: failed to remove file ...\pydantic_core/_pydantic_core.cp312-win_amd64.pyd: Access is denied. (os error 5)`.
4. The install exits 2 with pydantic-core half-removed, so every subsequent `comfy` invocation dies with `ImportError: cannot import name '__version__' from 'pydantic_core'`.

## The fix

- **`mixpanel<5`** in `pyproject.toml` (+ `uv lock`). mixpanel 4.x depends only on `requests`/`six`/`urllib3` — no pydantic anywhere in the closure, so no compiled DLL is loaded in-process before `install_deps` mutates the venv. Verified by dry-run fresh resolution: 48 packages, `mixpanel==4.11.1`, zero pydantic. `uv.lock` already pinned 4.10.1, so the lock diff is metadata-only and the whole test suite has been running against 4.x all along; comfy-cli only uses the stable `Mixpanel(token)` / `.track()` API.
- **Workflow path filter**: the smoke workflow only triggered on `comfy_cli/**`, so a dependency-only change — the exact class of change that broke it — never ran it. Added `pyproject.toml` and the workflow file itself to `paths`, which also makes the workflow run (and prove itself green) on this PR.

## Judgment calls

- **Bound is `<5`, not `<5.2`.** A `<5.2` bound would still resolve mixpanel 5.1.0/5.0.0, which *also* declare `pydantic>=2.0.0` (verified against PyPI metadata: 5.0.0 released 2025-11-04 and 5.1.0 released 2026-01-06 both list it). The pre-Jul-17 green runs with mixpanel 5.x installed were luck: their unbounded pydantic happened to resolve the same pydantic-core that ComfyUI's requirements chose, so uv never had to replace the loaded DLL — the last green run (Jul 17 09:17 UTC) had the *identical* `mixpanel-5.2.0 / pydantic-core-2.33.2` set as the failing runs; the break was triggered by the ComfyUI-side resolution shifting. Only removing pydantic from the closure entirely — the stated goal — is robust against that, and that requires `<5`.
- **`pylock.toml` deliberately untouched.** It is autogenerated (`uv export`) but already stale on main (missing `backoff`, posthog dep drift) and nothing in CI consumes it; regenerating it here would drag unrelated churn into this diff. Its mixpanel entry (4.10.1) is already consistent with the new constraint. Can be resynced separately.
- The lazy-import alternative (deferring the mixpanel import in `tracking.py`) was considered and not taken: it only helps while nothing else imports pydantic before `install_deps` runs, which is a fragile invariant; removing the dependency is strictly stronger.

## Verification

- `uvx ruff@0.15.15 check` + `format --diff` (CI-pinned version): clean.
- `pytest`: 2585 passed, 37 skipped.
- Fresh-install dry-run resolution: `mixpanel==4.11.1`, no pydantic/pydantic-core.
- "Windows Specific Commands" runs on this PR (path filter now includes `pyproject.toml`).
