### PR TITLE
feat(generate): spend-gate — consent before credit spend (BE-4103)

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -2,19 +2,28 @@
 
 UX shape, modeled on fal-ai's genmedia but creative-user-first:
 
-    comfy generate <model> [--<param> value]... [--download P] [--async]
+    comfy generate <model> [--<param> value]... [--download P] [--async] [--yes]
     comfy generate list [--partner P] [--style S]
     comfy generate schema <model>
     comfy generate refresh
     comfy generate resume <model> <job_id> [--download P]
+    comfy generate consent [show|always|ask]
 
 The first positional is either a reserved action (``list``/``schema``/
-``refresh``/``resume``) or a model alias (``flux-pro``, ``ideogram-edit``, …).
-Anything not in the reserved set falls through to the generate path.
+``refresh``/``resume``/``consent``) or a model alias (``flux-pro``,
+``ideogram-edit``, …). Anything not in the reserved set falls through to the
+generate path.
+
+Spend gate: a generation call spends Comfy credits, so the proxy call sits
+behind a consent interlock (``_confirm_spend``) — an interactive TTY prompt,
+bypassed by ``--yes`` or the persisted ``spend.auto_confirm`` config, and
+fail-closed (error, no spend) when neither is present and no prompt is
+possible (``--json`` or no TTY).
 """
 
 from __future__ import annotations
 
+import sys
 import uuid
 from pathlib import Path
 from typing import Annotated
@@ -32,8 +41,9 @@ import typer
 from rich import print as rprint
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
-from comfy_cli import tracking, ui
+from comfy_cli import constants, tracking, ui
 from comfy_cli.command.generate import adapters, client, emit, output, poll, schema, spec, upload
+from comfy_cli.config_manager import ConfigManager
 from comfy_cli.output.renderer import get_renderer
 
 _HELP = "Generate images via ComfyUI partner nodes (Flux, Ideogram, DALL·E, Recraft, Stability, …)."
@@ -58,7 +68,7 @@ def register_with(parent: typer.Typer) -> None:
             str | None,
             typer.Argument(
                 help="A model alias (e.g. flux-pro, ideogram-edit, dalle) "
-                "or one of: list, schema, refresh, upload, resume.",
+                "or one of: list, schema, refresh, upload, resume, consent.",
             ),
         ] = None,
     ) -> None:
@@ -87,12 +97,16 @@ def register_with(parent: typer.Typer) -> None:
                 {"model": resume_model, "job_id": resume_job_id},
             )
             return _resume(extra)
+        if target == "consent":
+            consent_action = extra[0] if extra and not extra[0].startswith("-") else None
+            tracking.track_event("generate:consent", {"action": consent_action})
+            return _consent(extra)
         _generate(target, extra)
 
 
 def _separate_meta_flags(extra_args: list[str]) -> tuple[list[str], dict[str, str | bool]]:
     """Pull run-level flags out of the user's argv tail."""
-    meta_names = {"download", "async", "json", "timeout", "api-key", "emit-workflow", "output-prefix"}
+    meta_names = {"download", "async", "json", "timeout", "api-key", "emit-workflow", "output-prefix", "yes"}
     meta: dict[str, str | bool] = {}
     remaining: list[str] = []
     i = 0
