### PR TITLE
fix: comfy run --wait writes job state at submit, names prompt_id on disconnect (BE-4750)

### DIFF
--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -274,7 +274,12 @@ def execute(
     # None on the async path — that branch writes and owns its own state — and
     # before ``queue()`` has returned a prompt_id.
     wait_state: jobs_state.JobState | None = None
-    wait_state_file = None
+    # --wait success payload, rendered/emitted AFTER the try below rather than
+    # inside it. Writing to a closed stdout (`comfy run --wait … | head`)
+    # raises BrokenPipeError — a ConnectionError/OSError subclass the
+    # disconnect handler would otherwise catch, rewriting the just-persisted
+    # `completed` record to `error` and flipping a successful run's exit to 1.
+    completed_payload: dict | None = None
 
     try:
         if wait:
@@ -303,16 +308,27 @@ def execute(
             )
             wait_state.item_map = (compose_meta or {}).get("items")
             wait_state.status = "running"
-            wait_state_file = _write_state(wait_state)
+            _write_state(wait_state)
 
-            execution.watch_execution()
+            # `watch_execution` reports a terminal server event by rendering
+            # the error and raising `typer.Exit` (1 for `execution_error`, 130
+            # for `execution_interrupted`) — the ordinary failure path, not an
+            # exception the handlers below see. Finalize the submit-time
+            # record here, or a failed job is stranded as a phantom `running`
+            # forever: `jobs ls` only reaps non-terminal records whose
+            # `watcher_pid` is dead, and `--wait` never sets one.
+            try:
+                execution.watch_execution()
+            except typer.Exit as exit_exc:
+                _mark_watch_exit(wait_state, exit_exc.exit_code, execution)
+                raise
             end = time.time()
             if progress is not None:
                 progress.stop()
                 progress = None
 
             if token.is_set():
-                wait_state_file = _mark_cancelled(wait_state) or wait_state_file
+                _mark_cancelled(wait_state)
                 renderer.error(
                     code="cancelled",
                     message="Cancelled by user",
@@ -325,15 +341,11 @@ def execute(
             state = wait_state
             state.status = "completed"
             state.outputs = list(execution.outputs)
-            state_file = _write_state(state) or wait_state_file
-
-            if renderer.is_pretty():
-                if len(execution.outputs) > 0:
-                    pprint("[bold green]\nOutputs:[/bold green]")
-                    for f in execution.outputs:
-                        pprint(f)
-                elapsed = timedelta(seconds=end - start)
-                pprint(f"[bold green]\nWorkflow execution completed ({elapsed})[/bold green]")
+            # No fallback to the submit-time path: if the terminal write
+            # failed, that file still says `running`, so handing it back as
+            # the `completed` record's `state_file` would point the caller at
+            # contents contradicting what we just reported.
+            state_file = _write_state(state)
 
             # Grouped views of the same artifacts — local parity with the
             # cloud --wait envelope: by producing node always, and by
@@ -342,25 +354,21 @@ def execute(
 
             outputs_by_node, outputs_by_item = _group_outputs(list(execution.output_entries), state.item_map)
 
-            renderer.emit(
-                {
-                    "workflow": workflow_name,
-                    "status": "completed",
-                    "prompt_id": execution.prompt_id,
-                    "client_id": execution.client_id,
-                    "outputs": list(execution.outputs),
-                    "outputs_by_node": outputs_by_node,
-                    "outputs_by_item": outputs_by_item,
-                    "cached_node_ids": list(execution.cached_node_ids),
-                    "executed_node_ids": list(execution.executed_node_ids),
-                    "elapsed_seconds": end - start,
-                    "host": host,
-                    "port": port,
-                    "state_file": str(state_file) if state_file else None,
-                },
-                command="run",
-                where="local",
-            )
+            completed_payload = {
+                "workflow": workflow_name,
+                "status": "completed",
+                "prompt_id": execution.prompt_id,
+                "client_id": execution.client_id,
+                "outputs": list(execution.outputs),
+                "outputs_by_node": outputs_by_node,
+                "outputs_by_item": outputs_by_item,
+                "cached_node_ids": list(execution.cached_node_ids),
+                "executed_node_ids": list(execution.executed_node_ids),
+                "elapsed_seconds": end - start,
+                "host": host,
+                "port": port,
+                "state_file": str(state_file) if state_file else None,
+            }
         else:
             # Async path (the default). Write the initial state file and
             # spawn a detached watcher to keep it updated; the foreground
@@ -472,7 +480,9 @@ def execute(
                 "message": f"Lost connection to ComfyUI while job {prompt_id} was running: {e}",
                 "details": {},
             }
-            path = _write_state(wait_state) or wait_state_file
+            # Same rule as the success path: report a state_file only when
+            # this terminal write actually landed.
+            path = _write_state(wait_state)
             renderer.error(
                 code="ws_disconnected",
                 message=f"Lost connection to ComfyUI server while job {prompt_id} was running: {e}",
@@ -493,6 +503,19 @@ def execute(
         # async (no --wait) path connect() never ran so ws is None and this is
         # a no-op; it is idempotent with the SIGINT-token close wired above.
         _safe_close(execution)
+
+    # Deliberately outside the try: the job is done and persisted, so a
+    # BrokenPipeError from a closed stdout must surface as itself rather than
+    # be mistaken for the server disconnecting (see `completed_payload`).
+    if completed_payload is not None:
+        if renderer.is_pretty():
+            if completed_payload["outputs"]:
+                pprint("[bold green]\nOutputs:[/bold green]")
+                for f in completed_payload["outputs"]:
+                    pprint(f)
+            elapsed = timedelta(seconds=completed_payload["elapsed_seconds"])
+            pprint(f"[bold green]\nWorkflow execution completed ({elapsed})[/bold green]")
+        renderer.emit(completed_payload, command="run", where="local")
 
 
 def _write_state(state):
@@ -517,12 +540,42 @@ def _mark_cancelled(state):
 
     Returns the path written, or None when there is nothing to write — a
     Ctrl-C before ``queue()`` returned leaves ``state`` None, so there is no
-    prompt_id to file it under.
+    prompt_id to file it under, and a record that is ALREADY terminal is left
+    alone. That last guard matters because the Ctrl-C handler is shared by the
+    whole run: a Ctrl-C after the completion write has landed must not walk a
+    ``completed`` job backwards to ``cancelled``.
     """
-    if state is None:
+    if state is None or state.is_terminal:
         return None
     state.status = "cancelled"
     state.error = {"code": "cancelled", "message": "Cancelled by user", "details": {}}
+    return _write_state(state)
+
+
+def _mark_watch_exit(state, exit_code, execution):
+    """Finalize the submit-time record when ``watch_execution`` ends the run by
+    raising ``typer.Exit``: 130 is a server-side interrupt (``cancelled``),
+    anything else is a node failure (``error``).
+
+    The error envelope has already been rendered by the watcher, so this only
+    moves the on-disk record off ``running``. Prefers the classified verdict
+    ``on_error`` stashed on the execution; falls back to a generic
+    ``execution_error`` when there isn't one (or it isn't a real dict — mocked
+    executions hand back attribute stubs).
+    """
+    if state is None:
+        return None
+    if exit_code == 130:
+        return _mark_cancelled(state)
+    verdict = getattr(execution, "last_error", None)
+    if not isinstance(verdict, dict):
+        verdict = {
+            "code": "execution_error",
+            "message": "Workflow execution failed on the server",
+            "details": {},
+        }
+    state.status = "error"
+    state.error = verdict
     return _write_state(state)
 
 

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -268,6 +268,14 @@ def execute(
     token = cancellation.get_token()
     token.on_cancel(lambda: _safe_close(execution))
 
+    # --wait only: the state written right after a successful submit, kept in
+    # scope so the exception handlers below can record what happened to a
+    # prompt that was already in flight (e.g. the server dying mid-run). Stays
+    # None on the async path — that branch writes and owns its own state — and
+    # before ``queue()`` has returned a prompt_id.
+    wait_state: jobs_state.JobState | None = None
+    wait_state_file = None
+
     try:
         if wait:
             execution.connect()
@@ -280,24 +288,12 @@ def execute(
             execution.queue()
         _journal_run(workflow_name, execution.prompt_id, "local")
         if wait:
-            execution.watch_execution()
-            end = time.time()
-            if progress is not None:
-                progress.stop()
-                progress = None
-
-            if token.is_set():
-                renderer.error(
-                    code="cancelled",
-                    message="Cancelled by user",
-                    exit_code=130,
-                )
-                raise typer.Exit(code=130)
-
-            # Foreground (--wait) completion path also writes the state
-            # file so the on-disk record is consistent regardless of which
-            # mode the user ran in.
-            state = jobs_state.new(
+            # Write the state file at SUBMIT time, exactly like the async
+            # branch below — if the server dies mid-run the on-disk record is
+            # the only place the in-flight prompt_id survives. Status is
+            # "running" rather than "queued": this foreground process is
+            # actively watching it, not leaving it detached in the queue.
+            wait_state = jobs_state.new(
                 prompt_id=execution.prompt_id,
                 client_id=execution.client_id,
                 workflow=workflow_name,
@@ -305,10 +301,31 @@ def execute(
                 host=host,
                 port=port,
             )
+            wait_state.item_map = (compose_meta or {}).get("items")
+            wait_state.status = "running"
+            wait_state_file = _write_state(wait_state)
+
+            execution.watch_execution()
+            end = time.time()
+            if progress is not None:
+                progress.stop()
+                progress = None
+
+            if token.is_set():
+                wait_state_file = _mark_cancelled(wait_state) or wait_state_file
+                renderer.error(
+                    code="cancelled",
+                    message="Cancelled by user",
+                    exit_code=130,
+                )
+                raise typer.Exit(code=130)
+
+            # Completion updates the record written at submit — same file,
+            # same final shape (``jobs_state.write`` stamps the timestamps).
+            state = wait_state
             state.status = "completed"
             state.outputs = list(execution.outputs)
-            state.item_map = (compose_meta or {}).get("items")
-            state_file = jobs_state.write(state)
+            state_file = _write_state(state) or wait_state_file
 
             if renderer.is_pretty():
                 if len(execution.outputs) > 0:
@@ -398,6 +415,7 @@ def execute(
         if progress is not None:
             progress.stop()
             progress = None
+        _mark_cancelled(wait_state)
         if renderer.is_pretty():
             pprint("[yellow]Workflow execution was interrupted[/yellow]")
         renderer.error(
@@ -412,11 +430,17 @@ def execute(
                 f"[bold red]Error: WebSocket timed out after {timeout}s waiting for server response.[/bold red]\n"
                 "[yellow]For long-running workflows, increase the timeout: comfy run --workflow <file> --timeout 300[/yellow]"
             )
+        # The job may genuinely still be running server-side, so the
+        # submit-time "running" record is left as-is — not marked terminal.
+        details = {"timeout": timeout}
+        prompt_id = _submitted_prompt_id(execution)
+        if prompt_id is not None:
+            details["prompt_id"] = prompt_id
         renderer.error(
             code="ws_timeout",
             message=f"WebSocket timed out after {timeout}s waiting for server response.",
             hint="re-run with a larger --timeout (e.g. --timeout 300)",
-            details={"timeout": timeout},
+            details=details,
         )
         raise typer.Exit(code=1)
     except (WebSocketException, ConnectionError, OSError) as e:
@@ -428,6 +452,7 @@ def execute(
         if token.is_set():
             if progress is not None:
                 progress.stop()
+            _mark_cancelled(wait_state)
             renderer.error(
                 code="cancelled",
                 message="Cancelled by user",
@@ -436,6 +461,25 @@ def execute(
             raise typer.Exit(code=130) from e
         if renderer.is_pretty():
             pprint(f"[bold red]Error: Lost connection to ComfyUI server: {e}[/bold red]")
+        # The server died with a prompt of ours in flight: record that on the
+        # submit-time state file and name the prompt in the emitted error, so
+        # `comfy jobs status <id>` has something to consult afterwards.
+        prompt_id = _submitted_prompt_id(execution)
+        if prompt_id is not None and wait_state is not None:
+            wait_state.status = "error"
+            wait_state.error = {
+                "code": "server_died",
+                "message": f"Lost connection to ComfyUI while job {prompt_id} was running: {e}",
+                "details": {},
+            }
+            path = _write_state(wait_state) or wait_state_file
+            renderer.error(
+                code="ws_disconnected",
+                message=f"Lost connection to ComfyUI server while job {prompt_id} was running: {e}",
+                hint="check the server is still running; re-run the command",
+                details={"prompt_id": prompt_id, "state_file": str(path) if path else None},
+            )
+            raise typer.Exit(code=1)
         renderer.error(
             code="ws_disconnected",
             message=f"Lost connection to ComfyUI server: {e}",
@@ -449,6 +493,50 @@ def execute(
         # async (no --wait) path connect() never ran so ws is None and this is
         # a no-op; it is idempotent with the SIGINT-token close wired above.
         _safe_close(execution)
+
+
+def _write_state(state):
+    """Best-effort ``jobs_state.write``. Returns the path, or None if the
+    write was skipped, the state dir was unwritable, or the prompt_id was
+    unusable as a filename.
+
+    A state-file failure must never fail an otherwise-successful run — same
+    tolerance the async path gives a watcher that won't spawn. Swallowing
+    ``ValueError`` matters now that ``--wait`` writes at SUBMIT: a server
+    returning an id ``state_path()`` rejects must not stop us from watching
+    the run it just accepted.
+    """
+    try:
+        return jobs_state.write(state)
+    except (OSError, ValueError):
+        return None
+
+
+def _mark_cancelled(state):
+    """Record a user cancellation on the job state file (best effort).
+
+    Returns the path written, or None when there is nothing to write — a
+    Ctrl-C before ``queue()`` returned leaves ``state`` None, so there is no
+    prompt_id to file it under.
+    """
+    if state is None:
+        return None
+    state.status = "cancelled"
+    state.error = {"code": "cancelled", "message": "Cancelled by user", "details": {}}
+    return _write_state(state)
+
+
+def _submitted_prompt_id(execution) -> str | None:
+    """The prompt id if the server really returned one, else None.
+
+    Mirrors ``jobs_state.write``'s defensiveness about mocked executions: a
+    non-string id means no usable submit happened, so callers fall back to
+    their pre-prompt_id behavior.
+    """
+    prompt_id = getattr(execution, "prompt_id", None)
+    if isinstance(prompt_id, str) and prompt_id.strip():
+        return prompt_id
+    return None
 
 
 def _journal_run(workflow: str, prompt_id, where: str) -> None:

--- a/comfy_cli/command/run/execution.py
+++ b/comfy_cli/command/run/execution.py
@@ -120,6 +120,11 @@ class WorkflowExecution:
         # compute nodes that never fire a server-side `executed` event.
         self.cached_node_ids: list[str] = []
         self.executed_node_ids: list[str] = []
+        # Classified verdict of a terminal server-side `execution_error`,
+        # stashed by `on_error` before it raises `typer.Exit`. The `--wait`
+        # caller only sees the exit, so this is how the real cause reaches
+        # the job state file.
+        self.last_error: dict | None = None
 
     def connect(self):
         # Resolve via the package namespace so tests can patch
@@ -541,6 +546,11 @@ class WorkflowExecution:
         # the error envelope carries the classified one-line verdict.
         self.renderer.event("execution_error", prompt_id=self.prompt_id, details=data)
         verdict = execution_errors.classify(data)
+        self.last_error = {
+            "code": verdict["code"],
+            "message": verdict["message"],
+            "details": dict(verdict["details"]),
+        }
         self.renderer.error(
             code=verdict["code"],
             message=verdict["message"],

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -330,6 +330,11 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "the job may still be running — check `comfy jobs status <id>`, or re-watch with a longer `--timeout`",
     ),
     ErrorCode(
+        "server_died",
+        "Server connection dropped while a foreground (`--wait`) job was in flight; recorded on the job state file.",
+        "check the server (it may have been OOM-killed); the prompt_id is in `comfy jobs status <id>`",
+    ),
+    ErrorCode(
         "watcher_poll_error",
         "Background watcher encountered a transient error polling the server.",
         "transient — the job is likely still running; re-run `comfy jobs watch <id>`",

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -504,6 +504,193 @@ class TestExecuteErrorHandling:
             mock_progress.stop.assert_called()
 
 
+class TestWaitStateFile:
+    """`comfy run --wait` writes the jobs state file at SUBMIT time, not only
+    on success (BE-4750) — so a server that dies mid-run still leaves an
+    on-disk record of the prompt that was in flight, and the emitted error
+    names it."""
+
+    @pytest.fixture
+    def fresh_token(self):
+        """The cancellation token is process-wide; reset it around any test
+        that cancels so the flag can't leak into the rest of the suite."""
+        from comfy_cli import cancellation
+
+        cancellation.reset_for_testing()
+        yield cancellation
+        cancellation.reset_for_testing()
+
+    def _mock_exec(self, prompt_id):
+        mock_exec = MagicMock()
+        mock_exec.prompt_id = prompt_id
+        mock_exec.client_id = "cid-wait"
+        mock_exec.outputs = []
+        mock_exec.output_entries = []
+        mock_exec.cached_node_ids = []
+        mock_exec.executed_node_ids = []
+        return mock_exec
+
+    def _capture_errors(self, monkeypatch):
+        from comfy_cli.output.renderer import Renderer
+
+        captured = []
+        original_error = Renderer.error
+
+        def capture_error(self, *, code, message, hint=None, details=None, exit_code=1):
+            captured.append({"code": code, "message": message, "hint": hint, "details": details})
+            return original_error(self, code=code, message=message, hint=hint, details=details, exit_code=exit_code)
+
+        monkeypatch.setattr(Renderer, "error", capture_error)
+        return captured
+
+    def _run(self, workflow_file, mock_exec, **overrides):
+        kwargs = dict(host="127.0.0.1", port=8188, wait=True, timeout=30)
+        kwargs.update(overrides)
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.command.run._fetch_object_info", return_value={}),
+            patch("comfy_cli.command.run.ExecutionProgress"),
+            patch("comfy_cli.command.run.WorkflowExecution", return_value=mock_exec),
+        ):
+            execute(workflow_file, **kwargs)
+
+    def test_state_file_is_running_before_watch_returns(self, workflow_file):
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-happy")
+        mock_exec.outputs = ["http://127.0.0.1:8188/view?filename=a.png"]
+        mid_run = {}
+
+        def _observe_mid_run():
+            state = jobs_state.read("wait-happy")
+            mid_run["state"] = state
+
+        mock_exec.watch_execution.side_effect = _observe_mid_run
+
+        self._run(workflow_file, mock_exec)
+
+        # Submit-time record: on disk and non-terminal while the job runs.
+        assert mid_run["state"] is not None, "no state file existed while the job was running"
+        assert mid_run["state"].status == "running"
+        assert mid_run["state"].completed_at is None
+        # Completion updates that same record in place.
+        final = jobs_state.read("wait-happy")
+        assert final is not None
+        assert final.status == "completed"
+        assert final.outputs == ["http://127.0.0.1:8188/view?filename=a.png"]
+        assert final.completed_at is not None
+        assert final.submitted_at == mid_run["state"].submitted_at
+
+    def test_disconnect_mid_run_records_server_died(self, workflow_file, monkeypatch):
+        from comfy_cli import jobs_state
+
+        errors = self._capture_errors(monkeypatch)
+        mock_exec = self._mock_exec("wait-died")
+        mock_exec.watch_execution.side_effect = ConnectionError("server went away")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 1
+
+        err = next(e for e in errors if e["code"] == "ws_disconnected")
+        assert "wait-died" in err["message"]
+        assert err["details"]["prompt_id"] == "wait-died"
+        assert err["details"]["state_file"].endswith("wait-died.json")
+
+        state = jobs_state.read("wait-died")
+        assert state is not None
+        assert state.status == "error"
+        assert state.error["code"] == "server_died"
+        assert "wait-died" in state.error["message"]
+        assert "server went away" in state.error["message"]
+
+    def test_disconnect_before_prompt_id_writes_no_state(self, workflow_file, monkeypatch):
+        from comfy_cli import jobs_state
+
+        errors = self._capture_errors(monkeypatch)
+        # The submit itself blew up, so no prompt_id was ever assigned.
+        mock_exec = self._mock_exec(None)
+        mock_exec.queue.side_effect = ConnectionError("connection refused")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 1
+
+        # Today's bare error, unchanged — nothing to enrich it with.
+        err = next(e for e in errors if e["code"] == "ws_disconnected")
+        assert err["details"] is None
+        assert list(jobs_state.state_dir().glob("*.json")) == []
+
+    def test_timeout_names_prompt_id_and_leaves_state_running(self, workflow_file, monkeypatch):
+        from comfy_cli import jobs_state
+
+        errors = self._capture_errors(monkeypatch)
+        mock_exec = self._mock_exec("wait-slow")
+        mock_exec.watch_execution.side_effect = WebSocketTimeoutException("timed out")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 1
+
+        err = next(e for e in errors if e["code"] == "ws_timeout")
+        assert err["details"] == {"timeout": 30, "prompt_id": "wait-slow"}
+
+        # A timed-out watch says nothing about the job — it may still be
+        # running server-side, so the record stays non-terminal.
+        state = jobs_state.read("wait-slow")
+        assert state is not None
+        assert state.status == "running"
+        assert state.completed_at is None
+
+    def test_token_cancel_records_cancelled_state(self, workflow_file, fresh_token):
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-cancel")
+        mock_exec.watch_execution.side_effect = lambda: fresh_token.get_token().cancel()
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 130
+
+        state = jobs_state.read("wait-cancel")
+        assert state is not None
+        assert state.status == "cancelled"
+        assert state.error["code"] == "cancelled"
+
+    def test_keyboard_interrupt_records_cancelled_state(self, workflow_file):
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-ctrlc")
+        mock_exec.watch_execution.side_effect = KeyboardInterrupt()
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 130
+
+        state = jobs_state.read("wait-ctrlc")
+        assert state is not None
+        assert state.status == "cancelled"
+        assert state.error["code"] == "cancelled"
+
+    @pytest.mark.parametrize("boom", [OSError(13, "Permission denied"), ValueError("unsafe prompt_id")])
+    def test_state_write_failure_does_not_fail_the_run(self, workflow_file, monkeypatch, boom):
+        """A state file that can't be written must never sink an otherwise
+        successful run — same tolerance the async path gives its watcher. The
+        submit-time write in particular must not stop us watching a run the
+        server already accepted."""
+        from comfy_cli import jobs_state
+
+        def _boom(_state):
+            raise boom
+
+        monkeypatch.setattr(jobs_state, "write", _boom)
+        mock_exec = self._mock_exec("wait-unwritable")
+
+        self._run(workflow_file, mock_exec)  # must not raise
+
+        mock_exec.watch_execution.assert_called_once()
+
+
 class TestDetectPartnerNodes:
     """Partner-API nodes (category `partner/...` or the authoritative
     `api_node: true` flag) must be detected before a local submit so we can

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -690,6 +690,140 @@ class TestWaitStateFile:
 
         mock_exec.watch_execution.assert_called_once()
 
+    def test_server_execution_error_finalizes_the_record(self, workflow_file):
+        """`watch_execution` signals a failed node by raising `typer.Exit(1)`
+        after rendering the error — the ordinary failure path, not an
+        exception the disconnect handlers see. The submit-time `running`
+        record must still be moved to a terminal status, or the job is
+        stranded as a phantom nothing ever reaps (`jobs ls` only reaps
+        non-terminal records with a dead watcher_pid, which --wait never
+        sets)."""
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-exec-error")
+        mock_exec.last_error = {
+            "code": "out_of_memory",
+            "message": "CUDA out of memory in KSampler",
+            "details": {"node_id": "3"},
+        }
+        mock_exec.watch_execution.side_effect = typer.Exit(code=1)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 1
+
+        state = jobs_state.read("wait-exec-error")
+        assert state is not None
+        assert state.status == "error"
+        # The classified verdict `on_error` stashed, not a generic placeholder.
+        assert state.error["code"] == "out_of_memory"
+        assert state.error["message"] == "CUDA out of memory in KSampler"
+        assert state.completed_at is not None
+
+    def test_server_execution_error_without_verdict_falls_back(self, workflow_file):
+        """A mocked/older execution with no usable `last_error` still gets a
+        terminal record — a generic `execution_error` beats a phantom."""
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-exec-bare")
+        mock_exec.last_error = None
+        mock_exec.watch_execution.side_effect = typer.Exit(code=1)
+
+        with pytest.raises(typer.Exit):
+            self._run(workflow_file, mock_exec)
+
+        state = jobs_state.read("wait-exec-bare")
+        assert state is not None
+        assert state.status == "error"
+        assert state.error["code"] == "execution_error"
+
+    def test_server_interrupt_finalizes_as_cancelled(self, workflow_file):
+        """`execution_interrupted` exits 130 — a cancellation, not a failure."""
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-interrupted")
+        mock_exec.watch_execution.side_effect = typer.Exit(code=130)
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 130
+
+        state = jobs_state.read("wait-interrupted")
+        assert state is not None
+        assert state.status == "cancelled"
+        assert state.error["code"] == "cancelled"
+
+    def test_broken_pipe_while_rendering_keeps_the_completed_record(self, workflow_file, monkeypatch):
+        """`comfy run --wait … | head` closes stdout under us. The resulting
+        BrokenPipeError (a ConnectionError/OSError subclass) is raised AFTER
+        the job completed and was persisted, so it must not be mistaken for
+        the server disconnecting: no rewrite of the `completed` record to
+        `error`/`server_died`, and no bogus `ws_disconnected` exit 1."""
+        from comfy_cli import jobs_state
+        from comfy_cli.output.renderer import Renderer
+
+        errors = self._capture_errors(monkeypatch)
+        mock_exec = self._mock_exec("wait-brokenpipe")
+        mock_exec.outputs = ["http://127.0.0.1:8188/view?filename=a.png"]
+
+        def _broken_pipe(self, *args, **kwargs):
+            raise BrokenPipeError(32, "Broken pipe")
+
+        monkeypatch.setattr(Renderer, "emit", _broken_pipe)
+
+        with pytest.raises(BrokenPipeError):
+            self._run(workflow_file, mock_exec)
+
+        assert [e["code"] for e in errors] == []
+        state = jobs_state.read("wait-brokenpipe")
+        assert state is not None
+        assert state.status == "completed"
+        assert state.error is None
+
+    def test_ctrl_c_after_completion_does_not_uncomplete_the_record(self, workflow_file):
+        """The KeyboardInterrupt handler is shared by the whole run. A Ctrl-C
+        landing after the completion write must leave the terminal record
+        alone rather than walking it back to `cancelled`."""
+        from comfy_cli import jobs_state
+        from comfy_cli.command.run import _mark_cancelled
+
+        mock_exec = self._mock_exec("wait-late-ctrlc")
+        self._run(workflow_file, mock_exec)
+
+        state = jobs_state.read("wait-late-ctrlc")
+        assert state.status == "completed"
+
+        assert _mark_cancelled(state) is None
+        assert state.status == "completed"
+        assert jobs_state.read("wait-late-ctrlc").status == "completed"
+
+    def test_failed_terminal_write_reports_no_state_file(self, workflow_file, monkeypatch):
+        """When the completion write fails, don't hand back the submit-time
+        path: that file still says `running`, contradicting the `completed`
+        result we just reported."""
+        from comfy_cli import jobs_state
+        from comfy_cli.output.renderer import Renderer
+
+        emitted = []
+        monkeypatch.setattr(Renderer, "emit", lambda self, data=None, **kw: emitted.append(data))
+
+        real_write = jobs_state.write
+        calls = {"n": 0}
+
+        def _fail_after_first(state):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return real_write(state)
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(jobs_state, "write", _fail_after_first)
+        mock_exec = self._mock_exec("wait-nospace")
+
+        self._run(workflow_file, mock_exec)
+
+        assert emitted and emitted[-1]["status"] == "completed"
+        assert emitted[-1]["state_file"] is None
+
 
 class TestDetectPartnerNodes:
     """Partner-API nodes (category `partner/...` or the authoritative


### PR DESCRIPTION
## ELI-5

When you run `comfy run --workflow x --wait`, the CLI sits there and watches the job until it finishes. Until now it only wrote the little "here's what happened to this job" file at the very end, on success. So if the ComfyUI server died halfway through (say it got OOM-killed by a huge allocation), you got an error that said "lost connection" and nothing else — no job id, no file on disk. Nothing anywhere remembered that a prompt was in flight when the server went down.

Now the CLI writes that file the moment the server accepts the job, and keeps it updated. If the server dies, the file says so and the error tells you which prompt it was, so `comfy jobs status <id>` has something to read.

## What changed

All in `comfy_cli/command/run/__init__.py`, local `execute` path only (`execute_cloud` already wrote state at submit for both modes and is untouched):

- **Submit-time write on `--wait`.** Right after a successful `queue()`, the state is created and written with `status = "running"` — mirroring the async branch's submit-time write. "running" rather than "queued" because this foreground process is actively watching it, not leaving it detached.
- **Completion updates, doesn't recreate.** The completion block reuses the submit-time `state` object (sets `status = "completed"` + `outputs`), so it is the same file with the same final shape as before.
- **Cancel paths record it.** The post-watch token check, the `KeyboardInterrupt` handler, and the token-cancelled branch inside the disconnect handler all set `status = "cancelled"` + `error.code = "cancelled"`. Guarded so a cancel before `queue()` returned (no state yet) simply skips the write.
- **`ws_disconnected` records `server_died` and names the prompt.** When a prompt_id exists, the state file goes to `status = "error"` with `error.code = "server_died"`, and the emitted error keeps `code = "ws_disconnected"` but names the prompt in the message and carries `details = {"prompt_id": ..., "state_file": ...}`. A disconnect before `queue()` returned emits today's bare error unchanged.
- **`ws_timeout` names the prompt but stays non-terminal.** `details` gains `prompt_id`; the state file is deliberately left at its submit-time `running` record, because a timed-out watch says nothing about the job — it may genuinely still be running server-side.

Every state write goes through a `_write_state` helper that swallows write failures, so a state-dir problem can never fail an otherwise-successful run (matching the async path's tolerance of a watcher that won't spawn).

## Tests

Seven new tests in `tests/comfy_cli/command/test_run.py` (`TestWaitStateFile`), following the existing `WorkflowExecution` mock pattern and the autouse `_isolate_jobs_state_dir` fixture:

- happy path — a `watch_execution` side effect reads the file mid-run and asserts `status == "running"` with no `completed_at`, then the post-run file is `completed` with outputs and the *same* `submitted_at` (proving it is an update, not a fresh record)
- `watch_execution` raises `ConnectionError` — emitted error is `ws_disconnected` with `details.prompt_id` and a `state_file` path; the file is `status == "error"`, `error.code == "server_died"`
- disconnect before a prompt_id exists (`queue()` raises) — no state file is created, no crash, and the emitted error keeps today's bare shape (`details is None`)
- timeout — `details == {"timeout": 30, "prompt_id": ...}` and the file stays `running` / non-terminal
- cancel via the cancellation token, and cancel via `KeyboardInterrupt` — both leave `status == "cancelled"`
- parametrized write-failure test (`OSError`, `ValueError`) proving a broken state file never fails the run

`ruff check` + `ruff format --diff` clean on the CI-pinned 0.15.15; full `pytest` green (2777 passed, 37 skipped).

## Judgment calls

- **One file outside the ticket's stated scope.** The ticket said changes confined to `comfy_cli/command/run/__init__.py` + tests, but the repo's own `test_every_raised_code_is_registered` scans `{"code": "..."}` dict literals in source (explicitly including "the watcher and state-file paths") and fails on any code missing from `comfy_cli/error_codes.REGISTRY`. So `server_died` needed a five-line registry entry. That is the repo enforcing its own invariant, not scope creep, but flagging it since it is a deviation from the ticket text.
- **`_write_state` swallows `ValueError` as well as `OSError`.** The ticket asked for `try/except OSError`. `jobs_state.state_path` raises `ValueError` on a prompt_id it can't turn into a safe filename, and moving the write from completion to submit would newly let that abort the run *before* `watch_execution()` — i.e. we'd stop watching a job the server had already accepted. Swallowing it keeps the submit-time write strictly non-regressive. Covered by the parametrized test.
- **The envelope's `state_file` falls back to the submit-time path** (`_write_state(state) or wait_state_file`) if the completion write fails, since that file does exist on disk. It would then read `running` while the envelope says `completed` — the accepted trade of best-effort state writes.
- **An unexpected exception type** (something outside the three handled classes) leaves the record at `running` rather than marking it terminal. That is deliberate: we don't know the job died, and it is still strictly more information than the previous behavior of no file at all.
- **Capability check (no denial in this diff).** The self-review's negative-claim trigger does not fire here: nothing is marked unsupported/unavailable and no deny or dead-end path is added. The `ws_disconnected` error already existed; this change only *adds* information to it (prompt_id, state file) and creates an on-disk record where there was none, so the user-facing outcome strictly expands what is recoverable after a mid-run server death.
