### PR TITLE
refactor(uv): delete dead 'dists' packaging path (BE-4351)

### DIFF
--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -325,42 +325,6 @@ class DependencyCompiler:
         return _check_call(cmd, cwd)
 
     @staticmethod
-    def Download(
-        cwd: PathLike,
-        executable: PathLike = sys.executable,
-        extraUrl: str | None = None,
-        noDeps: bool = False,
-        out: PathLike | None = None,
-        reqs: list[str] | None = None,
-        reqFile: list[PathLike] | None = None,
-    ) -> None:
-        """For now, the `download` cmd has no uv support, so use pip"""
-        cmd = [
-            str(executable),
-            "-m",
-            "pip",
-            "download",
-        ]
-
-        if extraUrl is not None:
-            cmd.extend(["--extra-index-url", extraUrl])
-
-        if noDeps:
-            cmd.append("--no-deps")
-
-        if out is not None:
-            cmd.extend(["-d", str(out)])
-
-        if reqs is not None:
-            cmd.extend(reqs)
-
-        if reqFile is not None:
-            for rf in reqFile:
-                cmd.extend(["--requirement", rf])
-
-        return _check_call(cmd, cwd)
-
-    @staticmethod
     def Wheel(
         cwd: PathLike,
         executable: PathLike = sys.executable,
@@ -577,26 +541,6 @@ class DependencyCompiler:
             reqFile=[self.out],
         )
 
-    def install_dists(self):
-        DependencyCompiler.Install(
-            cwd=self.cwd,
-            executable=self.executable,
-            find_links=[self.outDir / "dists"],
-            no_deps=True,
-            no_index=True,
-            reqFile=[self.out],
-        )
-
-    def install_wheels(self):
-        DependencyCompiler.Install(
-            cwd=self.cwd,
-            executable=self.executable,
-            find_links=[self.outDir / "wheels"],
-            no_deps=True,
-            no_index=True,
-            reqFile=[self.out],
-        )
-
     def install_wheels_directly(self):
         DependencyCompiler.Install(
             cwd=self.cwd,
@@ -604,29 +548,6 @@ class DependencyCompiler:
             no_deps=True,
             no_index=True,
             reqs=(self.outDir / "wheels").glob("*.whl"),
-        )
-
-    def sync_core_plus_ext(self):
-        DependencyCompiler.Sync(
-            cwd=self.cwd,
-            reqFile=[self.out],
-            executable=self.executable,
-            extraUrl=self.gpuUrl,
-        )
-
-    def fetch_dep_dists(self, skip_uv: bool = False):
-        skips = ["uv"] if skip_uv else None
-        reqs = parse_req_file(self.out, skips=skips)
-
-        extraUrl = None if "--extra-index-url" in reqs else self.gpuUrl
-
-        DependencyCompiler.Download(
-            cwd=self.cwd,
-            executable=self.executable,
-            extraUrl=extraUrl,
-            noDeps=True,
-            out=self.outDir / "dists",
-            reqs=reqs,
         )
 
     def fetch_dep_wheels(self, skip_uv: bool = False):


### PR DESCRIPTION
## ELI-5

`comfy-cli` has a helper class (`DependencyCompiler` in `uv.py`) that knows how to fetch and install Python packages for a Comfy workspace. Over time it grew **two parallel ways** to do the same job:

- a **wheels** path (fetch pre-built `.whl` files, then install them), and
- a **dists/sdists** path (fetch source distributions via `pip download`, then install them).

Only the **wheels** path is actually wired up and used (by `standalone.py`). The **dists** path — five methods totaling ~80 lines — is never called from anywhere, has no tests, and had already drifted out of sync with the live path. This PR deletes that dead half. Nothing users can do changes; there's just less unused code to trip over.

## What changed

Deleted from `comfy_cli/uv.py` (pure removal, no behavior change):

- `DependencyCompiler.Download` (static method) — a near-duplicate of the kept `Wheel` method, differing only in the pip subcommand (`download` vs `wheel`) and output flag (`-d` vs `-w`). Its **only** caller was `fetch_dep_dists`.
- `fetch_dep_dists`
- `install_dists`
- `install_wheels` (note: **not** `install_wheels_directly`, which is the live one and is kept)
- `sync_core_plus_ext`

**Kept untouched** (the live wheels path): `Wheel`, `fetch_dep_wheels`, `install_wheels_directly`, `install_deps`, `compile_deps`. The live install flow is `standalone.py` → `fetch_dep_wheels` (→ `Wheel`) → `install_wheels_directly`.

## Why it's safe

- **Zero call sites.** Word-boundary grep for each deleted symbol across the **entire repo** (not just `comfy_cli/` + `tests/`) — including string literals and any dynamic dispatch — returns nothing outside `uv.py`. No `getattr`-style dispatch on `DependencyCompiler` exists.
- **Live path preserved.** `standalone.py` only references `compile_deps`, `fetch_dep_wheels`, `install_wheels_directly`, and `install_deps`, all unchanged.
- **Full test suite green:** `2769 passed, 37 skipped`. `ruff check` + `ruff format --diff` clean.
- Git history preserves the sdist path if a future offline-install feature on wheel-less platforms ever wants it.

## Judgment call / follow-up

- `DependencyCompiler.Sync` (a low-level static pip-`sync` wrapper) is left in place. Its only caller was the now-deleted `sync_core_plus_ext`, so it becomes newly-orphaned by this change. It was **not** in the ticket's explicit deletion list (which enumerated exactly 5 symbols), so I kept the diff scoped and did not delete it as a drive-by — it sits alongside the other primitive pip wrappers (`Install`, `Compile`, `Wheel`). Flagging it as a candidate for a small follow-up cleanup if desired.

## Testing

- `uv run --locked --extra dev pytest -q` → `2769 passed, 37 skipped`
- `ruff check comfy_cli/uv.py` → All checks passed
- `ruff format --diff comfy_cli/uv.py` → already formatted