@@ -104,7 +118,7 @@ def _separate_meta_flags(extra_args: list[str]) -> tuple[list[str], dict[str, st
             if "=" in body:
                 body, raw = body.split("=", 1)
             if body in meta_names:
-                if body in {"async", "json"}:
+                if body in {"async", "json", "yes"}:
                     meta[body] = True if raw is None else raw.lower() not in {"false", "0", "no"}
                     i += 1
                     continue
@@ -171,6 +185,90 @@ def _emit_result(result: poll.PollResult, *, request_id: str, download: str | No
         output.print_urls(result.image_urls, request_id=request_id)
         if download and not result.image_urls:
             rprint("[yellow]--download requested but no image URLs found in response.[/yellow]")
+
+
+class SpendNotConfirmed(RuntimeError):
+    """A credit-spending call lacked consent — declined at the prompt, or
+    fail-closed because no prompt was possible and nothing pre-authorized it."""
+
+
+def _spend_auto_confirmed() -> bool:
+    """True only when the persisted ``spend.auto_confirm`` config is an
+    affirmative boolean. A missing key or a garbage value never authorizes
+    spending — the gate fails closed."""
+    try:
+        return bool(ConfigManager().get_bool(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM))
+    except ValueError:
+        return False
+
+
+def _stdin_is_tty() -> bool:
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except ValueError:
+        # stdin already closed (e.g. daemonized caller) — no prompt possible.
+        return False
+
+
+def _confirm_spend(*, model_name: str, assume_yes: bool, as_json: bool) -> None:
+    """The money interlock: explicit consent before a credit-spending proxy call.
+
+    - ``--yes`` or persisted ``spend.auto_confirm=true`` → proceed.
+    - Interactive TTY → prompt, default No.
+    - ``--json`` or no TTY with neither → fail closed: raise, spend nothing.
+      Never hang on a prompt a machine caller can't answer.
+    """
+    if assume_yes or _spend_auto_confirmed():
+        return
+    if as_json or not _stdin_is_tty():
+        msg = (
+            f"`comfy generate {model_name}` spends Comfy credits and no consent was given. "
+            "Re-run with --yes, or persist consent with `comfy generate consent always`."
+        )
+        if as_json:
+            output.print_json({"error": msg, "code": "spend_consent_required"})
+        else:
+            rprint(f"[bold red]{msg}[/bold red]")
+        raise SpendNotConfirmed(msg)
+    rprint(f"[bold]{model_name}[/bold] runs via the partner API and [bold]spends Comfy credits[/bold].")
+    rprint("[dim]Skip this prompt with --yes; persist always-proceed with `comfy generate consent always`.[/dim]")
+    if not typer.confirm("Proceed?", default=False):
+        rprint("Canceled — no credits were spent.")
+        raise SpendNotConfirmed("user declined the spend confirmation prompt")
+
+
+def _consent(extra_args: list[str]) -> None:
+    """``comfy generate consent [show|always|ask]`` — inspect or persist the
+    spend gate's always-proceed setting (``spend.auto_confirm`` in config.ini,
+    the same store that backs the CLI's other persisted settings)."""
+    try:
+        clean, meta = _separate_meta_flags(extra_args)
+    except schema.SchemaError as e:
+        rprint(f"[bold red]{e}[/bold red]")
+        raise typer.Exit(code=1)
+    as_json = bool(meta.get("json", False))
+    action = clean[0] if clean and not clean[0].startswith("-") else "show"
+    if action not in {"show", "always", "ask"}:
+        msg = f"Unknown consent action {action!r}. Usage: comfy generate consent [show|always|ask]"
+        if as_json:
+            output.print_json({"error": msg})
+        else:
+            rprint(f"[bold red]{msg}[/bold red]")
+        raise typer.Exit(code=1)
+    if action == "always":
+        ConfigManager().set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "true")
+    elif action == "ask":
+        ConfigManager().set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "false")
+    auto = _spend_auto_confirmed()
+    if as_json:
+        output.print_json({"spend_auto_confirm": auto, "action": action})
+        return
+    if auto:
+        rprint("[bold]spend.auto_confirm: true[/bold] — `comfy generate` spends credits without prompting.")
+        rprint("[dim]Revert with `comfy generate consent ask`.[/dim]")
+    else:
+        rprint("[bold]spend.auto_confirm: false[/bold] — credit-spending calls prompt first (or need --yes).")
+        rprint("[dim]Persist always-proceed with `comfy generate consent always`.[/dim]")
 
 
 def _generate(model: str, extra_args: list[str]) -> None:
@@ -271,6 +369,20 @@ def _generate(model: str, extra_args: list[str]) -> None:
                 command="generate emit-workflow",
             )
             return
