### PR TITLE
feat: `comfy model download --background` with persistent download state + status/list/cancel verbs

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -11,10 +11,11 @@ import requests
 import typer
 from rich.markup import escape
 
-from comfy_cli import constants, download_state, tracking, ui, utils
+from comfy_cli import constants, download_state, tracking, ui
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH
 from comfy_cli.file_utils import (
+    DownloadCancelled,
     DownloadException,
     _friendly_network_error,
     check_unauthorized,
@@ -425,16 +426,39 @@ def _hf_headers() -> dict | None:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _host_allowed(url: str, hosts: tuple[str, ...]) -> bool:
+    """True when ``url``'s host is one of ``hosts`` or a subdomain of one."""
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    return host in hosts or host.endswith(tuple(f".{h}" for h in hosts))
+
+
 def _worker_headers(state: download_state.DownloadState) -> dict | None:
     """Derive the transfer headers the worker should use.
 
     The state file deliberately records only *which* credential the resolved URL
     needs; the secret itself is re-read from config here, exactly as the
     foreground ``download()`` does.
+
+    The url is re-checked against the credential's own hosts before the token is
+    attached. ``needs_*_auth`` and ``url`` are separate fields of a file on disk,
+    so nothing structurally stops them from disagreeing — and a record that says
+    "use the CivitAI token" against ``https://attacker.example`` would hand the
+    user's bearer token to the attacker. The check costs nothing and makes that
+    combination inert.
     """
     if state.needs_civitai_auth:
-        return _civitai_headers()
+        headers = _civitai_headers() or {}
+        if not _host_allowed(state.url, constants.CIVITAI_ALLOWED_HOSTS):
+            headers.pop("Authorization", None)
+        return headers
     if state.needs_hf_auth:
+        if not _host_allowed(state.url, constants.HF_ALLOWED_HOSTS):
+            return None
         return _hf_headers()
     return None
 
@@ -522,17 +546,16 @@ def _submit_background_download(
         )
         raise typer.Exit(code=1) from e
 
-    # The worker writes its own os.getpid() on startup, but it may not have run
-    # yet — recording the Popen pid here means `download-cancel` works in that
-    # window. Re-read first and only patch an unclaimed file: a fast worker on a
-    # small file can already be `downloading` (or done) by now, and blindly
-    # writing this stale in-memory copy back would clobber its progress.
+    # Deliberately *not* writing the Popen pid back here. Only the worker
+    # records its pid, together with its start time, so the two can never
+    # disagree and a pid can never be trusted without its identity proof. The
+    # window before the worker's first write is covered instead by
+    # `reconcile`'s startup grace (a pidless `starting` record stays `starting`)
+    # and by the cancel sentinel (a worker that comes up after `download-cancel`
+    # sees the request and exits without downloading) — which also removes the
+    # read/write race this write-back used to have with a fast worker.
     on_disk = download_state.read_path(state_file)
     if on_disk is not None:
-        if on_disk.pid is None:
-            on_disk.pid = pid
-            with contextlib.suppress(OSError, ValueError):
-                download_state.write_path(state_file, on_disk)
         state = on_disk
 
     print(f"Downloading in the background: [cyan]{state.id}[/cyan] → {dest}")
@@ -566,7 +589,25 @@ def _download_worker(
         # only happens if it was deleted underneath us. Nothing to do.
         raise typer.Exit(code=1)
 
+    cancel_marker = download_state.cancel_marker_for(path)
+
+    def cancelled() -> bool:
+        return cancel_marker.exists()
+
+    # `download-cancel` may have landed while we were still starting up — it
+    # can't signal a process that has no pid on file yet, so the sentinel is how
+    # it reaches us. Check before claiming the record, and never write a status
+    # after one appears.
+    if cancelled() or state.is_terminal:
+        if not state.is_terminal:
+            state.status = "cancelled"
+            state.error = None
+            with contextlib.suppress(OSError):
+                download_state.write_path(path, state)
+        raise typer.Exit(code=0)
+
     state.pid = os.getpid()
+    state.pid_create_time = download_state.process_create_time(os.getpid())
     state.status = "downloading"
     download_state.write_path(path, state)
 
@@ -581,6 +622,11 @@ def _download_worker(
         if now - last_write < download_state.PROGRESS_THROTTLE_S:
             return
         last_write = now
+        # Poll for cancellation on the same tick as the progress write, so a
+        # cancelled download is never resurrected to `downloading` by a write
+        # that raced it.
+        if cancelled():
+            raise DownloadCancelled()
         with contextlib.suppress(OSError):
             download_state.write_path(path, state)
 
@@ -592,6 +638,15 @@ def _download_worker(
             downloader=state.downloader,
             progress_callback=on_progress,
         )
+    except DownloadCancelled:
+        state.status = "cancelled"
+        state.error = None
+        with contextlib.suppress(OSError):
+            pathlib.Path(state.dest).unlink(missing_ok=True)
+        state.completed_bytes = 0
+        with contextlib.suppress(OSError):
+            download_state.write_path(path, state)
+        raise typer.Exit(code=0) from None
     except BaseException as e:  # noqa: BLE001 — any failure must reach the state file
         state.status = "failed"
         state.error = _friendly_network_error(e) if isinstance(e, Exception) else f"{type(e).__name__}"
@@ -599,6 +654,10 @@ def _download_worker(
             download_state.write_path(path, state)
         raise typer.Exit(code=1) from None
 
+    # A transfer that beat the cancel to the finish line stays `completed` and
+    # keeps its file — `download-cancel` re-reads this record before deciding
+    # what to delete, so both sides agree that a fully-downloaded model is not
+    # something to throw away.
     state.status = "completed"
     state.error = None
     actual = pathlib.Path(state.dest)
@@ -613,7 +672,15 @@ def _download_worker(
 
 
 def _render_download_rows(rows: list[dict]) -> None:
-    """Human rendering shared by `download-status` and `downloads`."""
+    """Human rendering shared by `download-status` and `downloads`.
+
+    A no-op in JSON/NDJSON mode: `ui.display_table` writes to its own Rich
+    console on stdout, which is reserved for the envelope, and a table prepended
+    to the JSON would make the output unparseable for the agents this contract
+    exists for. They get the same rows in `downloads` / the status payload.
+    """
+    if get_renderer().is_json():
+        return
 
     def _size(value) -> str:
         if value is None:
@@ -709,36 +776,81 @@ def download_cancel(
         )
         raise typer.Exit(code=1)
 
+    # Reconcile before deciding there is anything to cancel: a worker SIGKILLed
+    # after the last byte landed but before it could persist `completed` still
+    # reads as `downloading`, and cancelling that would delete a finished model.
+    # Only a *finished* transfer short-circuits — a dead worker that left a
+    # partial behind is exactly what the user is trying to clean up, so it goes
+    # through the normal cancel path below.
+    if state.status not in download_state.TERMINAL_STATUSES:
+        fresh = download_state.reconcile(state)
+        if fresh.status == "completed":
+            state = fresh
+            with contextlib.suppress(OSError, ValueError):
+                download_state.write(workspace, state)
+
     if state.status in download_state.TERMINAL_STATUSES:
         payload = download_state.status_payload(state)
         print(f"Download {download_id} is already {state.status}; nothing to cancel.")
         renderer.emit(payload, command="model download-cancel", changed=False)
         return
 
-    killed = download_state.kill_worker(state.pid)
-    # Give the worker a moment to die so it can't resurrect the state file with
-    # a stale progress write after we mark it cancelled.
-    if killed:
-        deadline = time.monotonic() + 2.0
-        while time.monotonic() < deadline and utils.is_running(state.pid):
-            time.sleep(0.05)
+    # Sentinel first, then the signal. The sentinel is what a worker that is
+    # still starting up (no pid on file yet) — or one that outlives SIGTERM —
+    # will see, and once it exists the worker can only write `cancelled`.
+    with contextlib.suppress(OSError, ValueError):
+        download_state.request_cancel(download_state.cancel_path(workspace, download_id))
+
+    # Re-read before signalling: a worker that was still starting up when we
+    # first read has claimed its pid by now, and stopping the wrong (or no)
+    # process is how a "cancelled" download keeps writing bytes.
+    state = download_state.read(workspace, download_id) or state
+
+    # Escalates to SIGKILL if the worker doesn't go quietly; nothing below may
+    # touch the destination file until it is confirmed gone, or the worker would
+    # simply re-create what we delete.
+    stopped = download_state.stop_worker(state)
+
+    # Re-read the worker's last word before touching the destination. Our copy
+    # predates the kill and can still be missing the total the worker learned
+    # from the response headers — and that total is the only thing that tells a
+    # finished file from a partial one.
+    state = download_state.read(workspace, download_id) or state
 
     removed = False
+    partial = pathlib.Path(state.dest)
+    size = None
     with contextlib.suppress(OSError):
-        partial = pathlib.Path(state.dest)
-        if partial.exists():
-            partial.unlink()
-            removed = True
+        size = partial.stat().st_size
 
-    state.status = "cancelled"
-    state.error = None
-    if removed:
-        state.completed_bytes = 0
+    finished = state.status == "completed" or (
+        size is not None and state.total_bytes is not None and size >= state.total_bytes
+    )
+    if finished:
+        # The bytes are all there. Keep the file and record what actually
+        # happened rather than deleting a complete model out from under the user.
+        state.status = "completed"
+        state.error = None
+        if size is not None:
+            state.completed_bytes = size
+    else:
+        if stopped and size is not None:
+            with contextlib.suppress(OSError):
+                partial.unlink()
+                removed = True
+        state.status = "cancelled"
+        state.error = None if stopped else "worker may still be running; partial file left in place"
+        if removed:
+            state.completed_bytes = 0
+
     with contextlib.suppress(OSError, ValueError):
         download_state.write(workspace, state)
 
     payload = download_state.status_payload(state)
-    print(f"Cancelled download [cyan]{download_id}[/cyan].")
+    if finished:
+        print(f"Download [cyan]{download_id}[/cyan] had already finished; kept {partial}.")
+    else:
+        print(f"Cancelled download [cyan]{download_id}[/cyan].")
     renderer.emit(payload, command="model download-cancel", changed=True)
 
 

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -1,6 +1,8 @@
 import contextlib
 import os
 import pathlib
+import subprocess
+import sys
 import time
 from typing import Annotated
 from urllib.parse import parse_qs, unquote, urlparse
@@ -9,10 +11,16 @@ import requests
 import typer
 from rich.markup import escape
 
-from comfy_cli import constants, tracking, ui
+from comfy_cli import constants, download_state, tracking, ui, utils
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH
-from comfy_cli.file_utils import DownloadException, check_unauthorized, download_file
+from comfy_cli.file_utils import (
+    DownloadException,
+    _friendly_network_error,
+    check_unauthorized,
+    download_file,
+)
+from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as print  # context-aware: stderr in JSON mode
 from comfy_cli.workspace_manager import WorkspaceManager
 
@@ -243,6 +251,16 @@ def download(
             show_default=False,
         ),
     ] = None,
+    background: Annotated[
+        bool,
+        typer.Option(
+            "--background",
+            help=(
+                "Detach the byte transfer to a background worker and return immediately with a "
+                "download id. Poll it with `comfy model download-status <id>`."
+            ),
+        ),
+    ] = False,
 ):
     if relative_path is not None:
         relative_path = os.path.expanduser(relative_path)
@@ -325,36 +343,53 @@ def download(
 
     start_time = time.monotonic()
 
+    # Every resolution step above (metadata requests, token config, filename,
+    # destination-exists) has now run in the foreground, so a bad URL, a missing
+    # token, or an already-present file still fails fast and synchronously. Only
+    # the byte transfer below is eligible to detach.
+    needs_hf_auth = False
     if is_huggingface_url and check_unauthorized(url, headers):
         if hf_api_token is None:
             print(
                 f"Unauthorized access to Hugging Face model. Please set the Hugging Face API token using `comfy model download --set-hf-api-token` or via the `{constants.HF_API_TOKEN_ENV_KEY}` environment variable"
             )
             return
-        else:
-            try:
-                import huggingface_hub
-            except ImportError:
-                print("huggingface_hub not found. Installing...")
-                import subprocess
+        needs_hf_auth = True
 
-                from comfy_cli.resolve_python import resolve_workspace_python
+    if background:
+        _submit_background_download(
+            url=url,
+            dest=local_filepath,
+            downloader=resolved_downloader,
+            needs_civitai_auth=bool(is_civitai_model_url or is_civitai_api_url),
+            needs_hf_auth=needs_hf_auth,
+        )
+        return
 
-                python = resolve_workspace_python(str(get_workspace()))
-                subprocess.check_call([python, "-m", "pip", "install", "huggingface_hub"])
-                import huggingface_hub
+    if needs_hf_auth:
+        try:
+            import huggingface_hub
+        except ImportError:
+            print("huggingface_hub not found. Installing...")
+            import subprocess
 
-            print(f"Downloading model {model_id} from Hugging Face...")
-            output_path = huggingface_hub.hf_hub_download(
-                repo_id=repo_id,
-                filename=hf_filename,
-                subfolder=hf_folder_name,
-                revision=hf_branch_name,
-                token=hf_api_token,
-                local_dir=get_workspace() / relative_path,
-                cache_dir=get_workspace() / relative_path,
-            )
-            print(f"Model downloaded successfully to: {output_path}")
+            from comfy_cli.resolve_python import resolve_workspace_python
+
+            python = resolve_workspace_python(str(get_workspace()))
+            subprocess.check_call([python, "-m", "pip", "install", "huggingface_hub"])
+            import huggingface_hub
+
+        print(f"Downloading model {model_id} from Hugging Face...")
+        output_path = huggingface_hub.hf_hub_download(
+            repo_id=repo_id,
+            filename=hf_filename,
+            subfolder=hf_folder_name,
+            revision=hf_branch_name,
+            token=hf_api_token,
+            local_dir=get_workspace() / relative_path,
+            cache_dir=get_workspace() / relative_path,
+        )
+        print(f"Model downloaded successfully to: {output_path}")
     else:
         print(f"Start downloading URL: {url} into {local_filepath}")
         try:
@@ -367,6 +402,344 @@ def download(
 
     elapsed = time.monotonic() - start_time
     print(f"Done in {_format_elapsed(elapsed)}")
+
+
+# ---------------------------------------------------------------------------
+# background downloads: submit, worker, and the poll verbs
+# ---------------------------------------------------------------------------
+
+
+def _civitai_headers() -> dict | None:
+    """Rebuild CivitAI request headers from config — never from persisted state."""
+    headers = {"Content-Type": "application/json"}
+    token = config_manager.get_or_override(constants.CIVITAI_API_TOKEN_ENV_KEY, constants.CIVITAI_API_TOKEN_KEY, None)
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _hf_headers() -> dict | None:
+    token = config_manager.get_or_override(constants.HF_API_TOKEN_ENV_KEY, constants.HF_API_TOKEN_KEY, None)
+    if token is None:
+        return None
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _worker_headers(state: download_state.DownloadState) -> dict | None:
+    """Derive the transfer headers the worker should use.
+
+    The state file deliberately records only *which* credential the resolved URL
+    needs; the secret itself is re-read from config here, exactly as the
+    foreground ``download()`` does.
+    """
+    if state.needs_civitai_auth:
+        return _civitai_headers()
+    if state.needs_hf_auth:
+        return _hf_headers()
+    return None
+
+
+def _spawn_download_worker(state_file: pathlib.Path, log_file: pathlib.Path) -> int:
+    """Detach the transfer worker and return its pid.
+
+    stdin is /dev/null and stdout/stderr are *appended* to the download's log so
+    a crashed worker leaves a trace. POSIX gets its own session (so the worker
+    outlives the terminal and `download-cancel` can signal one process group);
+    Windows gets DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP for the equivalent.
+    """
+    argv = [sys.executable, "-m", "comfy_cli", "model", "_download-worker", "--state", str(state_file)]
+
+    kwargs: dict = {}
+    if sys.platform == "win32":
+        # Not module-level attributes on POSIX, hence the getattr lookups.
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0)
+        new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        kwargs["creationflags"] = detached | new_group
+    else:
+        kwargs["start_new_session"] = True
+
+    logfh = open(log_file, "ab")
+    try:
+        proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=logfh,
+            stderr=subprocess.STDOUT,
+            close_fds=True,
+            **kwargs,
+        )
+    finally:
+        logfh.close()
+    return proc.pid
+
+
+def _submit_background_download(
+    *,
+    url: str,
+    dest: pathlib.Path,
+    downloader: str,
+    needs_civitai_auth: bool,
+    needs_hf_auth: bool,
+) -> None:
+    """Write the state file, detach the worker, and emit the submit envelope."""
+    renderer = get_renderer()
+    workspace = get_workspace()
+    dest = pathlib.Path(dest).absolute()
+
+    state = download_state.new(
+        url=url,
+        dest=str(dest),
+        downloader=downloader,
+        needs_civitai_auth=needs_civitai_auth,
+        needs_hf_auth=needs_hf_auth,
+    )
+
+    try:
+        # The parent directory has to exist before the worker starts writing, and
+        # creating it here means a permission problem surfaces synchronously.
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        state_file = download_state.write(workspace, state)
+        log_file = download_state.log_path(workspace, state.id)
+    except OSError as e:
+        renderer.error(
+            code="download_state_unwritable",
+            message=f"Could not create the background download state: {e}",
+            hint=f"check that {workspace} is writable, or run without --background",
+        )
+        raise typer.Exit(code=1) from e
+
+    try:
+        pid = _spawn_download_worker(state_file, log_file)
+    except OSError as e:
+        state.status = "failed"
+        state.error = f"could not start the background worker: {e}"
+        with contextlib.suppress(OSError):
+            download_state.write(workspace, state)
+        renderer.error(
+            code="download_worker_spawn_failed",
+            message=f"Could not start the background download worker: {e}",
+            hint="run without --background to download in the foreground",
+        )
+        raise typer.Exit(code=1) from e
+
+    # The worker writes its own os.getpid() on startup, but it may not have run
+    # yet — recording the Popen pid here means `download-cancel` works in that
+    # window. Re-read first and only patch an unclaimed file: a fast worker on a
+    # small file can already be `downloading` (or done) by now, and blindly
+    # writing this stale in-memory copy back would clobber its progress.
+    on_disk = download_state.read_path(state_file)
+    if on_disk is not None:
+        if on_disk.pid is None:
+            on_disk.pid = pid
+            with contextlib.suppress(OSError, ValueError):
+                download_state.write_path(state_file, on_disk)
+        state = on_disk
+
+    print(f"Downloading in the background: [cyan]{state.id}[/cyan] → {dest}")
+    print(f"Track it with: [cyan]comfy model download-status {state.id}[/cyan]")
+    renderer.emit(
+        {
+            "download_id": state.id,
+            "pid": pid,
+            "dest": str(dest),
+            "total_bytes": state.total_bytes,
+            "status": state.status,
+        },
+        command="model download",
+        changed=True,
+    )
+
+
+@app.command("_download-worker", hidden=True)
+def _download_worker(
+    state_file: Annotated[str, typer.Option("--state", help="Path to the download state file.")],
+):
+    """Detached worker that performs the byte transfer for one background download.
+
+    Hidden: agents address downloads through `comfy model download-status` /
+    `downloads` / `download-cancel`, never by invoking this directly.
+    """
+    path = pathlib.Path(state_file)
+    state = download_state.read_path(path)
+    if state is None:
+        # The submitter always writes the state file before spawning us, so this
+        # only happens if it was deleted underneath us. Nothing to do.
+        raise typer.Exit(code=1)
+
+    state.pid = os.getpid()
+    state.status = "downloading"
+    download_state.write_path(path, state)
+
+    last_write = 0.0
+
+    def on_progress(completed: int, total: int | None) -> None:
+        nonlocal last_write
+        state.completed_bytes = completed
+        if total is not None:
+            state.total_bytes = total
+        now = time.monotonic()
+        if now - last_write < download_state.PROGRESS_THROTTLE_S:
+            return
+        last_write = now
+        with contextlib.suppress(OSError):
+            download_state.write_path(path, state)
+
+    try:
+        download_file(
+            state.url,
+            pathlib.Path(state.dest),
+            _worker_headers(state),
+            downloader=state.downloader,
+            progress_callback=on_progress,
+        )
+    except BaseException as e:  # noqa: BLE001 — any failure must reach the state file
+        state.status = "failed"
+        state.error = _friendly_network_error(e) if isinstance(e, Exception) else f"{type(e).__name__}"
+        with contextlib.suppress(OSError):
+            download_state.write_path(path, state)
+        raise typer.Exit(code=1) from None
+
+    state.status = "completed"
+    state.error = None
+    actual = pathlib.Path(state.dest)
+    try:
+        state.completed_bytes = actual.stat().st_size
+    except OSError:
+        pass
+    if state.total_bytes is None:
+        state.total_bytes = state.completed_bytes
+    with contextlib.suppress(OSError):
+        download_state.write_path(path, state)
+
+
+def _render_download_rows(rows: list[dict]) -> None:
+    """Human rendering shared by `download-status` and `downloads`."""
+
+    def _size(value) -> str:
+        if value is None:
+            return "?"
+        return f"{value / (1024 * 1024):.1f} MB"
+
+    data = [
+        (
+            row["id"],
+            row["status"],
+            "—" if row["percent"] is None else f"{row['percent']:.1f}%",
+            f"{_size(row['completed_bytes'])} / {_size(row['total_bytes'])}",
+            f"{row['elapsed_seconds']:.1f}s",
+            row["dest"],
+        )
+        for row in rows
+    ]
+    ui.display_table(data, ["ID", "Status", "%", "Bytes", "Elapsed", "Destination"])
+    for row in rows:
+        if row.get("error"):
+            print(f"[bold red]{row['id']}: {escape(str(row['error']))}[/bold red]")
+
+
+def _reconciled(state: download_state.DownloadState) -> tuple[download_state.DownloadState, bool]:
+    """Reconcile ``state`` against reality, persisting a *status* correction.
+
+    Only a status change is written back. Byte counts are re-derived from
+    ``stat(dest)`` on every poll anyway, so persisting them buys nothing — and
+    would let a poll racing a live worker rewind the file to whatever this
+    reader happened to load a moment earlier.
+    """
+    fresh = download_state.reconcile(state)
+    changed = fresh.status != state.status
+    if changed:
+        with contextlib.suppress(OSError, ValueError):
+            download_state.write(get_workspace(), fresh)
+    return fresh, changed
+
+
+@app.command("download-status")
+@tracking.track_command("model")
+def download_status(
+    _ctx: typer.Context,
+    download_id: Annotated[str, typer.Argument(help="The download id returned by `download --background`.")],
+):
+    """Report the progress of one background download."""
+    renderer = get_renderer()
+    state = download_state.read(get_workspace(), download_id)
+    if state is None:
+        renderer.error(
+            code="download_not_found",
+            message=f"No background download with id {download_id!r}.",
+            hint="list the known downloads with `comfy model downloads`",
+            details={"id": download_id},
+        )
+        raise typer.Exit(code=1)
+
+    fresh, _ = _reconciled(state)
+    payload = download_state.status_payload(fresh)
+    _render_download_rows([payload])
+    renderer.emit(payload, command="model download-status")
+
+
+@app.command("downloads")
+@tracking.track_command("model")
+def downloads(_ctx: typer.Context):
+    """List every background download this workspace knows about, newest first."""
+    renderer = get_renderer()
+    rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(get_workspace())]
+    if not rows:
+        print("No background downloads found.")
+    else:
+        _render_download_rows(rows)
+    renderer.emit({"total": len(rows), "downloads": rows}, command="model downloads")
+
+
+@app.command("download-cancel")
+@tracking.track_command("model")
+def download_cancel(
+    _ctx: typer.Context,
+    download_id: Annotated[str, typer.Argument(help="The download id returned by `download --background`.")],
+):
+    """Kill a background download's worker and remove its partial file."""
+    renderer = get_renderer()
+    workspace = get_workspace()
+    state = download_state.read(workspace, download_id)
+    if state is None:
+        renderer.error(
+            code="download_not_found",
+            message=f"No background download with id {download_id!r}.",
+            hint="list the known downloads with `comfy model downloads`",
+            details={"id": download_id},
+        )
+        raise typer.Exit(code=1)
+
+    if state.status in download_state.TERMINAL_STATUSES:
+        payload = download_state.status_payload(state)
+        print(f"Download {download_id} is already {state.status}; nothing to cancel.")
+        renderer.emit(payload, command="model download-cancel", changed=False)
+        return
+
+    killed = download_state.kill_worker(state.pid)
+    # Give the worker a moment to die so it can't resurrect the state file with
+    # a stale progress write after we mark it cancelled.
+    if killed:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and utils.is_running(state.pid):
+            time.sleep(0.05)
+
+    removed = False
+    with contextlib.suppress(OSError):
+        partial = pathlib.Path(state.dest)
+        if partial.exists():
+            partial.unlink()
+            removed = True
+
+    state.status = "cancelled"
+    state.error = None
+    if removed:
+        state.completed_bytes = 0
+    with contextlib.suppress(OSError, ValueError):
+        download_state.write(workspace, state)
+
+    payload = download_state.status_payload(state)
+    print(f"Cancelled download [cyan]{download_id}[/cyan].")
+    renderer.emit(payload, command="model download-cancel", changed=True)
 
 
 @app.command()

--- a/comfy_cli/constants.py
+++ b/comfy_cli/constants.py
@@ -54,6 +54,9 @@ CIVITAI_API_TOKEN_ENV_KEY = "CIVITAI_API_TOKEN"
 CIVITAI_ALLOWED_HOSTS: tuple[str, ...] = ("civitai.com", "civitai.red")
 HF_API_TOKEN_KEY = "hf_api_token"
 HF_API_TOKEN_ENV_KEY = "HF_API_TOKEN"
+# Hosts the HF bearer token may be sent to. `check_huggingface_url` accepts the
+# first two; `hf.co` is the official short form Hugging Face redirects from.
+HF_ALLOWED_HOSTS: tuple[str, ...] = ("huggingface.co", "huggingface.com", "hf.co")
 
 ARIA2_SERVER_ENV_KEY = "COMFYUI_MANAGER_ARIA2_SERVER"
 ARIA2_SECRET_ENV_KEY = "COMFYUI_MANAGER_ARIA2_SECRET"

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -82,6 +82,11 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy models show": "models",
     "comfy models list-folders": "models",
     "comfy models list-folder": "models",
+    # background model downloads (`comfy model download --background`)
+    "comfy model download": "download",
+    "comfy model download-status": "download_status",
+    "comfy model download-cancel": "download_status",
+    "comfy model downloads": "downloads",
     # template gallery
     "comfy templates ls": "templates",
     "comfy templates show": "templates",

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -14,6 +14,7 @@ State-file contract (``download-state/1``)::
       "schema": "download-state/1",
       "id": "<12 hex chars>",
       "pid": <int> | null,          # worker pid, written by the worker itself
+      "pid_create_time": <float> | null,  # worker process start time (identity)
       "url": "https://...",         # RESOLVED download url
       "dest": "/abs/path/model.safetensors",
       "total_bytes": <int> | null,  # null until response headers are read
@@ -27,9 +28,23 @@ State-file contract (``download-state/1``)::
       "needs_hf_auth": <bool>
     }
 
+``pid`` is only ever written by the worker itself, together with
+``pid_create_time`` — the pair identifies the process, so a recycled pid can
+never be mistaken for (or signalled as) a live worker. Until the worker's first
+write both are null; :func:`reconcile` gives a fresh ``starting`` record
+:data:`STARTUP_GRACE_S` to get that far before declaring it dead.
+
 No auth tokens or headers are ever persisted — the worker re-derives them from
 config the same way the foreground ``download()`` does. ``needs_civitai_auth`` /
-``needs_hf_auth`` only record *which* credential the resolved URL wants.
+``needs_hf_auth`` only record *which* credential the resolved URL wants. The
+state directory is created ``0700`` and each file ``0600`` regardless: a
+resolved url can still embed a presigned/SAS query token, and only the owner
+should be able to read — or tamper with — these records.
+
+Cancellation is signalled out-of-band by an empty ``<id>.cancel`` sentinel next
+to the state file. A sentinel can't be clobbered by a state write that raced it,
+so a worker that comes up (or ticks) after ``download-cancel`` always observes
+the request; see :func:`request_cancel`.
 
 Terminal statuses (``completed``, ``failed``, ``cancelled``) mean the file won't
 change further; agents can stop polling.
@@ -37,11 +52,13 @@ change further; agents can stop polling.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
 import secrets as _secrets
 import sys
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -59,6 +76,22 @@ ACTIVE_STATUSES = frozenset({"starting", "downloading"})
 # Terminal transitions always write, regardless of the throttle.
 PROGRESS_THROTTLE_S = 1.0
 
+# The state dir can hold presigned urls; keep it owner-only.
+STATE_DIR_MODE = 0o700
+STATE_FILE_MODE = 0o600
+
+# How long a `starting` record with no pid yet is trusted before reconcile
+# calls it dead. This only has to cover interpreter startup for the worker.
+STARTUP_GRACE_S = 60.0
+
+# Slack when matching a recorded process start time against the live one. Both
+# come from the same psutil source so they agree exactly in practice.
+PID_CREATE_TIME_TOLERANCE_S = 1.0
+
+# Every worker's argv contains this; used to identify a worker when its start
+# time was never recorded.
+WORKER_ARGV_MARKER = "_download-worker"
+
 _SAFE_ID = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 
@@ -67,9 +100,14 @@ def new_id() -> str:
 
 
 def state_dir(workspace: Path) -> Path:
-    """Return ``<workspace>/.comfy-downloads`` and ensure it exists."""
+    """Return ``<workspace>/.comfy-downloads`` and ensure it exists, owner-only."""
     base = Path(workspace) / STATE_DIRNAME
-    base.mkdir(parents=True, exist_ok=True)
+    base.mkdir(parents=True, exist_ok=True, mode=STATE_DIR_MODE)
+    if sys.platform != "win32":
+        # mkdir's mode is masked by the umask, and the directory may predate
+        # this code, so tighten it explicitly.
+        with contextlib.suppress(OSError):
+            base.chmod(STATE_DIR_MODE)
     return base
 
 
@@ -85,6 +123,37 @@ def log_path(workspace: Path, download_id: str) -> Path:
     return state_dir(workspace) / f"{download_id}.log"
 
 
+def cancel_path(workspace: Path, download_id: str) -> Path:
+    if not _SAFE_ID.match(download_id or ""):
+        raise ValueError(f"unsafe download id: {download_id!r}")
+    return state_dir(workspace) / f"{download_id}.cancel"
+
+
+def cancel_marker_for(state_file: Path) -> Path:
+    """The cancel sentinel that pairs with a state file addressed by path.
+
+    The worker is handed ``--state <file>`` and never re-resolves a workspace,
+    so it derives the sentinel the same way.
+    """
+    state_file = Path(state_file)
+    return state_file.with_name(f"{state_file.stem}.cancel")
+
+
+def request_cancel(path: Path) -> bool:
+    """Create the cancel sentinel at ``path``. Returns False if it couldn't be.
+
+    Creating a separate file (rather than flipping a field in the state file)
+    is what makes the request survive a worker write that raced it: the worker
+    checks the sentinel before every state write, so once this returns the
+    worker can only ever write ``cancelled``.
+    """
+    try:
+        Path(path).touch(mode=STATE_FILE_MODE, exist_ok=True)
+        return True
+    except OSError:
+        return False
+
+
 @dataclass
 class DownloadState:
     id: str
@@ -92,6 +161,7 @@ class DownloadState:
     dest: str
     schema: str = STATE_SCHEMA
     pid: int | None = None
+    pid_create_time: float | None = None
     total_bytes: int | None = None
     completed_bytes: int = 0
     status: str = "starting"
@@ -155,6 +225,11 @@ def write_path(path: Path, state: DownloadState) -> Path:
     payload = json.dumps(state.to_dict(), indent=2, default=str)
     try:
         tmp.write_text(payload, encoding="utf-8")
+        if sys.platform != "win32":
+            # write_text honours the umask, which may be group/world readable —
+            # and the payload can contain a presigned url.
+            with contextlib.suppress(OSError):
+                tmp.chmod(STATE_FILE_MODE)
         try:
             fd = os.open(str(tmp), os.O_RDONLY)
             try:
@@ -183,6 +258,37 @@ def read(workspace: Path, download_id: str) -> DownloadState | None:
     return read_path(path)
 
 
+def _is_int(value: Any) -> bool:
+    # bool is an int subclass; a `true` pid is corruption, not a pid.
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: Any) -> bool:
+    return _is_int(value) or isinstance(value, float)
+
+
+# Per-field validators. A file that fails any of them is corrupt or tampered
+# with; it reads as *absent* rather than constructing a DownloadState that
+# blows up later in kill_worker/reconcile and takes the whole command with it.
+_FIELD_VALIDATORS: dict[str, Any] = {
+    "id": lambda v: isinstance(v, str),
+    "url": lambda v: isinstance(v, str),
+    "dest": lambda v: isinstance(v, str),
+    "schema": lambda v: isinstance(v, str),
+    "pid": lambda v: v is None or _is_int(v),
+    "pid_create_time": lambda v: v is None or _is_number(v),
+    "total_bytes": lambda v: v is None or _is_int(v),
+    "completed_bytes": _is_int,
+    "status": lambda v: isinstance(v, str),
+    "error": lambda v: v is None or isinstance(v, str),
+    "started_at": lambda v: isinstance(v, str),
+    "updated_at": lambda v: isinstance(v, str),
+    "downloader": lambda v: isinstance(v, str),
+    "needs_civitai_auth": lambda v: isinstance(v, bool),
+    "needs_hf_auth": lambda v: isinstance(v, bool),
+}
+
+
 def read_path(path: Path) -> DownloadState | None:
     try:
         data = json.loads(Path(path).read_text(encoding="utf-8"))
