### PR TITLE
docs: document registry-install & --fast-deps, fix node-install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
 
   `comfy node install comfyui-impact-pack`
 
+  > **Note:** the argument is the node's **Comfy Registry ID**, which is
+  > lowercase (e.g. `comfyui-impact-pack`), not the GitHub repository name
+  > (`ComfyUI-Impact-Pack`). Passing the repo-name casing fails to resolve with
+  > an error like `Node 'ComfyUI-Impact-Pack@unknown' not found`. Find a node's
+  > ID on its [Comfy Registry](https://registry.comfy.org) page or via
+  > `comfy node show all`.
+
 - Managing snapshot:
 
   `comfy node save-snapshot`
@@ -241,6 +248,39 @@ comfy node [show|simple-show] [installed|enabled|not-installed|disabled|all|snap
 - Generate deps:
 
   `comfy node deps-in-workflow --workflow=<workflow .json/.png file> --output=<output deps .json file>`
+
+#### `install` vs `registry-install`
+
+comfy-cli offers two ways to install a custom node, backed by different
+mechanisms:
+
+- **`comfy node install <id>...`** delegates to
+  [ComfyUI-Manager](https://github.com/Comfy-Org/ComfyUI-Manager)'s `cm-cli`.
+  It accepts one or more node IDs, resolves them through the Manager's channel
+  database (`--channel`, `--mode`), and installs dependencies via the Manager
+  (so it also supports `--fast-deps`, `--no-deps`, and `--uv-compile`). This is
+  the recommended command for day-to-day node management, and it requires
+  ComfyUI-Manager to be present in the workspace.
+
+  `comfy node install comfyui-impact-pack`
+
+- **`comfy node registry-install <id> [version]`** talks directly to the
+  [Comfy Registry](https://registry.comfy.org) API. It downloads the published
+  archive for a single node (optionally pinned to a specific `version`),
+  extracts it into `custom_nodes/`, and runs the node's own install script. It
+  does **not** go through ComfyUI-Manager, so it does not require the Manager to
+  be installed — this is the command the Registry's own install instructions
+  use.
+
+  `comfy node registry-install comfyui-impact-pack`
+
+  `comfy node registry-install comfyui-impact-pack 1.0.0`  # install a specific version
+
+  Because `registry-install` bypasses the Manager's dependency machinery and
+  simply runs the node's bundled install script, it only accepts
+  `--force-download` — it does **not** accept `--fast-deps`, `--no-deps`, or
+  `--uv-compile`. If you want fast/unified dependency resolution, use
+  `comfy node install` instead.
 
 #### Unified Dependency Resolution (--uv-compile)
 
@@ -268,6 +308,26 @@ it can identify which node packs have incompatible dependencies and why.
 - Use `--no-uv-compile` to override the default for a single command:
 
   `comfy node install comfyui-impact-pack --no-uv-compile`
+
+#### --fast-deps
+
+`--fast-deps` swaps comfy-cli's dependency installation from `pip` to comfy-cli's
+built-in `uv`-based resolver (`DependencyCompiler`), which is significantly
+faster and only requires `uv` (no ComfyUI-Manager). On a dependency version
+conflict it prompts you interactively to pick a version.
+
+- Accepted by: `comfy install`, `comfy node install`, and
+  `comfy node reinstall`.
+
+  `comfy install --fast-deps`
+
+  `comfy node install comfyui-impact-pack --fast-deps`
+
+- **Not** accepted by `comfy node registry-install`: that command installs a
+  node directly from the Comfy Registry by running the node's own bundled
+  install script, so it never touches comfy-cli's dependency resolver (see
+  [`install` vs `registry-install`](#install-vs-registry-install) above).
+- Mutually exclusive with `--no-deps` and `--uv-compile`.
 
 #### --fast-deps vs --uv-compile
 

--- a/README.md
+++ b/README.md
@@ -293,17 +293,16 @@ mechanisms:
 
   `comfy node install comfyui-impact-pack`
 
-- **`comfy node registry-install <id> [version]`** talks directly to the
+- **`comfy node registry-install <id> [--version <v>]`** talks directly to the
   [Comfy Registry](https://registry.comfy.org) API. It downloads the published
-  archive for a single node (optionally pinned to a specific `version`),
-  extracts it into `custom_nodes/`, and runs the node's own install script. It
-  does **not** go through ComfyUI-Manager, so it does not require the Manager to
-  be installed — this is the command the Registry's own install instructions
-  use.
+  archive for a single node (optionally pinned with `--version`), extracts it
+  into `custom_nodes/`, and runs the node's own install script. It does **not**
+  go through ComfyUI-Manager, so it does not require the Manager to be
+  installed — this is the command the Registry's own install instructions use.
 
   `comfy node registry-install comfyui-impact-pack`
 
-  `comfy node registry-install comfyui-impact-pack 1.0.0`  # install a specific version
+  `comfy node registry-install comfyui-impact-pack --version 1.0.0`  # install a specific version
 
   Because `registry-install` bypasses the Manager's dependency machinery and
   simply runs the node's bundled install script, it only accepts
@@ -329,7 +328,9 @@ it can identify which node packs have incompatible dependencies and why.
 
   `comfy node uv-sync`
 
-- `--uv-compile` is mutually exclusive with `--fast-deps` and `--no-deps`.
+- `--uv-compile` is mutually exclusive with `--fast-deps` and `--no-deps` —
+  except on `restore-snapshot`, where `--fast-deps` selects the `--uv-compile`
+  path instead (see [--fast-deps](#--fast-deps) below).
 
 - To make `--uv-compile` the default for all commands, see
   [uv-compile default](#uv-compile-default) below.
@@ -345,8 +346,8 @@ built-in `uv`-based resolver (`DependencyCompiler`), which is significantly
 faster and only requires `uv` (no ComfyUI-Manager). On a dependency version
 conflict it prompts you interactively to pick a version.
 
-- Accepted by: `comfy install`, `comfy node install`, and
-  `comfy node reinstall`.
+- Accepted by: `comfy install`, `comfy node install`, `comfy node reinstall`,
+  and `comfy node restore-snapshot`.
 
   `comfy install --fast-deps`
 
@@ -356,7 +357,22 @@ conflict it prompts you interactively to pick a version.
   node directly from the Comfy Registry by running the node's own bundled
   install script, so it never touches comfy-cli's dependency resolver (see
   [`install` vs `registry-install`](#install-vs-registry-install) above).
-- Mutually exclusive with `--no-deps` and `--uv-compile`.
+- Mutually exclusive with `--no-deps` and `--uv-compile`, where those flags
+  exist — the exact pairing is per-command:
+
+  | Command | Rejected combination |
+  |---------|----------------------|
+  | `comfy node install` | `--fast-deps --no-deps`, `--fast-deps --uv-compile` |
+  | `comfy node reinstall` | `--fast-deps --uv-compile` (no `--no-deps` on this command) |
+  | `comfy node restore-snapshot` | `--fast-deps --no-uv-compile` (see below) |
+  | `comfy install` | none (neither flag exists on this command) |
+
+- **Exception — `comfy node restore-snapshot`:** here `--fast-deps` *selects*
+  the `--uv-compile` fast path rather than conflicting with it. ComfyUI-Manager's
+  `cm-cli` has no `--no-deps` on `restore-snapshot`, and its `--uv-compile`
+  already implies no-deps internally, so the two are synonyms on this command.
+  Combining `--fast-deps` with `--no-uv-compile` is the contradiction, and it
+  errors: `Cannot use --fast-deps with --no-uv-compile`.
 
 #### --fast-deps vs --uv-compile
 
@@ -365,7 +381,7 @@ Both flags use `uv` for faster dependency resolution, but they work differently:
 |                       | `--fast-deps`                                   | `--uv-compile`                                |
 |-----------------------|-------------------------------------------------|-----------------------------------------------|
 | **Resolver**          | comfy-cli built-in (`DependencyCompiler`)       | ComfyUI-Manager (`UnifiedDepResolver`)        |
-| **Scope**             | `comfy install`, `comfy node install/reinstall` | Custom node commands only                     |
+| **Scope**             | `comfy install`, `comfy node install/reinstall/restore-snapshot` | Custom node commands only    |
 | **Conflict handling** | Interactive prompt to pick a version            | Automatic detection with node attribution     |
 | **Config default**    | No                                              | Yes (`comfy manager uv-compile-default true`) |
 | **Requires**          | Only `uv`                                       | ComfyUI-Manager v4.1+                         |


### PR DESCRIPTION
## ELI-5

If you told comfy-cli to install a node using its GitHub-style name
(`ComfyUI-Impact-Pack`), it failed with a confusing `Node
'ComfyUI-Impact-Pack@unknown' not found` error, because the command actually
wants the node's lowercase **Comfy Registry ID** (`comfyui-impact-pack`). Also,
comfy-cli has two different install commands (`install` and `registry-install`)
and a `--fast-deps` speed flag that were never explained. This PR is docs-only:
it explains all of that in the README so nobody hits the same wall.

## What changed

Documentation only (`README.md`) — no code changes.

1. **Node-install casing note** — added a note under the `comfy node install`
   example clarifying the argument is the node's lowercase Comfy Registry ID,
   not the GitHub repo name, and that the wrong casing produces the
   `Node '...@unknown' not found` error from the issue.
2. **`install` vs `registry-install`** — new section explaining that `install`
   delegates to ComfyUI-Manager's `cm-cli` (multi-node, channel/mode-aware,
   supports the dependency flags, needs the Manager) while `registry-install`
   downloads a single published node straight from the Comfy Registry API and
   runs its bundled install script (no Manager required — the command the
   Registry's own instructions use).
3. **`--fast-deps`** — new section documenting what it does, the commands that
   accept it (`comfy install`, `comfy node install`, `comfy node reinstall`),
   and why `registry-install` does not (it bypasses comfy-cli's dependency
   resolver entirely).

## Acceptance criteria

- [x] README node-install example corrected to a working command — the literal
  example was already lowercase on `main` (fixed in `0cb2cb8`, Mar 2026, after
  the issue was filed); this PR adds the missing *explanation* of why the
  capitalized form fails, which is the actual reporter confusion.
- [x] `registry-install` vs `install` documented (what each does, when to use
  which), verified against `comfy_cli/command/custom_nodes/command.py`.
- [x] `--fast-deps` documented, including which node commands accept it and the
  current reason `registry-install` does not, verified against the command
  signatures in source.
- [x] Follow-up bug: **not needed.** The `ComfyUI-Impact-Pack` failure is a
  case-sensitivity / stale-doc issue (node IDs are the lowercase registry IDs),
  not an install-resolution bug — the working form already ships on `main`. No
  resolver change is in scope (per the ticket's out-of-scope note).

## Judgment calls / notes

- `registry-install` is defined with `hidden=True` in the CLI. I documented it
  anyway (the Registry's install instructions use it and the issue explicitly
  asks for its docs) but left it hidden — unhiding is a behavior change and
  out of scope for a docs ticket.
- The `--fast-deps` "not accepted by registry-install" claim was verified by
  reading `registry_install`'s signature (it only exposes `--force-download`),
  and the docs redirect users to `comfy node install` for that capability
  rather than presenting a dead-end.
- The docs.comfy.org custom-nodes pages that surface these commands live in a
  **separate docs repo**, not this repo — those are out of scope for this
  comfy-cli README PR and would need a follow-up there if the same guidance is
  wanted on the docs site.

Closes #257