+
+        # Spend gate — a proxy call spends Comfy credits, so consent comes
+        # BEFORE any network side effect (auth refresh, asset uploads, the
+        # generation request itself). Everything above this line is local:
+        # spec lookup, arg parsing, emit-workflow.
+        try:
+            _confirm_spend(
+                model_name=str(gen_props["model_alias"] or ep.id),
+                assume_yes=bool(meta.get("yes", False)),
+                as_json=as_json,
+            )
+        except SpendNotConfirmed as e:
+            _track_error("consent", e)
+            raise typer.Exit(code=1) from e
 
         try:
             api_key = client.resolve_api_key(meta.get("api-key") if isinstance(meta.get("api-key"), str) else None)
@@ -683,7 +795,7 @@ def _print_top_help() -> None:
     rprint("[bold]comfy generate[/bold] — call ComfyUI partner nodes")
     rprint("")
     rprint("[bold]Usage:[/bold]")
-    rprint("  comfy generate <model> [--<param> value]... [--download PATH] [--async] [--api-key KEY]")
+    rprint("  comfy generate <model> [--<param> value]... [--download PATH] [--async] [--yes] [--api-key KEY]")
     rprint("")
     rprint("[bold]Examples:[/bold]")
     rprint('  comfy generate flux-pro --prompt "a cat on the moon" --width 1024 --height 1024 --download cat.png')
@@ -702,7 +814,12 @@ def _print_top_help() -> None:
     rprint("  comfy generate refresh                 Refresh the model catalog")
     rprint("  comfy generate upload <file-or-url>    Host a local file or remote URL and print its signed URL")
     rprint("  comfy generate resume <model> <job>    Resume an async job")
+    rprint("  comfy generate consent [show|always|ask]  Inspect/persist the credit-spend confirmation")
     rprint("")
+    rprint(
+        "[dim]Generation spends Comfy credits: interactive runs confirm first; pass --yes (or "
+        "`comfy generate consent always`) to skip, required for --json / non-TTY runs.[/dim]"
+    )
     rprint(
         "[dim]Auth: run `comfy cloud login` (session outranks env var), set COMFY_API_KEY, or pass --api-key. Get one at https://platform.comfy.org.[/dim]"
     )

--- a/comfy_cli/command/generate/schema.py
+++ b/comfy_cli/command/generate/schema.py
@@ -259,6 +259,8 @@ def help_text(endpoint: Endpoint, flags: list[FlagDef]) -> str:
     lines.append("  --download <path>  Save outputs locally. Supports {request_id}, {index}, {ext}.")
     lines.append("  --async            Submit and return job id without waiting.")
     lines.append("  --json             Emit raw JSON response instead of pretty output.")
+    lines.append("  --yes              Skip the credit-spend confirmation (required for --json/non-TTY runs")
+    lines.append("                     unless `comfy generate consent always` was set).")
     lines.append("  --timeout <sec>    Override sync-poll timeout (default 300).")
     lines.append("  --api-key <key>    Per-call override. Auth: --api-key > login session > COMFY_API_KEY env.")
     lines.append("  --emit-workflow <path>  Write a runnable partner-node workflow instead of calling the proxy.")

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -45,6 +45,9 @@ CONFIG_KEY_BACKGROUND_LOG = "background_log"  # workspace logfile path for the b
 CONFIG_KEY_MANAGER_GUI_ENABLED = "manager_gui_enabled"  # Legacy, kept for backward compatibility
 CONFIG_KEY_MANAGER_GUI_MODE = "manager_gui_mode"  # Valid: "disable", "enable-gui", "disable-gui", "enable-legacy-gui"
 CONFIG_KEY_UV_COMPILE_DEFAULT = "uv_compile_default"
+# Persistent "always proceed" for credit-spending `comfy generate` calls
+# (the spend gate). Set via `comfy generate consent always|ask`.
+CONFIG_KEY_SPEND_AUTO_CONFIRM = "spend.auto_confirm"
 
 CIVITAI_API_TOKEN_KEY = "civitai_api_token"
 CIVITAI_API_TOKEN_ENV_KEY = "CIVITAI_API_TOKEN"

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -577,6 +577,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`generate --emit-workflow` could not build the partner-node workflow.",
         "check the model name and that all required inputs are provided",
     ),
