### PR TITLE
refactor(http): shared is_cloud-gated target_auth_headers builder; migrate 5 call sites (BE-4362)

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -1065,10 +1065,10 @@ def _cloud_cancel(prompt_id: str) -> None:
     # upstream too; encoding here is defense in depth.
     url = target.url("jobs", urllib.parse.quote(prompt_id, safe=""), "cancel")
     req = urllib.request.Request(url, data=b"", method="POST")
-    if target.api_key:
-        req.add_header("X-API-Key", target.api_key)
-    elif target.auth_token:
-        req.add_header("Authorization", f"Bearer {target.auth_token}")
+    from comfy_cli.http import target_auth_headers
+
+    for k, v in target_auth_headers(target).items():
+        req.add_header(k, v)
 
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -99,11 +99,11 @@ def _models_path_parts(target) -> tuple[str, ...]:
 
 
 def _authed_request(url: str, target) -> urllib.request.Request:
+    from comfy_cli.http import target_auth_headers
+
     req = urllib.request.Request(url)
-    if target.api_key:
-        req.add_header("X-API-Key", target.api_key)
-    elif target.auth_token:
-        req.add_header("Authorization", f"Bearer {target.auth_token}")
+    for k, v in target_auth_headers(target).items():
+        req.add_header(k, v)
     return req
 
 

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -28,6 +28,7 @@ import typer
 from comfy_cli import jobs_state
 from comfy_cli.comfy_client import Client, Unauthenticated, extract_output_entries
 from comfy_cli.http import NoRedirectHandler
+from comfy_cli.http import target_auth_headers as _auth_headers
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
 from comfy_cli.target import resolve_target
