### PR TITLE
test: fix repo-wide pytest failure — reconcile validate-command fixtures with the no-outputs check (BE-4097)

### DIFF
--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -105,8 +105,35 @@ def test_ui_export_that_converts_to_nothing_is_rejected(runner, tmp_path):
 
 def test_api_format_unchanged(runner, tmp_path):
     """An API-format file behaves exactly as before: validated directly, no
-    `converted_from_ui` key in the payload."""
-    api = {"1": {"class_type": "EmptyLatentImage", "inputs": {"width": 64, "height": 64, "batch_size": 1}}}
+    `converted_from_ui` key in the payload. The fixture is a complete sd15
+    txt2img graph — it carries a SaveImage output node, as any real API-format
+    export does, so it clears the server-parity no-outputs check (BE-3357)."""
+    api = {
+        "4": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": {"ckpt_name": "v1-5-pruned-emaonly-fp16.safetensors"},
+        },
+        "6": {"class_type": "CLIPTextEncode", "inputs": {"clip": ["4", 1], "text": "a cat"}},
+        "7": {"class_type": "CLIPTextEncode", "inputs": {"clip": ["4", 1], "text": "blurry"}},
+        "5": {"class_type": "EmptyLatentImage", "inputs": {"width": 512, "height": 512, "batch_size": 1}},
+        "3": {
+            "class_type": "KSampler",
+            "inputs": {
+                "model": ["4", 0],
+                "positive": ["6", 0],
+                "negative": ["7", 0],
+                "latent_image": ["5", 0],
+                "seed": 42,
+                "steps": 20,
+                "cfg": 8.0,
+                "sampler_name": "euler",
+                "scheduler": "simple",
+                "denoise": 1.0,
+            },
+        },
+        "8": {"class_type": "VAEDecode", "inputs": {"samples": ["3", 0], "vae": ["4", 2]}},
+        "9": {"class_type": "SaveImage", "inputs": {"images": ["8", 0], "filename_prefix": "ComfyUI"}},
+    }
     wf = _write(tmp_path, "api.json", api)
 
     result = _validate(runner, wf)
@@ -128,13 +155,17 @@ def test_non_dict_payload_unchanged(runner, tmp_path):
     assert _envelope(result)["error"]["code"] == "workflow_not_api_format"
 
 
-def test_empty_dict_payload_unchanged(runner, tmp_path):
+def test_empty_dict_payload_not_converted_and_rejected(runner, tmp_path):
     """An empty dict is not UI format and is left to the existing validator
-    (no conversion, no `converted_from_ui` key)."""
+    (no conversion, no `converted_from_ui` key) — which now rejects it: the
+    server refuses any prompt with zero output nodes, including a node-less
+    one, so validate mirrors that as `prompt_no_outputs` (BE-3357)."""
     wf = _write(tmp_path, "empty.json", {})
 
     result = _validate(runner, wf)
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     data = _envelope(result)["data"]
     assert "converted_from_ui" not in data
+    assert data["valid"] is False
+    assert any(e["code"] == "prompt_no_outputs" for e in data["errors"])


### PR DESCRIPTION
## ELI-5

Two recently merged PRs each work fine alone but broke the test suite together: #551 taught `comfy validate` to reject workflows with no output node (matching what the ComfyUI server does), and #553 added tests whose sample workflows… have no output node. Every PR's `build` CI has been red since. This PR fixes the two stale test fixtures so they match the intended behavior — no product code changes.

## What

Repo-wide pytest has been failing on `main` since 09de2e5 (#553 / BE-3359) landed on top of 354113a (#551 / BE-3357): two fixtures in `tests/comfy_cli/command/test_validate_command.py` trip the new `prompt_no_outputs` server-parity check.

- **`test_api_format_unchanged`** — fixture was a bare `EmptyLatentImage` (not an output node), so the CLI now correctly exits 1. Replaced with the complete, server-valid sd15 txt2img graph (same graph `test_engine.py::TestValidateServerParity._sd15_full` already proves clean against the same `sd15_object_info.json` catalog), which carries the `SaveImage` output node every real API-format export has. The test still proves exactly what it did: an API-format file is validated directly, exit 0, no `converted_from_ui` key.
- **`test_empty_dict_payload_unchanged` → `test_empty_dict_payload_not_converted_and_rejected`** — fixture is `{}`; rejecting a zero-output (including node-less) prompt is the *intended* behavior of #551, per the check's own code comment in `comfy_cli/cql/engine.py` (mirroring ComfyUI server `execution.py:1155-1162`). Updated to assert exit 1 + `prompt_no_outputs`, while keeping the test's original point: the empty dict is not treated as UI format (no conversion, no `converted_from_ui` key). Renamed since "unchanged" no longer describes it.

## Why this isn't a new dead-end

The flipped assertion (`exit_code == 1` for `{}`) does not introduce a capability denial — it aligns a stale test with behavior already merged and intentionally designed in #551, asserted identically by the engine's own unit test (`tests/comfy_cli/cql/test_engine.py::test_empty_workflow_is_no_outputs`) and grounded in real server behavior (ComfyUI `execution.py` rejects zero-output prompts with `prompt_no_outputs`). The ticket calls this reconciliation "mechanical, no design call."

## Verification

- `uv run --extra dev pytest .` — **2640 passed, 37 skipped, 0 failed** (main currently fails 2)
- `ruff check` + `ruff format --check` with the CI-pinned `ruff==0.15.15` — clean

## Judgment calls

- Inlined the sd15 graph rather than importing `_sd15_full` from `test_engine.py` — cross-test-module imports are worse coupling than one duplicated literal fixture, and this file already inlines all its fixtures.
- Renamed the empty-dict test (ticket offered "update or rename/repurpose"); nothing references the old name.

Note: the "Windows Specific Commands" smoke workflow is red on all PRs from an unrelated pre-existing issue (unpinned mixpanel) — not addressed here, out of scope.

## Overlap flag

Open PR #573 (BE-3358, feature work) incidentally bundles fixes to these same two tests. This PR is the standalone, minimal unbreaker so `main`'s CI goes green without waiting on #573's feature review. Whichever lands second takes a small conflict in `test_validate_command.py` — after this merges, #573 should rebase and keep this branch's version of the two tests (they're equivalent in intent; this one also renames the empty-dict test).