+    ErrorCode(
+        "spend_consent_required",
+        "A credit-spending `comfy generate` call ran non-interactively (--json / no TTY) "
+        "with no consent — the spend gate fails closed and nothing was spent.",
+        "re-run with --yes, or persist consent with `comfy generate consent always`",
+    ),
     # --- feedback ------------------------------------------------------------
     ErrorCode(
         "feedback_message_required",

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -646,6 +646,15 @@ comfy generate resume <model> <job_id> --download outputs/x.mp4
 
 Mechanical contracts that bite agents — encode them, don't rediscover:
 
+- **Spend gate — generation spends the user's Comfy credits and requires
+  consent.** Interactive TTY runs confirm before spending; `--json` / non-TTY
+  runs **fail closed** with error code `spend_consent_required` (exit 1,
+  nothing spent) unless consent is supplied. Pass `--yes` only when the human
+  has actually approved the spend — do not reflexively add it to make the
+  error go away. A human can persist always-proceed with
+  `comfy generate consent always` (revert: `consent ask`; inspect:
+  `consent show`). `list` / `schema` / `refresh` / `upload` / `resume` /
+  `--emit-workflow` spend nothing and are not gated.
 - **Machine-readable output:** `generate <model> --json` prints the raw API
   response as JSON; `generate upload <file> --json` emits structured
   `{url, expires_at, …}`; `generate <model> --emit-workflow out.json` goes

--- a/tests/comfy_cli/command/generate/conftest.py
+++ b/tests/comfy_cli/command/generate/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the ``comfy generate`` test package."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _auto_confirm_spend():
+    """Pre-authorize the credit-spend gate (BE-4103) for generate tests.
+
+    Most tests in this package exercise behavior *downstream* of the consent
+    interlock, and under CliRunner there is no TTY — without this, every
+    execution-path invocation would fail closed before reaching the code
+    under test. The gate's own tests override this fixture by name in
+    ``test_spend_gate.py`` to put the gate back in force.
+
+    ConfigManager is a process-wide singleton, so the teardown removes the
+    in-memory key rather than relying on the per-test config-dir isolation
+    alone (the file is isolated; the loaded configparser is not).
+    """
+    from comfy_cli import constants
+    from comfy_cli.config_manager import ConfigManager
+
+    cm = ConfigManager()
+    cm.set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "true")
+    yield
+    cm.config.remove_option("DEFAULT", constants.CONFIG_KEY_SPEND_AUTO_CONFIRM)

