### PR TITLE
feat: comfy update comfy --version <X> — headless version switch/rollback (BE-4763)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ dependencies using the following precedence:
      tool environment): a `.venv` is created inside the ComfyUI workspace.
      Use `comfy launch` to start ComfyUI with the correct Python.
 
+### Updating ComfyUI
+
+`comfy update` brings an existing workspace up to date:
+
+- `comfy update` (or `comfy update comfy`): pull the branch the workspace is currently on and reinstall `requirements.txt`.
+- `comfy update all`: also update every installed custom node.
+- `comfy update cli`: upgrade comfy-cli itself.
+
+#### Switching to a specific version
+
+`comfy update comfy --version <X>` moves an existing workspace to a specific ComfyUI version — a downgrade (rollback) or an upgrade — without prompting for anything, so it is safe to run headlessly or from a script. `<X>` is `nightly` (the repo's default branch), `latest` (the newest stable release), or a version number such as `0.3.0` (a leading `v` is optional).
+
+```bash
+comfy update comfy --version 0.3.0      # roll back to the v0.3.0 release
+comfy update comfy --version latest     # newest stable release
+comfy update comfy --version nightly    # roll forward to the default branch
+```
+
+Behavior worth knowing:
+
+- **The target is validated before anything is touched.** An unknown version exits non-zero, lists the nearest available versions, and leaves the working tree exactly as it was.
+- **Uncommitted changes are stashed by default** (`git stash push -u`) and are *never* popped or dropped automatically — the stash ref is printed so you can restore them with `git stash pop`. Pass `--no-stash` if you would rather the command refuse to run on a dirty tree.
+- **A version number checks out a tag, which leaves a detached HEAD.** That is expected. Roll forward again with `comfy update comfy --version nightly` (or `--version latest`); a plain `comfy update` cannot advance a detached HEAD.
+- **Dependencies are reinstalled** from the target version's `requirements.txt`. PyTorch is deliberately left alone: the ComfyUI version doesn't determine your torch build, your machine does. If the dependency install fails, the command exits non-zero and says so — the tree is already on the new version, and re-running the same command is safe.
+- `--version` and `--no-stash` apply only to target `comfy`; combining `--version` with `all` or `cli` is an error.
+
 ### Specifying execution path
 
 - You can specify the path of ComfyUI where the command will be applied through path indicators as follows:

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -39,7 +39,7 @@ from comfy_cli.command import transfer as transfer_inner
 from comfy_cli.command import (
     workflow as workflow_command,
 )
-from comfy_cli.command.install import validate_version
+from comfy_cli.command.install import validate_optional_version, validate_version
 from comfy_cli.command.launch import launch as launch_command
 from comfy_cli.command.launch import logs as logs_command
 from comfy_cli.command.models import models as models_command
@@ -608,6 +608,56 @@ def install(
     rprint(f"ComfyUI is installed at: {comfy_path}")
 
 
+def _switch_comfy_version(comfy_path: str, version: str, *, stash: bool) -> None:
+    """`comfy update comfy --version X` — move the workspace, then reinstall its deps.
+
+    Torch is deliberately left alone: a version switch is ComfyUI-version-specific
+    while the torch build is machine-specific, so re-resolving it would need the
+    GPU input this headless path exists to avoid.
+    """
+    renderer = get_renderer()
+
+    try:
+        result = install_inner.switch_comfyui_version(comfy_path, version, stash=stash)
+    except install_inner.VersionSwitchError as e:
+        renderer.error(code=e.code, message=e.message, hint=e.hint)
+        raise typer.Exit(code=1)
+
+    python = resolve_workspace_python(comfy_path)
+    # A uv-managed venv may have no pip — bootstrap it first so the install
+    # below doesn't crash with `No module named pip` (no-op if pip exists).
+    ensure_pip(python, cwd=comfy_path)
+    deps = subprocess.run(
+        [python, "-m", "pip", "install", "-r", "requirements.txt"],
+        cwd=comfy_path,
+        check=False,
+    )
+    if deps.returncode != 0:
+        renderer.error(
+            code="version_switch_deps_failed",
+            message=(
+                f"ComfyUI is now on {result['current']}, but installing its requirements.txt failed — "
+                "dependencies may be incomplete."
+            ),
+            hint="re-run the same command once the cause is fixed; it is idempotent and safe to repeat",
+        )
+        raise typer.Exit(code=1)
+
+    if renderer.is_pretty():
+        rprint(f"Switched ComfyUI: [bold]{result['previous']}[/bold] -> [bold]{result['current']}[/bold]")
+        if result["stashed"]:
+            rprint(
+                f"[yellow]Uncommitted changes were stashed as {result['stash_ref']} and left there — "
+                "restore them with `git stash pop`.[/yellow]"
+            )
+        if version != "nightly":
+            rprint(
+                "[dim]This is a tag checkout, so the workspace is on a detached HEAD. "
+                "Roll forward with `comfy update comfy --version nightly` (or `--version latest`).[/dim]"
+            )
+    renderer.emit(result, command="update")
+
+
 @app.command(help="Update ComfyUI Environment [all|comfy|cli]")
 @tracking.track_command()
 def update(
@@ -616,11 +666,46 @@ def update(
         help="\\[all|comfy|cli]",
         autocompletion=utils.create_choice_completer(["all", "comfy", "cli"]),
     ),
+    version: Annotated[
+        str | None,
+        typer.Option(
+            "--version",
+            show_default=False,
+            callback=validate_optional_version,
+            help=(
+                "Switch the existing ComfyUI workspace to a specific version instead of pulling the current "
+                "branch. Accepts 'nightly' (the default branch), 'latest' (newest stable release), or a version "
+                "number such as 0.3.0. Only valid for target 'comfy'. Uncommitted changes are stashed first and "
+                "never popped automatically; a version number checks out a tag, leaving a detached HEAD — roll "
+                "forward again with --version nightly. Dependencies are reinstalled from requirements.txt; torch "
+                "is left untouched."
+            ),
+        ),
+    ] = None,
+    no_stash: Annotated[
+        bool,
+        typer.Option(
+            "--no-stash",
+            show_default=False,
+            help=(
+                "With --version, refuse to switch when the ComfyUI workspace has uncommitted changes "
+                "instead of stashing them."
+            ),
+        ),
+    ] = False,
 ):
     if target not in ["all", "comfy", "cli"]:
         typer.echo(
             f"Invalid target: {target}. Allowed targets are 'all', 'comfy', 'cli'.",
             err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if version is not None and target != "comfy":
+        get_renderer().error(
+            code="update_version_target_invalid",
+            message=f"--version is only supported for target 'comfy', not '{target}'.",
+            hint="run `comfy update comfy --version <version>`",
         )
         raise typer.Exit(code=1)
 
@@ -640,16 +725,19 @@ def update(
         if comfy_path is None:
             rprint("ComfyUI path is not found.")
             raise typer.Exit(code=1)
-        os.chdir(comfy_path)
-        subprocess.run(["git", "pull"], check=True)
-        python = resolve_workspace_python(comfy_path)
-        # A uv-managed venv may have no pip — bootstrap it first so the install
-        # below doesn't crash with `No module named pip` (no-op if pip exists).
-        ensure_pip(python, cwd=comfy_path)
-        subprocess.run(
-            [python, "-m", "pip", "install", "-r", "requirements.txt"],
-            check=True,
-        )
+        if version is not None:
+            _switch_comfy_version(comfy_path, version, stash=not no_stash)
+        else:
+            os.chdir(comfy_path)
+            subprocess.run(["git", "pull"], check=True)
+            python = resolve_workspace_python(comfy_path)
+            # A uv-managed venv may have no pip — bootstrap it first so the install
+            # below doesn't crash with `No module named pip` (no-op if pip exists).
+            ensure_pip(python, cwd=comfy_path)
+            subprocess.run(
+                [python, "-m", "pip", "install", "-r", "requirements.txt"],
+                check=True,
+            )
 
     try:
         custom_nodes.command.update_node_id_cache()

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -1,3 +1,4 @@
+import bisect
 import os
 import platform
 import re
@@ -391,6 +392,23 @@ def validate_version(version: str) -> str | None:
         ) from exc
 
 
+def validate_optional_version(version: str | None) -> str | None:
+    """Typer callback for an *optional* ``--version`` flag.
+
+    ``validate_version`` is written for a flag that always has a value (``comfy
+    install --version`` defaults to ``nightly``). ``comfy update`` treats the
+    flag as opt-in, so ``None`` must pass through untouched. Invalid input is
+    re-raised as ``typer.BadParameter`` so a headless caller gets the standard
+    CLI usage error instead of a traceback.
+    """
+    if version is None:
+        return None
+    try:
+        return validate_version(version)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
 class GitHubRateLimitError(Exception):
     """Raised when GitHub API rate limit is exceeded"""
 
@@ -610,6 +628,268 @@ def checkout_stable_comfyui(version: str, repo_dir: str, url: str | None = None)
             console.print(f"\n[bold red]Failed to checkout tag '{tag}'![/bold red]")
             console.print("[yellow]The version may not exist. Please check available versions.[/yellow]")
             sys.exit(1)
+
+
+class VersionSwitchError(Exception):
+    """A failure while moving an existing workspace to another ComfyUI version.
+
+    Carries the stable envelope ``code`` and its ``hint`` so the command layer
+    can hand it straight to ``renderer.error`` without re-deriving them.
+    ``stash_ref`` is set when a stash was already created — the caller must tell
+    the user their work is still recoverable.
+    """
+
+    def __init__(self, code: str, message: str, hint: str | None = None, *, stash_ref: str | None = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.hint = hint
+        self.stash_ref = stash_ref
+
+
+class VersionSwitchResult(TypedDict):
+    """What ``switch_comfyui_version`` did, in envelope-ready form."""
+
+    previous: str
+    current: str
+    stashed: bool
+    stash_ref: str | None
+
+
+def _git_capture(repo_dir: str, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a git command in ``repo_dir`` and capture it, never raising.
+
+    Uses ``git -C`` rather than ``os.chdir`` so a failure part-way through a
+    switch can't leave the process in someone else's directory.
+    """
+    argv = ["git", "-C", repo_dir, *args]
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, check=False, timeout=timeout)
+    except (subprocess.SubprocessError, FileNotFoundError, OSError) as exc:
+        return subprocess.CompletedProcess(args=argv, returncode=1, stdout="", stderr=str(exc))
+
+
+def _git_error_detail(result: subprocess.CompletedProcess) -> str:
+    """Best-effort one-line reason from a failed git invocation."""
+    for stream in (result.stderr, result.stdout):
+        if stream and stream.strip():
+            return stream.strip().splitlines()[-1]
+    return f"git exited with code {result.returncode}"
+
+
+def _describe_head(repo_dir: str) -> str:
+    """Human-readable name for the current checkout, e.g. ``a1b2c3d (v0.3.0)``."""
+    sha_result = _git_capture(repo_dir, "rev-parse", "--short", "HEAD")
+    describe_result = _git_capture(repo_dir, "describe", "--tags", "--always")
+    sha = sha_result.stdout.strip() if sha_result.returncode == 0 else ""
+    described = describe_result.stdout.strip() if describe_result.returncode == 0 else ""
+    if sha and described and described != sha:
+        return f"{sha} ({described})"
+    return sha or described or "unknown"
+
+
+def _fetch_tags(repo_dir: str) -> bool:
+    """Refresh tags from the remote. Returns whether it succeeded.
+
+    Failure is tolerated by callers: a tag that already exists locally is still
+    checkout-able offline (mirrors ``git_utils.git_checkout_tag``).
+    """
+    return _git_capture(repo_dir, "fetch", "--tags", "--quiet", timeout=60).returncode == 0
+
+
+def _resolve_default_branch(repo_dir: str) -> str:
+    """The remote's default branch, falling back to ComfyUI's historical ``master``."""
+    result = _git_capture(repo_dir, "symbolic-ref", "refs/remotes/origin/HEAD")
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        prefix = "refs/remotes/origin/"
+        if ref.startswith(prefix):
+            branch = ref[len(prefix) :].strip()
+            if branch:
+                return branch
+    return "master"
+
+
+def _nearby_version_tags(repo_dir: str, version: str, limit: int = 5) -> list[str]:
+    """Up to ``limit`` local ``v*`` tags closest (by semver order) to ``version``.
+
+    Used to turn "that version doesn't exist" into something actionable. Tags
+    that don't parse as semver are skipped; if the requested version itself
+    doesn't parse we just return the newest tags.
+    """
+    result = _git_capture(repo_dir, "tag", "--list", "v*", timeout=10)
+    if result.returncode != 0:
+        return []
+
+    parsed: list[tuple[semver.VersionInfo, str]] = []
+    for line in result.stdout.splitlines():
+        tag = line.strip()
+        if not tag:
+            continue
+        try:
+            parsed.append((semver.VersionInfo.parse(tag.lstrip("v")), tag))
+        except ValueError:
+            continue
+    if not parsed:
+        return []
+
+    parsed.sort(key=lambda item: item[0])
+    try:
+        requested = semver.VersionInfo.parse(version.lstrip("v"))
+    except ValueError:
+        requested = None
+
+    if requested is None:
+        window = parsed[-limit:]
+    else:
+        index = bisect.bisect_left([item[0] for item in parsed], requested)
+        start = max(0, min(index - limit // 2, len(parsed) - limit))
+        window = parsed[start : start + limit]
+
+    # Newest first — that's the order a user scanning for "what can I pick?" wants.
+    return [tag for _, tag in reversed(window)]
+
+
+def _stash_note(stash_ref: str | None) -> str:
+    if not stash_ref:
+        return ""
+    return (
+        f" Your uncommitted changes are still stashed as {stash_ref} "
+        "(recover with `git stash list` then `git stash pop`)."
+    )
+
+
+def switch_comfyui_version(
+    comfy_path: str,
+    version: str,
+    *,
+    stash: bool = True,
+    url: str | None = None,
+) -> VersionSwitchResult:
+    """Move an existing ComfyUI workspace to ``version``, headlessly.
+
+    ``version`` is the output of ``validate_version``: ``nightly``, ``latest``,
+    or a semver string with or without a ``v`` prefix.
+
+    The target is resolved and validated *before* the working tree is touched,
+    so an unknown version leaves the workspace exactly as it was. A dirty tree
+    is stashed by default (never auto-popped — the stash ref is reported back);
+    ``stash=False`` refuses to proceed instead.
+
+    Checking out a tag leaves a detached HEAD, which is expected; ``nightly``
+    checks out the remote's default branch and pulls, which is also how a
+    previously rolled-back (detached) workspace rolls forward again.
+
+    Installing dependencies for the new version is the caller's job — this
+    function only moves the git tree.
+
+    :raises VersionSwitchError: on any resolution, stash, or checkout failure.
+    """
+    previous = _describe_head(comfy_path)
+
+    # --- 1. Resolve + validate the target before touching anything -----------
+    target_tag: str | None = None
+    target_branch: str | None = None
+
+    if version == "nightly":
+        target_branch = _resolve_default_branch(comfy_path)
+        target_label = target_branch
+    elif version == "latest":
+        # `_resolve_latest_tag_from_local` runs its own `git fetch --tags`.
+        target_tag, fetch_ok = _resolve_latest_tag_from_local(comfy_path)
+        if target_tag is None:
+            owner, repo = _parse_github_owner_repo(url) or ("comfyanonymous", "ComfyUI")
+            try:
+                release = get_latest_release(owner, repo)
+            except GitHubRateLimitError as exc:
+                raise VersionSwitchError(
+                    code="version_switch_unknown_version",
+                    message=f"Could not resolve the latest ComfyUI release: {exc}",
+                    hint="retry later, or pin an exact version with `--version <X.Y.Z>`",
+                ) from exc
+            if release is None:
+                detail = (
+                    "no local release tags and the remote could not be reached" if not fetch_ok else "no release found"
+                )
+                raise VersionSwitchError(
+                    code="version_switch_unknown_version",
+                    message=f"Could not resolve the latest ComfyUI release ({detail}).",
+                    hint="check your network, or pin an exact version with `--version <X.Y.Z>`",
+                )
+            target_tag = str(release["tag"])
+        target_label = target_tag
+    else:
+        fetch_ok = _fetch_tags(comfy_path)
+        target_tag = version if version.startswith("v") else f"v{version}"
+        if _git_capture(comfy_path, "rev-parse", "--verify", f"refs/tags/{target_tag}").returncode != 0:
+            nearby = _nearby_version_tags(comfy_path, version)
+            available = f" Nearest available versions: {', '.join(nearby)}." if nearby else ""
+            offline = "" if fetch_ok else " (tags could not be refreshed from the remote — you may be offline)"
+            raise VersionSwitchError(
+                code="version_switch_unknown_version",
+                message=f"ComfyUI version '{version}' not found: no tag '{target_tag}' in {comfy_path}{offline}.{available}",
+                hint="run `git tag --list 'v*'` in your ComfyUI workspace to see every available version",
+            )
+        target_label = target_tag
+
+    # --- 2. Stash by default -------------------------------------------------
+    status = _git_capture(comfy_path, "status", "--porcelain")
+    if status.returncode != 0:
+        raise VersionSwitchError(
+            code="version_switch_failed",
+            message=f"Could not read the git status of {comfy_path}: {_git_error_detail(status)}",
+            hint="make sure the workspace is a healthy git repository",
+        )
+
+    stash_ref: str | None = None
+    if status.stdout.strip():
+        if not stash:
+            raise VersionSwitchError(
+                code="version_switch_dirty_tree",
+                message=f"{comfy_path} has uncommitted changes and --no-stash was passed, so nothing was changed.",
+                hint="commit or stash your changes, or re-run without --no-stash to stash them automatically",
+            )
+        stash_result = _git_capture(
+            comfy_path, "stash", "push", "-u", "-m", f"comfy-cli: before switch to {target_label}"
+        )
+        if stash_result.returncode != 0:
+            raise VersionSwitchError(
+                code="version_switch_failed",
+                message=f"Could not stash uncommitted changes in {comfy_path}: {_git_error_detail(stash_result)}",
+                hint="commit or discard your changes manually, then re-run",
+            )
+        ref_result = _git_capture(comfy_path, "rev-parse", "--short", "refs/stash")
+        stash_ref = ref_result.stdout.strip() if ref_result.returncode == 0 else None
+        stash_ref = f"stash@{{0}} ({stash_ref})" if stash_ref else "stash@{0}"
+
+    # --- 3. Checkout ---------------------------------------------------------
+    checkout_target = target_tag if target_tag is not None else target_branch
+    checkout = _git_capture(comfy_path, "checkout", checkout_target)
+    if checkout.returncode != 0:
+        raise VersionSwitchError(
+            code="version_switch_failed",
+            message=f"Failed to check out '{checkout_target}': {_git_error_detail(checkout)}.{_stash_note(stash_ref)}",
+            hint="resolve the git error in your ComfyUI workspace, then re-run",
+            stash_ref=stash_ref,
+        )
+
+    if target_branch is not None:
+        pull = _git_capture(comfy_path, "pull", timeout=300)
+        if pull.returncode != 0:
+            raise VersionSwitchError(
+                code="version_switch_failed",
+                message=f"Checked out '{target_branch}' but `git pull` failed: {_git_error_detail(pull)}. "
+                f"The workspace is on '{target_branch}' but not up to date.{_stash_note(stash_ref)}",
+                hint="fix the git error (network, conflicts) and re-run — the command is safe to repeat",
+                stash_ref=stash_ref,
+            )
+
+    return VersionSwitchResult(
+        previous=previous,
+        current=_describe_head(comfy_path),
+        stashed=stash_ref is not None,
+        stash_ref=stash_ref,
+    )
 
 
 def get_latest_release(repo_owner: str, repo_name: str) -> GithubRelease | None:

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -36,6 +36,8 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy jobs status": "jobs",
     "comfy jobs watch": "jobs",
     "comfy jobs wait": "jobs_wait",
+    # workspace lifecycle
+    "comfy update": "update",
     # help / validation
     "comfy help": "help",
     "comfy validate": "workflow",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -588,6 +588,32 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "consent to the spend and re-run — `comfy run-template --allow-spend`, or "
         "`comfy generate --yes` (persist with `comfy generate consent always`)",
     ),
+    # --- update / version switch --------------------------------------------
+    ErrorCode(
+        "update_version_target_invalid",
+        "`comfy update --version` was combined with a target other than `comfy`.",
+        "run `comfy update comfy --version <version>`",
+    ),
+    ErrorCode(
+        "version_switch_unknown_version",
+        "`comfy update comfy --version X` could not resolve X to a ComfyUI tag; the workspace was left untouched.",
+        "run `git tag --list 'v*'` in your ComfyUI workspace to see every available version",
+    ),
+    ErrorCode(
+        "version_switch_dirty_tree",
+        "`comfy update comfy --version X --no-stash` found uncommitted changes and refused to switch.",
+        "commit or stash your changes, or re-run without --no-stash to stash them automatically",
+    ),
+    ErrorCode(
+        "version_switch_failed",
+        "A git operation during `comfy update comfy --version X` failed; any stash that was created is preserved.",
+        "resolve the git error in your ComfyUI workspace, then re-run",
+    ),
+    ErrorCode(
+        "version_switch_deps_failed",
+        "The version switch checked out successfully but reinstalling requirements.txt failed.",
+        "re-run the same command once the cause is fixed; it is idempotent and safe to repeat",
+    ),
     # --- feedback ------------------------------------------------------------
     ErrorCode(
         "feedback_message_required",

--- a/comfy_cli/schemas/update.json
+++ b/comfy_cli/schemas/update.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "comfy update",
+  "description": "Output shape for `comfy update comfy --version <X>` — the headless ComfyUI version switch.",
+  "type": "object",
+  "properties": {
+    "previous": {
+      "type": "string",
+      "description": "The ref the workspace was on before the switch (short sha, plus `git describe` when it differs)."
+    },
+    "current": {
+      "type": "string",
+      "description": "The ref the workspace is on after the switch."
+    },
+    "stashed": {
+      "type": "boolean",
+      "description": "Whether uncommitted changes were stashed before the switch. A stash is never popped or dropped automatically."
+    },
+    "stash_ref": {
+      "type": ["string", "null"],
+      "description": "The stash reference to recover from when `stashed` is true, otherwise null."
+    }
+  },
+  "required": ["previous", "current", "stashed", "stash_ref"]
+}

--- a/tests/comfy_cli/command/test_update_version.py
+++ b/tests/comfy_cli/command/test_update_version.py
@@ -1,0 +1,392 @@
+"""Tests for ``comfy update comfy --version X`` — headless version switch/rollback.
+
+Every git call is mocked (``FakeGit`` dispatches on the argv), so nothing here
+touches a real repository or the network. The unit-level cases drive
+``install.switch_comfyui_version`` directly; the CLI-level cases drive
+``cmdline.update`` so the flag wiring, the dependency reinstall, and the exit
+codes are covered too.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from comfy_cli import cmdline
+from comfy_cli.command import install as install_inner
+
+
+class FakeGit:
+    """A stand-in for ``subprocess.run`` that answers the git calls we make.
+
+    ``comfy_cli.command.install`` and ``comfy_cli.cmdline`` both do a plain
+    ``import subprocess``, so patching ``<module>.subprocess.run`` patches the
+    one global function for both. This dispatcher therefore has to serve the
+    whole command: git calls are simulated below, anything else (the pip
+    install) is recorded in ``self.other_calls`` and answered with
+    ``self.pip_returncode``.
+
+    Every argv is recorded in ``self.calls`` so a test can assert on what did
+    (and, more importantly, did NOT) run.
+    """
+
+    def __init__(
+        self,
+        *,
+        tags: tuple[str, ...] = (),
+        status: str = "",
+        head_sha: str = "abc1234",
+        describe: str = "v0.2.9",
+        default_branch: str = "master",
+        fail: tuple[str, ...] = (),
+        pip_returncode: int = 0,
+    ):
+        self.tags = list(tags)
+        self.status = status
+        self.head_sha = head_sha
+        self.describe = describe
+        self.default_branch = default_branch
+        self.fail = set(fail)
+        self.pip_returncode = pip_returncode
+        self.calls: list[list[str]] = []
+        self.other_calls: list[tuple[list[str], dict]] = []
+
+    # -- helpers ---------------------------------------------------------
+    @staticmethod
+    def _sub(call: list[str]) -> list[str]:
+        """The git subcommand argv, with any ``-C <repo>`` prefix stripped."""
+        return call[3:] if call[1:2] == ["-C"] else call[1:]
+
+    def ran(self, *prefix: str) -> bool:
+        return self.call_matching(*prefix) is not None
+
+    @property
+    def git_calls(self) -> list[list[str]]:
+        return [c for c in self.calls if c and c[0] == "git"]
+
+    def call_matching(self, *prefix: str) -> list[str] | None:
+        for call in self.git_calls:
+            if self._sub(call)[: len(prefix)] == list(prefix):
+                return call
+        return None
+
+    # -- the dispatcher --------------------------------------------------
+    def __call__(self, argv, **kwargs):
+        argv = list(argv)
+        if not argv or argv[0] != "git":
+            self.other_calls.append((argv, kwargs))
+            return self._done(argv, self.pip_returncode)
+
+        self.calls.append(argv)
+        if "fail_all" in self.fail:
+            return self._done(argv, 1, stderr="boom")
+        sub = self._sub(argv)
+
+        if sub[:1] == ["fetch"]:
+            return self._done(argv, 1 if "fetch" in self.fail else 0)
+        if sub[:1] == ["symbolic-ref"]:
+            if "symbolic-ref" in self.fail:
+                return self._done(argv, 1, stderr="ref HEAD is not a symbolic ref")
+            return self._done(argv, 0, stdout=f"refs/remotes/origin/{self.default_branch}\n")
+        if sub[:2] == ["rev-parse", "--verify"]:
+            tag = sub[2].removeprefix("refs/tags/")
+            return self._done(argv, 0 if tag in self.tags else 1)
+        if sub[:3] == ["rev-parse", "--short", "HEAD"]:
+            return self._done(argv, 0, stdout=f"{self.head_sha}\n")
+        if sub[:3] == ["rev-parse", "--short", "refs/stash"]:
+            return self._done(argv, 0, stdout="stash01\n")
+        if sub[:1] == ["describe"]:
+            return self._done(argv, 0, stdout=f"{self.describe}\n")
+        if sub[:2] == ["tag", "--list"]:
+            return self._done(argv, 0, stdout="\n".join(self.tags) + "\n")
+        if sub[:2] == ["status", "--porcelain"]:
+            return self._done(argv, 0, stdout=self.status)
+        if sub[:2] == ["stash", "push"]:
+            if "stash" in self.fail:
+                return self._done(argv, 1, stderr="cannot stash")
+            self.status = ""
+            return self._done(argv, 0)
+        if sub[:1] == ["checkout"]:
+            if "checkout" in self.fail:
+                return self._done(argv, 1, stderr=f"pathspec '{sub[1]}' did not match")
+            # A successful checkout moves HEAD — mirror that so the "current"
+            # ref reported back is not just an echo of "previous".
+            self.describe = sub[1]
+            self.head_sha = "def5678"
+            return self._done(argv, 0)
+        if sub[:1] == ["pull"]:
+            return self._done(argv, 1 if "pull" in self.fail else 0, stderr="network down")
+        raise AssertionError(f"unexpected git call: {argv}")
+
+    @staticmethod
+    def _done(argv, returncode, stdout="", stderr=""):
+        return subprocess.CompletedProcess(args=argv, returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def fake_git():
+    git = FakeGit(tags=("v0.2.7", "v0.2.9", "v0.3.0", "v0.3.1"))
+    with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+        yield git
+
+
+def _run_update(tmp_path, **kwargs):
+    """Drive ``cmdline.update``; subprocess is already faked by ``fake_git``."""
+    with (
+        patch.object(cmdline.workspace_manager, "workspace_path", str(tmp_path)),
+        patch("comfy_cli.cmdline.resolve_workspace_python", return_value="/resolved/python"),
+        patch("comfy_cli.cmdline.ensure_pip"),
+        patch("comfy_cli.cmdline.os.chdir"),
+        patch("comfy_cli.cmdline.custom_nodes.command.update_node_id_cache"),
+    ):
+        cmdline.update(target=kwargs.pop("target", "comfy"), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# (a) happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_semver_checks_out_tag_and_installs_requirements(self, fake_git, tmp_path):
+        _run_update(tmp_path, version="0.3.0")
+
+        assert fake_git.call_matching("checkout", "v0.3.0") is not None
+        pip_cmd, pip_kwargs = fake_git.other_calls[0]
+        assert pip_cmd == ["/resolved/python", "-m", "pip", "install", "-r", "requirements.txt"]
+        assert pip_kwargs["cwd"] == str(tmp_path)
+
+    def test_v_prefix_is_accepted_and_not_doubled(self, fake_git, tmp_path):
+        result = install_inner.switch_comfyui_version(str(tmp_path), "v0.3.0")
+
+        assert fake_git.call_matching("checkout", "v0.3.0") is not None
+        assert result["stashed"] is False
+        assert result["stash_ref"] is None
+        assert result["previous"] != result["current"]
+
+    def test_torch_is_never_touched(self, fake_git, tmp_path):
+        _run_update(tmp_path, version="0.3.0")
+
+        for argv, _ in fake_git.other_calls:
+            assert "torch" not in argv
+
+    def test_reports_previous_and_current_refs(self, fake_git, tmp_path):
+        result = install_inner.switch_comfyui_version(str(tmp_path), "0.3.0")
+
+        assert result["previous"] == "abc1234 (v0.2.9)"
+        assert result["current"] == "def5678 (v0.3.0)"
+
+
+# ---------------------------------------------------------------------------
+# (b) unknown version
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownVersion:
+    def test_unknown_version_raises_and_lists_tags(self, fake_git, tmp_path):
+        with pytest.raises(install_inner.VersionSwitchError) as exc:
+            install_inner.switch_comfyui_version(str(tmp_path), "9.9.9")
+
+        assert exc.value.code == "version_switch_unknown_version"
+        assert "v0.3.1" in exc.value.message
+
+    def test_unknown_version_leaves_the_tree_untouched(self, fake_git, tmp_path):
+        with pytest.raises(install_inner.VersionSwitchError):
+            install_inner.switch_comfyui_version(str(tmp_path), "9.9.9")
+
+        assert not fake_git.ran("checkout")
+        assert not fake_git.ran("stash", "push")
+        assert not fake_git.ran("pull")
+
+    def test_unknown_version_exits_nonzero_without_installing_deps(self, fake_git, tmp_path):
+        with pytest.raises(typer.Exit) as exc:
+            _run_update(tmp_path, version="9.9.9")
+
+        assert exc.value.exit_code == 1
+        assert not fake_git.ran("checkout")
+
+    def test_dirty_tree_is_not_stashed_when_validation_fails(self, fake_git, tmp_path):
+        fake_git.status = " M comfy_extras/foo.py\n"
+
+        with pytest.raises(install_inner.VersionSwitchError):
+            install_inner.switch_comfyui_version(str(tmp_path), "9.9.9")
+
+        assert not fake_git.ran("stash", "push")
+
+
+# ---------------------------------------------------------------------------
+# (c) dirty tree / stash behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDirtyTree:
+    def test_dirty_tree_stashes_before_checkout(self, fake_git, tmp_path):
+        fake_git.status = " M comfy_extras/foo.py\n"
+
+        result = install_inner.switch_comfyui_version(str(tmp_path), "0.3.0")
+
+        stash_call = fake_git.call_matching("stash", "push")
+        assert stash_call is not None
+        assert "-u" in stash_call
+        assert "comfy-cli: before switch to v0.3.0" in stash_call
+
+        stash_index = fake_git.git_calls.index(stash_call)
+        checkout_index = fake_git.git_calls.index(fake_git.call_matching("checkout", "v0.3.0"))
+        assert stash_index < checkout_index
+
+        assert result["stashed"] is True
+        assert "stash@{0}" in result["stash_ref"]
+
+    def test_stash_is_never_popped_or_dropped(self, fake_git, tmp_path):
+        fake_git.status = " M comfy_extras/foo.py\n"
+
+        install_inner.switch_comfyui_version(str(tmp_path), "0.3.0")
+
+        assert not fake_git.ran("stash", "pop")
+        assert not fake_git.ran("stash", "drop")
+
+    def test_no_stash_refuses_on_a_dirty_tree(self, fake_git, tmp_path):
+        fake_git.status = " M comfy_extras/foo.py\n"
+
+        with pytest.raises(install_inner.VersionSwitchError) as exc:
+            install_inner.switch_comfyui_version(str(tmp_path), "0.3.0", stash=False)
+
+        assert exc.value.code == "version_switch_dirty_tree"
+        assert not fake_git.ran("stash", "push")
+        assert not fake_git.ran("checkout")
+
+    def test_no_stash_is_a_noop_on_a_clean_tree(self, fake_git, tmp_path):
+        result = install_inner.switch_comfyui_version(str(tmp_path), "0.3.0", stash=False)
+
+        assert result["stashed"] is False
+        assert fake_git.call_matching("checkout", "v0.3.0") is not None
+
+    def test_checkout_failure_after_a_stash_says_the_stash_survives(self, tmp_path):
+        git = FakeGit(tags=("v0.3.0",), status=" M foo.py\n", fail=("checkout",))
+        with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+            with pytest.raises(install_inner.VersionSwitchError) as exc:
+                install_inner.switch_comfyui_version(str(tmp_path), "0.3.0")
+
+        assert exc.value.code == "version_switch_failed"
+        assert exc.value.stash_ref is not None
+        assert "stashed" in exc.value.message
+
+
+# ---------------------------------------------------------------------------
+# (d) nightly roll-forward from a detached HEAD
+# ---------------------------------------------------------------------------
+
+
+class TestNightly:
+    def test_nightly_from_detached_head_checks_out_default_branch_and_pulls(self, tmp_path):
+        git = FakeGit(tags=("v0.3.0",), describe="v0.3.0", default_branch="master")
+        with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+            result = install_inner.switch_comfyui_version(str(tmp_path), "nightly")
+
+        assert git.call_matching("checkout", "master") is not None
+        checkout_index = git.git_calls.index(git.call_matching("checkout", "master"))
+        pull_index = git.git_calls.index(git.call_matching("pull"))
+        assert checkout_index < pull_index
+        assert result["current"] == "def5678 (master)"
+
+    def test_nightly_honors_a_non_master_default_branch(self, tmp_path):
+        git = FakeGit(default_branch="main")
+        with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+            install_inner.switch_comfyui_version(str(tmp_path), "nightly")
+
+        assert git.call_matching("checkout", "main") is not None
+
+    def test_nightly_falls_back_to_master_when_origin_head_is_unset(self, tmp_path):
+        git = FakeGit(fail=("symbolic-ref",))
+        with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+            install_inner.switch_comfyui_version(str(tmp_path), "nightly")
+
+        assert git.call_matching("checkout", "master") is not None
+
+    def test_pull_failure_reports_the_branch_is_checked_out(self, tmp_path):
+        git = FakeGit(fail=("pull",))
+        with patch("comfy_cli.command.install.subprocess.run", side_effect=git):
+            with pytest.raises(install_inner.VersionSwitchError) as exc:
+                install_inner.switch_comfyui_version(str(tmp_path), "nightly")
+
+        assert exc.value.code == "version_switch_failed"
+        assert "not up to date" in exc.value.message
+
+
+# ---------------------------------------------------------------------------
+# (e) --version with the wrong target
+# ---------------------------------------------------------------------------
+
+
+class TestTargetValidation:
+    @pytest.mark.parametrize("target", ["all", "cli"])
+    def test_version_is_rejected_for_non_comfy_targets(self, fake_git, target, tmp_path):
+        with pytest.raises(typer.Exit) as exc:
+            _run_update(tmp_path, target=target, version="0.3.0")
+
+        assert exc.value.exit_code == 1
+        assert fake_git.calls == []
+        assert fake_git.other_calls == []
+
+    def test_plain_update_still_pulls(self, fake_git, tmp_path):
+        """The bare ``comfy update comfy`` path must be untouched by --version."""
+        _run_update(tmp_path)
+
+        assert fake_git.git_calls[0] == ["git", "pull"]
+        assert fake_git.other_calls[0][0] == [
+            "/resolved/python",
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            "requirements.txt",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# (f) validate_version rejection surfaces through typer
+# ---------------------------------------------------------------------------
+
+
+class TestVersionValidation:
+    def test_none_passes_through(self):
+        assert install_inner.validate_optional_version(None) is None
+
+    def test_valid_values_are_normalized(self):
+        assert install_inner.validate_optional_version("v0.3.0") == "0.3.0"
+        assert install_inner.validate_optional_version("NIGHTLY") == "nightly"
+
+    def test_garbage_becomes_a_bad_parameter(self):
+        with pytest.raises(typer.BadParameter):
+            install_inner.validate_optional_version("not-a-version")
+
+    def test_garbage_exits_nonzero_through_the_cli(self):
+        result = CliRunner().invoke(cmdline.app, ["update", "comfy", "--version", "not-a-version"])
+
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# (g) pip failure after a successful checkout
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyFailure:
+    def test_pip_failure_exits_nonzero_after_the_checkout_landed(self, fake_git, tmp_path, capsys):
+        fake_git.pip_returncode = 1
+
+        with pytest.raises(typer.Exit) as exc:
+            _run_update(tmp_path, version="0.3.0")
+
+        assert exc.value.exit_code == 1
+        assert fake_git.call_matching("checkout", "v0.3.0") is not None
+
+        # The rendered error panel soft-wraps, so match on words, not phrases.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "dependencies may be incomplete" in combined
+        assert "idempotent" in combined


### PR DESCRIPTION
## ELI-5

Today, the only way to move an existing ComfyUI folder to a specific version is `comfy install --version X --restore`, which can stop and ask you what GPU you have, has no answer for uncommitted edits sitting in the folder, and can't roll you *forward* to nightly once you've rolled back. This adds `comfy update comfy --version <X>`: it checks the version exists first, tucks any uncommitted work into a git stash (and tells you where), checks out the version, and reinstalls that version's requirements. It never asks a question, so scripts and the MCP wrapper can use it.

## What changed

New `switch_comfyui_version(comfy_path, version, *, stash=True, url=None)` in `comfy_cli/command/install.py`, sitting next to `checkout_stable_comfyui`, plus the `--version` / `--no-stash` wiring on the existing `update` command.

1. **Resolve + validate before touching anything.** `git fetch --tags` (failure tolerated — a locally-present tag still checks out offline). For a semver target, `git rev-parse --verify refs/tags/v{X}` must succeed; if it doesn't, the command exits non-zero listing the ~5 nearest `v*` tags by semver order and the working tree is untouched. `latest` reuses `_resolve_latest_tag_from_local` with the existing GitHub-API fallback. `nightly` resolves the default branch via `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `master`.
2. **Stash by default.** A non-empty `git status --porcelain` triggers `git stash push -u -m "comfy-cli: before switch to <target>"`. The stash is never popped or dropped automatically and its ref is printed/returned. `--no-stash` refuses to proceed on a dirty tree instead.
3. **Checkout.** Tag target: `git checkout v{X}` (detached HEAD, expected). Nightly target: `git checkout <default-branch>` then `git pull` — this is both the roll-forward gap and the detached-HEAD-breaks-`update` fix.
4. **Reinstall deps** via the existing update-path machinery (`resolve_workspace_python` + `ensure_pip` + `python -m pip install -r requirements.txt`). Torch is not touched and no GPU flag is required.
5. **Report.** `data = {previous, current, stashed, stash_ref}` via the renderer, with a registered `update` output schema; pretty mode prints the same information plus the detached-HEAD note.

Five error codes are registered in `comfy_cli/error_codes.py`: `update_version_target_invalid`, `version_switch_unknown_version`, `version_switch_dirty_tree`, `version_switch_failed`, `version_switch_deps_failed`.

## Failure behavior

- Validation/fetch failure → exit 1, working tree untouched (test asserts no `checkout` and no `stash push` ran).
- Checkout (or the nightly `git pull`) failing after a stash → exit 1, and the message says explicitly that the stash still exists and how to recover it.
- pip failure after a successful checkout → exit 1 with a message saying the tree IS on the new version, deps may be incomplete, and re-running is idempotent.

## Tests

`tests/comfy_cli/command/test_update_version.py` — 25 tests, subprocess fully mocked (a `FakeGit` dispatcher; nothing touches a real repo or the network). Covers every case the ticket asked for: happy path checkout + pip, unknown version (non-zero, no checkout/stash, tags listed), dirty tree stashes before checkout, `--no-stash` refuses, nightly rolls a detached HEAD forward onto the default branch and pulls, `--version` with `all`/`cli` errors before any git call, `validate_version` rejection surfacing as a typer error, and pip failure after checkout. Plus a regression test pinning that a bare `comfy update comfy` still does `git pull` exactly as before.

`uv run pytest tests/` → 2792 passed, 37 skipped, 0 failed. `ruff check` and `ruff format --diff` (CI-pinned 0.15.15) both clean.

## Docs

README gains an "Updating ComfyUI" section covering the whole `update` command and a "Switching to a specific version" subsection documenting stash-by-default, `--no-stash`, and that a tag checkout leaves a detached HEAD you roll forward with `--version nightly`/`latest`. The `--version` help text says the same.

## Self-review notes / judgment calls

- **Nothing existing was flipped, broadened, or removed.** The only change to the pre-existing code path is indentation — the bare `comfy update` branch moved under an `else:`. `test_plain_update_still_pulls` pins that it still runs `git pull` and the same pip command.
- **Capability-denial check.** The diff's negative outcomes are not product-capability denials: `version_switch_unknown_version` is decided at runtime by actually fetching from the remote and running `git rev-parse` against the real tag list, and it *redirects* by naming the nearest versions that do work; `version_switch_dirty_tree` only fires when the user explicitly asks for it with `--no-stash`; the `all`/`cli` rejection redirects to `comfy update comfy --version`. No path is closed off — this diff is purely additive capability.
- **`--no-stash` without `--version` is silently ignored** rather than an error, since it has no meaning for a plain `git pull` update. Documented as applying only with `--version`.
- **Known minor:** if `comfy_path` is not a git repository at all, a semver target reports "version not found" (with an offline hint) rather than "not a git repo", because the tag lookup runs before the `git status` health check. Both exit non-zero and touch nothing; the message just names the less likely cause. Deliberate — reordering would move the health check ahead of the "validate before touching anything" step.
- **`switch_comfyui_version` takes a `url` parameter** used only for the `latest` GitHub-API fallback (mirroring `checkout_stable_comfyui`). The `update` command doesn't pass one, so that fallback queries `comfyanonymous/ComfyUI`, matching today's behavior for a workspace whose remote isn't recorded on the command line.

Closes BE-4763.
