### PR TITLE
refactor(install): dedupe manager-install fallback and normalize exit conventions (BE-4356)

### DIFF
--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -81,7 +81,7 @@ def pip_install_comfyui_dependencies(
 
         if result and result.returncode != 0:
             rprint("Failed to install PyTorch dependencies. Please check your environment (`comfy env`) and try again")
-            sys.exit(1)
+            raise typer.Exit(code=1)
 
         # install directml for AMD windows
         if gpu == GPU_OPTION.AMD and plat == constants.OS.WINDOWS:
@@ -111,7 +111,7 @@ def pip_install_comfyui_dependencies(
     result = subprocess.run([python, "-m", "pip", "install", "-r", "requirements.txt"], check=False)
     if result.returncode != 0:
         rprint("Failed to install ComfyUI dependencies. Please check your environment (`comfy env`) and try again.")
-        sys.exit(1)
+        raise typer.Exit(code=1)
 
 
 def pip_install_manager(repo_dir, python=sys.executable):
@@ -141,6 +141,26 @@ def pip_install_manager(repo_dir, python=sys.executable):
     # Clear cache so find_cm_cli() picks up the newly installed module
     find_cm_cli.cache_clear()
     return True
+
+
+def _install_manager_with_fallback(repo_dir, python, *, bootstrap_pip: bool):
+    """Install ComfyUI-Manager, degrading gracefully when it fails.
+
+    On failure, disable the manager GUI mode so a later ``comfy launch`` doesn't
+    inject manager flags for a manager that isn't actually installed.
+
+    ``bootstrap_pip`` bootstraps pip first (no-op if already present): the
+    fast_deps path leaves a uv-managed venv that may ship no pip, whereas the
+    pip path has already bootstrapped it earlier in ``execute``.
+    """
+    if bootstrap_pip:
+        ensure_pip(python)
+    if not pip_install_manager(repo_dir, python=python):
+        # Manager installation failed - disable to prevent launch issues
+        from comfy_cli.config_manager import ConfigManager
+
+        ConfigManager().set(constants.CONFIG_KEY_MANAGER_GUI_MODE, "disable")
+        rprint("[yellow]Manager not installed. Launch will run without manager flags.[/yellow]")
 
 
 def execute(
@@ -189,7 +209,7 @@ def execute(
             checkout_stable_comfyui(version=version, repo_dir=repo_dir, url=url)
         except GitHubRateLimitError as e:
             rprint(f"[bold red]Error checking out ComfyUI version: {e}[/bold red]")
-            sys.exit(1)
+            raise typer.Exit(code=1) from e
 
     elif not check_comfy_repo(repo_dir)[0]:
         # Get actual remote URL for better error message
@@ -208,7 +228,7 @@ def execute(
             rprint(
                 f"[bold red]'{repo_dir}' already exists. But it is an invalid ComfyUI repository. Remove it and retry.[/bold red]"
             )
-        sys.exit(-1)
+        raise typer.Exit(code=1)
 
     # checkout specified commit
     if commit is not None:
@@ -249,12 +269,8 @@ def execute(
     else:
         rprint("\nInstalling ComfyUI-Manager..")
         if not fast_deps:
-            if not pip_install_manager(repo_dir, python=python):
-                # Manager installation failed - disable to prevent launch issues
-                from comfy_cli.config_manager import ConfigManager
-
-                ConfigManager().set(constants.CONFIG_KEY_MANAGER_GUI_MODE, "disable")
-                rprint("[yellow]Manager not installed. Launch will run without manager flags.[/yellow]")
+            # pip was already bootstrapped above for the pip path.
+            _install_manager_with_fallback(repo_dir, python, bootstrap_pip=False)
 
     if fast_deps:
         if python != sys.executable:
@@ -281,14 +297,9 @@ def execute(
         depComp.install_deps()
         # Install manager separately (not included in DependencyCompiler).
         # fast_deps leaves a uv-managed venv that may have no pip, but the
-        # manager install uses pip — bootstrap it first (no-op if present).
+        # manager install uses pip — the helper bootstraps it first.
         if not skip_manager:
-            ensure_pip(python)
-            if not pip_install_manager(repo_dir, python=python):
-                from comfy_cli.config_manager import ConfigManager
-
-                ConfigManager().set(constants.CONFIG_KEY_MANAGER_GUI_MODE, "disable")
-                rprint("[yellow]Manager not installed. Launch will run without manager flags.[/yellow]")
+            _install_manager_with_fallback(repo_dir, python, bootstrap_pip=True)
 
     if not skip_manager:
         try:
@@ -582,7 +593,7 @@ def checkout_stable_comfyui(version: str, repo_dir: str, url: str | None = None)
             selected_release = get_latest_release(owner, repo)
             if selected_release is None:
                 rprint(f"Error: No release found for version '{version}'.")
-                sys.exit(1)
+                raise typer.Exit(code=1)
             tag = str(selected_release["tag"])
         elif not fetch_ok:
             # Tag list comes from a cached state — flag it so the user knows
@@ -609,7 +620,7 @@ def checkout_stable_comfyui(version: str, repo_dir: str, url: str | None = None)
         if not success:
             console.print(f"\n[bold red]Failed to checkout tag '{tag}'![/bold red]")
             console.print("[yellow]The version may not exist. Please check available versions.[/yellow]")
-            sys.exit(1)
+            raise typer.Exit(code=1)
 
 
 def get_latest_release(repo_owner: str, repo_name: str) -> GithubRelease | None:

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import requests
+import typer
 from typer.testing import CliRunner
 
 from comfy_cli.cmdline import app, g_exclusivity, g_gpu_exclusivity
@@ -946,7 +947,7 @@ class TestCheckoutStableComfyUI:
     @patch("comfy_cli.command.install.get_latest_release", return_value=None)
     @patch("comfy_cli.command.install._resolve_latest_tag_from_local", return_value=(None, True))
     def test_latest_exits_when_both_local_and_api_fail(self, mock_local, mock_api, mock_co):
-        with pytest.raises(SystemExit):
+        with pytest.raises(typer.Exit):
             checkout_stable_comfyui("latest", "/repo")
         mock_co.assert_not_called()
 

--- a/tests/comfy_cli/test_install.py
+++ b/tests/comfy_cli/test_install.py
@@ -2,7 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from comfy_cli.command.install import pip_install_manager, validate_version
+from comfy_cli import constants
+from comfy_cli.command.install import _install_manager_with_fallback, pip_install_manager, validate_version
 
 
 def test_validate_version_nightly():
@@ -59,6 +60,36 @@ class TestPipInstallManager:
         mock_run.return_value = MagicMock(returncode=1, stderr="")
         result = pip_install_manager("/fake/repo")
         assert result is False
+
+
+class TestInstallManagerWithFallback:
+    """The dedupe'd manager-install-and-degrade helper shared by the pip and
+    fast_deps paths of ``execute`` (BE-4356)."""
+
+    @patch("comfy_cli.config_manager.ConfigManager")
+    @patch("comfy_cli.command.install.pip_install_manager", return_value=True)
+    @patch("comfy_cli.command.install.ensure_pip")
+    def test_bootstrap_pip_true_bootstraps_and_installs(self, mock_ensure_pip, mock_install, mock_cfg):
+        _install_manager_with_fallback("/fake/repo", "python", bootstrap_pip=True)
+        mock_ensure_pip.assert_called_once_with("python")
+        mock_install.assert_called_once_with("/fake/repo", python="python")
+        # Success: manager GUI mode is left untouched.
+        mock_cfg.return_value.set.assert_not_called()
+
+    @patch("comfy_cli.config_manager.ConfigManager")
+    @patch("comfy_cli.command.install.pip_install_manager", return_value=True)
+    @patch("comfy_cli.command.install.ensure_pip")
+    def test_bootstrap_pip_false_skips_bootstrap(self, mock_ensure_pip, mock_install, mock_cfg):
+        _install_manager_with_fallback("/fake/repo", "python", bootstrap_pip=False)
+        mock_ensure_pip.assert_not_called()
+        mock_install.assert_called_once_with("/fake/repo", python="python")
+
+    @patch("comfy_cli.config_manager.ConfigManager")
+    @patch("comfy_cli.command.install.pip_install_manager", return_value=False)
+    @patch("comfy_cli.command.install.ensure_pip")
+    def test_failure_disables_manager_gui_mode(self, mock_ensure_pip, mock_install, mock_cfg):
+        _install_manager_with_fallback("/fake/repo", "python", bootstrap_pip=False)
+        mock_cfg.return_value.set.assert_called_once_with(constants.CONFIG_KEY_MANAGER_GUI_MODE, "disable")
 
 
 # Run the tests


### PR DESCRIPTION
## ELI-5

When you run `comfy install`, the tool installs ComfyUI-Manager and, if that
install fails, quietly turns the manager off so a later launch doesn't try to
use something that isn't there. That little "install-or-degrade" dance was
written out **twice** — once for the normal pip path and once for the
`--fast-deps` path — and the two copies had already started to drift. This PR
folds them into one shared helper so they can't drift again.

While in the file, it also makes the module exit the way the rest of the
codebase does: `raise typer.Exit(code=1)` instead of `sys.exit(...)`.

## What changed

1. **Dedupe the manager-install fallback.** New module-private helper
   `_install_manager_with_fallback(repo_dir, python, *, bootstrap_pip: bool)`
   holds the single copy of "install the manager; on failure disable the
   manager GUI mode and warn." Both call sites in `execute()` (the pip path and
   the `fast_deps` path) now call it. The only behavioral difference between the
   old copies — the `fast_deps` path calls `ensure_pip(python)` first because
   its uv-managed venv may ship no pip, while the pip path already bootstrapped
   pip earlier — is preserved via the `bootstrap_pip` flag (`False` for the pip
   path, `True` for `fast_deps`). Pure code motion; no behavior change.

2. **Normalize exit conventions.** The module's six `sys.exit(...)` calls are
   now `raise typer.Exit(code=1)`, matching the convention used broadly
   elsewhere in the codebase. All of these already propagate straight up to
   `main()`, which re-raises both `typer.Exit` and `SystemExit` identically, so
   the exit code is unchanged (1) for five of them.

## ⚠️ One intentional observable change

`sys.exit(-1)` on the "path exists but isn't a recognized ComfyUI repo" branch
previously produced shell exit code **255** (a negative arg wraps to 255); it
now produces **1**, like every other failure in the module. This is the only
user-visible change and is a deliberate normalization.

## Notes / judgment calls

- **Deferred as ticketed:** the full `_install_deps_pip` / `_install_deps_fast`
  two-strategy extraction is intentionally **not** done here — install is the
  highest-blast-radius command and the groom verdict downgraded scope to just
  the concrete dedupe + exit normalization. Defer that split until install next
  changes for feature reasons.
- **Test update:** `typer.Exit` is **not** a subclass of `SystemExit`, so the
  one existing test asserting `pytest.raises(SystemExit)` on
  `checkout_stable_comfyui` was updated to `pytest.raises(typer.Exit)`. I
  verified none of the six exit sites sit inside a broad `except Exception:` in
  their call path (which would newly swallow a `typer.Exit` where `SystemExit`
  escaped) — they all propagate to `main()` unchanged.
- **New coverage:** added `TestInstallManagerWithFallback` locking the helper's
  bootstrap-vs-not behavior and the degrade-on-failure config write.

## Testing

- Full unit suite green: `2670 passed, 13 skipped` (`uv run pytest tests/comfy_cli`).
- `ruff check` + `ruff format --check` clean on the touched files.
