### PR TITLE
feat(jobs): fall back to the on-disk state file when jobs status finds the server down

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -601,7 +601,72 @@ def status_cmd(
         return _cloud_status(prompt_id)
 
     h, p = _resolve_host_port(host, port)
-    _server_or_error(h, p)
+    if not _server_or_error(h, p, raise_on_missing=False):
+        # Server is down. The on-disk state file (written by `comfy run` and
+        # maintained by the async watcher) still knows what this prompt was
+        # doing when the server was last seen — a bare `server_not_running`
+        # throws that attribution away.
+        from comfy_cli import jobs_state
+
+        try:
+            st = jobs_state.read(prompt_id)
+        except ValueError:  # unsafe prompt_id — no state file to read
+            st = None
+
+        if st is None:
+            # Untracked prompt: same envelope as before, byte for byte.
+            renderer.error(
+                code="server_not_running",
+                message=f"ComfyUI not running on {h}:{p}",
+                hint="run: comfy launch",
+                details={"host": h, "port": p},
+            )
+            raise typer.Exit(code=1)
+
+        if st.is_terminal:
+            # The job finished before the server stopped — the state file is
+            # the authoritative record, so this is a normal result, not an
+            # error. Callers branch on `status`/`error`.
+            snapshot = {
+                "prompt_id": prompt_id,
+                "status": st.status,
+                "outputs": list(st.outputs or []),
+                "error": st.error,
+                "host": h,
+                "port": p,
+                "server_running": False,
+                "source": "state_file",
+                "submitted_at": st.submitted_at,
+                "updated_at": st.updated_at,
+                "workflow": st.workflow,
+            }
+            if renderer.is_pretty():
+                _render_status_pretty(snapshot, host=h, port=p)
+            renderer.emit(snapshot, command="jobs status")
+            return
+
+        # Non-terminal: the job was queued/running when the server was last
+        # seen, so the server most likely died underneath it. Keep the
+        # `server_not_running` code (callers key on it) and attribute.
+        renderer.error(
+            code="server_not_running",
+            message=(
+                f"ComfyUI not running on {h}:{p} — job {prompt_id} was {st.status!r} when the server "
+                f"was last seen (submitted {st.submitted_at}, last update {st.updated_at}). The server "
+                f"may have died while executing it (e.g. killed by the OS on an out-of-memory allocation)."
+            ),
+            hint="run: comfy launch — then check `comfy jobs ls` for the job's last recorded state",
+            details={
+                "host": h,
+                "port": p,
+                "prompt_id": prompt_id,
+                "last_known_status": st.status,
+                "submitted_at": st.submitted_at,
+                "updated_at": st.updated_at,
+                "workflow": st.workflow,
+            },
+        )
+        raise typer.Exit(code=1)
 
     snapshot = _snapshot(h, p, prompt_id)
     if snapshot is None:

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -238,6 +238,118 @@ def test_jobs_status_no_server_emits_error_envelope():
 
 
 # ---------------------------------------------------------------------------
+# `jobs status` with the server down — fall back to the on-disk state file
+# ---------------------------------------------------------------------------
+
+
+def _invoke_status(prompt_id: str, *extra: str):
+    """Run `jobs status <id>` in-process with an NDJSON renderer installed.
+
+    Returns the CliRunner result; parse its stdout with ``_last_json``.
+    """
+    from typer.testing import CliRunner
+
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs status"))
+    return CliRunner().invoke(jobs_mod.app, ["status", prompt_id, "--where", "local", *extra])
+
+
+def test_jobs_status_server_down_no_state_file_keeps_bare_error(monkeypatch: pytest.MonkeyPatch):
+    """No state file for the prompt -> the pre-existing `server_not_running`
+    envelope, unchanged (backward compatibility for untracked prompts)."""
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+
+    result = _invoke_status("untracked-id", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 1, result.output
+    env = _last_json(result.stdout)
+    assert env["ok"] is False
+    err = env["error"]
+    assert err["code"] == "server_not_running"
+    assert err["message"] == "ComfyUI not running on 127.0.0.1:65431"
+    assert err["hint"] == "run: comfy launch"
+    assert err["details"] == {"host": "127.0.0.1", "port": 65431}
+
+
+def test_jobs_status_server_down_non_terminal_state_attributes_the_death(monkeypatch: pytest.MonkeyPatch):
+    """A job recorded as `running` when the server was last seen: same error
+    code, but the message/details say what the job was doing."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    st = jobs_state.new(prompt_id="dead-run", client_id="c", workflow="/tmp/wf.json", where="local")
+    st.status = "running"
+    jobs_state.write(st)
+
+    result = _invoke_status("dead-run", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 1, result.output
+    env = _last_json(result.stdout)
+    assert env["ok"] is False
+    err = env["error"]
+    assert err["code"] == "server_not_running"
+    assert "dead-run" in err["message"]
+    assert "was 'running'" in err["message"]
+    assert "out-of-memory" in err["message"]
+    details = err["details"]
+    assert details["last_known_status"] == "running"
+    assert details["prompt_id"] == "dead-run"
+    assert details["workflow"] == "/tmp/wf.json"
+    assert details["submitted_at"] == st.submitted_at
+    assert details["updated_at"] == st.updated_at
+
+
+def test_jobs_status_server_down_terminal_state_emits_ok_envelope(monkeypatch: pytest.MonkeyPatch):
+    """A job that completed before the server stopped is a normal result —
+    OK envelope sourced from the state file, exit 0."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    st = jobs_state.new(prompt_id="done-run", client_id="c", workflow="/tmp/wf.json", where="local")
+    st.status = "completed"
+    st.outputs = ["http://127.0.0.1:8188/view?filename=out.png"]
+    jobs_state.write(st)
+
+    result = _invoke_status("done-run", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 0, result.output
+    env = _last_json(result.stdout)
+    assert env["ok"] is True
+    data = env["data"]
+    assert data["prompt_id"] == "done-run"
+    assert data["status"] == "completed"
+    assert data["server_running"] is False
+    assert data["source"] == "state_file"
+    assert data["outputs"] == ["http://127.0.0.1:8188/view?filename=out.png"]
+    assert data["error"] is None
+    assert data["workflow"] == "/tmp/wf.json"
+    assert data["submitted_at"] == st.submitted_at
+
+
+def test_jobs_status_server_up_still_uses_live_snapshot(monkeypatch: pytest.MonkeyPatch):
+    """Server up: the live `/history` snapshot wins — the state file is never
+    consulted and the payload carries no state-file markers."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: True)
+    monkeypatch.setattr(
+        jobs_mod,
+        "_snapshot",
+        lambda h, p, pid: {"prompt_id": pid, "status": "running", "outputs": [], "host": h, "port": p},
+    )
+    # A stale terminal state file must NOT shadow the live answer.
+    st = jobs_state.new(prompt_id="live-run", client_id="c", workflow="/tmp/wf.json", where="local")
+    st.status = "completed"
+    jobs_state.write(st)
+
+    result = _invoke_status("live-run", "--host", "127.0.0.1", "--port", "8188")
+    assert result.exit_code == 0, result.output
+    data = _last_json(result.stdout)["data"]
+    assert data["status"] == "running"
+    assert "source" not in data
+    assert "server_running" not in data
+
+
+# ---------------------------------------------------------------------------
 # `jobs ls --orphaned` — surface watcher_crashed jobs for cleanup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## ELI-5

If you ask `comfy jobs status <id>` while ComfyUI isn't running, the CLI used to just say "ComfyUI not running" and stop — even when it had a file on disk saying "that job was *running* when I last looked." Now it reads that file: if the job had already finished, you get the normal result; if it was still running, you get the same error code as before plus the missing sentence — "job X was 'running' when the server was last seen … the server may have died while executing it (e.g. an OOM kill)." That turns an anonymous failure into an attributable one.

## What changed

`status_cmd` (`comfy_cli/command/jobs.py`) now probes with `_server_or_error(h, p, raise_on_missing=False)` instead of the hard-erroring default, and falls back to `jobs_state.read(prompt_id)` when the server is down — the same fallback `jobs wait` already implements in `_wait_fetch_snapshot`, and the exact use `_server_or_error`'s own docstring describes ("so the caller can fall back to a different source (e.g. on-disk state files)").

Four cases, in order:

1. **Server up** — unchanged. The live `/queue` + `/history` snapshot wins; the state file is never consulted.
2. **Server down, no state file** (untracked prompt) — the pre-existing `server_not_running` envelope, byte for byte: same code, message, hint, `details: {host, port}`, exit 1. A test pins all four fields so this can't drift.
3. **Server down, state file is terminal** (`completed` / `error` / `cancelled`) — the job finished before the server stopped, so the state file is the authoritative record and this is a normal result, not an error. Emits an OK envelope shaped like `_wait_fetch_snapshot`'s return plus provenance: `{prompt_id, status, outputs, error, host, port, server_running: false, source: "state_file", submitted_at, updated_at, workflow}`, exit 0.
4. **Server down, state file is non-terminal** (`queued` / `running`) — the attribution case. Keeps the `server_not_running` **code** so existing callers keying on it keep working, but the message names the job, its last known status and both timestamps, and `details` carries `last_known_status` / `submitted_at` / `updated_at` / `workflow`. Exit 1, as today.

`_snapshot`, `ls_cmd`, `wait` and the watcher are untouched. `renderer.error` already renders in pretty mode, and `_render_status_pretty` only reads keys the state-file payload has (`prompt_id`/`status`/`outputs`/`error`), so it is called as-is when `renderer.is_pretty()` — all three pretty paths were rendered manually and are included below.

## Tests

Four new tests in `tests/comfy_cli/jobs/test_jobs.py`, in-process via `CliRunner` + an NDJSON renderer (the pattern the cloud-status tests use), with the autouse `_isolate_jobs_state_dir` fixture providing the tmp state dir: server-down/no-state-file (asserts the full pre-existing envelope), server-down/non-terminal, server-down/terminal, and server-up (asserts the live snapshot still wins **and** that a stale terminal state file does not shadow it — the payload carries no `source`/`server_running` markers). The existing subprocess test `test_jobs_status_no_server_emits_error_envelope` also still passes unchanged.

## Verification

- `ruff check .` and `ruff format --diff .` clean with the CI-pinned `ruff==0.15.15`. (Heads-up unrelated to this PR: a *newer* ruff flags 15 pre-existing `UP038` violations in files this PR doesn't touch — CI's pin is what matters, but the lockfile's dev ruff has drifted past it.)
- Full `pytest` on Python 3.10 (`uv sync --extra dev --locked`, matching the pytest workflow): **2773 passed, 37 skipped**.
- Manual pretty-mode smoke of all three server-down paths — terminal renders the normal job panel (exit 0), non-terminal renders the enriched error panel with the details table (exit 1), missing state file renders the original two-line error panel (exit 1).

## Downstream

No code change is needed in `comfy-local-mcp`. Its `job_status` / `get_execution_error` tools shell out to `comfy --json jobs status` and parse the `envelope/1` result, surfacing a non-ok envelope through their `ComfyCliError` path — which carries `error.message` and `error.details` verbatim. Since case 4 keeps `code == "server_not_running"` and only enriches `message`/`details`, the added attribution flows through automatically and nothing that branches on the code breaks. Case 3 flips a previously-failing call to a successful envelope, which those tools already handle as the normal success shape.

## Judgment calls

- **Exit 0 for every terminal state, including `error`/`cancelled`.** Per the ticket, and it matches the live path: `jobs status` on a live errored job also emits an OK envelope with exit 0 (only `jobs watch` / `run --wait` map terminal status to an exit code via `_TERMINAL_VERDICT`). Callers branch on the payload's `status`/`error`.
- **The state-file read is not filtered on `st.where`.** A cloud job's state file read via a plain `jobs status <id>` (no `--where cloud`) with no local server running will now answer from that file, reporting the resolved local `host`/`port` in the envelope alongside `source: "state_file"`. I kept it unfiltered to match `_wait_fetch_snapshot`, which reads the same way, and because answering is more useful than the old bare error — but flagging it as a deliberate call rather than an oversight.
- **Hint wording.** The ticket's hint string had a stray backtick/space (`` comfy jobs ls `for ``); normalized to ``run: comfy launch — then check `comfy jobs ls` for the job's last recorded state``.
- **Pretty mode, terminal case** shows the ordinary job panel with no "server is down" annotation. The job is finished, so the server's state is not actionable; adding a warning line would have been behavior beyond the ticket.

## Self-review

Adversarial pass over the full diff before opening:

- **Chesterton's fence.** The diff does change existing behavior — it removes a hard error. `git log`/`git blame` on `_server_or_error` shows the `raise_on_missing=False` mode was added *for exactly this*, with a docstring naming on-disk state files as the intended fallback, and `jobs wait` is the existing precedent. Backward compatibility is preserved where it's observable: the untracked-prompt envelope is unchanged (pinned by test), and the non-terminal case keeps the same error code and exit status.
- **Negative-claim falsification (regression case comfy-cloud-mcp-server#581).** Trigger does not fire: this change does not deny a capability, add a throw/deny dead-end, or flip a test to assert one. It does the opposite — it *removes* a dead-end and routes the user to an answer that already existed on disk. The one error path that remains is the pre-existing one, reproduced byte for byte.
- **Riskiest line:** `if not _server_or_error(h, p, raise_on_missing=False):`. Safe because `_server_or_error` returns `True` on the server-up path *before* the `raise_on_missing` branch is ever consulted, so the live path is provably unchanged; a regression test asserts it (including that a stale state file can't shadow the live snapshot).
- **Absent-error handling:** `jobs_state.read` is wrapped in `try/except ValueError` for unsafe prompt_ids (mirroring `_snapshot`); it already returns `None` for a missing/corrupt/truncated file, and `None` routes to the unchanged bare-error path. `st.outputs` is defensively copied with `list(st.outputs or [])`.

No unmet acceptance criteria.