--- a/tests/comfy_cli/command/generate/test_spend_gate.py
+++ b/tests/comfy_cli/command/generate/test_spend_gate.py
@@ -1,0 +1,252 @@
+"""Spend-gate tests for ``comfy generate`` (BE-4103).
+
+A generation call spends Comfy credits, so the proxy call sits behind a
+consent interlock: interactive TTY runs prompt first, ``--yes`` or the
+persisted ``spend.auto_confirm`` config bypass the prompt, and ``--json`` /
+non-TTY runs with neither **fail closed** — error out, spend nothing, never
+hang on a prompt no one can answer.
+"""
+
+import json
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import constants
+from comfy_cli.cmdline import app as cli_app
+from comfy_cli.command.generate import app as gen_app
+from comfy_cli.config_manager import ConfigManager
+
+
+@pytest.fixture(autouse=True)
+def _auto_confirm_spend():
+    """Override the package conftest's pre-authorization: these tests
+    exercise the gate itself, so it starts (and ends) cleared."""
+    cm = ConfigManager()
+    cm.config.remove_option("DEFAULT", constants.CONFIG_KEY_SPEND_AUTO_CONFIRM)
+    yield
+    cm.config.remove_option("DEFAULT", constants.CONFIG_KEY_SPEND_AUTO_CONFIRM)
+
+
+@pytest.fixture(autouse=True)
+def disable_tracking_prompt(monkeypatch):
+    monkeypatch.setattr("comfy_cli.tracking.prompt_tracking_consent", lambda *a, **kw: None)
+    monkeypatch.setattr("comfy_cli.tracking.track_event", lambda *a, **kw: None)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv("COMFY_API_KEY", "comfyui-test")
+    return "comfyui-test"
+
+
+@pytest.fixture
+def post_spy(monkeypatch):
+    """Record every proxy POST; each recorded call is a would-be credit spend."""
+    calls: list = []
+
+    def _post(*a, **kw):
+        calls.append((a, kw))
+        return httpx.Response(200, json={"data": [{"url": "https://cdn.example/a.png"}]})
+
+    monkeypatch.setattr(gen_app.client.httpx, "post", _post)
+    return calls
+
+
+@pytest.fixture
+def interactive_tty(monkeypatch):
+    """Simulate a human at a terminal — CliRunner's piped stdin is never a TTY."""
+    monkeypatch.setattr(gen_app, "_stdin_is_tty", lambda: True)
+
+
+# ─── Fail-closed: no consent, no TTY → error, nothing spent ───────────────
+
+
+def test_json_without_consent_fails_closed_and_spends_nothing(runner, api_key, post_spy):
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 1
+    assert post_spy == []
+    payload = json.loads(r.stdout)
+    assert payload["code"] == "spend_consent_required"
+    assert "--yes" in payload["error"]
+
+
+def test_pretty_non_tty_without_consent_fails_closed(runner, api_key, post_spy):
+    # No --json, but stdin is a pipe (CliRunner): never hang on a prompt.
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x"])
+    assert r.exit_code == 1
+    assert post_spy == []
+    assert "spends Comfy credits" in r.stdout
+    assert "--yes" in r.stdout
+
+
+def test_async_submit_is_gated_too(runner, api_key, post_spy):
+    # --async still spends on submit — the gate must cover it.
+    r = runner.invoke(
+        cli_app,
+        ["generate", "flux-pro", "--prompt", "x", "--width", "1", "--height", "1", "--async", "--json"],
+    )
+    assert r.exit_code == 1
+    assert post_spy == []
+
+
+def test_gate_runs_before_auth_resolution(runner, post_spy):
+    # No COMFY_API_KEY in env: consent still decides first, so an
+    # unauthenticated machine caller sees the consent error, not an auth one,
+    # and no OAuth refresh / network happens without consent.
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 1
+    assert post_spy == []
+    assert json.loads(r.stdout)["code"] == "spend_consent_required"
+
+
+# ─── Bypasses: --yes flag and spend.auto_confirm config ───────────────────
+
+
+def test_json_with_yes_proceeds(runner, api_key, post_spy):
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json", "--yes"])
+    assert r.exit_code == 0, r.stdout
+    assert len(post_spy) == 1
+
+
+def test_json_with_auto_confirm_config_proceeds(runner, api_key, post_spy):
+    ConfigManager().set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "true")
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 0, r.stdout
+    assert len(post_spy) == 1
+
+
+def test_auto_confirm_false_still_fails_closed(runner, api_key, post_spy):
+    ConfigManager().set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "false")
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 1
+    assert post_spy == []
+
+
+def test_auto_confirm_garbage_value_fails_closed(runner, api_key, post_spy):
+    # A corrupt config value must never silently authorize spending.
+    ConfigManager().set(constants.CONFIG_KEY_SPEND_AUTO_CONFIRM, "banana")
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 1
+    assert post_spy == []
+
+
+# ─── Interactive TTY: prompt before spending ──────────────────────────────
+
+
+def test_interactive_prompt_accept_proceeds(runner, api_key, post_spy, interactive_tty):
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x"], input="y\n")
+    assert r.exit_code == 0, r.stdout
+    assert len(post_spy) == 1
+    assert "spends Comfy credits" in r.stdout
+
+
+def test_interactive_prompt_decline_spends_nothing(runner, api_key, post_spy, interactive_tty):
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x"], input="n\n")
+    assert r.exit_code == 1
+    assert post_spy == []
+    assert "no credits were spent" in r.stdout
+
+
+def test_interactive_prompt_default_is_no(runner, api_key, post_spy, interactive_tty):
+    # Bare Enter must not spend.
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x"], input="\n")
+    assert r.exit_code == 1
+    assert post_spy == []
+
+
+# ─── Ungated paths: nothing that spends ───────────────────────────────────
+
+
+def test_emit_workflow_is_not_gated(runner, post_spy, tmp_path):
+    # --emit-workflow writes a local artifact, calls no proxy, spends nothing.
+    out = tmp_path / "wf.json"
+    r = runner.invoke(cli_app, ["generate", "flux-pro", "--prompt", "x", "--emit-workflow", str(out)])
+    assert r.exit_code == 0, r.stdout
+    assert out.exists()
+    assert post_spy == []
+
+
+def test_schema_error_surfaces_before_consent(runner, api_key, post_spy):
+    # Bad args fail on validation, not on consent — no prompt, no spend.
+    r = runner.invoke(cli_app, ["generate", "flux-pro", "--prompt", "x", "--width", "abc", "--height", "1"])
+    assert r.exit_code == 1
+    assert post_spy == []
+    assert "spend" not in r.stdout.lower()
+
+
+# ─── Lifecycle: consent failures emit generate:error(kind=consent) ────────
+
+
+def test_consent_failure_emits_error_kind_consent(runner, api_key, post_spy, monkeypatch):
+    events: list[tuple[str, dict]] = []
+
+    def _record(event_name, properties=None, *, mixpanel_name=None):
+        events.append((event_name, dict(properties or {})))
+
+    monkeypatch.setattr("comfy_cli.tracking.track_event", _record)
+    monkeypatch.setattr("comfy_cli.command.generate.app.tracking.track_event", _record)
+    monkeypatch.setattr("comfy_cli.cmdline.tracking.track_event", _record)
+
+    r = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r.exit_code == 1
+    names = [n for n, _ in events]
+    assert names.count("generate:start") == 1
+    err_props = [p for n, p in events if n == "generate:error"]
+    assert len(err_props) == 1
+    assert err_props[0]["error_kind"] == "consent"
+    assert "generate:success" not in names
+
+
+# ─── `comfy generate consent` action ──────────────────────────────────────
+
+
+def test_consent_show_defaults_to_false(runner):
+    r = runner.invoke(cli_app, ["generate", "consent", "--json"])
+    assert r.exit_code == 0
+    payload = json.loads(r.stdout)
+    assert payload == {"spend_auto_confirm": False, "action": "show"}
+
+
+def test_consent_always_persists_and_unlocks_generate(runner, api_key, post_spy):
+    r = runner.invoke(cli_app, ["generate", "consent", "always", "--json"])
+    assert r.exit_code == 0
+    assert json.loads(r.stdout)["spend_auto_confirm"] is True
+    # Persisted to the config file on disk, not just in memory.
+    from pathlib import Path
+
+    cfg_text = Path(ConfigManager().get_config_file_path()).read_text()
+    assert "spend.auto_confirm = true" in cfg_text
+
+    r2 = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r2.exit_code == 0, r2.stdout
+    assert len(post_spy) == 1
+
+
+def test_consent_ask_reverts(runner, api_key, post_spy):
+    runner.invoke(cli_app, ["generate", "consent", "always"])
+    r = runner.invoke(cli_app, ["generate", "consent", "ask", "--json"])
+    assert r.exit_code == 0
+    assert json.loads(r.stdout)["spend_auto_confirm"] is False
+
+    r2 = runner.invoke(cli_app, ["generate", "dalle", "--prompt", "x", "--json"])
+    assert r2.exit_code == 1
+    assert post_spy == []
+
+
+def test_consent_show_pretty_output(runner):
+    r = runner.invoke(cli_app, ["generate", "consent"])
+    assert r.exit_code == 0
+    assert "spend.auto_confirm: false" in r.stdout
+
+
+def test_consent_unknown_action_errors(runner):
+    r = runner.invoke(cli_app, ["generate", "consent", "sometimes"])
+    assert r.exit_code == 1
+    assert "Unknown consent action" in r.stdout


