### PR TITLE
refactor: sweep dead-code cluster — unused Graph query API, vestigial installers, orphaned helpers (BE-4354)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -351,13 +351,6 @@ def entry(
             )
         ctx.exit()
 
-    # TODO: Move this to proper place
-    # start_time = time.time()
-    # workspace_manager.scan_dir()
-    # end_time = time.time()
-    #
-    # logging.info(f"scan_dir took {end_time - start_time:.2f} seconds to run")
-
 
 def validate_commit_and_version(commit: str | None, ctx: typer.Context) -> str | None:
     """
@@ -1158,12 +1151,6 @@ def run_cli(
     raise typer.Exit(
         code=run_cli_inner.execute(pause_seconds=effective_pause, no_cleanup=no_cleanup, show_agent=show_agent)
     )
-
-
-def validate_comfyui(_env_checker):
-    if _env_checker.comfy_repo is None:
-        rprint("[bold red]If ComfyUI is not installed, this feature cannot be used.[/bold red]")
-        raise typer.Exit(code=1)
 
 
 @app.command(help="Stop background ComfyUI")

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -543,41 +543,13 @@ class Graph:
         result.sort(key=lambda m: m.id)
         return result
 
-    def pack_nodes(self, pack: str) -> list[Morphism]:
-        """All nodes belonging to a custom-node pack (case-insensitive)."""
-        p = pack.lower()
-        return sorted([m for m in self._nodes.values() if m.pack.lower() == p], key=lambda m: m.id)
-
-    def label_nodes(self, label: str) -> list[Morphism]:
-        """All nodes carrying a specific behavioral label."""
-        return sorted([m for m in self._nodes.values() if label in m.labels], key=lambda m: m.id)
-
-    def cloud_disabled_nodes(self) -> list[Morphism]:
-        """All nodes that are disabled on Comfy Cloud."""
-        return sorted([m for m in self._nodes.values() if m.cloud_disabled], key=lambda m: m.id)
-
     def cloud_enabled_nodes(self) -> list[Morphism]:
         """All nodes that are enabled on Comfy Cloud."""
         return sorted([m for m in self._nodes.values() if not m.cloud_disabled], key=lambda m: m.id)
 
-    def api_nodes(self) -> list[Morphism]:
-        """All partner API nodes."""
-        return sorted([m for m in self._nodes.values() if m.is_api_node], key=lambda m: m.id)
-
-    def output_nodes(self) -> list[Morphism]:
-        """All terminal output nodes (SaveImage, etc.)."""
-        return sorted([m for m in self._nodes.values() if m.is_output_node], key=lambda m: m.id)
-
     def packs(self) -> list[str]:
         """All known pack names, sorted."""
         return sorted(set(m.pack for m in self._nodes.values() if m.pack))
-
-    def known_labels(self) -> list[str]:
-        """All known labels, sorted."""
-        labels: set[str] = set()
-        for m in self._nodes.values():
-            labels.update(m.labels)
-        return sorted(labels)
 
     def find_paths(
         self,

--- a/comfy_cli/cql/errors.py
+++ b/comfy_cli/cql/errors.py
@@ -24,6 +24,3 @@ class CQLRuntimeError(Exception):
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.runtime_message
-
-    def as_details(self) -> dict[str, Any]:
-        return {**self.details, "runtime_message": self.runtime_message}

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -105,9 +105,6 @@ class EnvChecker:
         self.python_version = sys.version_info
         self.check()
 
-    def is_isolated_env(self):
-        return self.virtualenv_path or self.conda_env
-
     def get_isolated_env(self):
         if self.virtualenv_path:
             return self.virtualenv_path

--- a/comfy_cli/standalone.py
+++ b/comfy_cli/standalone.py
@@ -167,18 +167,6 @@ class StandalonePython:
     def uv_install(self, *args: str):
         self.run_module("uv", "pip", "install", *args)
 
-    def install_comfy_cli(self, dev: bool = False):
-        if dev:
-            self.uv_install(str(_here.parent))
-        else:
-            self.uv_install("comfy_cli")
-
-    def run_comfy_cli(self, *args: str):
-        self.run_module("comfy_cli", *args)
-
-    def install_comfy(self, *args: str, gpu_arg: str = "--nvidia"):
-        self.run_comfy_cli("--here", "--skip-prompt", "install", "--fast-deps", gpu_arg, *args)
-
     def dehydrate_comfy_deps(
         self,
         comfyDir: PathLike,

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -38,26 +38,6 @@ def show_progress(iterable, total, description="Downloading..."):
 ChoiceType = str | Choice | dict[str, Any]
 
 
-def prompt_autocomplete(
-    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
-) -> ChoiceType | None:
-    """
-    Asks a single select question using questionary and returns the selected response.
-
-    Args:
-        question (str): The question to display to the user.
-        choices (List[ChoiceType]): A list of choices the user can autocomplete from.
-        default (ChoiceType): Default choice.
-        force_prompting (bool): Whether to force prompting even if skip_prompting is set.
-
-    Returns:
-        Optional[ChoiceType]: The selected choice from the user, or None if skipping prompts.
-    """
-    if workspace_manager.skip_prompting and not force_prompting:
-        return None
-    return questionary.autocomplete(question, choices=choices, default=default).ask()
-
-
 def prompt_select(
     question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
 ) -> ChoiceType | None:

--- a/comfy_cli/update.py
+++ b/comfy_cli/update.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import time
-from importlib.metadata import metadata
 from pathlib import Path
 
 import requests
@@ -38,11 +37,6 @@ def check_for_newer_pypi_version(package_name, current_version):
     except requests.RequestException as e:
         logger.warning(f"Failed to check for updates: {e}")
         return False, current_version
-
-
-def get_version_from_pyproject():
-    package_metadata = metadata("comfy-cli")
-    return package_metadata["Version"]
 
 
 def upgrade_cli():

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -5,7 +5,6 @@ Module for utility functions.
 import functools
 import platform
 import shutil
-import subprocess
 import tarfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -13,16 +12,11 @@ from typing import BinaryIO, cast
 
 import psutil
 import requests
-import typer
 from rich import progress
 from rich.live import Live
 from rich.table import Table
 
 from comfy_cli.constants import DEFAULT_COMFY_WORKSPACE, OS, PROC
-
-# Use the output shim so prints go to stderr (not stdout) in JSON mode,
-# preserving the one-envelope-on-stdout contract.
-from comfy_cli.output import rprint as print  # noqa: A001 - intentional shadowing
 from comfy_cli.typing import PathLike
 
 
@@ -68,15 +62,6 @@ def get_proc():
         return PROC.ARM
     else:
         raise ValueError
-
-
-def install_conda_package(package_name):
-    try:
-        subprocess.check_call(["conda", "install", "-y", package_name])
-        print(f"[bold green] Successfully installed {package_name} [/bold green]")
-    except subprocess.CalledProcessError as e:
-        print(f"[bold red] Failed to install {package_name}. Error: {e} [/bold red]")
-        raise typer.Exit(code=1)
 
 
 def get_not_user_set_default_workspace():


### PR DESCRIPTION
## ELI-5

Some code in comfy-cli was written but never actually used anywhere — a handful of
query helpers on the CQL `Graph`, two installer methods, a couple of module-level
helper functions, and a commented-out `TODO` block. Nothing calls them. This PR
deletes that dead code (~100 lines removed) so the codebase carries less unused
surface. Git history keeps it if it's ever wanted again.

## What & why

Dead-code cluster sweep (BE-4354). Every deleted symbol was re-verified as
**zero-reference** by a word-boundary grep across the whole repo (`*.py`, `*.toml`,
`*.md`) immediately before deletion, and `cql/engine.py` was confirmed to contain no
`getattr`/`__getattr__` dynamic dispatch that could reach the Graph methods.

Deleted:

- **`cql/engine.py`** `Graph`: `pack_nodes`, `label_nodes`, `cloud_disabled_nodes`,
  `api_nodes`, `output_nodes`, `known_labels`. The live siblings
  (`cloud_enabled_nodes`, `packs`, `downstream`, `find_paths`) are untouched.
- **`standalone.py`**: `install_comfy_cli`, `install_comfy` (both orphaned; the
  `StandalonePython` class stays live via other paths).
- **`cmdline.py`**: `validate_comfyui` (plain function, no decorator, no callers) and
  the commented-out `scan_dir` `# TODO: Move this to proper place` block.
- **`update.py`**: `get_version_from_pyproject`.
- **`ui.py`**: `prompt_autocomplete`.
- **`utils.py`**: `install_conda_package`.
- **`env_checker.py`**: `EnvChecker.is_isolated_env` (`get_isolated_env` stays).
- **`cql/errors.py`**: `CQLRuntimeError.as_details`.

## Judgment calls (consequential cleanups beyond the ticket's literal list)

To keep the tree lint-clean and free of code my own deletions orphaned:

- **`standalone.py` `run_comfy_cli`** — its only caller was the deleted `install_comfy`,
  so it became zero-reference; removed it too.
- **Now-unused imports removed**: `update.py` `from importlib.metadata import metadata`;
  `utils.py` `subprocess`, `typer`, and the `rprint as print` shim — each was used
  *only* by a function deleted here. `ruff check` on the changed files passes with these
  removed.

## Testing

- `ruff check` + `ruff format --check` on all changed files: **clean**. (The 16
  pre-existing `UP038` errors in the untouched `workflow_to_api.py` are unrelated to
  this PR.)
- Full suite: `uv run --extra dev pytest -q` → **2769 passed, 37 skipped** (exit 0).

Note on the negative-claim/falsification check: this is a pure deletion of *unused*
code. No user-reachable capability is denied — the removed symbols had zero call sites,
so no product path invoked them.
