### PR TITLE
fix(models): local search --text walks every model folder, not just checkpoints (BE-4746)

### DIFF
--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -4,7 +4,7 @@ Four subcommands, all routed by ``--where`` (cloud auto-detect by default):
 
     comfy models list-folders           # GET /api/experiment/models  | /models
     comfy models list-folder <folder>   # GET /api/experiment/models/<folder> | /models/<folder>
-    comfy models search [--text] [--type] [--limit]  # cloud: /api/assets; local: /models/<folder>
+    comfy models search [--text] [--type] [--limit]  # cloud: /api/assets; local: /models/<folder>, all folders w/o --type
     comfy models show <name>            # exact-match name across the catalog
 
 The search surface mirrors the asset→model extraction used by Comfy-Org's
@@ -16,8 +16,10 @@ ride along when present.
 
 Local-mode caveats:
   * ``/models/<folder>`` returns ``[{name, pathIndex}, ...]`` — filenames only,
-    no enrichment. ``search`` on local degrades to substring on the listing
-    of the resolved folder.
+    no enrichment. ``search`` on local degrades to a filename substring match:
+    without ``--type`` it walks *every* folder reported by ``/models`` (so a
+    diffusion_models/vae/lora file is findable by name), and ``--type`` scopes
+    the walk to that single folder.
   * The cloud asset catalog (``/api/assets``) has no local equivalent —
     local search is intentionally simpler.
 """
@@ -53,9 +55,16 @@ _MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 _PATH_SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]*$")
 
 
+def _is_safe_path_segment(value: str) -> bool:
+    """True if ``value`` can be interpolated into a URL path as a single segment."""
+    return (
+        bool(value) and ".." not in value and "/" not in value and "\\" not in value and bool(_PATH_SAFE.match(value))
+    )
+
+
 def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
     """Exit with an `invalid_argument` error if ``value`` isn't safe as a path segment."""
-    if not value or ".." in value or "/" in value or "\\" in value or not _PATH_SAFE.match(value):
+    if not _is_safe_path_segment(value):
         renderer.error(
             code="invalid_argument",
             message=f"{kind} {value!r} contains characters that aren't allowed in a path segment",
@@ -391,23 +400,32 @@ def _cloud_search(
     return rows, int(body.get("total") or len(rows))
 
 
-def _local_search(
-    target,
-    *,
-    text: str | None,
-    type_: str | None,
-    limit: int,
-) -> tuple[list[dict[str, Any]], int]:
-    """Filename listing from /models/<folder>. No enrichment available on local."""
-    if not type_:
-        # No tag-based filtering on local — pick a default that's almost always
-        # populated rather than scanning every folder (which would be slow).
-        folder = "checkpoints"
-    else:
-        folder = _TYPE_TO_FOLDER.get(type_, type_)
-    url = target.url(*_models_path_parts(target), folder)
-    data = _http_get_json(url, target)
-    items = []
+def _local_folder_names(target) -> list[str]:
+    """Fetch the backend's model-folder list, normalized to plain folder names.
+
+    Same endpoint (and same tolerant normalizer) as ``list_folders_cmd``: local
+    serves a flat list of folder-name strings, but the dict-entry shape is
+    accepted too so both server generations work.
+    """
+    data = _http_get_json(target.url(*_models_path_parts(target)), target)
+    names: list[str] = []
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, dict):
+                name = entry.get("name", "")
+            elif isinstance(entry, str):
+                name = entry
+            else:
+                continue
+            if isinstance(name, str) and name:
+                names.append(name)
+    return names
+
+
+def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict[str, Any]]:
+    """Rows for one ``/models/<folder>`` listing, client-side filtered by ``text``."""
+    data = _http_get_json(target.url(*_models_path_parts(target), folder), target)
+    rows: list[dict[str, Any]] = []
     if isinstance(data, list):
         for entry in data:
             name = entry.get("name", "") if isinstance(entry, dict) else (entry if isinstance(entry, str) else "")