### PR DESCRIPTION
## ELI-5

`comfy generate flux-pro --prompt "a cat"` costs real money (Comfy credits) the moment you run it — and until now it never asked. This PR makes it ask first. At a terminal you get a "this spends credits — proceed?" prompt; scripts and agents must pass `--yes` (or the user can persist "always proceed" once with `comfy generate consent always`); and a machine call (`--json` or no terminal) with neither errors out cleanly instead of spending silently or hanging on a question nobody can answer.

## What

The money interlock for `comfy generate` (launch blocker for exposing generation through the local MCP, parent BE-4102):

- **Interactive confirm** — TTY runs prompt (`default No`) before any credit-spending proxy call.
- **`--yes`** — explicit bypass for automation/evals (new meta flag, stripped like `--async`/`--json`).
- **`spend.auto_confirm` config** — persistent always-proceed, managed by a new `comfy generate consent [show|always|ask]` action; stored in `config.ini` via `ConfigManager` (see judgment calls).
- **Fail-closed non-interactive** — `--json` or no stdin TTY with neither consent source → error `spend_consent_required` (registered in `error_codes.REGISTRY`), exit 1, nothing spent, never a hanging prompt.

The gate sits in `_generate` **before every network side effect** — before OAuth refresh (`resolve_api_key`), before asset-upload transforms, before the generation request. Ungated because they spend nothing: `list` / `schema` / `refresh` / `upload` / `resume` (polls an already-paid job) / `--emit-workflow` (local artifact, no proxy call).