@@ -192,6 +298,10 @@ def read_path(path: Path) -> DownloadState | None:
         return None
     known = set(DownloadState.__dataclass_fields__)
     filtered = {k: v for k, v in data.items() if k in known}
+    for key, value in filtered.items():
+        validator = _FIELD_VALIDATORS.get(key)
+        if validator is not None and not validator(value):
+            return None
     try:
         return DownloadState(**filtered)
     except TypeError:
@@ -244,24 +354,83 @@ def elapsed_seconds(state: DownloadState) -> float:
     return max(0.0, (end - started).total_seconds())
 
 
+def process_create_time(pid: int | None) -> float | None:
+    """The process start time for ``pid``, or None if it can't be determined."""
+    if not pid or pid <= 0:
+        return None
+    try:
+        import psutil
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:  # noqa: BLE001 — gone, not ours, or unsupported platform
+        return None
+
+
+def is_worker_process(pid: int | None, create_time: float | None) -> bool:
+    """True only when ``pid`` is *still the download worker* we recorded.
+
+    Pids are recycled. Liveness alone is not proof: after a worker crashes and
+    the OS hands its number to something else, a bare ``is_running`` check would
+    keep a dead transfer pinned at ``downloading`` forever — and, worse, point
+    ``download-cancel``'s ``killpg`` at an unrelated process group.
+
+    The recorded start time is the discriminator: the worker writes it together
+    with its own pid, so the pair either matches a live process or it doesn't.
+    When no start time was recorded (psutil couldn't read it), fall back to
+    matching the worker's argv — never to liveness alone.
+    """
+    if not pid or pid <= 0:
+        return False
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        if create_time is not None:
+            return abs(proc.create_time() - create_time) <= PID_CREATE_TIME_TOLERANCE_S
+        return WORKER_ARGV_MARKER in " ".join(proc.cmdline() or [])
+    except Exception:  # noqa: BLE001 — gone, or not ours to inspect
+        return False
+
+
+def worker_alive(state: DownloadState, *, pid_alive=None) -> bool:
+    """True while ``state``'s worker is running and provably the same process.
+
+    Deliberately laxer than :func:`kill_worker` in one case: if a record somehow
+    carries a pid with no start time, this trusts liveness rather than falling
+    back to the argv check. The two get different answers because they cost
+    different things when wrong — mis-reporting a status is cheap and
+    self-corrects on the next poll, while signalling a stranger's process group
+    is not, so only the reporting side is allowed the benefit of the doubt.
+    """
+    if state.pid is None:
+        return False
+    if pid_alive is None:
+        from comfy_cli.utils import is_running as pid_alive  # noqa: N813
+    if not pid_alive(state.pid):
+        return False
+    if state.pid_create_time is None:
+        return True
+    return is_worker_process(state.pid, state.pid_create_time)
+
+
 def reconcile(state: DownloadState, *, pid_alive=None) -> DownloadState:
     """Return a copy of ``state`` corrected against reality on disk.
 
     A worker that was SIGKILLed (or whose machine rebooted) never gets to write
     a terminal status, so a state file claiming ``downloading`` is only
-    trustworthy while its pid is alive. Two corrections happen here:
+    trustworthy while its worker is alive — and still *is* that worker, not a
+    stranger who inherited its pid (see :func:`worker_alive`). Corrections:
 
     * ``completed_bytes`` prefers a live ``stat(dest)`` over the last value the
       worker managed to persist — the file on disk is the ground truth.
+    * a ``starting`` record that hasn't claimed a pid yet is left alone for
+      :data:`STARTUP_GRACE_S`; that window is the worker's interpreter startup.
     * an active status whose worker is gone becomes ``completed`` when the file
       reached the known total, and ``failed`` ("worker died") otherwise.
 
     ``pid_alive`` is injectable for tests; it defaults to the same liveness
     helper the launch/stop machinery uses.
     """
