### PR TITLE
feat(validate): report partner_nodes (paid) + spends_credits in comfy validate (BE-4328)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -943,6 +943,7 @@ def validate(
     from pathlib import Path
 
     from comfy_cli.command.run import is_ui_workflow
+    from comfy_cli.command.run.preflight import _detect_partner_nodes
     from comfy_cli.cql.engine import Graph, LoadError
     from comfy_cli.workflow_to_api import WorkflowConversionError, convert_ui_to_api
 
@@ -1026,6 +1027,14 @@ def validate(
 
     result = graph.validate_workflow(wf_data)
 
+    # Preview credit spend: partner-API (paid) nodes spend Comfy credits when the
+    # workflow is run. This is the same detection `comfy run` uses (authoritative
+    # `api_node: true`, `partner/...` category fallback), surfaced here read-only
+    # so agents can answer "will this spend credits?" without running. `wf_data`
+    # is API format at this point (any UI export already converted above), which
+    # is the format the detector reads. Purely informational — no exit-code gate.
+    partner_nodes = _detect_partner_nodes(wf_data, graph.object_info)
+
     payload = {
         "workflow": str(wf_path),
         "valid": result["valid"],
@@ -1033,6 +1042,8 @@ def validate(
         "warning_count": len(result["warnings"]),
         "errors": result["errors"],
         "warnings": result["warnings"],
+        "partner_nodes": partner_nodes,
+        "spends_credits": bool(partner_nodes),
     }
     if converted_from_ui:
         # Signal that validation ran against the converted graph, not the file's
@@ -1055,6 +1066,10 @@ def validate(
                 rprint(f"  [red]•[/red] node {e.get('node_id') or '?'}: {msg}")
             for w in result["warnings"]:
                 rprint(f"  [yellow]⚠[/yellow] {w.get('message', '')}")
+        if partner_nodes:
+            rprint(
+                f"[yellow]⚠ uses partner-API (paid) nodes that spend Comfy credits: {', '.join(partner_nodes)}[/yellow]"
+            )
     renderer.emit(payload, command="validate", ok=result["valid"])
 
     if not result["valid"]:

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1067,8 +1067,13 @@ def validate(
             for w in result["warnings"]:
                 rprint(f"  [yellow]⚠[/yellow] {w.get('message', '')}")
         if partner_nodes:
+            # class_type strings come from the workflow / object_info and can
+            # contain Rich-markup metacharacters (e.g. `[/yellow]`); escape each
+            # so an odd node name can't raise MarkupError and crash the command.
+            from rich.markup import escape as _escape
+
             rprint(
-                f"[yellow]⚠ uses partner-API (paid) nodes that spend Comfy credits: {', '.join(partner_nodes)}[/yellow]"
+                f"[yellow]⚠ uses partner-API (paid) nodes that spend Comfy credits: {', '.join(_escape(n) for n in partner_nodes)}[/yellow]"
             )
     renderer.emit(payload, command="validate", ok=result["valid"])
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -293,6 +293,39 @@ Without `--wait` (the default), the stream ends at the `queued` envelope
 watcher keeps the state file updated; follow up with
 `comfy jobs watch <prompt_id>` or `comfy jobs status <prompt_id>`.
 
+## `comfy validate --json` envelope
+
+`comfy validate --workflow <file> --json` checks a workflow without submitting
+it and emits a single envelope (no event stream). On a valid workflow `ok` is
+`true` and `data` carries:
+
+| Field                  | Type          | Description                                                                                     |
+| ---------------------- | ------------- | ----------------------------------------------------------------------------------------------- |
+| `workflow`             | str           | Absolute path of the validated workflow file                                                    |
+| `valid`                | bool          | Whether the graph passed validation (also the envelope `ok`)                                     |
+| `error_count`          | number        | Number of entries in `errors`                                                                    |
+| `warning_count`        | number        | Number of entries in `warnings`                                                                  |
+| `errors`               | array of dict | Per-node validation errors (empty when `valid`)                                                  |
+| `warnings`             | array of dict | Non-fatal validation warnings                                                                    |
+| `partner_nodes`        | array of str  | Sorted class_types in the workflow that are partner-API (paid) nodes. **Always present**; `[]` when none |
+| `spends_credits`       | bool          | `true` iff `partner_nodes` is non-empty — a convenience flag for "will this workflow spend Comfy credits?" |
+| `converted_from_ui`    | bool          | Present and `true` only when the input was a UI export that was lowered to API format before validating |
+| `converted_node_count` | number        | Present only alongside `converted_from_ui`: node count of the converted graph                    |
+
+`partner_nodes` / `spends_credits` are **informational only** — they never
+change validate's exit code (validate stays advisory; the credit-spend gate
+lives in `comfy run`). Detection is the same authoritative `api_node: true`
+flag (with a `partner/...` category fallback) that `comfy run` uses, run over
+the loaded `object_info`; in offline `--input` mode where the `object_info`
+lacks `api_node` flags the list is simply empty (fail-open). When
+`spends_credits` is `true`, pretty (non-`--json`) mode also prints a yellow
+`⚠ uses partner-API (paid) nodes …` line after the verdict.
+
+Invalid workflows emit `ok: false` with the same `data` fields (`valid: false`,
+a populated `errors` array, `partner_nodes`/`spends_credits` still present) and
+exit code `1`. Structural failures (missing file, non-object JSON, an
+unconvertible UI export) emit an [error object](#error-object) instead.
+
 ## Error object
 
 Every failure envelope carries:

--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -288,3 +288,23 @@ def test_invalid_workflow_still_reports_partner_nodes(runner, tmp_path):
     assert any(e["code"] == "unknown_class_type" for e in data["errors"])
     assert data["partner_nodes"] == ["AcmePartnerImage"]
     assert data["spends_credits"] is True
+
+
+def test_partner_node_name_with_markup_does_not_crash_pretty(runner, tmp_path):
+    """Regression: a partner `class_type` containing Rich-markup metacharacters
+    (e.g. `[/yellow]`) is escaped before it reaches `rprint`, so the pretty-mode
+    advisory line can't raise `MarkupError` and crash the command."""
+    name = "Acme[/yellow]Node"
+    oi = _write(tmp_path, "oi.json", {name: _node_info(category="image", api_node=True)})
+    wf = _write(tmp_path, "wf.json", {"1": {"class_type": name, "inputs": {}}})
+
+    result = runner.invoke(
+        app,
+        ["--no-json", "validate", "--workflow", str(wf), "--input", str(oi)],
+        env={"COMFY_WHERE": "local"},
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert result.exception is None, result.exception
+    # The name is still shown (escaped) in the paid-nodes advisory.
+    assert name in result.stdout

--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -169,3 +169,122 @@ def test_empty_dict_payload_not_converted_and_rejected(runner, tmp_path):
     assert "converted_from_ui" not in data
     assert data["valid"] is False
     assert any(e["code"] == "prompt_no_outputs" for e in data["errors"])
+
+
+# --- partner-node (paid) visibility (BE-4328) -----------------------------------
+#
+# `comfy validate` now previews credit spend: it reports `partner_nodes` (the
+# partner-API nodes a workflow uses) and `spends_credits` in its payload, using
+# the same detection `comfy run` gates on (authoritative `api_node: true`, with a
+# `partner/...` category fallback). It stays advisory — no exit-code change.
+#
+# These tests build a minimal object_info per case (a partner node needs only to
+# exist, be an output node, and have no required inputs to validate clean), so the
+# detection is exercised without depending on any real partner node's full schema.
+
+
+def _validate_against(runner: CliRunner, workflow: Path, object_info: Path):
+    """`comfy --json validate` offline against a caller-supplied object_info."""
+    return runner.invoke(
+        app,
+        ["--json", "validate", "--workflow", str(workflow), "--input", str(object_info)],
+        env={"COMFY_WHERE": "local"},
+    )
+
+
+def _node_info(*, category: str, api_node: bool | None = None) -> dict:
+    """A minimal output-node object_info entry with no required inputs — it
+    validates clean, so a one-node workflow using it is `valid: true`."""
+    info = {"input": {"required": {}}, "output": [], "output_node": True, "category": category}
+    if api_node is not None:
+        info["api_node"] = api_node
+    return info
+
+
+def test_partner_node_via_api_node_flag(runner, tmp_path):
+    """A valid API workflow whose node carries the authoritative `api_node: true`
+    flag → `partner_nodes` lists it, `spends_credits` is true, and the exit code
+    is unchanged (0, since the workflow is otherwise valid)."""
+    oi = _write(tmp_path, "oi.json", {"AcmePartnerImage": _node_info(category="image", api_node=True)})
+    wf = _write(tmp_path, "wf.json", {"1": {"class_type": "AcmePartnerImage", "inputs": {}}})
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["valid"] is True
+    assert data["partner_nodes"] == ["AcmePartnerImage"]
+    assert data["spends_credits"] is True
+
+
+def test_no_partner_nodes_is_empty_list(runner, tmp_path):
+    """A workflow with no partner nodes → `partner_nodes: []` (always present)
+    and `spends_credits: false`."""
+    oi = _write(tmp_path, "oi.json", {"PlainSave": _node_info(category="image")})
+    wf = _write(tmp_path, "wf.json", {"1": {"class_type": "PlainSave", "inputs": {}}})
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["valid"] is True
+    assert data["partner_nodes"] == []
+    assert data["spends_credits"] is False
+
+
+def test_partner_node_via_category_prefix_fallback(runner, tmp_path):
+    """A node with a `partner/...` category and no `api_node` flag is still
+    detected via the category-prefix fallback."""
+    oi = _write(tmp_path, "oi.json", {"AcmeVideo": _node_info(category="partner/video/Acme")})
+    wf = _write(tmp_path, "wf.json", {"1": {"class_type": "AcmeVideo", "inputs": {}}})
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["partner_nodes"] == ["AcmeVideo"]
+    assert data["spends_credits"] is True
+
+
+def test_partner_detection_runs_on_converted_ui_graph(runner, tmp_path):
+    """A UI-format workflow using a partner node: detection runs on the CONVERTED
+    (API-format) graph, so the partner node still surfaces alongside
+    `converted_from_ui: true`."""
+    oi = _write(tmp_path, "oi.json", {"AcmePartnerImage": _node_info(category="image", api_node=True)})
+    ui = {
+        "nodes": [{"id": 1, "type": "AcmePartnerImage", "mode": 0, "inputs": [], "outputs": [], "widgets_values": []}],
+        "links": [],
+    }
+    wf = _write(tmp_path, "ui.json", ui)
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["converted_from_ui"] is True
+    assert data["partner_nodes"] == ["AcmePartnerImage"]
+    assert data["spends_credits"] is True
+
+
+def test_invalid_workflow_still_reports_partner_nodes(runner, tmp_path):
+    """An invalid workflow that also uses a partner node: both `errors` and
+    `partner_nodes` are present (visibility is independent of validity), and the
+    exit code is 1 because of the error — not because of the partner node."""
+    oi = _write(tmp_path, "oi.json", {"AcmePartnerImage": _node_info(category="image", api_node=True)})
+    wf = _write(
+        tmp_path,
+        "wf.json",
+        {
+            "1": {"class_type": "AcmePartnerImage", "inputs": {}},
+            "2": {"class_type": "TotallyUnknownNode", "inputs": {}},
+        },
+    )
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 1
+    data = _envelope(result)["data"]
+    assert data["valid"] is False
+    assert any(e["code"] == "unknown_class_type" for e in data["errors"])
+    assert data["partner_nodes"] == ["AcmePartnerImage"]
+    assert data["spends_credits"] is True


### PR DESCRIPTION
## ELI-5

Before you run a workflow, `comfy validate` tells you if it's structurally OK. But some nodes are "partner-API" (paid) nodes — running them spends Comfy credits. Until now `validate` never told you that; the only way to find out was to try to `run` it and hit a credential error. This PR makes `validate` **preview the spend**: it now reports which paid nodes a workflow uses (`partner_nodes`) and a simple `spends_credits` yes/no flag, so an agent (or a human) can answer "will this cost me credits?" *without* running anything. It's purely informational — it never changes whether validation passes.

## What changed

`comfy validate` now, after loading the graph (and after any UI→API conversion), runs the same partner-node detection `comfy run` already uses — the authoritative `api_node: true` flag from `object_info`, with a `partner/...` category-prefix fallback (`_detect_partner_nodes`, reused from `comfy_cli/command/run/preflight.py`). Two fields are added to the emitted payload:

- **`partner_nodes`** — sorted list of the workflow's partner-API node class_types. **Always present**; `[]` when none.
- **`spends_credits`** — `bool(partner_nodes)`.

In pretty (non-`--json`) mode, when non-empty, a yellow line prints after the valid/invalid verdict:

```
⚠ uses partner-API (paid) nodes that spend Comfy credits: <comma-joined names>
```

Both fields are documented in a new `comfy validate --json` section in `docs/json-output.md`.

**Advisory only — this is pure visibility.** No exit-code change, no gate; validate stays advisory and the enforcement gate remains in `comfy run` (this ticket is independent of that gate). Detection runs over the loaded `object_info`, so offline `--input` mode works unchanged and fails open (empty list) when the object_info lacks `api_node` flags — the same posture `comfy run` takes.

## Tests

Extended `tests/comfy_cli/command/test_validate_command.py` (11 pass):

1. API workflow with an `api_node: true` node → `partner_nodes` contains it, `spends_credits` true, exit 0 (otherwise-valid).
2. No partner nodes → `partner_nodes: []`, `spends_credits: false`.
3. Category-prefix fallback (`partner/video/…`, no `api_node` flag) → detected.
4. UI-format workflow → detection runs on the **converted** graph.
5. Invalid workflow with a partner node → both `errors` and `partner_nodes` present, exit 1 (from the error, not the partner node).

Also verified `tests/comfy_cli/command/test_run.py`, `cql/test_engine.py`, `test_run_template.py`, and `tests/comfy_cli/output/` (envelope schemas) all still pass; `ruff check` + `ruff format --check` clean.

## Judgment calls

- **Detection reuses the "private" `_detect_partner_nodes`** — imported from `comfy_cli.command.run.preflight` exactly as the ticket specified (also re-exported from `comfy_cli.command.run`), keeping one source of truth for detection across `run` and `validate`.
- **`docs/json-output.md` had no existing `validate` section** (the doc is `comfy run`-centric and never documented validate's payload). Rather than document just the two fields in a non-existent section, I added a concise `comfy validate --json` section covering the full validate payload (including the pre-existing `converted_from_ui` / `converted_node_count` fields), with the two new fields called out.
- **Not a capability-denial change** (negative-claim falsification N/A): this diff only *adds* visibility — no "unsupported"/deny/dead-end path.
