### PR TITLE
feat(node): support --fast-deps on restore-snapshot (BE-4276)

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -218,6 +218,15 @@ def restore_snapshot(
         show_default=False,
         help="Restore for pip packages specified by local paths.",
     ),
+    fast_deps: Annotated[
+        bool,
+        typer.Option(
+            "--fast-deps",
+            show_default=False,
+            help="Use the fast (uv) dependency installer, matching `comfy install --fast-deps`. "
+            "For snapshot restore this runs the uv-compile fast path (requires ComfyUI-Manager v4.1+).",
+        ),
+    ] = False,
     uv_compile: Annotated[
         bool | None,
         typer.Option(
@@ -227,6 +236,16 @@ def restore_snapshot(
         ),
     ] = None,
 ):
+    # `--fast-deps` mirrors the `comfy install --fast-deps` UX (issue #217). cm_cli's
+    # `restore-snapshot` does NOT accept `--no-deps`, so the DependencyCompiler-based
+    # fast path used by `install`/`reinstall` is unavailable here; the fast uv path
+    # restore-snapshot *does* support is `--uv-compile` (it sets no-deps + batch-resolves
+    # with uv internally). So `--fast-deps` forwards the uv-compile fast path. Passing it
+    # alongside an explicit `--no-uv-compile` is contradictory.
+    if fast_deps and uv_compile is False:
+        typer.echo("Cannot use --fast-deps with --no-uv-compile", err=True)
+        raise typer.Exit(code=1)
+
     extras = []
 
     if pip_non_url:
@@ -238,8 +257,12 @@ def restore_snapshot(
     if pip_local_url:
         extras += ["--pip-local-url"]
 
+    effective_uv_compile = _resolve_uv_compile(uv_compile)
+    if fast_deps:
+        effective_uv_compile = True
+
     path = os.path.abspath(path)
-    execute_cm_cli(["restore-snapshot", path] + extras, uv_compile=_resolve_uv_compile(uv_compile))
+    execute_cm_cli(["restore-snapshot", path] + extras, uv_compile=effective_uv_compile)
 
 
 @app.command("restore-dependencies", help="Restore dependencies from installed custom nodes")

--- a/tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py
+++ b/tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py
@@ -1,0 +1,76 @@
+"""Tests for `comfy node restore-snapshot --fast-deps` (issue #217, BE-4276).
+
+cm_cli's `restore-snapshot` accepts `--uv-compile` but NOT `--no-deps`, so the
+DependencyCompiler-based fast path used by `install`/`reinstall` is unavailable
+there. `--fast-deps` therefore forwards the uv-compile fast path (which cm_cli's
+restore-snapshot does support). These tests pin that wiring: the flag forwards
+`uv_compile=True`, default behavior is unchanged when omitted, and the flag is
+never silently ignored.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from comfy_cli.command.custom_nodes import command as cn_command
+
+runner = CliRunner()
+
+
+def _invoke(args):
+    """Invoke restore-snapshot with execute_cm_cli mocked; return (result, call)."""
+    with patch.object(cn_command, "execute_cm_cli") as mock_exec:
+        result = runner.invoke(cn_command.app, ["restore-snapshot", *args])
+    return result, mock_exec
+
+
+def test_fast_deps_forwards_uv_compile(tmp_path):
+    """`--fast-deps` forwards the uv-compile fast path to cm_cli."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    result, mock_exec = _invoke([str(snap), "--fast-deps"])
+    assert result.exit_code == 0
+    mock_exec.assert_called_once()
+    assert mock_exec.call_args.kwargs["uv_compile"] is True
+
+
+def test_default_omitted_does_not_force_uv_compile(tmp_path):
+    """Default (no flag) is unchanged: uv_compile stays False."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    result, mock_exec = _invoke([str(snap)])
+    assert result.exit_code == 0
+    mock_exec.assert_called_once()
+    assert mock_exec.call_args.kwargs["uv_compile"] is False
+
+
+def test_explicit_uv_compile_still_works(tmp_path):
+    """The pre-existing `--uv-compile` flag is unaffected."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    result, mock_exec = _invoke([str(snap), "--uv-compile"])
+    assert result.exit_code == 0
+    assert mock_exec.call_args.kwargs["uv_compile"] is True
+
+
+def test_fast_deps_with_no_uv_compile_is_rejected(tmp_path):
+    """`--fast-deps --no-uv-compile` is contradictory and errors clearly (not ignored)."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    result, mock_exec = _invoke([str(snap), "--fast-deps", "--no-uv-compile"])
+    assert result.exit_code != 0
+    mock_exec.assert_not_called()
+
+
+def test_fast_deps_forwards_pip_extras(tmp_path):
+    """`--fast-deps` composes with the pip-restore extras (they still pass through)."""
+    snap = tmp_path / "snap.json"
+    snap.write_text("{}")
+    result, mock_exec = _invoke([str(snap), "--fast-deps", "--pip-non-url"])
+    assert result.exit_code == 0
+    args = mock_exec.call_args.args[0]
+    assert args[0] == "restore-snapshot"
+    assert "--pip-non-url" in args
+    assert mock_exec.call_args.kwargs["uv_compile"] is True


### PR DESCRIPTION
## ELI-5

`comfy install --fast-deps` uses the fast **uv** installer, but restoring a
snapshot with many custom nodes had no equivalent — so it stayed slow. This adds
a `--fast-deps` flag to `comfy node restore-snapshot` so the restore also uses
the fast uv dependency install. Requested in issue #217.

```
comfy node restore-snapshot snapshot.json --fast-deps
```

## What changed

- New `--fast-deps` option on `comfy node restore-snapshot`.
- When set, the restore forwards the **uv-compile fast path** to cm_cli.
- Default (flag omitted) behavior is **byte-for-byte unchanged**.
- Contradictory `--fast-deps --no-uv-compile` is rejected with a clear error.

## Why it maps to `--uv-compile` (the interesting bit / AC #3)

comfy-cli has two uv-based fast paths:
1. **`--fast-deps`** (install/reinstall): pass `--no-deps` to cm_cli, then run
   comfy-cli's own `DependencyCompiler`.
2. **`--uv-compile`**: pass `--uv-compile` to cm_cli, which batch-resolves with uv.

I verified against ComfyUI-Manager's actual cm_cli v4 source
(`cm_cli/__main__.py`, `manager-v4` branch): its `restore-snapshot` subcommand
accepts `--uv-compile` but **does not accept `--no-deps`** (only
`install`/`reinstall`/`fix`/`update` accept `--no-deps`). So path (1) is
**genuinely unavailable upstream** for snapshot restore — passing `--no-deps`
would make cm_cli error out.

The fast uv install that `restore-snapshot` *does* support is `--uv-compile`,
which internally does `cmd_ctx.set_no_deps(True)` + a batch uv resolve — i.e. it
already *is* the fast-deps equivalent. So `--fast-deps` forwards that path rather
than being silently ignored. On a ComfyUI-Manager older than v4.1 (no
`--uv-compile` on restore-snapshot), cm_cli surfaces its own "no such option"
error — same contract as the pre-existing `--uv-compile` flag.

## Acceptance criteria

- [x] `restore-snapshot <file> --fast-deps` accepts the flag and forwards the
  uv/fast path.
- [x] Restore uses the fast (uv) dependency install when `--fast-deps` is set;
  default behavior unchanged when omitted.
- [x] cm_cli honors it (v4.1+); never silently ignored, and the upstream
  limitation (no `--no-deps` on restore-snapshot) is documented above.

## Judgment calls

- **`restore-dependencies`** has the identical uv plumbing and could gain the
  same alias, but issue #217 and the ticket scope this to `restore-snapshot`
  only — left as an easy follow-up rather than expanding scope.
- `--fast-deps` maps to the `--uv-compile` mechanism here (not the
  `DependencyCompiler` mechanism it uses for `install`), because that is the only
  fast uv path cm_cli exposes for snapshot restore. The help text says so.

## Testing

- New `tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py` (5 tests):
  flag forwards `uv_compile=True`, default omitted stays `False`, `--uv-compile`
  still works, `--fast-deps --no-uv-compile` is rejected, pip extras compose.
- Full `tests/comfy_cli/command` + cm_cli suites: **1282 passed, 2 skipped**.
- `ruff check` + `ruff format --diff`: clean.