-    if pid_alive is None:
-        from comfy_cli.utils import is_running as pid_alive  # noqa: N813
-
     fresh = DownloadState(**state.to_dict())
 
     size = _dest_size(fresh.dest)
@@ -271,7 +440,10 @@ def reconcile(state: DownloadState, *, pid_alive=None) -> DownloadState:
     if fresh.status not in ACTIVE_STATUSES:
         return fresh
 
-    if fresh.pid is not None and pid_alive(fresh.pid):
+    if fresh.pid is None and fresh.status == "starting" and elapsed_seconds(fresh) < STARTUP_GRACE_S:
+        return fresh
+
+    if worker_alive(fresh, pid_alive=pid_alive):
         return fresh
 
     total = fresh.total_bytes
@@ -311,21 +483,29 @@ def status_payload(state: DownloadState) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def kill_worker(pid: int | None) -> bool:
+def kill_worker(pid: int | None, create_time: float | None = None, *, force: bool = False) -> bool:
     """Terminate a worker and everything it spawned. Best effort.
 
+    Refuses to signal a pid that isn't provably still our worker — a recycled
+    pid would otherwise get a ``killpg`` aimed at whatever unrelated process
+    group now owns that number. See :func:`is_worker_process`.
+
     POSIX workers are detached with ``start_new_session=True``, so the worker is
-    its own process-group leader and one ``killpg`` reaches the whole tree.
-    Windows workers get ``CREATE_NEW_PROCESS_GROUP``; there is no ``killpg``, so
-    fall back to killing the process and its children directly.
+    its own process-group leader and one ``killpg`` reaches the whole tree;
+    ``force`` escalates SIGTERM to SIGKILL. Windows workers get
+    ``CREATE_NEW_PROCESS_GROUP``; there is no ``killpg``, so fall back to
+    killing the process and its children directly.
     """
     if not pid or pid <= 0:
         return False
+    if not is_worker_process(pid, create_time):
+        return False
+
     if sys.platform != "win32":
         import signal
 
         try:
-            os.killpg(os.getpgid(pid), signal.SIGTERM)
+            os.killpg(os.getpgid(pid), signal.SIGKILL if force else signal.SIGTERM)
             return True
         except (ProcessLookupError, PermissionError, OSError):
             pass  # fall through to the per-process path below
@@ -343,3 +523,38 @@ def kill_worker(pid: int | None) -> bool:
         return True
     except Exception:  # noqa: BLE001 — already gone, or not ours to signal
         return False