Consent failures emit `generate:error` with `error_kind="consent"`; the `consent` action emits `generate:consent`. Docs updated: top help, per-model schema help, and the agent-facing `skills/comfy/SKILL.md` (explicitly tells agents **not** to reflexively add `--yes` — it must represent real human approval).

## Acceptance criteria

- `comfy generate <model> --json` with no consent → errors, spends nothing ✅ (test + live CLI run: exits 1 with `spend_consent_required` before any network call)
- `--yes` or `spend.auto_confirm=true` → proceeds ✅ (tests for both, plus config-persistence-to-disk check)
- Interactive TTY → prompts before spending ✅ (accept / decline / bare-Enter-defaults-to-No tests)

## Judgment calls

- **`spend.auto_confirm` lives in `config.ini` (ConfigManager), not `secrets.json`.** The ticket says "same persistence that backs `comfy cloud set-key`", which literally is the auth-record store (`secrets.json`, provider→key schema). A boolean preference doesn't fit that schema; `config.ini` is the CLI's canonical settings persistence (same durability, same directory). Easy to move if the literal store was intended.
- **Added `comfy generate consent [show|always|ask]`** — the ticket asks for the config but no setter; without one, users would hand-edit `config.ini`. Small (~40 lines), makes the acceptance path actually usable, and gives the fail-closed error a concrete remediation to name.
- **Gate before auth resolution**: an unauthenticated non-consenting machine caller gets the consent error, not the auth error, and no OAuth token refresh happens pre-consent. Everything before the gate is local-only.
- **TTY check is stdin-only** (prompt reads stdin). `stdin=TTY, stdout=redirected` will prompt into the redirect — consistent with every other prompt in this CLI (`typer.confirm` defaults); the no-input-TTY hang case fails closed.
- **Breaking change by design**: previously-working unattended `comfy generate` invocations now require `--yes` — that is the ticket. Fallback for garbage `spend.auto_confirm` values is fail-closed.
- **Deny-path falsification**: the fail-closed error is a consent interlock, not a capability denial — every deny message names the working paths (`--yes`, `consent always`), and each of those paths is empirically proven by tests + a live CLI run.

## Tests

- New `tests/comfy_cli/command/generate/test_spend_gate.py` — 19 tests: fail-closed (json / pretty-non-TTY / async / pre-auth), bypasses (flag, config true/false/garbage), interactive prompt (accept/decline/default), ungated paths (emit-workflow, schema errors), lifecycle telemetry, and the `consent` action incl. on-disk persistence.
- New package `conftest.py` autouse fixture pre-authorizes the gate for the existing 177 generate tests (they exercise post-gate behavior; CliRunner has no TTY), overridden by name in the gate's own tests.
- Full suite: 2554 passed; the only failures are the 2 known `test_validate_command` reds from main (BE-3357×BE-3359, fix in #576). Ruff format clean; the 15 local `ruff check` UP038 hits are the known ruff-0.12.7-vs-CI-0.15.15 false flags in untouched files.

**Safety note (from the ticket): human review required before merge — this is the money interlock. Do not auto-merge.**