@@ -65,17 +66,6 @@ def _default_out_dir() -> str:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _auth_headers(target: Any) -> dict[str, str]:
-    """Build auth headers for a target (cloud only)."""
-    headers: dict[str, str] = {}
-    if target.is_cloud:
-        if target.api_key:
-            headers["X-API-Key"] = target.api_key
-        elif target.auth_token:
-            headers["Authorization"] = f"Bearer {target.auth_token}"
-    return headers
 
 
 # Stripped on every download redirect so auth never crosses origins.

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -607,11 +607,11 @@ def _authed_request(
     loosely to keep urllib out of the module's top-level imports."""
     import urllib.request
 
+    from comfy_cli.http import target_auth_headers
+
     req = urllib.request.Request(url, data=data, method=method)
-    if target.api_key:
-        req.add_header("X-API-Key", target.api_key)
-    elif target.auth_token:
-        req.add_header("Authorization", f"Bearer {target.auth_token}")
+    for k, v in target_auth_headers(target).items():
+        req.add_header(k, v)
     if content_type:
         req.add_header("Content-Type", content_type)
     return req

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -1249,11 +1249,10 @@ def _load_from_target(*, mode: str = "local", host: str | None = None, port: int
     req.add_header("Accept", "application/json")
 
     # Auth headers (cloud only — local has no auth)
-    if target.is_cloud:
-        if target.api_key:
-            req.add_header("X-API-Key", target.api_key)
-        elif target.auth_token:
-            req.add_header("Authorization", f"Bearer {target.auth_token}")
+    from comfy_cli.http import target_auth_headers
+
+    for k, v in target_auth_headers(target).items():
+        req.add_header(k, v)
 
     try:
         with _opener.open(req, timeout=30.0) as resp:

--- a/comfy_cli/http.py
+++ b/comfy_cli/http.py
@@ -24,3 +24,21 @@ class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         raise urllib.error.HTTPError(req.full_url, code, self._message, headers, fp)
 
     http_error_302 = http_error_303 = http_error_307 = http_error_308 = http_error_301
+
+
+def target_auth_headers(target) -> dict[str, str]:
+    """Auth headers for a routing Target — cloud only.
+
+    Local ComfyUI has no auth; refusing to attach credentials to a non-cloud
+    target means a stray token on a local Target can never leak to a
+    plaintext server (same defense-in-depth gate as comfy_client.Client).
+    ``resolve_target`` populates at most one of api_key / auth_token, so the
+    precedence branch is mechanics, not policy.
+    """
+    headers: dict[str, str] = {}
+    if target.is_cloud:
+        if target.api_key:
+            headers["X-API-Key"] = target.api_key
+        elif target.auth_token:
+            headers["Authorization"] = f"Bearer {target.auth_token}"
+    return headers

--- a/tests/comfy_cli/test_http.py
+++ b/tests/comfy_cli/test_http.py
@@ -4,7 +4,8 @@ import urllib.request
 
 import pytest
 
-from comfy_cli.http import NoRedirectHandler
+from comfy_cli.http import NoRedirectHandler, target_auth_headers
+from comfy_cli.target import Target
 
 
 def _call(handler, method_name, code=302):
@@ -42,3 +43,31 @@ def test_custom_message_passthrough():
         _call(handler, "http_error_302", code=302)
     assert str(exc_info.value.reason) == "redirect refused (auth leak prevention)"
     assert exc_info.value.code == 302
+
+
+def test_target_auth_headers_local_attaches_nothing_even_with_creds():
+    """The security property this builder exists to enforce: a local Target
+    NEVER contributes auth headers, even if stray credentials are set on it
+    (the exact misuse the ``is_cloud`` gate defends against)."""
+    target = Target(
+        kind="local",
+        base_url="http://127.0.0.1:8188",
+        auth_token="stray",
+        api_key="stray",
+    )
+    assert target_auth_headers(target) == {}
+
+
+def test_target_auth_headers_cloud_api_key_only():
+    target = Target(kind="cloud", base_url="https://cloud.example", api_key="k")
+    assert target_auth_headers(target) == {"X-API-Key": "k"}
+
+
+def test_target_auth_headers_cloud_auth_token_only():
+    target = Target(kind="cloud", base_url="https://cloud.example", auth_token="t")
+    assert target_auth_headers(target) == {"Authorization": "Bearer t"}
+
+
+def test_target_auth_headers_cloud_both_api_key_wins():
+    target = Target(kind="cloud", base_url="https://cloud.example", auth_token="t", api_key="k")
+    assert target_auth_headers(target) == {"X-API-Key": "k"}


### PR DESCRIPTION
## ELI-5

Five different places in the code each wrote their own little "attach the login token to this request" snippet. They'd drifted: three of them attached the token to **any** target — even a plain-HTTP local ComfyUI — instead of only to Comfy Cloud. This PR replaces all five copies with **one** shared helper, `target_auth_headers(target)`, that attaches credentials **only when `target.is_cloud`**. Same behavior in practice today (local targets are built with no credentials), but a stray token on a local target can now never leak to a plaintext server.

## What changed

Adds `target_auth_headers(target) -> dict[str, str]` to `comfy_cli/http.py` — the strictest variant (promoted verbatim from `transfer._auth_headers`): it returns `{}` unless `target.is_cloud`, then `X-API-Key` (api_key) taking precedence over `Authorization: Bearer` (auth_token). This is the same defense-in-depth gate `comfy_client.Client` already uses.

Migrated the five hand-rolled non-client copies onto it:

| Site | Change |
|---|---|
| `command/workflow.py` `_authed_request` | lazy import + header loop (was **ungated** — now gated) |
| `command/models/search.py` `_authed_request` | lazy import + header loop (was **ungated** — now gated) |
| `command/jobs.py` `_cloud_cancel` (inline) | lazy import + header loop (was **ungated** — now gated) |
| `command/transfer.py` `_auth_headers` | deleted body, re-exported: `from comfy_cli.http import target_auth_headers as _auth_headers` (was already gated — byte-identical) |
| `cql/engine.py` `_load_from_target` (inline) | header loop (was already gated, api_key-first — byte-identical) |

**Left untouched by design:** `comfy_client.py:264-268` (superset path with safe-URL assertion + 401 refresh-retry), and every HTTPError→envelope mapper / capped-reader (a separate follow-up ticket). Non-Target header sites (`generate/client.py`'s bare-`api_key` builder, GitHub/Civitai token headers in `install.py`/`models.py`) are out of scope — they don't route a `Target`.

## Security note

The gate **direction** is the point: attach **nothing** unless `target.is_cloud`. The three previously-ungated sites (workflow/search/jobs) attached credentials whenever they were present, regardless of target kind. Behavior is preserved today because `resolve_target` builds local Targets with `auth_token=None` and no `api_key` (`target.py:118-127`), so no observable change — but the latent leak path (a stray credential on a local target → plaintext server) is now closed. This also means local `/userdata` calls in `workflow.py` go from "attach if creds present" to "never attach," which `_userdata_request`'s docstring already described as a no-op.

## Tests

- Added 4 cases to `tests/comfy_cli/test_http.py`, including the security property: a **local** Target with **both** `auth_token` and `api_key` set → `target_auth_headers` returns `{}`; plus cloud api-key-only, cloud auth-token-only, and cloud-both (api_key wins).
- Full existing suites for all migrated commands pass unchanged: `test_workflow_saved.py`, `models/test_search.py`, `jobs/test_jobs.py`, `test_transfer_{download,redirect,upload}.py`, and the `cql/` suite (`135 passed` + `248 passed, 1 skipped`). Their target fixtures are cloud-kind, so headers still attach.
- `ruff check` + `ruff format --check` clean on all touched files.

Phase 1 of BE-4350.