+
+
+def stop_worker(state: DownloadState, *, grace_s: float = 5.0) -> bool:
+    """Stop ``state``'s worker for good: SIGTERM, wait, then SIGKILL.
+
+    Returns True once no verified worker is left running. A plain SIGTERM is not
+    enough on its own — a worker wedged in a syscall (or one that has only just
+    been spawned) can outlive it, and if it survives it goes on writing bytes
+    and progress updates after the caller has already declared the download
+    cancelled.
+    """
+    if state.pid is None:
+        return True
+
+    def gone() -> bool:
+        return not is_worker_process(state.pid, state.pid_create_time)
+
+    if gone():
+        return True
+
+    kill_worker(state.pid, state.pid_create_time)
+    if _wait_for_exit(gone, grace_s):
+        return True
+
+    kill_worker(state.pid, state.pid_create_time, force=True)
+    return _wait_for_exit(gone, 2.0)
+
+
+def _wait_for_exit(gone, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if gone():
+            return True
+        time.sleep(0.05)
+    return gone()

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -1,0 +1,345 @@
+"""On-disk state for backgrounded model downloads.
+
+``comfy model download --background`` resolves the download in the foreground
+(CivitAI/HF metadata, token config, filename, destination check) and then
+detaches a worker that performs only the byte transfer. The worker's progress
+lives in ``<workspace>/.comfy-downloads/<id>.json``; its stdout/stderr are
+appended to ``<workspace>/.comfy-downloads/<id>.log``. Any agent or shell
+session can poll the file — or ``comfy model download-status <id>`` — without a
+second network call.
+
+State-file contract (``download-state/1``)::
+
+    {
+      "schema": "download-state/1",
+      "id": "<12 hex chars>",
+      "pid": <int> | null,          # worker pid, written by the worker itself
+      "url": "https://...",         # RESOLVED download url
+      "dest": "/abs/path/model.safetensors",
+      "total_bytes": <int> | null,  # null until response headers are read
+      "completed_bytes": <int>,
+      "status": "starting" | "downloading" | "completed" | "failed" | "cancelled",
+      "error": "<friendly message>" | null,
+      "started_at": "<iso8601>",
+      "updated_at": "<iso8601>",
+      "downloader": "httpx" | "aria2",
+      "needs_civitai_auth": <bool>,
+      "needs_hf_auth": <bool>
+    }
+
+No auth tokens or headers are ever persisted — the worker re-derives them from
+config the same way the foreground ``download()`` does. ``needs_civitai_auth`` /
+``needs_hf_auth`` only record *which* credential the resolved URL wants.
+
+Terminal statuses (``completed``, ``failed``, ``cancelled``) mean the file won't
+change further; agents can stop polling.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets as _secrets
+import sys
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+STATE_SCHEMA = "download-state/1"
+
+STATE_DIRNAME = ".comfy-downloads"
+
+TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+ACTIVE_STATUSES = frozenset({"starting", "downloading"})
+
+# The worker rewrites the state file at most this often while bytes stream in.
+# Terminal transitions always write, regardless of the throttle.
+PROGRESS_THROTTLE_S = 1.0
+
+_SAFE_ID = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
+
+
+def new_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def state_dir(workspace: Path) -> Path:
+    """Return ``<workspace>/.comfy-downloads`` and ensure it exists."""
+    base = Path(workspace) / STATE_DIRNAME
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def state_path(workspace: Path, download_id: str) -> Path:
+    if not _SAFE_ID.match(download_id or ""):
+        raise ValueError(f"unsafe download id: {download_id!r}")
+    return state_dir(workspace) / f"{download_id}.json"
+
+
+def log_path(workspace: Path, download_id: str) -> Path:
+    if not _SAFE_ID.match(download_id or ""):
+        raise ValueError(f"unsafe download id: {download_id!r}")
+    return state_dir(workspace) / f"{download_id}.log"
+
+
+@dataclass
+class DownloadState:
+    id: str
+    url: str
+    dest: str
+    schema: str = STATE_SCHEMA
+    pid: int | None = None
+    total_bytes: int | None = None
+    completed_bytes: int = 0
+    status: str = "starting"
+    error: str | None = None
+    started_at: str = ""
+    updated_at: str = ""
+    downloader: str = "httpx"
+    needs_civitai_auth: bool = False
+    needs_hf_auth: bool = False
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def new(
+    *,
+    url: str,
+    dest: str,
+    downloader: str = "httpx",
+    needs_civitai_auth: bool = False,
+    needs_hf_auth: bool = False,
+    download_id: str | None = None,
+) -> DownloadState:
+    """Build a fresh state in ``starting``. Call :func:`write` to persist."""
+    now = _now_iso()
+    return DownloadState(
+        id=download_id or new_id(),
+        url=url,
+        dest=dest,
+        downloader=downloader,
+        needs_civitai_auth=needs_civitai_auth,
+        needs_hf_auth=needs_hf_auth,
+        started_at=now,
+        updated_at=now,
+    )
+
+
+def write(workspace: Path, state: DownloadState) -> Path:
+    """Atomically persist ``state`` under ``workspace``'s state directory."""
+    return write_path(state_path(workspace, state.id), state)
+
+
+def write_path(path: Path, state: DownloadState) -> Path:
+    """Atomically persist ``state`` at ``path`` (write a tmp file, ``os.replace``).
+
+    The worker addresses its state file by path rather than by workspace: it is
+    handed ``--state <file>`` and must not have to re-resolve a workspace that
+    the foreground already resolved.
+    """
+    state.updated_at = _now_iso()
+    path = Path(path)
+    tmp = path.with_suffix(f".{os.getpid()}.{_secrets.token_hex(4)}.tmp")
+    payload = json.dumps(state.to_dict(), indent=2, default=str)
+    try:
+        tmp.write_text(payload, encoding="utf-8")
+        try:
+            fd = os.open(str(tmp), os.O_RDONLY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    except OSError:
+        # Never let a bookkeeping failure kill an in-flight transfer.
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return path
+
+
+def read(workspace: Path, download_id: str) -> DownloadState | None:
+    """Read one state file. Returns None when it's absent or unreadable."""
+    try:
+        path = state_path(workspace, download_id)
+    except ValueError:
+        return None
+    return read_path(path)
+
+
+def read_path(path: Path) -> DownloadState | None:
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    known = set(DownloadState.__dataclass_fields__)
+    filtered = {k: v for k, v in data.items() if k in known}
+    try:
+        return DownloadState(**filtered)
+    except TypeError:
+        # Truncated/legacy file missing a required field — treat as absent.
+        return None
+
+
+def list_all(workspace: Path) -> list[DownloadState]:
+    """Every readable state file, newest ``started_at`` first."""
+    base = Path(workspace) / STATE_DIRNAME
+    if not base.is_dir():
+        return []
+    states = [s for s in (read_path(p) for p in sorted(base.glob("*.json"))) if s is not None]
+    states.sort(key=lambda s: (s.started_at or "", s.id), reverse=True)
+    return states
+
+
+# ---------------------------------------------------------------------------
+# reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _dest_size(dest: str) -> int | None:
+    try:
+        return os.stat(dest).st_size
+    except OSError:
+        return None
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def elapsed_seconds(state: DownloadState) -> float:
+    """Wall-clock seconds the download has been (or was) running."""
+    started = _parse_iso(state.started_at)
+    if started is None:
+        return 0.0
+    end = _parse_iso(state.updated_at) if state.is_terminal else None
+    if end is None:
+        end = datetime.now(timezone.utc)
+    return max(0.0, (end - started).total_seconds())
+
+
+def reconcile(state: DownloadState, *, pid_alive=None) -> DownloadState:
+    """Return a copy of ``state`` corrected against reality on disk.
+
+    A worker that was SIGKILLed (or whose machine rebooted) never gets to write
+    a terminal status, so a state file claiming ``downloading`` is only
+    trustworthy while its pid is alive. Two corrections happen here:
+
+    * ``completed_bytes`` prefers a live ``stat(dest)`` over the last value the
+      worker managed to persist — the file on disk is the ground truth.
+    * an active status whose worker is gone becomes ``completed`` when the file
+      reached the known total, and ``failed`` ("worker died") otherwise.
+
+    ``pid_alive`` is injectable for tests; it defaults to the same liveness
+    helper the launch/stop machinery uses.
+    """
+    if pid_alive is None:
+        from comfy_cli.utils import is_running as pid_alive  # noqa: N813
+
+    fresh = DownloadState(**state.to_dict())
+
+    size = _dest_size(fresh.dest)
+    if size is not None and fresh.status != "cancelled":
+        fresh.completed_bytes = size
+
+    if fresh.status not in ACTIVE_STATUSES:
+        return fresh
+
+    if fresh.pid is not None and pid_alive(fresh.pid):
+        return fresh
+
+    total = fresh.total_bytes
+    if total is not None and fresh.completed_bytes >= total and size is not None:
+        fresh.status = "completed"
+        fresh.error = None
+    else:
+        fresh.status = "failed"
+        fresh.error = fresh.error or "worker died before the download finished"
+    return fresh
+
+
+def percent(state: DownloadState) -> float | None:
+    """Completion percentage, or None while the total is unknown."""
+    total = state.total_bytes
+    if not total or total <= 0:
+        return None
+    return round(min(100.0, state.completed_bytes / total * 100.0), 2)
+
+
+def status_payload(state: DownloadState) -> dict[str, Any]:
+    """The ``download-status`` / ``downloads`` envelope row for one download."""
+    return {
+        "id": state.id,
+        "status": state.status,
+        "completed_bytes": state.completed_bytes,
+        "total_bytes": state.total_bytes,
+        "percent": percent(state),
+        "elapsed_seconds": round(elapsed_seconds(state), 1),
+        "dest": state.dest,
+        "error": state.error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# process control
+# ---------------------------------------------------------------------------
+
+
+def kill_worker(pid: int | None) -> bool:
+    """Terminate a worker and everything it spawned. Best effort.
+
+    POSIX workers are detached with ``start_new_session=True``, so the worker is
+    its own process-group leader and one ``killpg`` reaches the whole tree.
+    Windows workers get ``CREATE_NEW_PROCESS_GROUP``; there is no ``killpg``, so
+    fall back to killing the process and its children directly.
+    """
+    if not pid or pid <= 0:
+        return False
+    if sys.platform != "win32":
+        import signal
+
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGTERM)
+            return True
+        except (ProcessLookupError, PermissionError, OSError):
+            pass  # fall through to the per-process path below
+
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        for child in proc.children(recursive=True):
+            try:
+                child.kill()
+            except Exception:  # noqa: BLE001 — best effort
+                pass
+        proc.kill()
+        return True
+    except Exception:  # noqa: BLE001 — already gone, or not ours to signal
+        return False

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -534,6 +534,22 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "The prompt_id wasn't found in state files or the server API.",
         "check the prompt_id and ensure the job has completed",
     ),
+    # --- background model downloads (`model download --background`) ----------
+    ErrorCode(
+        "download_not_found",
+        "No background download state file matches the given download id.",
+        "list the known downloads with `comfy model downloads`",
+    ),
+    ErrorCode(
+        "download_state_unwritable",
+        "The `<workspace>/.comfy-downloads` state directory could not be written.",
+        "check the workspace is writable, or run without --background",
+    ),
+    ErrorCode(
+        "download_worker_spawn_failed",
+        "The detached background download worker could not be started.",
+        "run without --background to download in the foreground",
+    ),
     ErrorCode(
         "setup_missing_where",
         "--non-interactive requires --where (local or cloud).",

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -4,6 +4,7 @@ import pathlib
 import subprocess
 import time
 import zipfile
+from collections.abc import Callable
 from http import HTTPStatus
 
 import httpx
@@ -15,6 +16,26 @@ from comfy_cli import constants, ui
 
 class DownloadException(Exception):
     pass
+
+
+# ``(completed_bytes, total_bytes_or_None)``. Called from inside the transfer
+# loop, so implementations must be cheap and must never raise — see
+# ``_report_progress``.
+ProgressCallback = Callable[[int, int | None], None]
+
+
+def _report_progress(callback: ProgressCallback | None, completed: int, total: int | None) -> None:
+    """Invoke a progress callback, swallowing anything it raises.
+
+    A misbehaving observer (a full disk while persisting state, say) must never
+    abort an otherwise-healthy download.
+    """
+    if callback is None:
+        return
+    try:
+        callback(completed, total)
+    except Exception:  # noqa: BLE001 — progress reporting is strictly advisory
+        pass
 
 
 def guess_status_code_reason(status_code: int, message: str) -> str:
@@ -65,8 +86,14 @@ def check_unauthorized(url: str, headers: dict | None = None) -> bool:
         return False
 
 
-def _poll_aria2_download(download) -> None:
-    """Poll an aria2 download until completion, showing progress."""
+def _poll_aria2_download(download, progress_callback: ProgressCallback | None = None) -> None:
+    """Poll an aria2 download until completion, showing progress.
+
+    ``progress_callback`` (optional) receives ``(completed_bytes, total_bytes)``
+    on every poll, with ``total_bytes`` None until aria2 knows the size. It is
+    fed from the same ``completed_length``/``total_length`` pair the progress bar
+    uses, so a background worker sees exactly what the human would.
+    """
     import time
 
     from rich.progress import (
@@ -93,12 +120,15 @@ def _poll_aria2_download(download) -> None:
             except Exception as e:
                 raise DownloadException(f"Lost connection to aria2 RPC server: {e}") from e
 
-            if download.total_length > 0:
-                progress.update(task, total=download.total_length, completed=download.completed_length)
+            total = download.total_length if download.total_length > 0 else None
+            if total is not None:
+                progress.update(task, total=total, completed=download.completed_length)
+            _report_progress(progress_callback, download.completed_length, total)
 
             if download.is_complete:
-                if download.total_length > 0:
-                    progress.update(task, completed=download.total_length)
+                if total is not None:
+                    progress.update(task, completed=total)
+                    _report_progress(progress_callback, total, total)
                 break
             elif download.has_failed:
                 raise DownloadException(
@@ -110,7 +140,12 @@ def _poll_aria2_download(download) -> None:
             time.sleep(0.5)
 
 
-def _download_file_aria2(url: str, local_filepath: pathlib.Path, headers: dict | None = None) -> None:
+def _download_file_aria2(
+    url: str,
+    local_filepath: pathlib.Path,
+    headers: dict | None = None,
+    progress_callback: ProgressCallback | None = None,
+) -> None:
     """Download a file using aria2 RPC."""
     try:
         import aria2p
@@ -157,7 +192,7 @@ def _download_file_aria2(url: str, local_filepath: pathlib.Path, headers: dict |
     except Exception as e:
         raise DownloadException(f"Failed to add download to aria2: {e}") from e
 
-    _poll_aria2_download(download)
+    _poll_aria2_download(download, progress_callback)
 
     if not local_filepath.exists():
         raise DownloadException(f"aria2 download completed but file not found at expected path: {local_filepath}")
@@ -231,8 +266,14 @@ def _download_file_httpx(
     headers: dict | None = None,
     *,
     state: dict | None = None,
+    progress_callback: ProgressCallback | None = None,
 ) -> None:
     """Download a file using httpx streaming. Raises on HTTP or network errors.
+
+    ``progress_callback`` (optional) receives ``(completed_bytes, total_bytes)``
+    as chunks land — ``total_bytes`` comes from Content-Length and is None when
+    the server doesn't send one. It fires once with ``(0, total)`` before the
+    first chunk so a caller learns the size as soon as the headers are read.
 
     If ``state`` is provided, ``state["file_opened"]`` is set to True immediately
     after the output file is opened for writing. Callers use this to distinguish
@@ -261,16 +302,36 @@ def _download_file_httpx(
         with open(local_filepath, "wb") as f:
             if state is not None:
                 state["file_opened"] = True
+            # Announce the size (and the zeroed counter) before the first chunk
+            # so a background observer stops reporting `total_bytes: null` as
+            # soon as the headers are in.
+            _report_progress(progress_callback, 0, total)
+            completed = 0
             for data in ui.show_progress(
                 response.iter_bytes(),
                 total,
                 description=description,
             ):
                 f.write(data)
+                completed += len(data)
+                _report_progress(progress_callback, completed, total)
 
 
-def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None = None, downloader: str = "httpx"):
-    """Helper function to download a file."""
+def download_file(
+    url: str,
+    local_filepath: pathlib.Path,
+    headers: dict | None = None,
+    downloader: str = "httpx",
+    progress_callback: ProgressCallback | None = None,
+):
+    """Helper function to download a file.
+
+    ``progress_callback`` (optional) is invoked with ``(completed_bytes,
+    total_bytes)`` as the transfer advances; ``total_bytes`` is None until the
+    size is known. When a retry discards a partial file the callback is reset to
+    ``(0, None)`` first, so an observer never sees a counter run backwards from
+    a stale high-water mark.
+    """
     if downloader not in _VALID_DOWNLOADERS:
         raise DownloadException(
             f"Unknown downloader: {downloader!r}. Valid options: {', '.join(sorted(_VALID_DOWNLOADERS))}"
@@ -279,7 +340,7 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
     local_filepath.parent.mkdir(parents=True, exist_ok=True)
 
     if downloader == "aria2":
-        return _download_file_aria2(url, local_filepath, headers)
+        return _download_file_aria2(url, local_filepath, headers, progress_callback)
 
     last_exc: Exception | None = None
     state: dict = {"file_opened": False}
@@ -287,7 +348,7 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
     for attempt in range(_DOWNLOAD_MAX_RETRIES):
         state["file_opened"] = False
         try:
-            _download_file_httpx(url, local_filepath, headers, state=state)
+            _download_file_httpx(url, local_filepath, headers, state=state, progress_callback=progress_callback)
             return
         except _RETRIABLE_EXCEPTIONS as exc:
             last_exc = exc
@@ -295,6 +356,7 @@ def download_file(url: str, local_filepath: pathlib.Path, headers: dict | None =
             # otherwise we'd delete an unrelated pre-existing file at the same path.
             if state["file_opened"]:
                 _cleanup_partial(local_filepath)
+                _report_progress(progress_callback, 0, None)
             if attempt < _DOWNLOAD_MAX_RETRIES - 1:
                 wait = _DOWNLOAD_RETRY_BACKOFF * (attempt + 1)
                 print(f"Download error (attempt {attempt + 1}/{_DOWNLOAD_MAX_RETRIES}): {_friendly_network_error(exc)}")

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -24,16 +24,30 @@ class DownloadException(Exception):
 ProgressCallback = Callable[[int, int | None], None]
 
 
+class DownloadCancelled(Exception):
+    """Raised by a progress callback to abort an in-flight download.
+
+    The one thing an observer is allowed to say that isn't advisory. The
+    background-download worker polls its cancel sentinel from the progress
+    callback and raises this to unwind out of the transfer; every other
+    exception a callback raises is swallowed by :func:`_report_progress`.
+    """
+
+
 def _report_progress(callback: ProgressCallback | None, completed: int, total: int | None) -> None:
     """Invoke a progress callback, swallowing anything it raises.
 
     A misbehaving observer (a full disk while persisting state, say) must never
-    abort an otherwise-healthy download.
+    abort an otherwise-healthy download. :class:`DownloadCancelled` is the sole
+    exception: it means the caller wants the transfer stopped, not that
+    reporting failed.
     """
     if callback is None:
         return
     try:
         callback(completed, total)
+    except DownloadCancelled:
+        raise
     except Exception:  # noqa: BLE001 — progress reporting is strictly advisory
         pass
 
@@ -93,6 +107,11 @@ def _poll_aria2_download(download, progress_callback: ProgressCallback | None = 
     on every poll, with ``total_bytes`` None until aria2 knows the size. It is
     fed from the same ``completed_length``/``total_length`` pair the progress bar
     uses, so a background worker sees exactly what the human would.
+
+    If the callback raises :class:`DownloadCancelled` the daemon-side transfer is
+    removed before the exception propagates: with aria2 the bytes move inside the
+    aria2c process, not this one, so simply walking away would leave it happily
+    finishing a download the user just cancelled.
     """
     import time
 
@@ -114,30 +133,42 @@ def _poll_aria2_download(download, progress_callback: ProgressCallback | None = 
     ) as progress:
         task = progress.add_task("Downloading...", total=None)
 
-        while True:
-            try:
-                download.update()
-            except Exception as e:
-                raise DownloadException(f"Lost connection to aria2 RPC server: {e}") from e
+        try:
+            while True:
+                try:
+                    download.update()
+                except Exception as e:
+                    raise DownloadException(f"Lost connection to aria2 RPC server: {e}") from e
 
-            total = download.total_length if download.total_length > 0 else None
-            if total is not None:
-                progress.update(task, total=total, completed=download.completed_length)
-            _report_progress(progress_callback, download.completed_length, total)
-
-            if download.is_complete:
+                total = download.total_length if download.total_length > 0 else None
                 if total is not None:
-                    progress.update(task, completed=total)
-                    _report_progress(progress_callback, total, total)
-                break
-            elif download.has_failed:
-                raise DownloadException(
-                    f"aria2 download failed: {download.error_message} (code: {download.error_code})"
-                )
-            elif download.is_removed:
-                raise DownloadException("aria2 download was removed before completion")
+                    progress.update(task, total=total, completed=download.completed_length)
+                _report_progress(progress_callback, download.completed_length, total)
 
-            time.sleep(0.5)
+                if download.is_complete:
+                    if total is not None:
+                        progress.update(task, completed=total)
+                        _report_progress(progress_callback, total, total)
+                    break
+                elif download.has_failed:
+                    raise DownloadException(
+                        f"aria2 download failed: {download.error_message} (code: {download.error_code})"
+                    )
+                elif download.is_removed:
+                    raise DownloadException("aria2 download was removed before completion")
+
+                time.sleep(0.5)
+        except DownloadCancelled:
+            _remove_aria2_download(download)
+            raise
+
+
+def _remove_aria2_download(download) -> None:
+    """Stop and forget a daemon-side aria2 transfer. Best effort."""
+    try:
+        download.remove(force=True, files=True)
+    except Exception:  # noqa: BLE001 — the daemon may already have dropped it
+        pass
 
 
 def _download_file_aria2(

--- a/comfy_cli/schemas/download.json
+++ b/comfy_cli/schemas/download.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/download.json",
+  "title": "comfy model download --background --json data payload",
+  "description": "Submit receipt for a backgrounded model download. Resolution (metadata, tokens, filename, destination-exists) already succeeded synchronously; only the byte transfer is detached. Poll with `comfy model download-status <download_id>`.",
+  "type": "object",
+  "required": ["download_id", "pid", "dest", "total_bytes", "status"],
+  "additionalProperties": true,
+  "properties": {
+    "download_id": {
+      "type": "string",
+      "description": "Opaque id for this download; the key for download-status / download-cancel."
+    },
+    "pid": {
+      "type": "integer",
+      "description": "PID of the detached worker process."
+    },
+    "dest": {
+      "type": "string",
+      "description": "Absolute path the model will be written to."
+    },
+    "total_bytes": {
+      "type": ["integer", "null"],
+      "description": "Total size in bytes. Null at submit time — the worker learns it from the response headers."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["starting", "downloading", "completed", "failed", "cancelled"],
+      "description": "Lifecycle status. Always 'starting' in a submit receipt."
+    }
+  }
+}

--- a/comfy_cli/schemas/download_status.json
+++ b/comfy_cli/schemas/download_status.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/download_status.json",
+  "title": "comfy model download-status <id> --json data payload",
+  "description": "Reconciled progress for one background download. The reported status is the state file corrected against reality: completed_bytes prefers a live stat() of dest, and an 'downloading' record whose worker pid is gone resolves to 'completed' (size reached the known total) or 'failed' (it did not).",
+  "type": "object",
+  "$defs": {
+    "row": {
+      "type": "object",
+      "required": ["id", "status", "completed_bytes", "total_bytes", "percent", "elapsed_seconds", "dest", "error"],
+      "additionalProperties": true,
+      "properties": {
+        "id": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["starting", "downloading", "completed", "failed", "cancelled"]
+        },
+        "completed_bytes": { "type": "integer" },
+        "total_bytes": {
+          "type": ["integer", "null"],
+          "description": "Null while the size is unknown (no Content-Length yet)."
+        },
+        "percent": {
+          "type": ["number", "null"],
+          "description": "Null when total_bytes is unknown."
+        },
+        "elapsed_seconds": { "type": "number" },
+        "dest": { "type": "string" },
+        "error": {
+          "type": ["string", "null"],
+          "description": "Friendly failure description; null unless status is 'failed'."
+        }
+      }
+    }
+  },
+  "allOf": [{ "$ref": "#/$defs/row" }]
+}

--- a/comfy_cli/schemas/downloads.json
+++ b/comfy_cli/schemas/downloads.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/downloads.json",
+  "title": "comfy model downloads --json data payload",
+  "description": "Every background download this workspace knows about, newest first. Each row is reconciled exactly as `download-status` reconciles a single id.",
+  "type": "object",
+  "required": ["total", "downloads"],
+  "additionalProperties": true,
+  "properties": {
+    "total": { "type": "integer" },
+    "downloads": {
+      "type": "array",
+      "items": { "$ref": "download_status.json#/$defs/row" }
+    }
+  }
+}

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -431,7 +431,11 @@ class TestWorkerThrottle:
 
     def test_worker_rederives_auth_headers_from_config_not_state(self, workspace, monkeypatch, tmp_path):
         """The state file records *which* credential is needed, never the secret."""
-        state = _state(dest=str(tmp_path / "m.safetensors"), needs_civitai_auth=True)
+        state = _state(
+            url="https://civitai.com/api/download/models/1",
+            dest=str(tmp_path / "m.safetensors"),
+            needs_civitai_auth=True,
+        )
         path = download_state.write(workspace, state)
         assert "Authorization" not in path.read_text()
 
@@ -446,6 +450,41 @@ class TestWorkerThrottle:
         models._download_worker(state_file=str(path))
 
         assert seen["headers"] == {"Authorization": "Bearer from-config"}
+
+
+class TestWorkerCredentialScoping:
+    """A state file is data on disk; `needs_*_auth` and `url` can disagree.
+
+    Whoever can write one must not be able to aim the user's bearer token at a
+    host of their choosing.
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://attacker.example/m.safetensors",
+            "https://civitai.com.attacker.example/m.safetensors",
+            "https://notcivitai.com/m.safetensors",
+        ],
+    )
+    def test_civitai_token_is_withheld_from_a_foreign_host(self, monkeypatch, url):
+        monkeypatch.setattr(models, "_civitai_headers", lambda: {"Authorization": "Bearer secret"})
+        headers = models._worker_headers(_state(url=url, needs_civitai_auth=True))
+        assert "Authorization" not in (headers or {})
+
+    @pytest.mark.parametrize("url", ["https://civitai.com/x", "https://cdn.civitai.com/x", "https://civitai.red/x"])
+    def test_civitai_token_is_sent_to_civitai(self, monkeypatch, url):
+        monkeypatch.setattr(models, "_civitai_headers", lambda: {"Authorization": "Bearer secret"})
+        assert models._worker_headers(_state(url=url, needs_civitai_auth=True))["Authorization"] == "Bearer secret"
+
+    def test_hf_token_is_withheld_from_a_foreign_host(self, monkeypatch):
+        monkeypatch.setattr(models, "_hf_headers", lambda: {"Authorization": "Bearer secret"})
+        assert models._worker_headers(_state(url="https://attacker.example/m", needs_hf_auth=True)) is None
+
+    @pytest.mark.parametrize("url", ["https://huggingface.co/x", "https://cdn-lfs.huggingface.co/x", "https://hf.co/x"])
+    def test_hf_token_is_sent_to_hugging_face(self, monkeypatch, url):
+        monkeypatch.setattr(models, "_hf_headers", lambda: {"Authorization": "Bearer secret"})
+        assert models._worker_headers(_state(url=url, needs_hf_auth=True))["Authorization"] == "Bearer secret"
 
 
 # ---------------------------------------------------------------------------
@@ -538,13 +577,33 @@ class TestSubmitEnvelope:
         assert data["dest"] == str(workspace / "models" / "loras" / "m.safetensors")
         assert Path(data["dest"]).is_absolute()
 
-    def test_writes_a_state_file_with_the_spawn_pid(self, workspace, monkeypatch, json_renderer):
+    def test_writes_a_state_file_the_worker_has_not_claimed_yet(self, workspace, monkeypatch, json_renderer):
+        """The submitter never writes a pid — only the worker does, together
+        with the start time that proves the pid is still that worker."""
         self._submit(workspace, monkeypatch)
         download_id = json_renderer()["data"]["download_id"]
 
         state = download_state.read(workspace, download_id)
-        assert (state.pid, state.status, state.schema) == (31337, "starting", "download-state/1")
+        assert (state.pid, state.pid_create_time) == (None, None)
+        assert (state.status, state.schema) == ("starting", "download-state/1")
         assert state.url == "https://example.com/m.safetensors"
+
+    def test_a_pidless_starting_record_is_not_declared_dead_immediately(self, workspace, json_renderer, tmp_path):
+        """Reconcile has to tolerate the worker's interpreter startup, or every
+        poll issued in the first moments would report a phantom failure."""
+        state = _state(dest=str(tmp_path / "m.safetensors"), status="starting", pid=None)
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+        assert json_renderer()["data"]["status"] == "starting"
+
+    def test_a_starting_record_that_never_claims_a_pid_eventually_fails(self, workspace, json_renderer, tmp_path):
+        state = _state(dest=str(tmp_path / "m.safetensors"), status="starting", pid=None)
+        state.started_at = "2020-01-01T00:00:00+00:00"
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+        assert json_renderer()["data"]["status"] == "failed"
 
     def test_creates_the_destination_directory_up_front(self, workspace, monkeypatch, json_renderer):
         self._submit(workspace, monkeypatch)
@@ -783,14 +842,18 @@ class TestPollVerbs:
     def test_cancel_kills_the_worker_and_removes_the_partial(self, workspace, json_renderer, tmp_path):
         dest = tmp_path / "m.safetensors"
         dest.write_bytes(b"x" * 10)
-        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        state = _state(
+            dest=str(dest), status="downloading", pid=5150, pid_create_time=1.0, total_bytes=100, completed_bytes=10
+        )
         download_state.write(workspace, state)
 
-        with patch.object(download_state, "kill_worker", return_value=True) as kill:
-            with patch("comfy_cli.utils.is_running", return_value=False):
+        # Alive for the identity check, then gone once it has been signalled.
+        alive = [True, True, False]
+        with patch.object(download_state, "is_worker_process", side_effect=lambda *a: alive.pop(0) if alive else False):
+            with patch.object(download_state, "kill_worker", return_value=True) as kill:
                 models.download_cancel(None, download_id=state.id)
 
-        kill.assert_called_once_with(5150)
+        kill.assert_called_once_with(5150, 1.0)
         assert not dest.exists()
 
         env = json_renderer()
@@ -799,6 +862,44 @@ class TestPollVerbs:
         assert env["data"]["status"] == "cancelled"
         assert env["data"]["completed_bytes"] == 0
         assert download_state.read(workspace, state.id).status == "cancelled"
+
+    def test_cancel_writes_the_sentinel_before_signalling(self, workspace, json_renderer, tmp_path):
+        """A worker still in interpreter startup has no pid to signal; the
+        sentinel is the only thing that reaches it."""
+        state = _state(dest=str(tmp_path / "m.safetensors"), status="starting", pid=None)
+        download_state.write(workspace, state)
+
+        models.download_cancel(None, download_id=state.id)
+
+        assert download_state.cancel_path(workspace, state.id).exists()
+        assert json_renderer()["data"]["status"] == "cancelled"
+
+    def test_cancel_keeps_a_file_that_finished_during_the_kill_window(self, workspace, json_renderer, tmp_path):
+        """A worker SIGKILLed after the last byte landed but before it could
+        persist `completed` still reads as `downloading`. Deleting its file
+        would be silent data loss."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 100)
+        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            models.download_cancel(None, download_id=state.id)
+
+        assert dest.exists(), "a fully-downloaded file must never be deleted by cancel"
+        assert json_renderer()["data"]["status"] == "completed"
+
+    def test_cancel_of_a_dead_worker_still_clears_the_partial(self, workspace, json_renderer, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            models.download_cancel(None, download_id=state.id)
+
+        assert not dest.exists()
+        assert json_renderer()["data"]["status"] == "cancelled"
 
     def test_cancel_of_a_terminal_download_is_a_no_op(self, workspace, json_renderer, tmp_path):
         dest = tmp_path / "m.safetensors"
@@ -867,11 +968,15 @@ class TestKillWorker:
         import signal
 
         killed = []
+        monkeypatch.setattr(download_state, "is_worker_process", lambda *a: True)
         monkeypatch.setattr(os, "getpgid", lambda pid: pid)
         monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)))
 
