### PR TITLE
refactor(git_utils): shared git-error panel printer + cwd= over chdir guards

### DIFF
--- a/comfy_cli/git_utils.py
+++ b/comfy_cli/git_utils.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 from rich.console import Console
@@ -24,6 +23,40 @@ def sanitize_for_local_branch(branch_name: str) -> str:
     return sanitized or "unknown"
 
 
+def _print_git_error(
+    title: str,
+    panel_title: str,
+    context: str,
+    details: list[str],
+    exc: subprocess.CalledProcessError,
+) -> None:
+    """Render a git ``CalledProcessError`` as a rich error panel.
+
+    Shared by ``git_checkout_tag`` and ``checkout_pr`` so the two failure
+    displays stay in lock-step. ``context`` is the bold headline line, each
+    ``details`` entry is an italic follow-up line, and the command's stderr
+    (when present) is appended verbatim.
+    """
+    error_message = Text()
+    error_message.append(title, style="bold red on white")
+    error_message.append(f"\n\n{context}", style="bold yellow")
+    for detail in details:
+        error_message.append(f"\n{detail}", style="italic")
+
+    if exc.stderr:
+        error_message.append("\n\nError output:", style="bold red")
+        error_message.append(f"\n{exc.stderr}", style="italic yellow")
+
+    console.print(
+        Panel(
+            error_message,
+            title=f"[bold white on red]{panel_title}[/bold white on red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+
+
 def git_checkout_tag(repo_path: str, tag: str) -> bool:
     """
     Checkout a specific Git tag in the given repository.
@@ -39,16 +72,12 @@ def git_checkout_tag(repo_path: str, tag: str) -> bool:
     :param tag: The tag to checkout
     :return: True if the checkout succeeds, False if any git command failed.
     """
-    original_dir = os.getcwd()
     try:
-        # Change to the repository directory
-
-        os.chdir(repo_path)
-
         # Skip the network fetch when the tag is already present locally.
         tag_present_locally = (
             subprocess.run(
                 ["git", "rev-parse", "--verify", f"refs/tags/{tag}"],
+                cwd=repo_path,
                 capture_output=True,
                 text=True,
                 check=False,
@@ -56,62 +85,49 @@ def git_checkout_tag(repo_path: str, tag: str) -> bool:
             == 0
         )
         if not tag_present_locally:
-            subprocess.run(["git", "fetch", "--tags"], check=True, capture_output=True, text=True)
+            subprocess.run(["git", "fetch", "--tags"], cwd=repo_path, check=True, capture_output=True, text=True)
 
         # Checkout the specified tag
-        subprocess.run(["git", "checkout", tag], check=True, capture_output=True, text=True)
+        subprocess.run(["git", "checkout", tag], cwd=repo_path, check=True, capture_output=True, text=True)
 
         console.print(f"[bold green]Successfully checked out tag: [cyan]{tag}[/cyan][/bold green]")
 
         return True
     except subprocess.CalledProcessError as e:
-        error_message = Text()
-        error_message.append("Git Checkout Error", style="bold red on white")
-        error_message.append("\n\nFailed to checkout tag: ", style="bold yellow")
-        error_message.append(f"[cyan]{tag}[/cyan]")
-        error_message.append("\n\nError details:", style="bold red")
-        error_message.append(f"\n{str(e)}", style="italic")
-
-        if e.stderr:
-            error_message.append("\n\nError output:", style="bold red")
-            error_message.append(f"\n{e.stderr}", style="italic yellow")
-
-        console.print(
-            Panel(
-                error_message,
-                title="[bold white on red]Git Checkout Failed[/bold white on red]",
-                border_style="red",
-                expand=False,
-            )
+        _print_git_error(
+            title="Git Checkout Error",
+            panel_title="Git Checkout Failed",
+            context=f"Failed to checkout tag: {tag}",
+            details=[f"Error details:\n{e}"],
+            exc=e,
         )
-
         return False
-    finally:
-        # Ensure we always return to the original directory
-        os.chdir(original_dir)
 
 
 def checkout_pr(repo_path: str, pr_info: PRInfo) -> bool:
-    original_dir = os.getcwd()
-
     try:
-        os.chdir(repo_path)
-
         if pr_info.is_fork:
             remote_name = f"pr-{pr_info.number}-{pr_info.user}"
 
-            result = subprocess.run(["git", "remote", "get-url", remote_name], capture_output=True, text=True)
+            result = subprocess.run(
+                ["git", "remote", "get-url", remote_name], cwd=repo_path, capture_output=True, text=True
+            )
 
             if result.returncode != 0:
                 subprocess.run(
                     ["git", "remote", "add", remote_name, pr_info.head_repo_url],
+                    cwd=repo_path,
                     check=True,
                     capture_output=True,
                     text=True,
                 )
 
             subprocess.run(
-                ["git", "fetch", remote_name, pr_info.head_branch], check=True, capture_output=True, text=True
+                ["git", "fetch", remote_name, pr_info.head_branch],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+                text=True,
             )
 
             # fix: "feature/add-support" -> "pr-123-feature-add-support"
@@ -120,19 +136,27 @@ def checkout_pr(repo_path: str, pr_info: PRInfo) -> bool:
 
             subprocess.run(
                 ["git", "checkout", "-B", local_branch, f"{remote_name}/{pr_info.head_branch}"],
+                cwd=repo_path,
                 check=True,
                 capture_output=True,
                 text=True,
             )
 
         else:
-            subprocess.run(["git", "fetch", "origin", pr_info.head_branch], check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "fetch", "origin", pr_info.head_branch],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
             sanitized_branch = sanitize_for_local_branch(pr_info.head_branch)
             local_branch = f"pr-{pr_info.number}-{sanitized_branch}"
 
             subprocess.run(
                 ["git", "checkout", "-B", local_branch, f"origin/{pr_info.head_branch}"],
+                cwd=repo_path,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -143,25 +167,11 @@ def checkout_pr(repo_path: str, pr_info: PRInfo) -> bool:
         return True
 
     except subprocess.CalledProcessError as e:
-        error_message = Text()
-        error_message.append("Git PR Checkout Error", style="bold red on white")
-        error_message.append(f"\n\nFailed to checkout PR #{pr_info.number}", style="bold yellow")
-        error_message.append(f"\nTitle: {pr_info.title}", style="italic")
-        error_message.append(f"\nBranch: {pr_info.head_branch}", style="italic")
-
-        if e.stderr:
-            error_message.append("\n\nError output:", style="bold red")
-            error_message.append(f"\n{e.stderr}", style="italic yellow")
-
-        console.print(
-            Panel(
-                error_message,
-                title="[bold white on red]PR Checkout Failed[/bold white on red]",
-                border_style="red",
-                expand=False,
-            )
+        _print_git_error(
+            title="Git PR Checkout Error",
+            panel_title="PR Checkout Failed",
+            context=f"Failed to checkout PR #{pr_info.number}",
+            details=[f"Title: {pr_info.title}", f"Branch: {pr_info.head_branch}"],
+            exc=e,
         )
         return False
-
-    finally:
-        os.chdir(original_dir)

--- a/comfy_cli/git_utils.py
+++ b/comfy_cli/git_utils.py
@@ -123,7 +123,9 @@ def checkout_pr(repo_path: str, pr_info: PRInfo) -> bool:
                 )
 
             subprocess.run(
-                ["git", "fetch", remote_name, pr_info.head_branch],
+                # ``--`` guards against a fork-controlled branch name beginning with ``-`` being
+                # parsed as a git option (argument injection); ``comfy install --pr`` runs against forks.
+                ["git", "fetch", remote_name, "--", pr_info.head_branch],
                 cwd=repo_path,
                 check=True,
                 capture_output=True,
@@ -144,7 +146,8 @@ def checkout_pr(repo_path: str, pr_info: PRInfo) -> bool:
 
         else:
             subprocess.run(
-                ["git", "fetch", "origin", pr_info.head_branch],
+                # ``--`` guards against a branch name beginning with ``-`` being parsed as a git option.
+                ["git", "fetch", "origin", "--", pr_info.head_branch],
                 cwd=repo_path,
                 check=True,
                 capture_output=True,

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -238,12 +238,8 @@ class TestGitOperations:
     """Test Git operations for PR checkout"""
 
     @patch("subprocess.run")
-    @patch("os.chdir")
-    @patch("os.getcwd")
-    def test_checkout_pr_fork_success(self, mock_getcwd, mock_chdir, mock_subprocess, sample_pr_info):
+    def test_checkout_pr_fork_success(self, mock_subprocess, sample_pr_info):
         """Test successful checkout of PR from fork"""
-        mock_getcwd.return_value = "/original/dir"
-
         mock_subprocess.side_effect = [
             subprocess.CompletedProcess([], 1),
             subprocess.CompletedProcess([], 0),
@@ -261,14 +257,12 @@ class TestGitOperations:
         assert "remote" in calls[1][0][0]
         assert "fetch" in calls[2][0][0]
         assert "checkout" in calls[3][0][0]
+        # Every git command runs against repo_path via cwd= (no process chdir).
+        assert all(call.kwargs.get("cwd") == "/repo/path" for call in calls)
 
     @patch("subprocess.run")
-    @patch("os.chdir")
-    @patch("os.getcwd")
-    def test_checkout_pr_non_fork_success(self, mock_getcwd, mock_chdir, mock_subprocess):
+    def test_checkout_pr_non_fork_success(self, mock_subprocess):
         """Test successful checkout of PR from same repo"""
-        mock_getcwd.return_value = "/original/dir"
-
         pr_info = PRInfo(
             number=123,
             head_repo_url="https://github.com/comfyanonymous/ComfyUI.git",
@@ -289,14 +283,11 @@ class TestGitOperations:
 
         assert result is True
         assert mock_subprocess.call_count == 2
+        assert all(call.kwargs.get("cwd") == "/repo/path" for call in mock_subprocess.call_args_list)
 
     @patch("subprocess.run")
-    @patch("os.chdir")
-    @patch("os.getcwd")
-    def test_checkout_pr_git_failure(self, mock_getcwd, mock_chdir, mock_subprocess, sample_pr_info):
+    def test_checkout_pr_git_failure(self, mock_subprocess, sample_pr_info):
         """Test Git operation failure"""
-        mock_getcwd.return_value = "/original/dir"
-
         error = subprocess.CalledProcessError(1, "git", stderr="Permission denied")
         mock_subprocess.side_effect = error
 
@@ -553,12 +544,8 @@ class TestEdgeCases:
             assert headers["Authorization"] == "Bearer test-token"
 
     @patch("subprocess.run")
-    @patch("os.chdir")
-    @patch("os.getcwd")
-    def test_checkout_pr_remote_already_exists(self, mock_getcwd, mock_chdir, mock_subprocess, sample_pr_info):
+    def test_checkout_pr_remote_already_exists(self, mock_subprocess, sample_pr_info):
         """Test checkout when remote already exists"""
-        mock_getcwd.return_value = "/dir"
-
         mock_subprocess.side_effect = [
             subprocess.CompletedProcess([], 0),
             subprocess.CompletedProcess([], 0),
@@ -569,6 +556,7 @@ class TestEdgeCases:
 
         assert result is True
         assert mock_subprocess.call_count == 3
+        assert all(call.kwargs.get("cwd") == "/repo" for call in mock_subprocess.call_args_list)
 
 
 class TestGetLatestRelease:

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -179,7 +179,7 @@ class TestGitHubAPIIntegration:
 
     @patch("requests.get")
     def test_find_pr_by_branch_rate_limit(self, mock_get):
-        """A rate-limited 403 surfaces as GitHubRateLimitError, not a silent "no PR found\" """
+        """A rate-limited 403 surfaces as GitHubRateLimitError, not a silent "no PR found\""""
         mock_response = Mock()
         mock_response.status_code = 403
         mock_response.headers = {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1777415867"}

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -179,7 +179,7 @@ class TestGitHubAPIIntegration:
 
     @patch("requests.get")
     def test_find_pr_by_branch_rate_limit(self, mock_get):
-        """A rate-limited 403 surfaces as GitHubRateLimitError, not a silent "no PR found\""""
+        """A rate-limited 403 surfaces as GitHubRateLimitError, not a silent "no PR found\" """
         mock_response = Mock()
         mock_response.status_code = 403
         mock_response.headers = {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1777415867"}
@@ -257,6 +257,9 @@ class TestGitOperations:
         assert "remote" in calls[1][0][0]
         assert "fetch" in calls[2][0][0]
         assert "checkout" in calls[3][0][0]
+        # ``--`` separates options from the fork-controlled branch refspec (argument-injection guard).
+        fetch_argv = calls[2][0][0]
+        assert fetch_argv[-2:] == ["--", "load-3d-nodes"]
         # Every git command runs against repo_path via cwd= (no process chdir).
         assert all(call.kwargs.get("cwd") == "/repo/path" for call in calls)
 
@@ -283,6 +286,9 @@ class TestGitOperations:
 
         assert result is True
         assert mock_subprocess.call_count == 2
+        # ``--`` separates options from the branch refspec (argument-injection guard).
+        fetch_argv = mock_subprocess.call_args_list[0][0][0]
+        assert fetch_argv[-2:] == ["--", "feature-branch"]
         assert all(call.kwargs.get("cwd") == "/repo/path" for call in mock_subprocess.call_args_list)
 
     @patch("subprocess.run")


### PR DESCRIPTION
## ELI-5

Two functions in `git_utils.py` — `git_checkout_tag` and `checkout_pr` — each did the same two clunky things: (1) built a nearly-identical fancy red error box by hand, and (2) `cd`-ed the whole process into the repo folder to run git, then `cd`-ed back in a `finally`. This PR pulls the error box into one shared helper, and tells each `git` command *which folder to run in* (`cwd=`) instead of changing the whole process's working directory.

It also plugs a **real argument-injection hole**: a pull request author controls their own branch name, and we were handing that name straight to `git fetch` as a bare word. A branch literally named `--upload-pack=<some command>` would be read by git as an *option*, not a branch — and git would run that command. Adding `--` before the branch tells git "everything after this is a name, not a flag."

## Security fix: `--` end-of-options separator on `git fetch` (667887d)

`pr_info.head_branch` comes straight from the GitHub API (`data["head"]["ref"]`) and is fully controlled by the PR author. It flowed positionally into `git fetch` on both the fork and non-fork paths. Because `git check-ref-format` accepts `refs/heads/--upload-pack=x`, neither git nor GitHub rejects such a name for us — and `comfy install --pr` is *designed* to run against untrusted forks.

Verified against live git:

```
before:  git fetch origin '--upload-pack=touch …'   → command EXECUTED
after:   git fetch origin -- '--upload-pack=touch …' → fatal: invalid refspec  (blocked)
```

Both `fetch` call sites now pass `["git", "fetch", <remote>, "--", head_branch]`. The remaining git invocations in this function were audited and are safe by construction: the two `git checkout -B` start-points are prefixed (`origin/…`, `<remote>/…`), `local_branch` is prefixed `pr-`, and `git remote add <name> <url>` rejects a dash-leading URL outright. Regression assertions were added to both `checkout_pr` tests (the suite mocks `subprocess.run`, so nothing would otherwise have caught a wrong refspec syntax).

## What else changed

- **New `_print_git_error(title, panel_title, context, details, exc)` helper** renders the shared rich error `Panel` (bold-red title, bold-yellow context line, italic detail lines, optional `stderr` block). Both `except subprocess.CalledProcessError` blocks now call it.
- **`cwd=repo_path` on every `subprocess.run` call** in both functions, replacing the `os.getcwd()` / `os.chdir(repo_path)` / `finally: os.chdir(original_dir)` scaffolding. `import os` is now unused and removed.

## Why the `cwd=` change matters (beyond dedup)

`os.chdir` mutates process-global state. Passing `cwd=` per-call eliminates that mutation, so the functions are safe under any future threaded/concurrent use (no shared-cwd races) and there is no global state left to restore on the error path.

To be precise about what this does *not* buy: a missing `repo_path` still raises an uncaught `FileNotFoundError` — the throw simply moves from `os.chdir` to `subprocess.run(cwd=…)`. That is unchanged from `main`; removing the process-global cwd mutation is the actual win.

Behavior is otherwise preserved: git commands still execute against `repo_path`, and each function still returns `False` on a git failure.

## Behavior note (judgment call)

The **`checkout_pr` error panel is byte-identical** to before. The **`git_checkout_tag` panel has minor cosmetic differences** on the failure path, which I consider a net improvement:
- The tag line was previously appended via `Text.append(f"[cyan]{tag}[/cyan]")`, but `Text.append` does **not** parse console markup — so users literally saw `[cyan]v1.2.3[/cyan]` (brackets and all). It now shows a clean `v1.2.3` in the header line.
- The "Error details:" separator is now italic (was bold-red) with one fewer blank line, matching the shared helper's layout.

If exact byte-for-byte preservation of the old (buggy) tag panel is preferred, I can special-case it — but the current output reads better.

## Testing

- `tests/comfy_cli/command/github/test_pr.py` — the four mocked `checkout_pr` tests dropped their now-dead `@patch("os.chdir")`/`@patch("os.getcwd")` decorators and now assert `cwd=repo_path` is passed to every `subprocess.run`, plus the two `--`-separator regression assertions described above.
- Verified against the branch **merged with current `main`**: `3541 passed, 37 skipped`; `uvx ruff@0.15.15 format --diff .` → `270 files already formatted`; `ruff check` clean.