@@ -415,7 +433,7 @@ def _local_search(
                 continue
             if text and text.lower() not in name.lower():
                 continue
-            items.append(
+            rows.append(
                 {
                     "name": name,
                     "type": folder,
@@ -429,13 +447,52 @@ def _local_search(
                     "id": None,
                 }
             )
-    total = len(items)
-    return items[:limit], total
+    return rows
+
+
+def _local_search(
+    target,
+    *,
+    text: str | None,
+    type_: str | None,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Filename listing from /models/<folder>. No enrichment available on local.
+
+    With ``--type`` this is a single-folder fetch. Without it we walk every
+    folder ``/models`` reports: local has no tag-based filtering, so a
+    single-folder default (historically ``checkpoints``) made every model
+    outside it invisible to text search. Walking is cheap — filename-only
+    listings against a localhost server, ~20 small GETs.
+    """
+    if type_:
+        scoped = _local_folder_matches(target, _TYPE_TO_FOLDER.get(type_, type_), text=text)
+        return scoped[:limit], len(scoped)
+
+    all_matches: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for folder in _local_folder_names(target):
+        # Folder names are server-provided, so they can't be trusted into a URL
+        # path. Skip anything unsafe silently — it isn't user input to reject.
+        if not _is_safe_path_segment(folder) or folder in seen:
+            continue
+        seen.add(folder)
+        try:
+            all_matches.extend(_local_folder_matches(target, folder, text=text))
+        except urllib.error.HTTPError:
+            # An exotic folder the listing advertises but doesn't serve (404) or
+            # otherwise errors shouldn't sink the whole search.
+            continue
+    all_matches.sort(key=lambda r: (r["type"], r["name"]))
+    return all_matches[:limit], len(all_matches)
 
 
 @app.command(
     "search",
-    help="Search models. Cloud: enriched via /api/assets. Local: filename substring on /models/<folder>.",
+    help=(
+        "Search models. Cloud: enriched via /api/assets. "
+        "Local: filename substring across every /models folder (--type scopes it to one)."
+    ),
 )
 @tracking.track_command("models")
 def search_cmd(

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -27,7 +27,6 @@ Local-mode caveats:
 from __future__ import annotations
 
 import json
-import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -46,45 +45,61 @@ app = typer.Typer(no_args_is_help=True, help="Discover models — folders, files
 # a misconfigured backend or hostile and would only serve to OOM the CLI.
 _MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 
-# Folder + asset-name arguments are interpolated into URL paths or query
-# strings. We disallow path-traversal sequences and control characters so a
-# crafted argument can't escape the intended endpoint. The set of legitimate
-# folder names (loras, checkpoints, …) is alphanumeric + ``_``/`-`/`.`; the
-# regex below is permissive enough for real-world filenames while rejecting
-# the obvious attack shapes.
-_PATH_SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]*$")
-
-
-def _is_safe_path_segment(value: str) -> bool:
-    """True if ``value`` can be interpolated into a URL path as a single segment."""
-    return (
-        bool(value) and ".." not in value and "/" not in value and "\\" not in value and bool(_PATH_SAFE.match(value))
-    )
+# Folder names are interpolated into URL paths, so they must stay a *single*
+# path segment. Only genuine traversal shapes are refused; everything else is
+# percent-encoded before it reaches the URL (see `_is_walkable_folder_name`).
 
 
 def _is_walkable_folder_name(value: str) -> bool:
-    """True if a *server-advertised* folder name is safe to walk.
+    """True if ``value`` is usable as a single URL path segment.
 
-    Deliberately laxer than :func:`_is_safe_path_segment`, which gates
-    user-supplied arguments and stays strict-ASCII on purpose. Real installs
-    configure folders like ``my loras``, ``SDXL (base)``, or non-ASCII names;
-    holding those to the strict regex silently skipped them, so every model
-    inside them stayed unfindable by ``models search`` — the exact bug this
-    command is meant to fix. Only genuine traversal shapes are refused here;
-    everything else is percent-encoded by :func:`_local_folder_matches` before
-    it reaches the URL, so spaces, ``?``/``#``, and control characters can't
-    alter the request.
+    Applies to both server-advertised folder names (the ``models search
+    --where local`` walk) and user-supplied ones (``models list-folder <folder>``,
+    ``models search --type``). Real installs configure folders like ``my loras``,
+    ``SDXL (base)``, or non-ASCII names; holding those to a strict-ASCII regex
+    silently skipped them on the walk and rejected them outright on user input,
+    leaving every model inside them unreachable even though ComfyUI serves the
+    folder fine. Only genuine traversal shapes are refused here; every call site
+    percent-encodes the segment with ``quote(..., safe="")`` before it reaches
+    the URL, so spaces, ``?``/``#``, and control characters can't alter the
+    request.
     """
-    return bool(value) and ".." not in value and "/" not in value and "\\" not in value
+    if not value or "/" in value or "\\" in value:
+        return False
+    # Only the *exact* segments `.` and `..` are rewritten by a URL resolver
+    # (RFC 3986 remove_dot_segments); `..` merely *inside* a name (`model..v2`)
+    # is an ordinary run of characters and must stay usable. `quote` leaves `.`
+    # unencoded, so a bare `.` would otherwise reach the server as `/models/.`
+    # and normalize back to the `/models` collection.
+    if value in (".", ".."):
+        return False
+    try:
+        # argv can carry undecodable bytes as lone surrogates (PEP 383
+        # `surrogateescape`), and a JSON `"\udcff"` escape does the same for
+        # server-advertised names. `quote(..., safe="")` raises
+        # `UnicodeEncodeError` on those — a `ValueError` that no call site's
+        # handler catches, so it would surface as an uncaught traceback.
+        # Rejecting costs no reachable capability: `quote(..., errors=
+        # "surrogateescape")` would encode the raw bytes instead, but a backend's
+        # folder names are config-defined `str` keys (`folder_names_and_paths`,
+        # `extra_model_paths.yaml`) that are always valid UTF-8, so such a segment
+        # can never match one — it would only turn this clear error into a 404.
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
 
 
 def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
     """Exit with an `invalid_argument` error if ``value`` isn't safe as a path segment."""
-    if not _is_safe_path_segment(value):
+    if not _is_walkable_folder_name(value):
         renderer.error(
             code="invalid_argument",
-            message=f"{kind} {value!r} contains characters that aren't allowed in a path segment",
-            hint=f"valid {kind} names are alphanumeric with `_`, `-`, or `.`",
+            message=f"{kind} {value!r} is not usable as a single path segment",
+            hint=(
+                f"a {kind} name must be non-empty, must not be `.` or `..`, must not contain "
+                "`/` or `\\`, and must be valid UTF-8"
+            ),
         )
         raise typer.Exit(code=1)
 
@@ -260,7 +275,11 @@ def list_folder_cmd(
     renderer = get_renderer()
     _reject_unsafe_path_segment(folder, kind="folder", renderer=renderer)
     target = resolve_target(where=where)
-    url = target.url(*_models_path_parts(target), folder)
+    # Percent-encoded for the same reason `_local_folder_matches` does it: the
+    # relaxed validation above admits spaces, `?`/`#`, and non-ASCII, none of
+    # which may be allowed to alter the request. Error payloads below carry the
+    # decoded `folder` so the user sees what they typed.
+    url = target.url(*_models_path_parts(target), urllib.parse.quote(folder, safe=""))
 
     try:
         data = _http_get_json(url, target)

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -62,6 +62,22 @@ def _is_safe_path_segment(value: str) -> bool:
     )
 
 
+def _is_walkable_folder_name(value: str) -> bool:
+    """True if a *server-advertised* folder name is safe to walk.
+
+    Deliberately laxer than :func:`_is_safe_path_segment`, which gates
+    user-supplied arguments and stays strict-ASCII on purpose. Real installs
+    configure folders like ``my loras``, ``SDXL (base)``, or non-ASCII names;
+    holding those to the strict regex silently skipped them, so every model
+    inside them stayed unfindable by ``models search`` — the exact bug this
+    command is meant to fix. Only genuine traversal shapes are refused here;
+    everything else is percent-encoded by :func:`_local_folder_matches` before
+    it reaches the URL, so spaces, ``?``/``#``, and control characters can't
+    alter the request.
+    """
+    return bool(value) and ".." not in value and "/" not in value and "\\" not in value
+
+
 def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
     """Exit with an `invalid_argument` error if ``value`` isn't safe as a path segment."""
     if not _is_safe_path_segment(value):
@@ -423,13 +439,23 @@ def _local_folder_names(target) -> list[str]:
 
 
 def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict[str, Any]]:
-    """Rows for one ``/models/<folder>`` listing, client-side filtered by ``text``."""
-    data = _http_get_json(target.url(*_models_path_parts(target), folder), target)
+    """Rows for one ``/models/<folder>`` listing, client-side filtered by ``text``.
+
+    ``folder`` is percent-encoded into the path so folder names with spaces or
+    non-ASCII characters resolve correctly; the emitted rows carry the decoded
+    name so ``type``/``tags`` stay human-readable.
+    """
+    segment = urllib.parse.quote(folder, safe="")
+    data = _http_get_json(target.url(*_models_path_parts(target), segment), target)
     rows: list[dict[str, Any]] = []
     if isinstance(data, list):
         for entry in data:
             name = entry.get("name", "") if isinstance(entry, dict) else (entry if isinstance(entry, str) else "")
-            if not name:
+            # A dict entry's `name` is server-controlled and may not be a string;
+            # `name.lower()` below (and the cross-folder sort in `_local_search`)
+            # would blow up on a non-str, so drop those the way the folder-name
+            # normalizer does.
+            if not isinstance(name, str) or not name:
                 continue
             if text and text.lower() not in name.lower():
                 continue
@@ -465,6 +491,11 @@ def _local_search(
     outside it invisible to text search. Walking is cheap — filename-only
     listings against a localhost server, ~20 small GETs.
     """
+    # `--limit -1` would otherwise become a negative slice that silently drops
+    # the last N rows while `total` still reports the full count. Clamp like
+    # `_cloud_search` and `list_folder_cmd` already do.
+    limit = max(0, limit)
+
     if type_:
         scoped = _local_folder_matches(target, _TYPE_TO_FOLDER.get(type_, type_), text=text)
         return scoped[:limit], len(scoped)
@@ -473,15 +504,19 @@ def _local_search(
     seen: set[str] = set()
     for folder in _local_folder_names(target):
         # Folder names are server-provided, so they can't be trusted into a URL
-        # path. Skip anything unsafe silently — it isn't user input to reject.
-        if not _is_safe_path_segment(folder) or folder in seen:
+        # path. Skip traversal shapes silently — it isn't user input to reject.
+        if not _is_walkable_folder_name(folder) or folder in seen:
             continue
         seen.add(folder)
         try:
             all_matches.extend(_local_folder_matches(target, folder, text=text))
-        except urllib.error.HTTPError:
-            # An exotic folder the listing advertises but doesn't serve (404) or
-            # otherwise errors shouldn't sink the whole search.
+        except (OSError, ValueError):
+            # One misbehaving folder must not sink the whole walk: a folder the
+            # listing advertises but doesn't serve (HTTPError 404), a hung or
+            # refused fetch (URLError/OSError — HTTPError and URLError are both
+            # OSError subclasses), a proxy serving HTML instead of JSON
+            # (json.JSONDecodeError, a ValueError), or a body over the 64 MiB
+            # cap (ValueError).
             continue
     all_matches.sort(key=lambda r: (r["type"], r["name"]))
     return all_matches[:limit], len(all_matches)

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -229,7 +229,7 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "invalid_argument",
         "An argument intended for a URL path failed safe-path validation.",
-        "use only alphanumerics, `_`, `-`, or `.` in path-segment arguments",
+        "a path-segment argument must be a single segment: non-empty, not `.` or `..`, and free of `/` and `\\`",
     ),
     ErrorCode(
         "folder_not_found",

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -395,12 +395,77 @@ class TestSearch:
         ]
         assert env["data"]["total"] == 3
 
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            pytest.param(urllib.error.URLError("connection refused"), id="urlerror"),
+            pytest.param(OSError("socket hung up"), id="oserror"),
+            pytest.param(json.JSONDecodeError("Expecting value", "<html>", 0), id="html-proxy-page"),
+            pytest.param(ValueError("response exceeds 67108864 byte cap"), id="oversize-cap"),
+        ],
+    )
+    def test_local_folder_transport_errors_are_skipped(self, local_target, monkeypatch, capsys, failure):
+        """Every way `_http_get_json` can fail on ONE folder is tolerated, not fatal.
+
+        The walk used to catch only `HTTPError`, so a hung folder or a proxy
+        serving an HTML error page aborted the entire multi-folder search.
+        """
+        routes = _local_routes()
+        routes["127.0.0.1:8188/models/vae"] = failure
+        _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == [
+            "ltx-video-2b-v0.9.safetensors",
+            "ltxv-13b-0.9.7-dev.safetensors",
+            "ltx-lora-detail.safetensors",
+        ]
+        assert env["data"]["total"] == 3
+
+    def test_local_folder_name_with_space_is_walked_and_encoded(self, local_target, monkeypatch, capsys):
+        """A user-configured folder like `my loras` is searched, not silently skipped."""
+        # Built explicitly (not via `_local_routes`) so the per-folder needle is
+        # registered before the bare `/models` one — first-wins substring match.
+        routes = {
+            "127.0.0.1:8188/models/my%20loras": [{"name": "ltx-custom.safetensors", "pathIndex": 0}],
+            "127.0.0.1:8188/models": ["my loras"],
+        }
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-custom.safetensors"]
+        # The segment is percent-encoded on the wire but decoded in the payload.
+        assert [c["url"] for c in calls[1:]] == ["http://127.0.0.1:8188/models/my%20loras"]
+        assert env["data"]["rows"][0]["type"] == "my loras"
+        assert env["data"]["rows"][0]["tags"] == ["my loras"]
+
+    def test_local_non_string_entry_name_is_skipped(self, local_target, monkeypatch, capsys):
+        """A server sending a non-string `name` must not crash the walk or the sort."""
+        routes = _local_routes()
+        routes["127.0.0.1:8188/models/vae"] = [{"name": 1234, "pathIndex": 0}, {"name": "ltx-vae.safetensors"}]
+        _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert "ltx-vae.safetensors" in [r["name"] for r in env["data"]["rows"]]
+        assert all(isinstance(r["name"], str) for r in env["data"]["rows"])
+
     def test_local_limit_caps_rows_but_not_total(self, local_target, monkeypatch, capsys):
         _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "ltx", "--limit", "2", "--where", "local"], capsys)
         assert env["data"]["shown"] == 2
         assert len(env["data"]["rows"]) == 2
         assert env["data"]["total"] == 4
+
+    @pytest.mark.parametrize("extra", [[], ["--type", "lora"]])
+    def test_local_negative_limit_yields_no_rows_not_a_negative_slice(self, local_target, monkeypatch, capsys, extra):
+        """`--limit -1` must not silently drop the *last* row via a negative slice."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "ltx", "--limit", "-1", "--where", "local", *extra], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["rows"] == []
+        assert env["data"]["shown"] == 0
+        # `total` still reports every match behind the cap.
+        assert env["data"]["total"] == (1 if extra else 4)
 
     def test_local_unsafe_folder_name_is_skipped(self, local_target, monkeypatch, capsys):
         """A server-advertised folder that can't be a URL path segment is skipped, not fatal."""

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -94,6 +94,33 @@ _CLOUD_FILES_LORAS = [
 ]
 
 
+# A local install as BE-4733 found it: the interesting models (flux, ltx) live
+# OUTSIDE `checkpoints`, spread across diffusion_models / loras / vae.
+_LOCAL_SEARCH_FOLDERS = ["checkpoints", "diffusion_models", "loras", "vae"]
+
+_LOCAL_FILES_BY_FOLDER: dict[str, list[dict[str, Any]]] = {
+    "checkpoints": [{"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0}],
+    "diffusion_models": [
+        {"name": "flux1-dev.safetensors", "pathIndex": 0},
+        {"name": "ltx-video-2b-v0.9.safetensors", "pathIndex": 0},
+        {"name": "ltxv-13b-0.9.7-dev.safetensors", "pathIndex": 0},
+    ],
+    "loras": [{"name": "ltx-lora-detail.safetensors", "pathIndex": 0}],
+    "vae": [{"name": "ltx-vae.safetensors", "pathIndex": 0}],
+}
+
+
+def _local_routes() -> dict[str, Any]:
+    """Routes for a local `models search`: the per-folder listings, then `/models`.
+
+    Order matters — `_patch_urlopen` matches URL substrings first-wins, and the
+    bare `/models` needle would otherwise swallow every `/models/<folder>` hit.
+    """
+    routes: dict[str, Any] = {f"127.0.0.1:8188/models/{f}": files for f, files in _LOCAL_FILES_BY_FOLDER.items()}
+    routes["127.0.0.1:8188/models"] = _LOCAL_SEARCH_FOLDERS
+    return routes
+
+
 _ASSETS_RESPONSE = {
     "assets": [
         {
@@ -308,33 +335,98 @@ class TestSearch:
         assert "include_tags=models%2Cloras" in url
 
     def test_local_falls_back_to_folder_listing(self, local_target, monkeypatch, capsys):
-        _patch_urlopen(
-            monkeypatch,
-            {"127.0.0.1:8188/models/checkpoints": [{"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0}]},
-        )
+        _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "sd_xl", "--where", "local"], capsys)
         assert env["ok"] is True
         assert env["data"]["mode"] == "local"
         rows = env["data"]["rows"]
         assert len(rows) == 1
         assert rows[0]["name"] == "sd_xl_base_1.0.safetensors"
+        assert rows[0]["type"] == "checkpoints"
         # Local has no enrichment.
         assert rows[0]["base_model"] is None
         assert rows[0]["source_url"] is None
 
     def test_local_text_filter_is_client_side(self, local_target, monkeypatch, capsys):
-        _patch_urlopen(
-            monkeypatch,
-            {
-                "127.0.0.1:8188/models/checkpoints": [
-                    {"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0},
-                    {"name": "flux1-dev.safetensors", "pathIndex": 0},
-                ]
-            },
-        )
+        _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "flux", "--where", "local"], capsys)
         names = [r["name"] for r in env["data"]["rows"]]
+        # BE-4733: flux lives in diffusion_models, not checkpoints — it must still be found.
         assert names == ["flux1-dev.safetensors"]
+        assert env["data"]["rows"][0]["type"] == "diffusion_models"
+
+    def test_local_text_matches_across_folders(self, local_target, monkeypatch, capsys):
+        """BE-4733: every on-disk ltx* file is returned, whatever folder it lives in."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        rows = env["data"]["rows"]
+        by_name = {r["name"]: r["type"] for r in rows}
+        assert by_name == {
+            "ltx-video-2b-v0.9.safetensors": "diffusion_models",
+            "ltxv-13b-0.9.7-dev.safetensors": "diffusion_models",
+            "ltx-lora-detail.safetensors": "loras",
+            "ltx-vae.safetensors": "vae",
+        }
+        # `tags` mirrors the source folder, and `total` counts every cross-folder match.
+        assert all(r["tags"] == [r["type"]] for r in rows)
+        assert env["data"]["total"] == 4
+        assert env["data"]["shown"] == 4
+
+    def test_local_type_still_scopes_to_one_folder(self, local_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "ltx", "--type", "lora", "--where", "local"], capsys)
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-lora-detail.safetensors"]
+        # Exactly one fetch, of /models/loras — no folder-list walk.
+        assert [c["url"] for c in calls] == ["http://127.0.0.1:8188/models/loras"]
+
+    def test_local_folder_fetch_error_is_skipped(self, local_target, monkeypatch, capsys):
+        routes = _local_routes()
+        routes["127.0.0.1:8188/models/vae"] = urllib.error.HTTPError(
+            "http://127.0.0.1:8188/models/vae", 404, "Not Found", {}, io.BytesIO(b"nope")
+        )
+        _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True
+        # The vae hit is gone; the other folders' matches still come back.
+        assert [r["name"] for r in env["data"]["rows"]] == [
+            "ltx-video-2b-v0.9.safetensors",
+            "ltxv-13b-0.9.7-dev.safetensors",
+            "ltx-lora-detail.safetensors",
+        ]
+        assert env["data"]["total"] == 3
+
+    def test_local_limit_caps_rows_but_not_total(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "ltx", "--limit", "2", "--where", "local"], capsys)
+        assert env["data"]["shown"] == 2
+        assert len(env["data"]["rows"]) == 2
+        assert env["data"]["total"] == 4
+
+    def test_local_unsafe_folder_name_is_skipped(self, local_target, monkeypatch, capsys):
+        """A server-advertised folder that can't be a URL path segment is skipped, not fatal."""
+        routes = _local_routes()
+        routes["127.0.0.1:8188/models"] = ["../../etc", "loras"]
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-lora-detail.safetensors"]
+        assert not any("etc" in c["url"] for c in calls)
+
+    def test_local_duplicate_folder_is_fetched_once(self, local_target, monkeypatch, capsys):
+        """A folder listed twice by the server must not double-count its files."""
+        routes = _local_routes()
+        routes["127.0.0.1:8188/models"] = ["loras", "loras", "vae"]
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-lora-detail.safetensors", "ltx-vae.safetensors"]
+        assert env["data"]["total"] == 2
+        assert sum(1 for c in calls if c["url"].endswith("/models/loras")) == 1
+
+    def test_local_folder_list_error_surfaces_server_not_running(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, {"127.0.0.1:8188/models": urllib.error.URLError("connection refused")})
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_not_running"
 
     def test_cloud_http_error_decodes_body(self, cloud_target, monkeypatch, capsys):
         # Shared `_emit_http_error` path via the search handler.

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import io
 import json
 import urllib.error
+import urllib.parse
 from typing import Any
 
 import pytest
@@ -296,6 +297,110 @@ class TestListFolder:
         assert env["ok"] is False
         assert env["error"]["code"] == "folder_not_found"
 
+    def test_folder_name_with_space_is_accepted_and_encoded(self, local_target, monkeypatch, capsys):
+        """A user-configured folder like `my loras` lists, matching what `search --where local` finds."""
+        routes = {"127.0.0.1:8188/models/my%20loras": [{"name": "ltx-custom.safetensors", "pathIndex": 0}]}
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["list-folder", "my loras", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [c["url"] for c in calls] == ["http://127.0.0.1:8188/models/my%20loras"]
+        # The payload echoes the decoded name the user typed, not the wire form.
+        assert env["data"]["folder"] == "my loras"
+        assert [f["name"] for f in env["data"]["files"]] == ["ltx-custom.safetensors"]
+
+    @pytest.mark.parametrize(
+        "folder",
+        [
+            "SDXL (base)",  # parentheses
+            "モデル",  # non-ASCII
+            "_hidden",  # leading underscore — rejected by the old strict regex
+            "a?b#c",  # URL-significant characters, neutralized by percent-encoding
+        ],
+    )
+    def test_non_traversal_folder_names_are_accepted(self, local_target, monkeypatch, capsys, folder):
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        # Every character that could re-shape the request is encoded away.
+        assert [c["url"] for c in calls] == [f"http://127.0.0.1:8188/models/{segment}"]
+        assert env["data"]["folder"] == folder
+
+    @pytest.mark.parametrize("folder", ["../../etc", "..", "a/b", "a\\b", ""])
+    def test_traversal_shapes_still_rejected(self, local_target, monkeypatch, capsys, folder):
+        """Relaxing the charset must not relax the traversal guard — and no request is issued."""
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    @pytest.mark.parametrize("folder", ["%2e%2e%2fetc", "%2E%2E%2Fetc", "a%00b", "a\r\nX-Evil: 1"])
+    def test_encoded_traversal_and_injection_shapes_are_neutralized(self, local_target, monkeypatch, capsys, folder):
+        """`%` and control characters are no longer charset-rejected, so encoding must defuse them.
+
+        These are the shapes the old strict regex blocked incidentally. The
+        traversal guard alone lets them through — `..` and `/` are not
+        *literally* present — so the percent-encoding in `list_folder_cmd` is
+        what keeps them inside one path segment: `%` becomes `%25`, so an
+        encoded `../` can never be decoded back into one by the server.
+        """
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        url = calls[0]["url"]
+        assert url == f"http://127.0.0.1:8188/models/{segment}"
+        # Exactly one layer of encoding: the server decodes back to the literal
+        # folder name the user asked for, never to a traversal or a new header.
+        assert urllib.parse.unquote(segment) == folder
+        # And nothing escaped the segment on the wire.
+        assert url.count("/") == 4  # http:// + /127.0.0.1:8188 + /models + /<segment>
+        assert not any(c in url for c in "\r\n\x00")
+
+    @pytest.mark.parametrize("folder", ["model..v2", "my..folder", "..hidden", "trailing.."])
+    def test_dots_inside_a_name_are_not_traversal(self, local_target, monkeypatch, capsys, folder):
+        """Only the exact segments `.`/`..` are dot-segments; `..` mid-name is an ordinary name.
+
+        A substring `".." not in value` guard silently skipped these on the
+        `search --where local` walk and rejected them outright here, even though
+        `/models/model..v2` resolves to exactly that folder — no resolver rewrites it.
+        """
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [c["url"] for c in calls] == [f"http://127.0.0.1:8188/models/{segment}"]
+        assert env["data"]["folder"] == folder
+
+    @pytest.mark.parametrize("folder", [".", ".."])
+    def test_bare_dot_segments_are_rejected(self, local_target, monkeypatch, capsys, folder):
+        """`.` and `..` are rewritten by a URL resolver, so they can't stay one segment.
+
+        `quote(..., safe="")` leaves `.` untouched, so a bare `.` would reach the
+        server as `/models/.` and normalize back to the `/models` *collection* —
+        rendering the folder list as if it were a file listing.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    def test_undecodable_argv_bytes_error_cleanly(self, local_target, monkeypatch, capsys):
+        """A non-UTF-8 filename from argv must be `invalid_argument`, not a traceback.
+
+        Python decodes undecodable argv bytes into lone surrogates (PEP 383
+        `surrogateescape`). `quote(..., safe="")` raises `UnicodeEncodeError` on
+        those, and it runs *before* `list_folder_cmd`'s try block — so without a
+        guard the CLI dies with an uncaught stack trace.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", "a\udcffb", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
 
 # ---------------------------------------------------------------------------
 # search
@@ -438,6 +543,58 @@ class TestSearch:
         assert [c["url"] for c in calls[1:]] == ["http://127.0.0.1:8188/models/my%20loras"]
         assert env["data"]["rows"][0]["type"] == "my loras"
         assert env["data"]["rows"][0]["tags"] == ["my loras"]
+
+    def test_local_type_with_space_scopes_to_that_folder(self, local_target, monkeypatch, capsys):
+        """`--type "my loras"` is an unmapped passthrough — it must scope, not error."""
+        routes = {"127.0.0.1:8188/models/my%20loras": [{"name": "ltx-custom.safetensors", "pathIndex": 0}]}
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--type", "my loras", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        # Scoped: the bare `/models` folder listing is never fetched.
+        assert [c["url"] for c in calls] == ["http://127.0.0.1:8188/models/my%20loras"]
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-custom.safetensors"]
+        assert env["data"]["rows"][0]["type"] == "my loras"
+
+    def test_local_type_traversal_still_rejected(self, local_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["search", "--text", "ltx", "--type", "../../etc", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    def test_local_type_undecodable_argv_bytes_error_cleanly(self, local_target, monkeypatch, capsys):
+        """`--type` reaches `quote` via `_local_folder_matches`, whose handler misses this.
+
+        `search`'s except clause catches `json.JSONDecodeError` but not bare
+        `ValueError`, so the `UnicodeEncodeError` a surrogate raises would escape
+        uncaught. The guard rejects it up front instead.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["search", "--text", "ltx", "--type", "a\udcffb", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    def test_local_walk_skips_undecodable_server_folder_name(self, local_target, monkeypatch, capsys):
+        """A server-advertised name carrying a lone surrogate is skipped, not fatal.
+
+        `json.loads('"\\udcff"')` yields a lone surrogate, so this shape is
+        reachable from a malicious or buggy backend. The walk must drop just that
+        folder and still return every other folder's models.
+        """
+        routes = {
+            "127.0.0.1:8188/models/loras": [{"name": "ltx-lora-detail.safetensors", "pathIndex": 0}],
+            "127.0.0.1:8188/models": ["loras", "bad\udcffname"],
+        }
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-lora-detail.safetensors"]
+        # The undecodable folder is never fetched at all.
+        assert [c["url"] for c in calls] == [
+            "http://127.0.0.1:8188/models",
+            "http://127.0.0.1:8188/models/loras",
+        ]
 
     def test_local_non_string_entry_name_is_skipped(self, local_target, monkeypatch, capsys):
         """A server sending a non-string `name` must not crash the walk or the sort."""


### PR DESCRIPTION
## ELI-5

`comfy models search --text flux` against a local ComfyUI used to only look inside the `checkpoints` folder. Your flux and ltx files live in `diffusion_models`, `loras`, and `vae` — so the CLI told you they weren't there. Now, when you don't pass `--type`, it asks the server for the list of model folders and looks in all of them.

## What changed

`_local_search()` in `comfy_cli/command/models/search.py` hardcoded `folder = "checkpoints"` on the no-`--type` path, so the local text search substring-filtered exactly one folder's listing. BE-4733 is the symptom: `--text flux` returned 0 results while the files sat in `diffusion_models`, and `--text ltx` returned 1 of 5. `comfy-local-mcp`'s `search_models(query=...)` is a thin passthrough to this command, so agents concluded installed models were missing.

Without `--type`, the search now fetches the folder list from `/models` — the same endpoint and the same tolerant normalizer `list-folders` uses (flat string list, dict entries with a `name` key) — and GETs each folder's listing, applying the existing case-insensitive substring filter. Rows carry `"type": <folder>` and `"tags": [<folder>]` per source folder, are sorted deterministically by `(type, name)`, and `total` is computed on the full aggregate *before* the `[:limit]` slice, so the `(items, total)` contract is unchanged.

Two skip paths keep one bad folder from sinking the search: a folder name that fails the `_PATH_SAFE` path-segment check is skipped silently (it's server-provided, not user input to reject, and it must never be interpolated into a URL), and a per-folder `HTTPError` (e.g. a 404 on an exotic folder the listing advertises but doesn't serve) drops that folder and continues. `URLError` / `OSError` / `JSONDecodeError` from the *initial* folder-list fetch still propagate, so a genuinely-down server keeps hitting the existing `server_not_running` handling in `search_cmd`.

The `--type` path is unchanged: `_TYPE_TO_FOLDER.get(type_, type_)`, one fetch, server ordering preserved, errors propagating as before. `_cloud_search` is untouched.

The stale "scanning every folder would be slow" comment is gone — these are filename-only listings against a localhost server, ~20 small GETs.

## Verification

Full suite green: `2775 passed, 37 skipped`. `ruff check` + `ruff format --diff` clean at the CI-pinned 0.15.15 (note: the repo's `uv.lock` pins ruff 0.12.7 for local dev, which reports 15 pre-existing findings on untouched files — 0.15.15, what `ruff_check.yml` installs, is clean).

Beyond the unit tests I ran the real CLI against a stdlib HTTP server impersonating a local ComfyUI (folders `checkpoints`, `diffusion_models`, `loras`, `vae`, `text_encoders`, plus a `ghost_folder` that 404s), confirming each acceptance criterion end-to-end:

- `--text flux --where local` → 2 rows: `diffusion_models/flux1-dev.safetensors`, `vae/flux-ae.safetensors` (previously 0).
- `--text ltx --where local` → 4 rows across `diffusion_models` (2), `loras`, `vae` (previously 1).
- `--text ltx --type lora` → 1 row, `/models/loras` only.
- `--limit 2` → `shown: 2`, `total: 4`.
- The 404 folder was skipped with exit code 0; with the server stopped the envelope is still `server_not_running`, exit 1.

## Tests

`test_local_falls_back_to_folder_listing` and `test_local_text_filter_is_client_side` now mock a multi-folder install (the second one is the direct BE-4733 regression: flux lives in `diffusion_models`). Added: cross-folder matching with per-row `type`/`tags` and full `total`; `--type` scoping asserted by URL (exactly one call, to `/models/loras`); a per-folder 404 skipped while the rest still return; limit vs total; an unsafe folder name skipped without its URL ever being requested; a duplicate folder name fetched once; and folder-list failure surfacing `server_not_running`.

## Judgment calls

- **Duplicate-folder guard (beyond the ticket).** A server listing the same folder twice would have double-counted its files into `total` and `rows`. One `seen` set, one test. Not spec'd, but it's the kind of thing the aggregation newly makes possible.
- **Per-folder `HTTPError` is swallowed for any status, not just 404** — as the ticket specifies. Worth naming the edge: if *every* folder 5xx'd, the user would see 0 results and exit 0 with no signal. The initial folder-list fetch is deliberately left unguarded, which is what covers the realistic "server is unhealthy" case; a server healthy enough to serve `/models` but 5xx-ing every subfolder is exotic. Happy to narrow it to `404` if you'd rather fail loud.
- **Sorting is applied only to the aggregated path.** Sorting the `--type` path too would have been tidier, but it changes today's output order (server listing order) for a path the ticket says to keep as-is.
- **`_reject_unsafe_path_segment` was split into a boolean `_is_safe_path_segment` predicate** so the folder walk can skip rather than exit. The condition is De Morgan-identical to the original; the exiting wrapper is byte-for-byte equivalent in behavior for its two existing callers.
- **Negative-claim falsification: not applicable.** This diff is purely capability-*expanding* — no "not supported"/"unavailable" strings, no new throw/deny dead-end, no test flipped to assert a dead-end. The two skip paths narrow error handling within an existing success path; they don't deny a user-facing capability.

## Not covered

Local search remains filename-substring only — no enrichment, no tag-based type inference, since `/models/<folder>` returns filenames and nothing else. That's the documented local-mode caveat, unchanged.
