### PR TITLE
feat: comfy run-template — fetch, fill params, spend-gate, run to completion (BE-4131)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1678,6 +1678,13 @@ app.add_typer(
 app.add_typer(custom_nodes.app, name="node", help="Manage custom nodes.")
 app.add_typer(nodes_command.app, name="nodes", help="Introspect ComfyUI node classes (inputs, outputs, categories).")
 app.add_typer(templates_command.app, name="templates", help="Browse the Comfy workflow-template gallery.")
+app.command(
+    "run-template",
+    help=(
+        "Fetch a gallery template, fill its parameterized inputs (--param KEY=VALUE), "
+        "and run it to completion on local ComfyUI. Paid partner-API templates require --allow-spend."
+    ),
+)(templates_command.run_template_cmd)
 app.add_typer(workflow_command.app, name="workflow", help="Slot-based editing of frontend-format ComfyUI workflows.")
 app.command(
     "preview",

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -751,7 +751,6 @@ def run_template_cmd(
     import tempfile
 
     from comfy_cli.command import run as run_module
-    from comfy_cli.config_manager import ConfigManager
     from comfy_cli.env_checker import check_comfy_server_running
 
     renderer = get_renderer()
@@ -819,20 +818,17 @@ def run_template_cmd(
         )
         raise typer.Exit(code=1) from e
 
-    # -- Resolve host/port exactly like `comfy run`'s local branch.
-    config = ConfigManager()
+    # -- Resolve host/port through the shared resolver, exactly like `comfy
+    # run`'s local branch (cmdline.py). This validates the host (rejecting
+    # URL-injection characters), brackets IPv6 literals, and honors
+    # config.background — behavior the old hand-rolled block lacked.
+    from comfy_cli.host_port import parse_host_port_arg, resolve_host_port
+
     if host:
-        s = host.split(":")
-        host = s[0]
-        if not port and len(s) == 2:
-            port = int(s[1])
-    if config.background:
-        host = host or config.background[0]
-        port = port or config.background[1]
-    host = host or "127.0.0.1"
-    if host == "0.0.0.0":  # wildcard bind, not a connect address
-        host = "127.0.0.1"
-    port = port or 8188
+        host, parsed_port = parse_host_port_arg(host)
+        if not port and parsed_port is not None:
+            port = parsed_port
+    host, port = resolve_host_port(host, port)
 
     if not check_comfy_server_running(port, host, timeout=timeout):
         renderer.error(

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -524,3 +524,425 @@ def fetch_cmd(
     if renderer.is_pretty() and out:
         rprint(f"[green]✓[/green] wrote {len(body):,} bytes ({payload['node_count']} nodes) to {target_repr}")
     renderer.emit(payload, command="templates fetch")
+
+
+# ---------------------------------------------------------------------------
+# run-template — fetch → fill params → spend-gate → run via the run path
+# ---------------------------------------------------------------------------
+
+
+def _parse_param_value(raw: str) -> Any:
+    """Parse a ``--param`` value as JSON; fall back to the literal string.
+
+    Mirrors ``comfy workflow set-slot`` semantics so `--param seed=42` writes
+    an int and `--param prompt="a cat"` writes a string.
+    """
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+
+def _workflow_node_types(workflow: Any) -> set[str]:
+    """Collect node class names from a workflow in either format.
+
+    Frontend format: ``nodes[].type`` plus every ``definitions.subgraphs[].nodes[].type``
+    (gallery templates routinely hide partner nodes inside UUID subgraphs).
+    API format: ``values()[].class_type``.
+    """
+    types: set[str] = set()
+    if not isinstance(workflow, dict):
+        return types
+    if isinstance(workflow.get("nodes"), list):
+        node_lists = [workflow.get("nodes") or []]
+        subgraphs = (workflow.get("definitions") or {}).get("subgraphs") or []
+        for sg in subgraphs:
+            if isinstance(sg, dict):
+                node_lists.append(sg.get("nodes") or [])
+        for nodes in node_lists:
+            for node in nodes:
+                if isinstance(node, dict) and isinstance(node.get("type"), str):
+                    types.add(node["type"])
+        return types
+    for node in workflow.values():
+        if isinstance(node, dict) and isinstance(node.get("class_type"), str):
+            types.add(node["class_type"])
+    return types
+
+
+def _detect_paid_nodes(workflow: Any, object_info: dict) -> list[str]:
+    """Sorted node class names in ``workflow`` that are partner-API (paid) nodes.
+
+    Same signals as ``comfy_cli.command.run``'s partner detection — the
+    authoritative ``api_node: true`` flag with a ``partner/`` category-prefix
+    fallback — but format-agnostic so it works on the frontend-format JSON
+    gallery templates ship as (run's detector only reads API format).
+    """
+    from comfy_cli.command.run import PARTNER_NODE_CATEGORY_PREFIXES
+
+    out: list[str] = []
+    for ct in _workflow_node_types(workflow):
+        info = object_info.get(ct) or {}
+        if not isinstance(info, dict):
+            continue
+        if info.get("api_node") is True:
+            out.append(ct)
+            continue
+        category = info.get("category")
+        if isinstance(category, str) and category.startswith(PARTNER_NODE_CATEGORY_PREFIXES):
+            out.append(ct)
+    return sorted(out)
+
+
+def _gallery_paid_signals(row: dict[str, Any]) -> list[str]:
+    """Gallery-index evidence that a template runs partner/API nodes.
+
+    Belt-and-suspenders for the spend gate: when the local server's
+    object_info is unavailable (fail-open fetch) node detection can miss, but
+    the curated gallery still marks paid templates with the ``API`` tag and
+    provider logos. Returns human-readable signal strings, empty = no signal.
+    """
+    signals: list[str] = []
+    for tag in row.get("tags") or []:
+        if isinstance(tag, str) and tag.lower() == "api":
+            signals.append("tag:API")
+    for prov in row.get("providers") or []:
+        if isinstance(prov, str) and prov:
+            signals.append(f"provider:{prov}")
+    return signals
+
+
+def _resolve_param_addresses(
+    renderer,
+    overrides: dict[str, Any],
+    slots: list[dict],
+) -> dict[str, Any]:
+    """Map ``--param KEY=VALUE`` keys onto slot addresses.
+
+    KEY may be a full slot address (``6.text``, ``62/34.text``) or a bare slot
+    name (``prompt``) when exactly one slot carries that name. Ambiguous or
+    unknown keys error with the candidate list so agents can self-correct.
+    """
+    addresses = {s.get("address") for s in slots if isinstance(s, dict)}
+    by_name: dict[str, list[str]] = {}
+    for s in slots:
+        if not isinstance(s, dict):
+            continue
+        n = s.get("name")
+        if isinstance(n, str) and n:
+            by_name.setdefault(n.lower(), []).append(str(s.get("address")))
+
+    resolved: dict[str, Any] = {}
+    for key, value in overrides.items():
+        if key in addresses:
+            resolved[key] = value
+            continue
+        candidates = by_name.get(key.lower(), [])
+        if len(candidates) == 1:
+            resolved[candidates[0]] = value
+            continue
+        if len(candidates) > 1:
+            renderer.error(
+                code="workflow_slot_invalid",
+                message=f"--param key {key!r} is ambiguous: {len(candidates)} slots share that name",
+                hint="use the full slot address instead: " + ", ".join(f"{a}={key}" for a in candidates[:5]),
+                details={"key": key, "candidates": candidates},
+            )
+            raise typer.Exit(code=1)
+        sample = sorted(a for a in addresses if a)[:10]
+        renderer.error(
+            code="workflow_slot_invalid",
+            message=f"--param key {key!r} matches no slot in this template",
+            hint=(
+                "valid addresses include: " + ", ".join(sample)
+                if sample
+                else "this template exposes no tweakable slots"
+            ),
+            details={"key": key, "available": sample},
+        )
+        raise typer.Exit(code=1)
+    return resolved
+
+
+@tracking.track_command("templates")
+def run_template_cmd(
+    name: Annotated[str, typer.Argument(help="Template name (matches `comfy templates ls` rows).")],
+    params: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--param",
+            "-p",
+            metavar="KEY=VALUE",
+            show_default=False,
+            help=(
+                "Fill a parameterized input before running (repeatable). KEY is a slot "
+                "address (`6.text`) or a unique slot name (`prompt`); VALUE parses as "
+                "JSON with string fallback. List slots with `comfy templates fetch "
+                "<name> -o wf.json && comfy workflow slots wf.json`."
+            ),
+        ),
+    ] = None,
+    allow_spend: Annotated[
+        bool,
+        typer.Option(
+            "--allow-spend",
+            help=(
+                "Consent to running partner-API (paid) nodes that spend Comfy credits. "
+                "Required for API templates when not confirming interactively."
+            ),
+        ),
+    ] = False,
+    async_: Annotated[
+        bool,
+        typer.Option(
+            "--async",
+            show_default=False,
+            help="Submit and return immediately instead of waiting for completion.",
+        ),
+    ] = False,
+    host: Annotated[
+        str | None,
+        typer.Option(show_default=False, help="ComfyUI host (default 127.0.0.1)."),
+    ] = None,
+    port: Annotated[
+        int | None,
+        typer.Option(show_default=False, help="ComfyUI port (default 8188)."),
+    ] = None,
+    timeout: Annotated[
+        int,
+        typer.Option(help="Per-event timeout in seconds (same semantics as `comfy run --timeout`)."),
+    ] = 120,
+    verbose: Annotated[
+        bool,
+        typer.Option(help="Verbose execution output."),
+    ] = False,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            envvar="COMFY_API_KEY",
+            help="Comfy API key for partner-API nodes (prefer the COMFY_API_KEY env var).",
+        ),
+    ] = None,
+    gallery_path: Annotated[
+        str | None,
+        typer.Option("--gallery", show_default=False, help="Path to a local index.json (skips the cache + fetch)."),
+    ] = None,
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", help="Re-fetch the gallery index from GitHub before resolving."),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Stream NDJSON run events to stdout (same dialect as `comfy run --json`).",
+        ),
+    ] = False,
+):
+    """Fetch a gallery template, fill its parameterized inputs, and run it on local ComfyUI.
+
+    OSS templates need their referenced models installed locally first
+    (`comfy model download`); missing models surface through the normal run
+    validation errors. Templates that embed partner-API nodes spend Comfy
+    credits and are gated behind --allow-spend / an interactive confirmation.
+    """
+    import sys
+    import tempfile
+
+    from comfy_cli.command import run as run_module
+    from comfy_cli.config_manager import ConfigManager
+    from comfy_cli.env_checker import check_comfy_server_running
+
+    renderer = get_renderer()
+    if json_output:
+        renderer.force_stream()
+
+    # -- Parse --param pairs up front so syntax errors fail before any I/O.
+    overrides: dict[str, Any] = {}
+    for raw in params or []:
+        if "=" not in raw:
+            renderer.error(
+                code="workflow_slot_invalid",
+                message=f"Expected `--param KEY=VALUE`, got {raw!r}",
+                hint='example: --param 6.text="a cat" or --param prompt="a cat"',
+            )
+            raise typer.Exit(code=1)
+        key, _, val = raw.partition("=")
+        overrides[key.strip()] = _parse_param_value(val)
+
+    # -- Resolve the template against the gallery index (close-matches on miss).
+    try:
+        cats = _load_gallery(gallery_path, refresh=refresh)
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        renderer.error(code="gallery_load_failed", message=str(e))
+        raise typer.Exit(code=1) from e
+
+    rows = _flatten_templates(cats)
+    row = next((r for r in rows if r["name"] == name), None)
+    if row is None:
+        lower = name.lower()
+        close = [r["name"] for r in rows if lower in r["name"].lower()][:5]
+        renderer.error(
+            code="template_not_found",
+            message=f"no template named {name!r} in the gallery",
+            hint="try `comfy templates ls --name <substring>` to search",
+            details={"close_matches": close},
+        )
+        raise typer.Exit(code=1)
+
+    # -- Fetch + parse the template's workflow JSON.
+    try:
+        body = _fetch_template_workflow(name)
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        status = getattr(e, "code", None)
+        renderer.error(
+            code="template_fetch_failed",
+            message=f"failed to fetch workflow for {name!r}: {e}",
+            hint=(
+                "the gallery index references a template whose workflow JSON "
+                "is missing upstream — report at "
+                "https://github.com/Comfy-Org/workflow_templates/issues"
+                if status == 404
+                else "check network connectivity"
+            ),
+            details={"status": status} if status else None,
+        )
+        raise typer.Exit(code=1) from e
+    try:
+        workflow = json.loads(body)
+    except json.JSONDecodeError as e:
+        renderer.error(
+            code="template_workflow_invalid_json",
+            message=f"upstream returned non-JSON for {name!r}: {e}",
+            hint="report at https://github.com/Comfy-Org/workflow_templates/issues",
+        )
+        raise typer.Exit(code=1) from e
+
+    # -- Resolve host/port exactly like `comfy run`'s local branch.
+    config = ConfigManager()
+    if host:
+        s = host.split(":")
+        host = s[0]
+        if not port and len(s) == 2:
+            port = int(s[1])
+    if config.background:
+        host = host or config.background[0]
+        port = port or config.background[1]
+    host = host or "127.0.0.1"
+    if host == "0.0.0.0":  # wildcard bind, not a connect address
+        host = "127.0.0.1"
+    port = port or 8188
+
+    if not check_comfy_server_running(port, host, timeout=timeout):
+        renderer.error(
+            code="server_not_running",
+            message=f"ComfyUI not running on specified address ({host}:{port})",
+            hint="run: comfy launch",
+            details={"host": host, "port": port},
+        )
+        raise typer.Exit(code=1)
+
+    # object_info powers both slot filling and paid-node detection. Fail-open
+    # ({}) keeps template runs working against bare servers — the gallery-index
+    # signals below still gate paid templates in that case.
+    object_info = run_module._fetch_object_info(host, port)
+
+    # -- Fill parameterized inputs via the CQL slot engine.
+    if overrides:
+        if not isinstance(workflow.get("nodes"), list):
+            renderer.error(
+                code="workflow_slot_invalid",
+                message=f"template {name!r} is not a frontend-format workflow; --param is not supported for it",
+                hint="run it without --param, or fetch + edit it directly",
+            )
+            raise typer.Exit(code=1)
+        if not object_info:
+            renderer.error(
+                code="object_info_unavailable",
+                message="could not fetch /object_info from the server; --param needs the node catalog to fill slots",
+                hint="check the ComfyUI server logs, or run without --param",
+            )
+            raise typer.Exit(code=1)
+        from comfy_cli.cql.engine import Graph
+
+        graph = Graph.from_object_info(object_info)
+        graph._try_default_annotations()
+        try:
+            schema = graph.get_template_schema(name, workflow)
+        except (ValueError, KeyError) as e:
+            renderer.error(code="workflow_slot_invalid", message=f"Could not extract slots: {e}")
+            raise typer.Exit(code=1) from e
+        resolved = _resolve_param_addresses(renderer, overrides, schema.get("slots") or [])
+        try:
+            workflow, warnings = graph.apply_slots(workflow, resolved)
+        except ValueError as e:
+            renderer.error(
+                code="workflow_slot_invalid",
+                message=str(e),
+                hint="fetch the template and run `comfy workflow slots <file>` to see valid addresses + types",
+            )
+            raise typer.Exit(code=1) from e
+        if renderer.is_pretty():
+            rprint(f"[bold green]✓[/bold green] filled {len(resolved)} parameter(s)")
+            for addr in resolved:
+                rprint(f"  [dim]·[/dim] {addr}")
+            for w in warnings:
+                rprint(f"  [yellow]warning:[/yellow] {w}")
+
+    # -- Spend gate (BE-4113): partner-API nodes spend Comfy credits. Require
+    # explicit consent before submitting anything that would burn them.
+    paid_nodes = _detect_paid_nodes(workflow, object_info)
+    gallery_signals = _gallery_paid_signals(row)
+    if (paid_nodes or gallery_signals) and not allow_spend:
+        evidence = {
+            "template": name,
+            "partner_nodes": paid_nodes,
+            "gallery_signals": gallery_signals,
+        }
+        if renderer.is_pretty() and sys.stdin.isatty():
+            rprint(f"[yellow]⚠ Template [bold]{name}[/bold] uses partner-API nodes that spend Comfy credits.[/yellow]")
+            if paid_nodes:
+                rprint(f"  [dim]nodes:[/dim] {', '.join(paid_nodes)}")
+            if gallery_signals:
+                rprint(f"  [dim]gallery:[/dim] {', '.join(gallery_signals)}")
+            if not typer.confirm("Run anyway and spend credits?", default=False):
+                renderer.error(
+                    code="spend_consent_required",
+                    message="declined — template not submitted, no credits spent",
+                    details=evidence,
+                )
+                raise typer.Exit(code=1)
+        else:
+            renderer.error(
+                code="spend_consent_required",
+                message=(
+                    f"template {name!r} uses partner-API (paid) nodes; "
+                    "re-run with --allow-spend to consent to spending Comfy credits"
+                ),
+                hint="paid nodes only run with explicit consent; OSS templates run without this flag",
+                details=evidence,
+            )
+            raise typer.Exit(code=1)
+
+    # -- Hand off to the existing run path (UI→API conversion, partner
+    # credential injection, preflight validation, execution, jobs state).
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    fd, tmp_path = tempfile.mkstemp(prefix=f"comfy_template_{safe}_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(workflow, f)
+        run_module.execute(
+            tmp_path,
+            host,
+            port,
+            wait=not async_,
+            verbose=verbose,
+            timeout=timeout,
+            api_key=api_key,
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -150,6 +150,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy auth set comfy-cloud-api-key --key …` so the local submit path can inject it too",
     ),
     ErrorCode(
+        "spend_consent_required",
+        "`comfy run-template` resolved a template that uses partner-API (paid) nodes — running it "
+        "would spend Comfy credits — and no consent was given (`--allow-spend` absent, or the "
+        "interactive confirmation was declined). Nothing was submitted; no credits were spent. "
+        "`details.partner_nodes` / `details.gallery_signals` carry the evidence.",
+        "re-run with `--allow-spend` to consent to the credit spend",
+    ),
+    ErrorCode(
         "workflow_empty",
         "Workflow JSON is an empty object (no nodes).",
         "add at least one node to the workflow",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -150,17 +150,6 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy auth set comfy-cloud-api-key --key …` so the local submit path can inject it too",
     ),
     ErrorCode(
-        "spend_consent_required",
-        "A credit-spending command hit its spend gate with no consent, so it failed closed — "
-        "nothing was submitted and no credits were spent. `comfy run-template` raises this when a "
-        "template uses partner-API (paid) nodes and `--allow-spend` is absent or the interactive "
-        "confirmation was declined (`details.partner_nodes` / `details.gallery_signals` carry the "
-        "evidence); `comfy generate` raises it when a credit-spending call runs non-interactively "
-        "(`--json` / no TTY) with no consent.",
-        "consent to the spend and re-run — `comfy run-template --allow-spend`, or "
-        "`comfy generate --yes` (persist with `comfy generate consent always`)",
-    ),
-    ErrorCode(
         "workflow_empty",
         "Workflow JSON is an empty object (no nodes).",
         "add at least one node to the workflow",
@@ -590,9 +579,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "spend_consent_required",
-        "A credit-spending `comfy generate` call ran non-interactively (--json / no TTY) "
-        "with no consent — the spend gate fails closed and nothing was spent.",
-        "re-run with --yes, or persist consent with `comfy generate consent always`",
+        "A credit-spending command hit its spend gate with no consent, so it failed closed — "
+        "nothing was submitted and no credits were spent. `comfy run-template` raises this when a "
+        "template uses partner-API (paid) nodes and `--allow-spend` is absent or the interactive "
+        "confirmation was declined (`details.partner_nodes` / `details.gallery_signals` carry the "
+        "evidence); `comfy generate` raises it when a credit-spending call runs non-interactively "
+        "(`--json` / no TTY) with no consent.",
+        "consent to the spend and re-run — `comfy run-template --allow-spend`, or "
+        "`comfy generate --yes` (persist with `comfy generate consent always`)",
     ),
     # --- feedback ------------------------------------------------------------
     ErrorCode(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -151,11 +151,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "spend_consent_required",
-        "`comfy run-template` resolved a template that uses partner-API (paid) nodes — running it "
-        "would spend Comfy credits — and no consent was given (`--allow-spend` absent, or the "
-        "interactive confirmation was declined). Nothing was submitted; no credits were spent. "
-        "`details.partner_nodes` / `details.gallery_signals` carry the evidence.",
-        "re-run with `--allow-spend` to consent to the credit spend",
+        "A credit-spending command hit its spend gate with no consent, so it failed closed — "
+        "nothing was submitted and no credits were spent. `comfy run-template` raises this when a "
+        "template uses partner-API (paid) nodes and `--allow-spend` is absent or the interactive "
+        "confirmation was declined (`details.partner_nodes` / `details.gallery_signals` carry the "
+        "evidence); `comfy generate` raises it when a credit-spending call runs non-interactively "
+        "(`--json` / no TTY) with no consent.",
+        "consent to the spend and re-run — `comfy run-template --allow-spend`, or "
+        "`comfy generate --yes` (persist with `comfy generate consent always`)",
     ),
     ErrorCode(
         "workflow_empty",

--- a/tests/comfy_cli/command/test_run_template.py
+++ b/tests/comfy_cli/command/test_run_template.py
@@ -1,0 +1,389 @@
+"""Tests for ``comfy run-template`` — fetch → fill params → spend-gate → run.
+
+All offline: the gallery index comes from a tmp fixture file, the template
+workflow fetch and the server probe / object_info / run handoff are
+monkeypatched. Covers name resolution, --param filling (address and name
+keys), the spend gate (gallery signals + object_info partner nodes,
+--allow-spend, interactive decline), and the handoff into the run path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import templates as templates_cmd
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+# Mirrors the real gallery schema: OSS templates carry no logos; paid
+# templates carry the API tag and/or provider logos (both observed in the
+# live index — some paid rows have only one of the two signals).
+FIXTURE = [
+    {
+        "moduleName": "default",
+        "category": "GENERATION TYPE",
+        "title": "Image",
+        "type": "image",
+        "templates": [
+            {
+                "name": "api_flux2",
+                "title": "Flux 2 (API)",
+                "description": "Text-to-image via the BFL API.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["API", "Text to Image"],
+                "models": [],
+                "logos": [{"provider": ["Black Forest Labs"]}],
+                "openSource": False,
+                "usage": 100,
+            },
+            {
+                "name": "image_local_sd",
+                "title": "Local SD",
+                "description": "Local text-to-image.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["Local", "Text to Image"],
+                "models": ["SD 1.5"],
+                "logos": [],
+                "openSource": True,
+                "usage": 50,
+            },
+        ],
+    },
+]
+
+# Frontend-format template body with one editable text widget and a sampler.
+TEMPLATE_WORKFLOW = {
+    "nodes": [
+        {"id": 3, "type": "KSampler", "widgets_values": [42, "fixed", 20, 8.0, "euler", "normal", 1.0]},
+        {"id": 6, "type": "CLIPTextEncode", "widgets_values": ["a cat in space"]},
+    ],
+    "links": [],
+}
+
+OBJECT_INFO = {
+    "KSampler": {
+        "input": {
+            "required": {
+                "seed": ["INT", {"default": 0, "control_after_generate": True}],
+                "steps": ["INT", {"default": 20}],
+                "cfg": ["FLOAT", {"default": 8.0}],
+                "sampler_name": [["euler", "euler_ancestral"]],
+                "scheduler": [["normal", "karras"]],
+                "denoise": ["FLOAT", {"default": 1.0}],
+            },
+        },
+        "input_order": {"required": ["seed", "steps", "cfg", "sampler_name", "scheduler", "denoise"]},
+        "output": ["LATENT"],
+        "output_name": ["LATENT"],
+        "category": "sampling",
+        "display_name": "KSampler",
+        "python_module": "nodes",
+    },
+    "CLIPTextEncode": {
+        "input": {"required": {"text": ["STRING", {"multiline": True}], "clip": "CLIP"}},
+        "input_order": {"required": ["clip", "text"]},
+        "output": ["CONDITIONING"],
+        "output_name": ["CONDITIONING"],
+        "category": "conditioning",
+        "display_name": "CLIP Text Encode",
+        "python_module": "nodes",
+    },
+    "FluxProNode": {
+        "input": {"required": {"prompt": ["STRING", {"default": ""}]}},
+        "input_order": {"required": ["prompt"]},
+        "output": ["IMAGE"],
+        "output_name": ["IMAGE"],
+        "category": "partner/image/BFL",
+        "api_node": True,
+        "display_name": "Flux Pro",
+        "python_module": "nodes",
+    },
+}
+
+
+@pytest.fixture
+def gallery_file(tmp_path: Path) -> str:
+    path = tmp_path / "index.json"
+    path.write_text(json.dumps(FIXTURE))
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _envelope(stdout: str) -> dict:
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope in stdout:\n{stdout}")
+
+
+@pytest.fixture
+def app() -> typer.Typer:
+    a = typer.Typer()
+    a.command("run-template")(templates_cmd.run_template_cmd)
+
+    # A second (hidden) command so typer doesn't collapse the app into
+    # single-command mode, which would swallow the "run-template" prefix.
+    @a.command("noop", hidden=True)
+    def _noop():  # pragma: no cover
+        pass
+
+    return a
+
+
+class _RunSpy:
+    """Records the run-path handoff; captures the workflow file content
+    before the command's finally-block unlinks it."""
+
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, workflow_path, host, port, **kwargs):
+        self.calls.append(
+            {
+                "workflow": json.loads(Path(workflow_path).read_text(encoding="utf-8")),
+                "host": host,
+                "port": port,
+                **kwargs,
+            }
+        )
+
+
+@pytest.fixture
+def run_spy(monkeypatch) -> _RunSpy:
+    spy = _RunSpy()
+    monkeypatch.setattr("comfy_cli.command.run.execute", spy)
+    return spy
+
+
+@pytest.fixture
+def server_up(monkeypatch):
+    monkeypatch.setattr("comfy_cli.env_checker.check_comfy_server_running", lambda *a, **k: True)
+    monkeypatch.setattr("comfy_cli.command.run._fetch_object_info", lambda host, port: OBJECT_INFO)
+    # Keep the user's real config (background server address) out of the tests.
+    monkeypatch.setattr("comfy_cli.config_manager.ConfigManager.background", None, raising=False)
+
+
+@pytest.fixture
+def template_body(monkeypatch):
+    def set_body(data) -> None:
+        body = json.dumps(data).encode()
+        monkeypatch.setattr(templates_cmd, "_fetch_template_workflow", lambda name, **kw: body)
+
+    set_body(TEMPLATE_WORKFLOW)
+    return set_body
+
+
+HOSTPORT = ["--host", "127.0.0.1", "--port", "8188"]
+
+
+# ---------------------------------------------------------------------------
+# Resolution + validation failures (no run handoff)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_template_surfaces_not_found_with_close_matches(app, gallery_file, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "flux"])
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "template_not_found"
+    assert env["error"]["details"]["close_matches"] == ["api_flux2"]
+    assert run_spy.calls == []
+
+
+def test_malformed_param_fails_before_any_io(app, gallery_file, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "image_local_sd", "--param", "seed"])
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "workflow_slot_invalid"
+    assert run_spy.calls == []
+
+
+def test_server_not_running_short_circuits(app, gallery_file, template_body, run_spy, monkeypatch):
+    _force_json_renderer()
+    monkeypatch.setattr("comfy_cli.env_checker.check_comfy_server_running", lambda *a, **k: False)
+    monkeypatch.setattr("comfy_cli.config_manager.ConfigManager.background", None, raising=False)
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "image_local_sd", *HOSTPORT])
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "server_not_running"
+    assert run_spy.calls == []
+
+
+def test_unknown_param_key_lists_available_slots(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(
+        app,
+        ["run-template", "--gallery", gallery_file, "image_local_sd", "--param", "nope=1", *HOSTPORT],
+    )
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "workflow_slot_invalid"
+    assert "6.text" in env["error"]["details"]["available"]
+    assert run_spy.calls == []
+
+
+def test_param_on_api_format_template_is_rejected(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    template_body({"9": {"class_type": "KSampler", "inputs": {}}})  # API format, no `nodes` list
+    result = CliRunner().invoke(
+        app,
+        ["run-template", "--gallery", gallery_file, "image_local_sd", "--param", "seed=1", *HOSTPORT],
+    )
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "workflow_slot_invalid"
+    assert run_spy.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Spend gate
+# ---------------------------------------------------------------------------
+
+
+def test_paid_template_without_consent_is_blocked(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "api_flux2", *HOSTPORT])
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "spend_consent_required"
+    assert "tag:API" in env["error"]["details"]["gallery_signals"]
+    assert run_spy.calls == []
+
+
+def test_partner_nodes_gate_even_without_gallery_signals(app, gallery_file, template_body, server_up, run_spy):
+    # An OSS-listed template whose workflow embeds a partner node (api_node
+    # flag in object_info) must still hit the gate — node detection is the
+    # authoritative signal, the gallery index is the fallback.
+    _force_json_renderer()
+    template_body({"nodes": [{"id": 1, "type": "FluxProNode", "widgets_values": ["x"]}], "links": []})
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "image_local_sd", *HOSTPORT])
+    assert result.exit_code == 1
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "spend_consent_required"
+    assert env["error"]["details"]["partner_nodes"] == ["FluxProNode"]
+    assert run_spy.calls == []
+
+
+def test_partner_node_inside_subgraph_definition_is_detected():
+    wf = {
+        "nodes": [{"id": 1, "type": "uuid-subgraph"}],
+        "links": [],
+        "definitions": {"subgraphs": [{"id": "uuid-subgraph", "nodes": [{"id": 10, "type": "FluxProNode"}]}]},
+    }
+    assert templates_cmd._detect_paid_nodes(wf, OBJECT_INFO) == ["FluxProNode"]
+
+
+def test_allow_spend_unblocks_paid_template(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(
+        app, ["run-template", "--gallery", gallery_file, "api_flux2", "--allow-spend", *HOSTPORT]
+    )
+    assert result.exit_code == 0, result.output
+    assert len(run_spy.calls) == 1
+
+
+def test_interactive_decline_blocks_without_submitting(
+    app, gallery_file, template_body, server_up, run_spy, monkeypatch
+):
+    # Pretty renderer + a tty stdin → the gate confirms interactively; a "no"
+    # answer must not submit anything.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    monkeypatch.setattr("typer.confirm", lambda *a, **k: False)
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "api_flux2", *HOSTPORT])
+    assert result.exit_code == 1
+    assert run_spy.calls == []
+
+
+def test_oss_template_runs_without_spend_flag(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "image_local_sd", *HOSTPORT])
+    assert result.exit_code == 0, result.output
+    assert len(run_spy.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Param filling + run handoff
+# ---------------------------------------------------------------------------
+
+
+def test_params_fill_by_address_and_name_then_run_waits(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(
+        app,
+        [
+            "run-template",
+            "--gallery",
+            gallery_file,
+            "image_local_sd",
+            "--param",
+            "6.text=a dog on the moon",  # full address
+            "--param",
+            "seed=7",  # unique slot name → resolves to 3.seed, JSON-parsed int
+            *HOSTPORT,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(run_spy.calls) == 1
+    call = run_spy.calls[0]
+    assert call["wait"] is True  # run-template runs to completion by default
+    assert call["host"] == "127.0.0.1"
+    assert call["port"] == 8188
+    nodes = {n["id"]: n for n in call["workflow"]["nodes"]}
+    assert nodes[6]["widgets_values"][0] == "a dog on the moon"
+    assert nodes[3]["widgets_values"][0] == 7
+    assert isinstance(nodes[3]["widgets_values"][0], int)
+
+
+def test_async_flag_hands_off_without_waiting(app, gallery_file, template_body, server_up, run_spy):
+    _force_json_renderer()
+    result = CliRunner().invoke(
+        app, ["run-template", "--gallery", gallery_file, "image_local_sd", "--async", *HOSTPORT]
+    )
+    assert result.exit_code == 0, result.output
+    assert run_spy.calls[0]["wait"] is False
+
+
+def test_temp_workflow_file_is_cleaned_up(app, gallery_file, template_body, server_up, run_spy, tmp_path, monkeypatch):
+    _force_json_renderer()
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    import tempfile
+
+    monkeypatch.setattr(tempfile, "tempdir", None)  # re-resolve from TMPDIR
+    result = CliRunner().invoke(app, ["run-template", "--gallery", gallery_file, "image_local_sd", *HOSTPORT])
+    assert result.exit_code == 0, result.output
+    assert list(tmp_path.glob("comfy_template_*")) == []


### PR DESCRIPTION
## ELI-5

`comfy templates` could only *browse* the gallery — you could list templates and fetch their JSON, but actually running one meant a manual fetch → edit → `comfy run` chain. This PR adds `comfy run-template <name>`: one command that fetches a gallery template, fills in any inputs you pass with `--param KEY=VALUE`, and runs it to completion on your local ComfyUI. If the template uses paid partner-API nodes (Flux Pro, Kling, Gemini, …), the command stops and asks for consent first — `--allow-spend` (or an interactive yes) is required before anything that burns Comfy credits is submitted.

## What

- New top-level verb **`comfy run-template <name>`** (`comfy_cli/command/templates.py`, registered in `cmdline.py`):
  - Resolves `<name>` against the gallery index (same close-matches affordance as `templates fetch`), pulls `templates/<name>.json`.
  - **`--param KEY=VALUE`** (repeatable) fills parameterized inputs via the existing CQL slot engine (`get_template_schema` / `apply_slots`). KEY is a slot address (`6.text`, `62/34.text`) or a unique slot *name* (`prompt`); VALUE is JSON-parsed with string fallback — identical semantics to `comfy workflow set-slot`. Unknown/ambiguous keys error with the candidate list so agents can self-correct.
  - **Spend gate**: before anything is submitted, the workflow's node types (including nodes inside UUID subgraph definitions) are checked against `object_info` (`api_node: true` / `partner/` category — same signals as `comfy run`'s partner detection), belt-and-suspendered with the gallery index's own paid markers (`API` tag, provider logos). Paid template + no `--allow-spend` → interactive confirm on a tty, hard error `spend_consent_required` (new registered error code) otherwise. Nothing is submitted, no credits spent.
  - Hands off to the **existing run path** (`command.run.execute`): UI→API conversion, partner-credential injection, preflight validation, execution, jobs state — nothing re-implemented. Runs to completion by default (`wait=True`); `--async` submits and returns. `--host/--port/--timeout/--verbose/--api-key/--json/--gallery/--refresh` mirror the surrounding commands.
- 14 new offline tests (`tests/comfy_cli/command/test_run_template.py`): resolution failures, param syntax/unknown-key/API-format rejection, the gate in all four postures (gallery-signal block, partner-node block without gallery signals, `--allow-spend` unblock, interactive decline), OSS pass-through, param filling by address and by name, wait/async handoff, temp-file cleanup.

## Judgment calls

- **BE-4103's shared spend-gate does not exist yet** (no branch, PR, or commit in this repo references it), so there was nothing to "route through." I implemented the gate inline in `run-template` with a registered error code and the `--allow-spend` consent flag — the same consent-before-credit contract the BE-4103 ticket describes for `comfy generate`. When BE-4103 lands a shared helper, this call site is a one-line adoption.
- **Gallery-signal calibration was checked against the live index** (528 templates): 0 of 224 OSS templates carry provider logos, so the provider signal cannot over-gate OSS runs; `openSource: false` alone is deliberately NOT a signal (60 local-model workflows like `sdxl_simple_example` carry it). Exactly one OSS template (`utility-gan_upscaler`) carries the `API` tag and would be conservatively gated — cost is one flag, spends nothing.
- **Missing-model behavior** is deferred to the existing run path: local model gaps surface through `comfy run`'s preflight/`/prompt` validation errors, which the local MCP already maps (`local-mcp-nomodel-001`); the per-template runnable/missing verdict is #557's scope (`comfy templates check`, in review). The command help points OSS users at `comfy model download`.
- The completion envelope comes from the run path and is labeled `command: "run"` — kept as-is rather than threading a label parameter through `execute()`'s stable contract.
- Residual under-gate window: an API-format paid template + unreachable `object_info` would skip node detection — but every current gallery template is frontend-format (verified), frontend conversion hard-fails without `object_info`, and credential injection would also be absent, so no spend can occur silently.

## Testing

- `pytest tests/comfy_cli` — 2550 passed; the only 2 failures (`test_validate_command.py::test_api_format_unchanged` / `test_empty_dict_payload_unchanged`) are pre-existing on `main` (fix is in-flight in #576).
- `ruff check` + `ruff format --check` clean on all touched files.
- `comfy --json discover` verified to surface the new command + error code.