-        assert download_state.kill_worker(4242) is True
+        assert download_state.kill_worker(4242, 1.0) is True
         assert killed == [(4242, signal.SIGTERM)]
+
+        assert download_state.kill_worker(4242, 1.0, force=True) is True
+        assert killed[-1] == (4242, signal.SIGKILL)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="killpg is POSIX-only")
     def test_an_already_dead_worker_reports_false(self, monkeypatch):
@@ -879,3 +984,227 @@ class TestKillWorker:
         monkeypatch.setattr("psutil.Process", MagicMock(side_effect=Exception("no such process")))
 
         assert download_state.kill_worker(4242) is False
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="killpg is POSIX-only")
+    def test_a_recycled_pid_is_never_signalled(self, monkeypatch):
+        """The worker died and the OS handed its number to something else.
+        Signalling it would kill an unrelated process group."""
+        killed = []
+        monkeypatch.setattr(os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)))
+        monkeypatch.setattr("psutil.Process", MagicMock(return_value=MagicMock(create_time=lambda: 9999.0)))
+
+        assert download_state.kill_worker(4242, 1.0) is False
+        assert killed == []
+
+    def test_a_pid_with_no_recorded_start_time_falls_back_to_argv(self, monkeypatch):
+        stranger = MagicMock(cmdline=lambda: ["/usr/bin/vim", "notes.txt"])
+        monkeypatch.setattr("psutil.Process", MagicMock(return_value=stranger))
+        assert download_state.is_worker_process(4242, None) is False
+
+        worker = MagicMock(cmdline=lambda: [sys.executable, "-m", "comfy_cli", "model", "_download-worker", "--state"])
+        monkeypatch.setattr("psutil.Process", MagicMock(return_value=worker))
+        assert download_state.is_worker_process(4242, None) is True
+
+
+class TestMachineOutputIsParseable:
+    """The whole point of the envelope is that `jq` / `json.loads` can read it.
+
+    `ui.display_table` writes to its own Rich console on stdout, so a table
+    rendered in JSON mode would be prepended to the envelope and break every
+    strict consumer.
+    """
+
+    def test_status_emits_only_the_envelope(self, workspace, capsys, tmp_path):
+        set_renderer(Renderer(mode=OutputMode.JSON, version="test"))
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 50)
+        state = _state(dest=str(dest), status="downloading", pid=os.getpid(), total_bytes=200)
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+
+        out = capsys.readouterr().out
+        assert json.loads(out)["data"]["id"] == state.id
+
+    def test_downloads_emits_only_the_envelope(self, workspace, capsys, tmp_path):
+        set_renderer(Renderer(mode=OutputMode.JSON, version="test"))
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 50)
+        download_state.write(workspace, _state(dest=str(dest), status="downloading", pid=os.getpid(), total_bytes=200))
+
+        models.downloads(None)
+
+        assert json.loads(capsys.readouterr().out)["data"]["total"] == 1
+
+
+class TestCancellationReachesTheWorker:
+    """SIGTERM alone doesn't cancel: a worker that is still starting up has no
+    pid to signal, and one wedged in a syscall can outlive the grace period.
+    Either way it must not go on downloading — or resurrect a cancelled record.
+    """
+
+    def test_worker_exits_without_downloading_when_the_sentinel_is_already_there(
+        self, workspace, monkeypatch, tmp_path
+    ):
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), status="starting", pid=None)
+        path = download_state.write(workspace, state)
+        download_state.request_cancel(download_state.cancel_path(workspace, state.id))
+
+        monkeypatch.setattr(
+            models,
+            "download_file",
+            MagicMock(side_effect=AssertionError("a cancelled download must never transfer bytes")),
+        )
+        with pytest.raises(typer.Exit) as exc:
+            models._download_worker(state_file=str(path))
+
+        assert exc.value.exit_code == 0
+        assert download_state.read(workspace, state.id).status == "cancelled"
+        assert not dest.exists()
+
+    def test_worker_aborts_mid_transfer_and_clears_the_partial(self, workspace, monkeypatch, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), status="starting", pid=None)
+        path = download_state.write(workspace, state)
+
+        def transfer(url, filepath, headers, downloader, progress_callback):
+            filepath.write_bytes(b"partial")
+            # The cancel lands after the transfer is already under way.
+            download_state.request_cancel(download_state.cancel_path(workspace, state.id))
+            progress_callback(7, 4096)
+
+        monkeypatch.setattr(models, "download_file", transfer)
+        monkeypatch.setattr(download_state, "PROGRESS_THROTTLE_S", 0.0)
+
+        with pytest.raises(typer.Exit) as exc:
+            models._download_worker(state_file=str(path))
+
+        assert exc.value.exit_code == 0
+        final = download_state.read(workspace, state.id)
+        assert (final.status, final.completed_bytes) == ("cancelled", 0)
+        assert not dest.exists(), "the partial file must not survive the cancel"
+
+    def test_a_transfer_that_beat_the_cancel_keeps_its_file(self, workspace, json_renderer, monkeypatch, tmp_path):
+        """Both sides have to agree on this one, or cancel deletes a model that
+        the state file calls `completed`."""
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), status="starting", pid=None)
+        path = download_state.write(workspace, state)
+
+        def transfer(url, filepath, headers, downloader, progress_callback):
+            filepath.write_bytes(b"done")
+            download_state.request_cancel(download_state.cancel_path(workspace, state.id))
+
+        monkeypatch.setattr(models, "download_file", transfer)
+        models._download_worker(state_file=str(path))
+        assert download_state.read(workspace, state.id).status == "completed"
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            models.download_cancel(None, download_id=state.id)
+
+        assert dest.exists()
+        assert json_renderer()["data"]["status"] == "completed"
+
+    def test_cancel_does_not_delete_a_finished_file_when_the_total_was_unknown(
+        self, workspace, json_renderer, monkeypatch, tmp_path
+    ):
+        """The canceller's in-memory copy predates the worker learning the size
+        from the response headers; only the file on disk is up to date."""
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), status="downloading", pid=None, total_bytes=None)
+        download_state.write(workspace, state)
+
+        # The worker finishes (and records the total) between our read and the kill.
+        def stop(_state, **_kwargs):
+            done = download_state.read(workspace, state.id)
+            dest.write_bytes(b"x" * 4096)
+            done.status, done.total_bytes, done.completed_bytes = "completed", 4096, 4096
+            download_state.write(workspace, done)
+            return True
+
+        monkeypatch.setattr(download_state, "stop_worker", stop)
+        models.download_cancel(None, download_id=state.id)
+
+        assert dest.exists(), "cancel must not delete a model the worker had already finished"
+        assert json_renderer()["data"]["status"] == "completed"
+
+
+class TestStateFilePermissions:
+    """A resolved url can carry a presigned/SAS query token, so these files are
+    secrets on a shared host — and a writable one is an attack surface."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    def test_directory_is_owner_only(self, workspace):
+        base = download_state.state_dir(workspace)
+        assert base.stat().st_mode & 0o777 == 0o700
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    def test_state_file_is_owner_only(self, workspace):
+        path = download_state.write(workspace, _state())
+        assert path.stat().st_mode & 0o777 == 0o600
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    def test_a_preexisting_loose_directory_is_tightened(self, workspace):
+        base = workspace / download_state.STATE_DIRNAME
+        base.mkdir(mode=0o777)
+        assert download_state.state_dir(workspace).stat().st_mode & 0o777 == 0o700
+
+
+class TestCorruptStateFiles:
+    """A tampered or truncated file must read as *absent*, not construct a
+    DownloadState that raises a TypeError deep inside kill_worker/reconcile and
+    takes `downloads` down with it."""
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("pid", "not-a-pid"),
+            ("pid", True),
+            ("total_bytes", "1024"),
+            ("completed_bytes", None),
+            ("needs_civitai_auth", "yes"),
+            ("error", 42),
+            ("dest", ["/tmp/x"]),
+            ("pid_create_time", "soon"),
+        ],
+    )
+    def test_a_wrongly_typed_field_reads_as_absent(self, workspace, tmp_path, field, value):
+        path = tmp_path / "corrupt.json"
+        payload = _state().to_dict()
+        payload[field] = value
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        assert download_state.read_path(path) is None
+
+    def test_list_all_skips_a_corrupt_file_instead_of_crashing(self, workspace):
+        good = _state()
+        download_state.write(workspace, good)
+        (download_state.state_dir(workspace) / "bad.json").write_text('{"pid": "nope"}', encoding="utf-8")
+
+        assert [s.id for s in download_state.list_all(workspace)] == [good.id]
+
+
+class TestWorkerIdentity:
+    def test_reconcile_ignores_liveness_when_the_start_time_disagrees(self, tmp_path):
+        """A live-but-recycled pid must not pin a dead transfer at `downloading`
+        forever — pollers would loop on it indefinitely."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(dest=str(dest), status="downloading", pid=4242, pid_create_time=1.0, total_bytes=100)
+
+        with patch("psutil.Process", MagicMock(return_value=MagicMock(create_time=lambda: 9999.0))):
+            fresh = download_state.reconcile(state, pid_alive=lambda pid: True)
+
+        assert fresh.status == "failed"
+
+    def test_reconcile_trusts_a_matching_start_time(self, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(dest=str(dest), status="downloading", pid=4242, pid_create_time=1.0, total_bytes=100)
+
+        with patch("psutil.Process", MagicMock(return_value=MagicMock(create_time=lambda: 1.0))):
+            fresh = download_state.reconcile(state, pid_alive=lambda pid: True)
+
+        assert fresh.status == "downloading"

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -1,0 +1,881 @@
+"""`comfy model download --background` + the download-status / downloads /
+download-cancel poll verbs.
+
+Covers the four things that are easy to get wrong and impossible to notice
+without a test: state reconciliation against a dead worker, the fail-fast
+guarantee (nothing detaches until resolution has succeeded), progress-callback
+accounting through the real transfer loop, and the envelope shapes agents parse.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import typer
+
+from comfy_cli import download_state
+from comfy_cli.command.models import models
+from comfy_cli.file_utils import DownloadException, _download_file_httpx, download_file
+from comfy_cli.output import Renderer, set_renderer
+from comfy_cli.output.renderer import OutputMode
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """Point ``models.get_workspace()`` at a per-test directory."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    monkeypatch.setattr(models, "get_workspace", lambda: ws)
+    return ws
+
+
+@pytest.fixture
+def json_renderer(capsys):
+    """Install a JSON-mode renderer and return a reader for the emitted envelope."""
+    set_renderer(Renderer(mode=OutputMode.JSON, version="test"))
+
+    def read_envelope() -> dict:
+        out = capsys.readouterr().out.strip().splitlines()
+        assert out, "no envelope was written to stdout"
+        return json.loads(out[-1])
+
+    return read_envelope
+
+
+def _state(**overrides) -> download_state.DownloadState:
+    """A fresh DownloadState with any field overridden."""
+    fields = {"url": "https://example.com/m.safetensors", "dest": "/tmp/m.safetensors"}
+    fields.update(overrides)
+    state = download_state.new(url=fields.pop("url"), dest=fields.pop("dest"))
+    for key, value in fields.items():
+        setattr(state, key, value)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# 1. state persistence
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    def test_round_trip(self, workspace):
+        state = _state(total_bytes=100, completed_bytes=40, status="downloading", pid=1234)
+        download_state.write(workspace, state)
+
+        loaded = download_state.read(workspace, state.id)
+        assert loaded is not None
+        assert loaded.schema == "download-state/1"
+        assert (loaded.total_bytes, loaded.completed_bytes, loaded.status, loaded.pid) == (100, 40, "downloading", 1234)
+
+    def test_write_is_atomic_and_leaves_no_tmp_files(self, workspace):
+        state = _state()
+        path = download_state.write(workspace, state)
+        state.completed_bytes = 999
+        download_state.write(workspace, state)
+
+        leftovers = [p.name for p in path.parent.iterdir() if p.suffix == ".tmp" or ".tmp" in p.name]
+        assert leftovers == []
+        assert json.loads(path.read_text())["completed_bytes"] == 999
+
+    def test_read_missing_returns_none(self, workspace):
+        assert download_state.read(workspace, "deadbeefcafe") is None
+
+    def test_read_tolerates_unknown_keys(self, workspace):
+        state = _state()
+        path = download_state.write(workspace, state)
+        data = json.loads(path.read_text())
+        data["invented_by_a_future_version"] = True
+        path.write_text(json.dumps(data))
+
+        assert download_state.read(workspace, state.id) is not None
+
+    def test_read_rejects_corrupt_json(self, workspace):
+        state = _state()
+        path = download_state.write(workspace, state)
+        path.write_text("{not json")
+        assert download_state.read(workspace, state.id) is None
+
+    @pytest.mark.parametrize("bad_id", ["../../etc/passwd", "a/b", "", "x" * 65])
+    def test_unsafe_ids_are_rejected(self, workspace, bad_id):
+        with pytest.raises(ValueError):
+            download_state.state_path(workspace, bad_id)
+        # read() swallows the rejection rather than exploding on a user-typed id.
+        assert download_state.read(workspace, bad_id) is None
+
+    def test_list_all_is_newest_first(self, workspace):
+        old = _state(started_at="2020-01-01T00:00:00+00:00")
+        new = _state(started_at="2030-01-01T00:00:00+00:00")
+        # write() stamps updated_at but leaves started_at alone.
+        download_state.write(workspace, old)
+        download_state.write(workspace, new)
+
+        assert [s.id for s in download_state.list_all(workspace)] == [new.id, old.id]
+
+    def test_list_all_on_missing_dir(self, tmp_path):
+        assert download_state.list_all(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# 2. reconciliation matrix: (pid alive|dead) x (size==total | size<total | total unknown)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcile:
+    @staticmethod
+    def _with_dest(tmp_path, size: int) -> Path:
+        dest = tmp_path / "model.safetensors"
+        dest.write_bytes(b"x" * size)
+        return dest
+
+    @pytest.mark.parametrize(
+        ("total", "size", "expected"),
+        [
+            (100, 100, "downloading"),  # complete but the worker hasn't said so yet
+            (100, 40, "downloading"),
+            (None, 40, "downloading"),
+        ],
+    )
+    def test_pid_alive_keeps_status(self, tmp_path, total, size, expected):
+        dest = self._with_dest(tmp_path, size)
+        state = _state(dest=str(dest), status="downloading", pid=4242, total_bytes=total, completed_bytes=0)
+
+        fresh = download_state.reconcile(state, pid_alive=lambda pid: True)
+
+        assert fresh.status == expected
+        # A live stat() always wins over the last value the worker persisted.
+        assert fresh.completed_bytes == size
+
+    def test_pid_dead_and_size_equals_total_is_completed(self, tmp_path):
+        dest = self._with_dest(tmp_path, 100)
+        state = _state(dest=str(dest), status="downloading", pid=4242, total_bytes=100)
+
+        fresh = download_state.reconcile(state, pid_alive=lambda pid: False)
+
+        assert (fresh.status, fresh.completed_bytes, fresh.error) == ("completed", 100, None)
+
+    def test_pid_dead_and_size_exceeds_total_is_completed(self, tmp_path):
+        """A server that under-reports Content-Length must not read as a failure."""
+        dest = self._with_dest(tmp_path, 120)
+        state = _state(dest=str(dest), status="downloading", pid=4242, total_bytes=100)
+
+        assert download_state.reconcile(state, pid_alive=lambda pid: False).status == "completed"
+
+    def test_pid_dead_and_size_below_total_is_failed(self, tmp_path):
+        dest = self._with_dest(tmp_path, 40)
+        state = _state(dest=str(dest), status="downloading", pid=4242, total_bytes=100)
+
+        fresh = download_state.reconcile(state, pid_alive=lambda pid: False)
+
+        assert fresh.status == "failed"
+        assert "worker died" in fresh.error
+
+    def test_pid_dead_and_total_unknown_is_failed(self, tmp_path):
+        """Without a total there is no evidence the transfer finished."""
+        dest = self._with_dest(tmp_path, 40)
+        state = _state(dest=str(dest), status="downloading", pid=4242, total_bytes=None)
+
+        fresh = download_state.reconcile(state, pid_alive=lambda pid: False)
+
+        assert fresh.status == "failed"
+
+    def test_pid_dead_and_dest_missing_is_failed(self, tmp_path):
+        state = _state(dest=str(tmp_path / "never-written"), status="downloading", pid=4242, total_bytes=0)
+
+        assert download_state.reconcile(state, pid_alive=lambda pid: False).status == "failed"
+
+    def test_starting_with_dead_pid_is_failed(self, tmp_path):
+        """A worker that died before its first write is still a dead worker."""
+        state = _state(dest=str(tmp_path / "nothing"), status="starting", pid=4242)
+
+        assert download_state.reconcile(state, pid_alive=lambda pid: False).status == "failed"
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_terminal_statuses_are_never_rewritten(self, tmp_path, status):
+        dest = self._with_dest(tmp_path, 10)
+        state = _state(dest=str(dest), status=status, pid=4242, total_bytes=100)
+
+        assert download_state.reconcile(state, pid_alive=lambda pid: False).status == status
+
+    def test_cancelled_does_not_adopt_a_stale_dest_size(self, tmp_path):
+        """`download-cancel` removed the partial; an unrelated file reappearing at
+        dest must not resurrect a byte count for a cancelled download."""
+        dest = self._with_dest(tmp_path, 10)
+        state = _state(dest=str(dest), status="cancelled", completed_bytes=0)
+
+        assert download_state.reconcile(state, pid_alive=lambda pid: False).completed_bytes == 0
+
+    def test_percent_is_none_without_a_total(self):
+        assert download_state.percent(_state(total_bytes=None, completed_bytes=5)) is None
+        assert download_state.percent(_state(total_bytes=0, completed_bytes=5)) is None
+        assert download_state.percent(_state(total_bytes=200, completed_bytes=50)) == 25.0
+
+    def test_percent_is_capped_at_100(self):
+        assert download_state.percent(_state(total_bytes=100, completed_bytes=120)) == 100.0
+
+    def test_elapsed_seconds_freezes_at_terminal(self):
+        state = _state(
+            status="completed",
+            started_at="2024-01-01T00:00:00+00:00",
+            updated_at="2024-01-01T00:00:30+00:00",
+        )
+        assert download_state.elapsed_seconds(state) == pytest.approx(30.0)
+
+    def test_elapsed_seconds_tolerates_a_garbage_timestamp(self):
+        assert download_state.elapsed_seconds(_state(started_at="not-a-date")) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 3. progress callback plumbing
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, chunks: list[bytes], *, total: int | None, status_code: int = 200):
+        self.chunks = chunks
+        self.status_code = status_code
+        self.headers = {} if total is None else {"Content-Length": str(total)}
+
+    def iter_bytes(self):
+        yield from self.chunks
+
+    def read(self):
+        return b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestProgressCallback:
+    def test_counts_bytes_and_reports_the_total(self, tmp_path):
+        seen: list[tuple[int, int | None]] = []
+        response = _FakeResponse([b"aaaa", b"bb", b"cccccc"], total=12)
+
+        with patch("httpx.stream", return_value=response):
+            _download_file_httpx(
+                "https://x/y", tmp_path / "out.bin", progress_callback=lambda c, t: seen.append((c, t))
+            )
+
+        # Fires once before the first chunk so `total_bytes` stops being null
+        # as soon as the headers are read, then once per chunk.
+        assert seen == [(0, 12), (4, 12), (6, 12), (12, 12)]
+        assert (tmp_path / "out.bin").read_bytes() == b"aaaabbcccccc"
+
+    def test_total_is_none_without_content_length(self, tmp_path):
+        seen: list[tuple[int, int | None]] = []
+        response = _FakeResponse([b"abc"], total=None)
+
+        with patch("httpx.stream", return_value=response):
+            _download_file_httpx(
+                "https://x/y", tmp_path / "out.bin", progress_callback=lambda c, t: seen.append((c, t))
+            )
+
+        assert seen == [(0, None), (3, None)]
+
+    def test_no_callback_is_fine(self, tmp_path):
+        with patch("httpx.stream", return_value=_FakeResponse([b"abc"], total=3)):
+            _download_file_httpx("https://x/y", tmp_path / "out.bin")
+        assert (tmp_path / "out.bin").read_bytes() == b"abc"
+
+    def test_a_raising_callback_never_breaks_the_download(self, tmp_path):
+        def boom(completed, total):
+            raise RuntimeError("disk full while persisting state")
+
+        with patch("httpx.stream", return_value=_FakeResponse([b"abc"], total=3)):
+            _download_file_httpx("https://x/y", tmp_path / "out.bin", progress_callback=boom)
+
+        assert (tmp_path / "out.bin").read_bytes() == b"abc"
+
+    def test_retry_resets_the_counter_when_the_partial_is_cleaned(self, tmp_path):
+        """A retry deletes the partial file, so the observer must be told the
+        count went back to zero rather than left holding a stale high-water mark."""
+        seen: list[tuple[int, int | None]] = []
+        attempts = {"n": 0}
+
+        def stream(*args, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return _FakeResponse([b"aaaa"], total=8)
+            return _FakeResponse([b"bbbbbbbb"], total=8)
+
+        original = _download_file_httpx
+
+        def flaky(url, path, headers=None, *, state=None, progress_callback=None):
+            if attempts["n"] == 0:
+                attempts["n"] = 1
+                if state is not None:
+                    state["file_opened"] = True
+                path.write_bytes(b"aaaa")
+                progress_callback(0, 8)
+                progress_callback(4, 8)
+                raise httpx.ReadTimeout("boom")
+            return original(url, path, headers, state=state, progress_callback=progress_callback)
+
+        with (
+            patch("comfy_cli.file_utils._download_file_httpx", side_effect=flaky),
+            patch("comfy_cli.file_utils.time.sleep"),
+            patch("httpx.stream", side_effect=stream),
+        ):
+            download_file("https://x/y", tmp_path / "out.bin", progress_callback=lambda c, t: seen.append((c, t)))
+
+        # (4, 8) from the doomed attempt, then the reset, then the clean run.
+        assert (0, None) in seen
+        assert seen.index((0, None)) > seen.index((4, 8))
+        assert seen[-1] == (8, 8)
+
+    def test_aria2_callback_is_fed_from_the_poll_loop(self):
+        from comfy_cli.file_utils import _poll_aria2_download
+
+        seen: list[tuple[int, int | None]] = []
+        download = MagicMock()
+        # total_length unknown -> known; completed_length advances; then complete.
+        states = [(0, 0, False), (100, 40, False), (100, 100, True)]
+
+        def update():
+            total, completed, complete = states.pop(0)
+            download.total_length = total
+            download.completed_length = completed
+            download.is_complete = complete
+            download.has_failed = False
+            download.is_removed = False
+
+        download.update.side_effect = update
+
+        with patch("time.sleep"):
+            _poll_aria2_download(download, lambda c, t: seen.append((c, t)))
+
+        assert (0, None) in seen  # size not yet known
+        assert (40, 100) in seen
+        assert seen[-1] == (100, 100)
+
+
+class TestWorkerThrottle:
+    def test_progress_writes_are_throttled_but_terminal_always_lands(self, workspace, monkeypatch, tmp_path):
+        """~1 write/s while streaming; the completed transition is unconditional."""
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), total_bytes=9)
+        path = download_state.write(workspace, state)
+
+        writes: list[int] = []
+        real_write = download_state.write_path
+        monkeypatch.setattr(
+            download_state,
+            "write_path",
+            lambda p, s: (writes.append(s.completed_bytes), real_write(p, s))[1],
+        )
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(models.time, "monotonic", lambda: clock["t"])
+
+        def fake_download_file(url, filepath, headers, downloader, progress_callback):
+            for completed, tick in [(3, 0.1), (6, 0.2), (9, 5.0)]:
+                clock["t"] += tick
+                progress_callback(completed, 9)
+            dest.write_bytes(b"x" * 9)
+
+        monkeypatch.setattr(models, "download_file", fake_download_file)
+        models._download_worker(state_file=str(path))
+
+        # The first callback always lands (it carries the just-learned total);
+        # the one 0.2s behind it is dropped; the one 5s later lands again.
+        assert writes.count(3) == 1
+        assert writes.count(6) == 0
+        assert writes.count(9) >= 1
+
+        final = download_state.read(workspace, state.id)
+        assert (final.status, final.completed_bytes, final.total_bytes) == ("completed", 9, 9)
+
+    def test_worker_records_a_failure_with_a_friendly_message(self, workspace, monkeypatch, tmp_path):
+        state = _state(dest=str(tmp_path / "m.safetensors"))
+        path = download_state.write(workspace, state)
+
+        def boom(*args, **kwargs):
+            raise DownloadException("Failed to download file.\nFile not found on server (404)")
+
+        monkeypatch.setattr(models, "download_file", boom)
+        with pytest.raises(typer.Exit):
+            models._download_worker(state_file=str(path))
+
+        final = download_state.read(workspace, state.id)
+        assert final.status == "failed"
+        assert "404" in final.error
+
+    def test_worker_writes_its_own_pid_on_startup(self, workspace, monkeypatch, tmp_path):
+        state = _state(dest=str(tmp_path / "m.safetensors"), pid=None)
+        path = download_state.write(workspace, state)
+
+        recorded = {}
+
+        def capture(url, filepath, headers, downloader, progress_callback):
+            recorded.update(download_state.read(workspace, state.id).to_dict())
+            filepath.write_bytes(b"ok")
+
+        monkeypatch.setattr(models, "download_file", capture)
+        models._download_worker(state_file=str(path))
+
+        assert recorded["pid"] == os.getpid()
+        assert recorded["status"] == "downloading"
+
+    def test_worker_exits_quietly_when_the_state_file_vanished(self, tmp_path):
+        with pytest.raises(typer.Exit):
+            models._download_worker(state_file=str(tmp_path / "gone.json"))
+
+    def test_worker_rederives_auth_headers_from_config_not_state(self, workspace, monkeypatch, tmp_path):
+        """The state file records *which* credential is needed, never the secret."""
+        state = _state(dest=str(tmp_path / "m.safetensors"), needs_civitai_auth=True)
+        path = download_state.write(workspace, state)
+        assert "Authorization" not in path.read_text()
+
+        monkeypatch.setattr(models, "_civitai_headers", lambda: {"Authorization": "Bearer from-config"})
+        seen = {}
+
+        def capture(url, filepath, headers, downloader, progress_callback):
+            seen["headers"] = headers
+            filepath.write_bytes(b"ok")
+
+        monkeypatch.setattr(models, "download_file", capture)
+        models._download_worker(state_file=str(path))
+
+        assert seen["headers"] == {"Authorization": "Bearer from-config"}
+
+
+# ---------------------------------------------------------------------------
+# 4. submit: fail fast, then detach
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_spawn(monkeypatch):
+    """Assert nothing detaches, by making a spawn attempt an outright failure."""
+    calls = []
+
+    def spawn(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("a worker was spawned but resolution should have failed first")
+
+    monkeypatch.setattr(models, "_spawn_download_worker", spawn)
+    return calls
+
+
+class TestSubmitFailsFast:
+    def test_unknown_scheme_never_detaches(self, workspace, no_spawn, monkeypatch):
+        """An unrecognized source can't resolve a filename; under skip_prompting
+        `ui.prompt_input` returns "" and the empty-filename guard fires."""
+        monkeypatch.setattr(models.ui, "prompt_input", lambda *a, **k: k.get("default", ""))
+
+        with pytest.raises(DownloadException, match="Filename cannot be empty"):
+            models.download(None, url="ftp://example.com/model.safetensors", background=True)
+
+    def test_destination_exists_never_detaches(self, workspace, no_spawn, monkeypatch, capsys):
+        dest = workspace / "models" / "loras" / "already.safetensors"
+        dest.parent.mkdir(parents=True)
+        dest.write_bytes(b"already here")
+        monkeypatch.setattr(models.ui, "prompt_input", lambda *a, **k: k.get("default", ""))
+
+        models.download(
+            None,
+            url="https://example.com/already.safetensors",
+            relative_path="models/loras",
+            filename="already.safetensors",
+            background=True,
+        )
+
+        assert "already exists" in capsys.readouterr().out
+
+    def test_unresolvable_filename_under_skip_prompting_never_detaches(self, workspace, no_spawn, monkeypatch):
+        monkeypatch.setattr(models.ui, "prompt_input", lambda *a, **k: k.get("default", ""))
+
+        with pytest.raises(DownloadException, match="Filename cannot be empty"):
+            models.download(None, url="https://example.com/", background=True)
+
+    def test_missing_hf_token_never_detaches(self, workspace, no_spawn, monkeypatch, capsys):
+        monkeypatch.setattr(models, "check_unauthorized", lambda url, headers: True)
+        monkeypatch.setattr(models.config_manager, "get_or_override", lambda *a, **k: None)
+
+        models.download(
+            None,
+            url="https://huggingface.co/org/repo/resolve/main/model.safetensors",
+            relative_path="models/loras",
+            filename="model.safetensors",
+            background=True,
+        )
+
+        assert "Hugging Face API token" in capsys.readouterr().out
+
+
+class TestSubmitEnvelope:
+    def _submit(self, workspace, monkeypatch, **kwargs):
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+            **kwargs,
+        )
+
+    def test_emits_the_submit_envelope(self, workspace, monkeypatch, json_renderer):
+        self._submit(workspace, monkeypatch)
+        env = json_renderer()
+
+        assert env["ok"] is True
+        assert env["command"] == "model download"
+        data = env["data"]
+        assert set(data) == {"download_id", "pid", "dest", "total_bytes", "status"}
+        assert data["pid"] == 31337
+        assert data["total_bytes"] is None
+        assert data["status"] == "starting"
+        assert data["dest"] == str(workspace / "models" / "loras" / "m.safetensors")
+        assert Path(data["dest"]).is_absolute()
+
+    def test_writes_a_state_file_with_the_spawn_pid(self, workspace, monkeypatch, json_renderer):
+        self._submit(workspace, monkeypatch)
+        download_id = json_renderer()["data"]["download_id"]
+
+        state = download_state.read(workspace, download_id)
+        assert (state.pid, state.status, state.schema) == (31337, "starting", "download-state/1")
+        assert state.url == "https://example.com/m.safetensors"
+
+    def test_creates_the_destination_directory_up_front(self, workspace, monkeypatch, json_renderer):
+        self._submit(workspace, monkeypatch)
+        assert (workspace / "models" / "loras").is_dir()
+
+    def test_a_fast_worker_is_not_clobbered_by_the_submit_writeback(
+        self, workspace, monkeypatch, json_renderer, tmp_path
+    ):
+        """The submitter records the Popen pid after spawning. A small file can
+        already be finished by then, so that write-back must not roll the state
+        file back to `starting` and lose the worker's progress."""
+
+        def spawn_and_finish(state_file, log_file):
+            state = download_state.read_path(state_file)
+            state.pid = 999
+            state.status = "completed"
+            state.total_bytes = state.completed_bytes = 4096
+            download_state.write_path(state_file, state)
+            return 999
+
+        monkeypatch.setattr(models, "_spawn_download_worker", spawn_and_finish)
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+        )
+
+        data = json_renderer()["data"]
+        assert data["status"] == "completed"
+        assert data["total_bytes"] == 4096
+
+        persisted = download_state.read(workspace, data["download_id"])
+        assert (persisted.status, persisted.completed_bytes) == ("completed", 4096)
+
+    def test_spawn_failure_is_a_structured_error(self, workspace, monkeypatch, json_renderer):
+        def boom(state_file, log_file):
+            raise OSError("fork: resource temporarily unavailable")
+
+        monkeypatch.setattr(models, "_spawn_download_worker", boom)
+        with pytest.raises(typer.Exit):
+            models.download(
+                None,
+                url="https://example.com/m.safetensors",
+                relative_path="models/loras",
+                filename="m.safetensors",
+                background=True,
+            )
+
+        env = json_renderer()
+        assert env["ok"] is False
+        assert env["error"]["code"] == "download_worker_spawn_failed"
+        # ...and the download is recorded as failed rather than left dangling.
+        assert download_state.list_all(workspace)[0].status == "failed"
+
+    def test_foreground_is_unchanged_by_the_new_flag(self, workspace, monkeypatch, capsys):
+        """Without --background the transfer still runs inline and nothing detaches."""
+        monkeypatch.setattr(models, "_spawn_download_worker", MagicMock(side_effect=AssertionError))
+        calls = []
+        monkeypatch.setattr(models, "download_file", lambda *a, **k: calls.append((a, k)))
+
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+        )
+
+        assert len(calls) == 1
+        # The foreground call site does not pass a progress callback.
+        assert "progress_callback" not in calls[0][1]
+        assert download_state.list_all(workspace) == []
+
+
+class TestSpawnFlags:
+    """The detach flags are platform-specific; CI runs both POSIX and Windows."""
+
+    def _capture_popen(self, monkeypatch):
+        popen = MagicMock()
+        popen.return_value.pid = 4242
+        monkeypatch.setattr(subprocess, "Popen", popen)
+        return popen
+
+    def test_posix_uses_a_new_session(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        popen = self._capture_popen(monkeypatch)
+
+        pid = models._spawn_download_worker(tmp_path / "s.json", tmp_path / "s.log")
+
+        assert pid == 4242
+        kwargs = popen.call_args.kwargs
+        assert kwargs["start_new_session"] is True
+        assert "creationflags" not in kwargs
+
+    def test_windows_uses_detached_process_flags(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        # These constants only exist on Windows builds of the stdlib.
+        monkeypatch.setattr(subprocess, "DETACHED_PROCESS", 0x8, raising=False)
+        monkeypatch.setattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200, raising=False)
+        popen = self._capture_popen(monkeypatch)
+
+        models._spawn_download_worker(tmp_path / "s.json", tmp_path / "s.log")
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["creationflags"] == 0x8 | 0x200
+        assert "start_new_session" not in kwargs
+
+    def test_worker_argv_targets_the_hidden_command(self, tmp_path, monkeypatch):
+        popen = self._capture_popen(monkeypatch)
+        models._spawn_download_worker(tmp_path / "s.json", tmp_path / "s.log")
+
+        argv = popen.call_args.args[0]
+        assert argv[:1] == [sys.executable]
+        assert argv[1:5] == ["-m", "comfy_cli", "model", "_download-worker"]
+        assert argv[-2:] == ["--state", str(tmp_path / "s.json")]
+
+    def test_stdio_is_detached_and_the_log_is_appended(self, tmp_path, monkeypatch):
+        log = tmp_path / "s.log"
+        log.write_text("previous run\n")
+        popen = self._capture_popen(monkeypatch)
+
+        models._spawn_download_worker(tmp_path / "s.json", log)
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["stderr"] is subprocess.STDOUT
+        assert kwargs["stdout"].mode == "ab"
+        # opened for append -> the prior run's output survives
+        assert log.read_text() == "previous run\n"
+
+
+# ---------------------------------------------------------------------------
+# 5. poll verbs
+# ---------------------------------------------------------------------------
+
+
+class TestPollVerbs:
+    def test_status_envelope_shape(self, workspace, json_renderer, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 50)
+        state = _state(dest=str(dest), status="downloading", pid=os.getpid(), total_bytes=200)
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+        env = json_renderer()
+
+        assert env["ok"] is True
+        assert env["command"] == "model download-status"
+        assert env["data"] == {
+            "id": state.id,
+            "status": "downloading",
+            "completed_bytes": 50,
+            "total_bytes": 200,
+            "percent": 25.0,
+            "elapsed_seconds": env["data"]["elapsed_seconds"],
+            "dest": str(dest),
+            "error": None,
+        }
+
+    def test_status_percent_is_null_without_a_total(self, workspace, json_renderer, tmp_path):
+        state = _state(dest=str(tmp_path / "m"), status="downloading", pid=os.getpid(), total_bytes=None)
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+        assert json_renderer()["data"]["percent"] is None
+
+    def test_status_reconciles_a_dead_worker_and_persists_it(self, workspace, json_renderer, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 200)
+        state = _state(dest=str(dest), status="downloading", pid=2**22 - 1, total_bytes=200)
+        download_state.write(workspace, state)
+
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            models.download_status(None, download_id=state.id)
+
+        assert json_renderer()["data"]["status"] == "completed"
+        # The correction is written back so the next poll is cheap.
+        assert download_state.read(workspace, state.id).status == "completed"
+
+    def test_polling_a_live_worker_does_not_rewind_its_state_file(self, workspace, json_renderer, tmp_path):
+        """A poll re-derives byte counts from stat() every time, so it must not
+        write its (already stale) in-memory copy back over a live worker."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(dest=str(dest), status="downloading", pid=os.getpid(), total_bytes=200, completed_bytes=10)
+        path = download_state.write(workspace, state)
+
+        # The worker races ahead between our read and any write-back.
+        state.completed_bytes = 150
+        download_state.write_path(path, state)
+        dest.write_bytes(b"x" * 150)
+
+        models.download_status(None, download_id=state.id)
+
+        assert json_renderer()["data"]["completed_bytes"] == 150
+        assert download_state.read(workspace, state.id).completed_bytes == 150
+
+    def test_unknown_id_is_a_structured_error(self, workspace, json_renderer):
+        with pytest.raises(typer.Exit):
+            models.download_status(None, download_id="nosuchid1234")
+
+        env = json_renderer()
+        assert env["ok"] is False
+        assert env["error"]["code"] == "download_not_found"
+        assert env["error"]["hint"]
+
+    def test_downloads_lists_newest_first(self, workspace, json_renderer, tmp_path):
+        old = _state(dest=str(tmp_path / "a"), status="completed", started_at="2020-01-01T00:00:00+00:00")
+        new = _state(dest=str(tmp_path / "b"), status="completed", started_at="2030-01-01T00:00:00+00:00")
+        download_state.write(workspace, old)
+        download_state.write(workspace, new)
+
+        models.downloads(None)
+        env = json_renderer()
+
+        assert env["command"] == "model downloads"
+        assert env["data"]["total"] == 2
+        assert [row["id"] for row in env["data"]["downloads"]] == [new.id, old.id]
+        assert set(env["data"]["downloads"][0]) == {
+            "id",
+            "status",
+            "completed_bytes",
+            "total_bytes",
+            "percent",
+            "elapsed_seconds",
+            "dest",
+            "error",
+        }
+
+    def test_downloads_on_an_empty_workspace(self, workspace, json_renderer):
+        models.downloads(None)
+        env = json_renderer()
+        assert env["data"] == {"total": 0, "downloads": []}
+
+    def test_cancel_kills_the_worker_and_removes_the_partial(self, workspace, json_renderer, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "kill_worker", return_value=True) as kill:
+            with patch("comfy_cli.utils.is_running", return_value=False):
+                models.download_cancel(None, download_id=state.id)
+
+        kill.assert_called_once_with(5150)
+        assert not dest.exists()
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["changed"] is True
+        assert env["data"]["status"] == "cancelled"
+        assert env["data"]["completed_bytes"] == 0
+        assert download_state.read(workspace, state.id).status == "cancelled"
+
+    def test_cancel_of_a_terminal_download_is_a_no_op(self, workspace, json_renderer, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 100)
+        state = _state(dest=str(dest), status="completed", total_bytes=100, completed_bytes=100)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "kill_worker") as kill:
+            models.download_cancel(None, download_id=state.id)
+
+        kill.assert_not_called()
+        assert dest.exists(), "a completed download's file must never be deleted"
+        env = json_renderer()
+        assert env["data"]["status"] == "completed"
+        assert env["changed"] is False
+
+    def test_cancel_of_an_unknown_id_is_a_structured_error(self, workspace, json_renderer):
+        with pytest.raises(typer.Exit):
+            models.download_cancel(None, download_id="nosuchid1234")
+        assert json_renderer()["error"]["code"] == "download_not_found"
+
+
+class TestHumanRendering:
+    """Pretty mode writes a table to stdout and no envelope."""
+
+    def test_status_renders_a_table(self, workspace, capsys, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 50)
+        state = _state(dest=str(dest), status="downloading", pid=os.getpid(), total_bytes=200)
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+
+        out = capsys.readouterr().out
+        assert state.id in out
+        assert "downloading" in out
+        assert "25.0%" in out
+
+    def test_status_renders_an_error(self, workspace, capsys, tmp_path):
+        state = _state(dest=str(tmp_path / "gone"), status="failed", error="the server returned HTTP 503")
+        download_state.write(workspace, state)
+
+        models.download_status(None, download_id=state.id)
+        assert "503" in capsys.readouterr().out
+
+    def test_empty_downloads_renders_a_message(self, workspace, capsys):
+        models.downloads(None)
+        assert "No background downloads" in capsys.readouterr().out
+
+    def test_unknown_total_renders_without_crashing(self, workspace, capsys, tmp_path):
+        state = _state(dest=str(tmp_path / "m"), status="starting", total_bytes=None)
+        download_state.write(workspace, state)
+
+        models.downloads(None)
+        assert state.id in capsys.readouterr().out
+
+
+class TestKillWorker:
+    def test_no_pid_is_a_no_op(self):
+        assert download_state.kill_worker(None) is False
+        assert download_state.kill_worker(0) is False
+        assert download_state.kill_worker(-1) is False
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="killpg is POSIX-only")
+    def test_posix_signals_the_process_group(self, monkeypatch):
+        import signal
+
+        killed = []
+        monkeypatch.setattr(os, "getpgid", lambda pid: pid)
+        monkeypatch.setattr(os, "killpg", lambda pgid, sig: killed.append((pgid, sig)))
+
+        assert download_state.kill_worker(4242) is True
+        assert killed == [(4242, signal.SIGTERM)]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="killpg is POSIX-only")
+    def test_an_already_dead_worker_reports_false(self, monkeypatch):
+        monkeypatch.setattr(os, "getpgid", MagicMock(side_effect=ProcessLookupError))
+        monkeypatch.setattr("psutil.Process", MagicMock(side_effect=Exception("no such process")))
+
+        assert download_state.kill_worker(4242) is False

--- a/tests/comfy_cli/output/test_envelope_schemas.py
+++ b/tests/comfy_cli/output/test_envelope_schemas.py
@@ -49,6 +49,9 @@ def _validator_for(name: str) -> jsonschema.Validator:
         "which.json",
         "run.json",
         "run_event.json",
+        "download.json",
+        "download_status.json",
+        "downloads.json",
     ],
 )
 def test_schemas_are_well_formed(schema_name):

--- a/tests/comfy_cli/test_aria2_download.py
+++ b/tests/comfy_cli/test_aria2_download.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from comfy_cli import constants
-from comfy_cli.file_utils import DownloadException, _download_file_aria2, download_file
+from comfy_cli.file_utils import DownloadCancelled, DownloadException, _download_file_aria2, download_file
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -269,6 +269,72 @@ class TestAria2Download:
 
         with pytest.raises(DownloadException, match="Lost connection to aria2"):
             _download_file_aria2("http://example.com/f.bin", tmp_path / "f.bin")
+
+    def test_cancelling_removes_the_daemon_side_download(self, tmp_path, aria2_env, fake_aria2p):
+        """With aria2 the bytes move inside the aria2c daemon, not in this
+        process. Walking away from the poll loop would leave it finishing a
+        download the user just cancelled — and re-creating the file the caller
+        deleted. The transfer has to be removed over RPC."""
+        mock_download = Mock(
+            total_length=1024,
+            completed_length=10,
+            is_complete=False,
+            has_failed=False,
+            is_removed=False,
+            update=Mock(),
+        )
+        mock_api = Mock()
+        mock_api.add_uris.return_value = mock_download
+        fake_aria2p.API.return_value = mock_api
+
+        def cancel_on_first_progress(_completed, _total):
+            raise DownloadCancelled()
+
+        with pytest.raises(DownloadCancelled):
+            _download_file_aria2(
+                "http://example.com/f.bin",
+                tmp_path / "f.bin",
+                progress_callback=cancel_on_first_progress,
+            )
+
+        mock_download.remove.assert_called_once_with(force=True, files=True)
+
+    def test_a_failed_removal_does_not_mask_the_cancellation(self, tmp_path, aria2_env, fake_aria2p):
+        mock_download = Mock(
+            total_length=1024,
+            completed_length=10,
+            is_complete=False,
+            has_failed=False,
+            is_removed=False,
+            update=Mock(),
+            remove=Mock(side_effect=ConnectionError("RPC server gone")),
+        )
+        mock_api = Mock()
+        mock_api.add_uris.return_value = mock_download
+        fake_aria2p.API.return_value = mock_api
+
+        def cancel_on_first_progress(_completed, _total):
+            raise DownloadCancelled()
+
+        with pytest.raises(DownloadCancelled):
+            _download_file_aria2(
+                "http://example.com/f.bin",
+                tmp_path / "f.bin",
+                progress_callback=cancel_on_first_progress,
+            )
+
+    def test_an_ordinary_callback_failure_is_still_swallowed(self, tmp_path, mock_aria2_success):
+        """Progress reporting stays advisory; only cancellation aborts."""
+
+        def boom(_completed, _total):
+            raise RuntimeError("disk full while persisting state")
+
+        _download_file_aria2(
+            "http://example.com/f.bin",
+            tmp_path / "f.bin",
+            progress_callback=boom,
+        )
+        mock_aria2_success["download"].remove.assert_not_called()
 
     def test_file_missing_after_download_raises(self, tmp_path, aria2_env, fake_aria2p):
         """Error when aria2 reports success but file is not on disk."""

--- a/tests/comfy_cli/test_aria2_download.py
+++ b/tests/comfy_cli/test_aria2_download.py
@@ -326,7 +326,9 @@ class TestDownloadFileDispatch:
         """When downloader='aria2', aria2 backend is used."""
         with patch("comfy_cli.file_utils._download_file_aria2") as mock_aria2:
             download_file("http://example.com/f.bin", tmp_path / "f.bin", downloader="aria2")
-            mock_aria2.assert_called_once_with("http://example.com/f.bin", tmp_path / "f.bin", None)
+            # Trailing None is the optional progress_callback (unused in the
+            # foreground path; fed by the background download worker).
+            mock_aria2.assert_called_once_with("http://example.com/f.bin", tmp_path / "f.bin", None, None)
 
     def test_invalid_downloader_raises(self, tmp_path):
         """Invalid downloader value raises DownloadException."""


### PR DESCRIPTION
## ELI-5

`comfy model download` used to hold the terminal hostage until the whole model finished downloading. If you were a script (or an agent) driving it, you had no job id, no progress you could parse, and nothing to poll — so you just waited and hoped, and long downloads blew up at whatever timeout your transport happened to impose. This adds `--background`: the CLI still does all the *thinking* up front (resolve the CivitAI/HF metadata, check your token, work out the filename, refuse if the file is already there) so mistakes still blow up immediately in front of you. Only the actual byte-shovelling gets handed to a detached worker, which writes its progress to a small JSON file. You get a `download_id` back instantly and can ask `comfy model download-status <id>` how it's going, `comfy model downloads` for all of them, or `comfy model download-cancel <id>` to stop one.

Nothing about the default (foreground) download changes.

## What's in here

**Submit — `comfy model download ... --background`**

Resolution runs in the foreground, unchanged, before anything detaches: CivitAI/HF metadata requests, token config, filename resolution, and the destination-exists check. Bad URL, missing token, unresolvable filename, and already-exists all still fail fast and synchronously. Under `--json` (or any agentic caller) `skip_prompting` is already auto-set, so `ui.prompt_input` returns its default and an unresolvable filename raises rather than prompting — `--background` inherits that for free.

Then it mints a `download_id` (`uuid4().hex[:12]`), writes `<workspace>/.comfy-downloads/<id>.json`, detaches the worker with stdout/stderr appended to `<id>.log`, and emits `{download_id, pid, dest, total_bytes, status}`.

**State — `comfy_cli/download_state.py` (new)**

`download-state/1`: `{schema, id, pid, url, dest, total_bytes, completed_bytes, status, error, started_at, updated_at}` with `status ∈ starting|downloading|completed|failed|cancelled`, written atomically (tmp file + `os.replace`, fsync before the rename). It follows the shape of the existing `jobs_state.py` deliberately.

**No secrets are persisted.** The file records only *which* credential the resolved URL needs (`needs_civitai_auth` / `needs_hf_auth`); the worker re-reads the token from config through the same `config_manager.get_or_override` path `download()` uses. There is a test asserting the written file contains no `Authorization`.

**Worker progress**

An optional `progress_callback(completed_bytes, total_bytes)` is threaded through `download_file()` → `_download_file_httpx()`, counting bytes around `response.iter_bytes()` with `total` from Content-Length; the aria2 backend feeds the same callback from `download.completed_length`/`total_length` in `_poll_aria2_download`. The worker persists it throttled to ~1/s (terminal transitions always write). The existing retry loop keeps working: when a retry cleans the partial, the callback is reset to `(0, None)` so an observer never sees the counter run backwards from a stale high-water mark. A callback that raises can never abort a healthy transfer.

**Poll verbs**

- `download-status <id>` — reads the state file and reconciles it against reality. `completed_bytes` prefers a live `stat(dest)`; if the record is active but the worker pid is gone (`utils.is_running`, the same helper the launch/stop machinery uses), it resolves to `completed` when the file reached the known total and `failed` ("worker died") otherwise. Envelope: `{id, status, completed_bytes, total_bytes, percent, elapsed_seconds, dest, error}`, `percent` null while the total is unknown. Unknown id → `download_not_found`.
- `downloads` — every state file, same reconciliation, newest first.
- `download-cancel <id>` — kills the worker's process group, marks `cancelled`, removes the partial at `dest`.

Schemas `download.json`, `download_status.json`, `downloads.json` are registered in `discovery.COMMAND_SCHEMAS` and added to the well-formedness gate; three error codes are registered.

## Verification

`pytest` — **2842 passed, 37 skipped**. `ruff check` + `ruff format --diff` clean under the CI-pinned `ruff==0.15.15`. 70 new tests cover the reconciliation matrix (pid alive|dead × size==total | size<total | total unknown, plus size>total, dest-missing, and every terminal status), submit fail-fast, progress-callback counting through the real transfer loop, atomic writes and throttling, all four envelope shapes under `--json`, human rendering, and the platform-guarded detach flags.

I also ran it for real against a local HTTP server rather than trusting the mocks: a 3 MB file backgrounded and reported `completed` with `percent: 100.0`; a deliberately slow 50 MB stream reported `downloading` at `2.4%` mid-flight, then `download-cancel` killed the process group, removed the partial, and reported `cancelled`; and `kill -9` on a worker mid-transfer correctly reconciled to `failed` / "worker died before the download finished" on the next poll.

## Judgment calls

**The HF-authorized path downloads differently in background mode.** The foreground authorized-Hugging-Face branch uses `huggingface_hub.hf_hub_download`, which owns its own progress reporting and cache layout — there is no callback to thread through it, and its return path is a cache path rather than the resolved `dest`. Rather than deny `--background` on that branch, the worker performs the same transfer through `download_file` with an `Authorization: Bearer <hf-token>` header (the token re-derived from config). That is the same request the unauthenticated HF path already makes, and it means progress, `dest`, and cancellation behave identically across every source. The trade-off is that a background HF download does not populate the `huggingface_hub` cache. Flagging it explicitly rather than burying it — if you'd rather background mode refuse this branch, that's a one-line change.

**Two races I found in my own self-review and fixed, both with regression tests.** (1) The submitter records the `Popen` pid *after* spawning, but a small file can already be finished by then — blindly writing its stale in-memory copy back would roll the state file from `completed` to `starting` and lose the worker's progress. It now re-reads and only patches an unclaimed (`pid is None`) file. (2) `download-status` used to persist its full reconciliation, which could rewind a live worker's byte counts to whatever the reader loaded a moment earlier; it now only writes back a *status* correction, since byte counts are re-derived from `stat(dest)` on every poll anyway.

**Reconciling a dead worker with an unknown total is `failed`, not `completed`.** Without a Content-Length there is no evidence the transfer finished, so the conservative verdict wins; a size *exceeding* a known total still reads as `completed` (servers under-report).

**`download-cancel` on an already-terminal download is a no-op** rather than an error — it never deletes a completed download's file. `changed: false` in the envelope.

**One pre-existing thing I left alone:** `tests/comfy_cli/command/github/test_pr.py` is unformatted under older local ruff versions but clean under the CI-pinned 0.15.15. `ruff format` touched it incidentally; I reverted that to keep this diff scoped.
