### PR TITLE
fix(logs): candidate-based log resolution with user/comfyui.log fallback, crash-surviving pointer, and staleness metadata

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1204,7 +1204,7 @@ def launch(
     launch_command(background, extra, frontend_pr)
 
 
-@app.command(help="Show the captured background ComfyUI log (from `comfy launch --background`).")
+@app.command(help="Show a captured ComfyUI log (from `comfy launch --background`, or ComfyUI-Manager's own logfile).")
 @tracking.track_command()
 def logs(
     tail: Annotated[
@@ -1215,8 +1215,18 @@ def logs(
         str | None,
         typer.Option("--where", show_default=False, help="Routing target. Only 'local' is supported."),
     ] = None,
+    port: Annotated[
+        int | None,
+        typer.Option(
+            "--port",
+            show_default=False,
+            help="Show the log for this port instead of auto-resolving "
+            "(falls back to user/comfyui.log, which is where a server started "
+            "without an explicit --port logs).",
+        ),
+    ] = None,
 ):
-    logs_command(tail=tail, where=where)
+    logs_command(tail=tail, where=where, port=port)
 
 
 @app.command("setup", help="Interactive setup wizard — routing, auth, and agent skills in one step.")

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -11,9 +11,11 @@ import time
 import uuid
 from collections import deque
 from datetime import datetime, timezone
+from stat import S_ISREG
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 
 from comfy_cli import constants, utils
@@ -471,6 +473,22 @@ def unsuffixed_log_path(workspace: str) -> str:
     return os.path.join(workspace, "user", "comfyui.log")
 
 
+def _path_within(path: str, directory: str) -> bool:
+    """True when ``path`` lies inside ``directory``, compared lexically.
+
+    Deliberately does NOT touch the filesystem (no ``realpath``): the caller
+    only needs to know whether a *recorded* path claims to belong to the current
+    workspace, and that question must stay answerable for a file that no longer
+    exists.
+    """
+    try:
+        target = os.path.normcase(os.path.abspath(path))
+        root = os.path.normcase(os.path.abspath(directory))
+    except (OSError, ValueError):
+        return False
+    return target == root or target.startswith(root.rstrip(os.sep) + os.sep)
+
+
 def candidate_log_paths(port: int | None = None) -> list[tuple[str, str]]:
     """The ordered candidates `comfy logs` considers, existing or not.
 
@@ -494,26 +512,39 @@ def candidate_log_paths(port: int | None = None) -> list[tuple[str, str]]:
         ]
 
     cfg = ConfigManager()
-    candidates: list[tuple[str, str]] = []
-
     recorded = cfg.get(constants.CONFIG_KEY_BACKGROUND_LOG)
-    if recorded:
-        candidates.append((recorded, "recorded"))
 
     if not workspace:
-        return candidates
+        # Nothing local to prefer it over, and nothing else to check.
+        return [(recorded, "recorded")] if recorded else []
 
     live_port = cfg.background[1] if cfg.background else None
     derived_port = live_port if live_port is not None else DEFAULT_LOG_PORT
-    candidates.append(
+    local: list[tuple[str, str]] = [
         (
             background_log_path(derived_port, workspace),
             "derived_port" if live_port is not None else "default_port",
-        )
-    )
-    candidates.append((unsuffixed_log_path(workspace), "fallback_unsuffixed"))
-    candidates.append((os.path.join(workspace, "user", "comfyui_*.log"), "fallback_glob"))
-    return candidates
+        ),
+        (unsuffixed_log_path(workspace), "fallback_unsuffixed"),
+        (os.path.join(workspace, "user", "comfyui_*.log"), "fallback_glob"),
+    ]
+
+    if not recorded:
+        return local
+
+    # The recorded pointer outranks the workspace-local candidates only when it
+    # is still relevant HERE: either the background server it describes is live,
+    # or it names a file inside the current workspace (the crash-log case — the
+    # pointer deliberately survives `comfy stop` and dead-pid cleanup).
+    #
+    # Otherwise it is a pointer into some OTHER workspace left over from an
+    # earlier run, and serving it ahead of this workspace's own `comfyui_*.log`
+    # would silently show a cross-workspace log with no live server to raise
+    # `port_mismatch`. Demote it to last so it is still a usable last resort
+    # when this workspace has no log at all, but never shadows a local one.
+    if live_port is not None or _path_within(recorded, workspace):
+        return [(recorded, "recorded"), *local]
+    return [*local, (recorded, "recorded")]
 
 
 def _newest_globbed_log(pattern: str) -> str | None:
@@ -522,6 +553,12 @@ def _newest_globbed_log(pattern: str) -> str | None:
     Only the BASENAME of ``pattern`` is a glob; its directory is escaped, so a
     workspace path containing glob metacharacters (``/Users/a[1]/comfy``) still
     matches instead of silently globbing nothing.
+
+    Symlinks are skipped: on a shared host an attacker with write access to
+    ``<workspace>/user`` could plant ``comfyui_<n>.log`` as a link to a file
+    outside the workspace and backdate/forward-date it to win the newest-mtime
+    pick, making `comfy logs` disclose the target. ``lstat`` + ``S_ISREG`` is the
+    read-side counterpart of ``_open_log_for_write``'s ``O_NOFOLLOW``.
     """
     directory, filename = os.path.split(pattern)
     newest: str | None = None
@@ -530,11 +567,13 @@ def _newest_globbed_log(pattern: str) -> str | None:
         if _ROTATED_LOG_RE.search(os.path.basename(path)):
             continue
         try:
-            if not os.path.isfile(path):
+            # lstat, not stat: a symlink must not be resolved to its target here.
+            st = os.lstat(path)
+            if not S_ISREG(st.st_mode):
                 continue
-            mtime = os.stat(path).st_mtime
+            mtime = st.st_mtime
         except OSError:
-            # Raced away between glob and stat, or unreadable — not a candidate.
+            # Raced away between glob and lstat, or unreadable — not a candidate.
             continue
         if mtime > newest_mtime:
             newest, newest_mtime = path, mtime
@@ -644,24 +683,41 @@ def logs(tail: int = 200, where: str | None = None, port: int | None = None):
     # and whether it belongs to a different port than the live background server
     # (the wrong-port-empty-log case a failed launch attempt leaves behind).
     try:
-        stat = os.stat(log_path)
-        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
-        size = stat.st_size
-    except OSError:
-        # Same TOCTOU window as the read above; metadata is best-effort.
+        st = os.stat(log_path)
+        mtime = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).isoformat()
+        size = st.st_size
+    except (OSError, ValueError, OverflowError):
+        # OSError: the same TOCTOU window as the read above. ValueError/OverflowError:
+        # an out-of-range or corrupt st_mtime that fromtimestamp can't represent
+        # (notably any negative value on Windows). Metadata is best-effort.
         mtime, size = None, None
 
     background = ConfigManager().background
     served_port = _served_log_port(log_path)
-    port_mismatch = bool(background and served_port is not None and served_port != background[1])
+    # Suppressed when --port was passed: there the served file is *by definition*
+    # the port the user asked for, so reporting it as a mismatch — and advising
+    # them to retry with the live port they deliberately did not ask for — would
+    # contradict the request they just made.
+    port_mismatch = bool(port is None and background and served_port is not None and served_port != background[1])
 
     if renderer.is_pretty():
         if port_mismatch:
             # Without this a human just sees an empty/stale file and no reason why.
             print(
-                f"[bold yellow]Warning: showing {log_path} (port {served_port}), but the running "
+                f"[bold yellow]Warning: showing {escape(log_path)} (port {served_port}), but the running "
                 f"background server is on port {background[1]}. "
                 f"Try `comfy logs --port {background[1]}`.[/bold yellow]"
+            )
+        elif port is not None and source == "fallback_unsuffixed":
+            # An explicit --port that resolved to the unsuffixed Manager log is a
+            # deliberate fallback (a server on that port started without a --port
+            # argv flag logs only there) — but that file encodes no port, so it
+            # can equally be some other port's log and `port_mismatch` cannot
+            # detect it. Say so rather than answering the request silently.
+            print(
+                f"[bold yellow]Warning: no comfyui_{port}.log was found; showing "
+                f"{escape(log_path)}, ComfyUI-Manager's unsuffixed log, which does not "
+                f"record which port it served.[/bold yellow]"
             )
         # Write raw so ComfyUI log text (which can contain '[...]') isn't
         # reinterpreted as Rich markup, and byte-for-byte matches the file.

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import glob
 import os
+import re
 import subprocess
 import sys
 import threading
 import time
 import uuid
 from collections import deque
+from datetime import datetime, timezone
 
 import typer
 from rich.console import Console
@@ -445,27 +448,133 @@ def read_log_tail(
     return lines, truncated
 
 
-def resolve_background_log_path() -> str | None:
-    """Locate the background logfile: the path recorded at launch, else the
-    default derived from the resolved workspace and background/default port.
+# ComfyUI-Manager rotates its logfile on startup: `comfyui.log` becomes
+# `comfyui.prev.log`, and the previous `.prev` becomes `.prev2`. Those rotations
+# are stale by construction, so the glob fallback must never serve one.
+_ROTATED_LOG_RE = re.compile(r"\.prev\d*\.log$")
 
-    Returns None when no workspace can be resolved and nothing was recorded.
+# `<workspace>/user/comfyui_<port>.log` — the suffix carries the port the server
+# was serving, which is what makes a port mismatch detectable after the fact.
+_PORTED_LOG_RE = re.compile(r"^comfyui_(\d+)\.log$")
+
+DEFAULT_LOG_PORT = 8188
+
+
+def unsuffixed_log_path(workspace: str) -> str:
+    """``<workspace>/user/comfyui.log`` — ComfyUI-Manager's own logfile.
+
+    Manager only appends ``_<port>`` when ``--port`` is in ComfyUI's argv, so a
+    server started outside ``comfy launch --background`` (foreground, desktop
+    app, no explicit ``--port``) logs here and nowhere else. `comfy install`
+    installs Manager, so this file exists on a default install.
     """
+    return os.path.join(workspace, "user", "comfyui.log")
+
+
+def candidate_log_paths(port: int | None = None) -> list[tuple[str, str]]:
+    """The ordered candidates `comfy logs` considers, existing or not.
+
+    Each entry is ``(path, source)``; the ``fallback_glob`` entry's "path" is a
+    glob PATTERN rather than a concrete file. Kept separate from resolution so
+    the miss path can report everything that was checked.
+
+    With ``port`` given (``comfy logs --port N``) the list is restricted to that
+    port's logfile plus the unsuffixed Manager file — the latter covers a server
+    on port N that was started without an explicit ``--port`` argv flag, which is
+    exactly when Manager omits the suffix.
+    """
+    workspace = workspace_manager.workspace_path
+
+    if port is not None:
+        if not workspace:
+            return []
+        return [
+            (background_log_path(port, workspace), "explicit_port"),
+            (unsuffixed_log_path(workspace), "fallback_unsuffixed"),
+        ]
+
     cfg = ConfigManager()
+    candidates: list[tuple[str, str]] = []
+
     recorded = cfg.get(constants.CONFIG_KEY_BACKGROUND_LOG)
     if recorded:
-        return recorded
+        candidates.append((recorded, "recorded"))
 
-    workspace = workspace_manager.workspace_path
     if not workspace:
-        return None
+        return candidates
 
-    port = cfg.background[1] if cfg.background else 8188
-    return background_log_path(port, workspace)
+    live_port = cfg.background[1] if cfg.background else None
+    derived_port = live_port if live_port is not None else DEFAULT_LOG_PORT
+    candidates.append(
+        (
+            background_log_path(derived_port, workspace),
+            "derived_port" if live_port is not None else "default_port",
+        )
+    )
+    candidates.append((unsuffixed_log_path(workspace), "fallback_unsuffixed"))
+    candidates.append((os.path.join(workspace, "user", "comfyui_*.log"), "fallback_glob"))
+    return candidates
 
 
-def logs(tail: int = 200, where: str | None = None):
-    """Print the tail of the background ComfyUI log captured by `comfy launch`."""
+def _newest_globbed_log(pattern: str) -> str | None:
+    """Newest-mtime match of ``pattern``, ignoring ComfyUI-Manager's rotations.
+
+    Only the BASENAME of ``pattern`` is a glob; its directory is escaped, so a
+    workspace path containing glob metacharacters (``/Users/a[1]/comfy``) still
+    matches instead of silently globbing nothing.
+    """
+    directory, filename = os.path.split(pattern)
+    newest: str | None = None
+    newest_mtime = float("-inf")
+    for path in glob.glob(os.path.join(glob.escape(directory), filename)):
+        if _ROTATED_LOG_RE.search(os.path.basename(path)):
+            continue
+        try:
+            if not os.path.isfile(path):
+                continue
+            mtime = os.stat(path).st_mtime
+        except OSError:
+            # Raced away between glob and stat, or unreadable — not a candidate.
+            continue
+        if mtime > newest_mtime:
+            newest, newest_mtime = path, mtime
+    return newest
+
+
+def resolve_background_log_path(port: int | None = None) -> tuple[str, str] | None:
+    """Locate a ComfyUI logfile, returning ``(path, source)`` for the first
+    candidate of :func:`candidate_log_paths` that actually exists.
+
+    Returns None when no candidate exists — including the "no workspace resolves
+    and nothing was recorded" case, where there is nothing to check at all.
+    """
+    for path, source in candidate_log_paths(port):
+        if source == "fallback_glob":
+            match = _newest_globbed_log(path)
+            if match:
+                return match, source
+        elif os.path.isfile(path):
+            return path, source
+    return None
+
+
+def _served_log_port(path: str) -> int | None:
+    """The port encoded in a ``comfyui_<port>.log`` filename, else None."""
+    match = _PORTED_LOG_RE.match(os.path.basename(path))
+    return int(match.group(1)) if match else None
+
+
+def logs(tail: int = 200, where: str | None = None, port: int | None = None):
+    """Print the tail of a captured ComfyUI log.
+
+    Resolution walks :func:`candidate_log_paths` — the path recorded by
+    `comfy launch --background`, the port-derived logfile, ComfyUI-Manager's
+    unsuffixed ``user/comfyui.log``, then the newest ``user/comfyui_*.log`` —
+    so a server started outside `comfy launch --background` is still readable.
+    ``port`` restricts that walk to a single port's log (plus the unsuffixed
+    file, which is where a server on that port lands when it was started without
+    an explicit ``--port`` argv flag).
+    """
     from comfy_cli import where as where_mod
     from comfy_cli.output import get_renderer
 
@@ -496,15 +605,19 @@ def logs(tail: int = 200, where: str | None = None):
         )
         raise typer.Exit(code=1)
 
-    log_path = resolve_background_log_path()
-    if not log_path or not os.path.isfile(log_path):
+    resolved = resolve_background_log_path(port)
+    if resolved is None:
+        # Report EVERY candidate that was checked, not just the last one — with
+        # four candidates "no log file" is otherwise unactionable.
+        checked = [path for path, _ in candidate_log_paths(port)]
         renderer.error(
             code="no_log_file",
-            message="No captured ComfyUI log was found." + (f" Looked for: {log_path}" if log_path else ""),
+            message="No captured ComfyUI log was found." + (f" Looked for: {', '.join(checked)}" if checked else ""),
             hint="start ComfyUI with `comfy launch` so its output is captured",
             command="logs",
         )
         raise typer.Exit(code=1)
+    log_path, source = resolved
 
     # Pretty output goes to a human terminal: honor the requested --tail. The
     # line/byte caps exist to keep JSON payloads bounded, so apply them only in
@@ -527,13 +640,43 @@ def logs(tail: int = 200, where: str | None = None):
         )
         raise typer.Exit(code=1)
 
+    # Staleness metadata: which candidate won, how old/big the served file is,
+    # and whether it belongs to a different port than the live background server
+    # (the wrong-port-empty-log case a failed launch attempt leaves behind).
+    try:
+        stat = os.stat(log_path)
+        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+        size = stat.st_size
+    except OSError:
+        # Same TOCTOU window as the read above; metadata is best-effort.
+        mtime, size = None, None
+
+    background = ConfigManager().background
+    served_port = _served_log_port(log_path)
+    port_mismatch = bool(background and served_port is not None and served_port != background[1])
+
     if renderer.is_pretty():
+        if port_mismatch:
+            # Without this a human just sees an empty/stale file and no reason why.
+            print(
+                f"[bold yellow]Warning: showing {log_path} (port {served_port}), but the running "
+                f"background server is on port {background[1]}. "
+                f"Try `comfy logs --port {background[1]}`.[/bold yellow]"
+            )
         # Write raw so ComfyUI log text (which can contain '[...]') isn't
         # reinterpreted as Rich markup, and byte-for-byte matches the file.
         renderer.pretty_stream.write("".join(lines))
 
     renderer.emit(
-        {"lines": lines, "path": log_path, "truncated": truncated},
+        {
+            "lines": lines,
+            "path": log_path,
+            "truncated": truncated,
+            "source": source,
+            "mtime": mtime,
+            "size": size,
+            "port_mismatch": port_mismatch,
+        },
         command="logs",
         where="local",
     )

--- a/comfy_cli/config_manager.py
+++ b/comfy_cli/config_manager.py
@@ -91,7 +91,10 @@ class ConfigManager:
             self.background = bg_info[0], int(bg_info[1]), int(bg_info[2])
 
             if not is_running(self.background[2]):
-                self.remove_background()
+                # The recorded pid is gone — but the logfile it points at is the
+                # ONLY pointer to a crash log, so clear the process record and
+                # keep CONFIG_KEY_BACKGROUND_LOG.
+                self.clear_background_process()
 
     def get_env_data(self):
         """
@@ -176,14 +179,27 @@ class ConfigManager:
             ),
         }
 
-    def remove_background(self):
-        del self.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
-        # Also drop the recorded logfile path so `comfy logs` doesn't keep
-        # surfacing the previous run's stale log after the server is stopped or
-        # its pid is cleaned up.
-        self.config["DEFAULT"].pop(constants.CONFIG_KEY_BACKGROUND_LOG, None)
+    def clear_background_process(self):
+        """Forget the recorded background server, PRESERVING its logfile path.
+
+        ``CONFIG_KEY_BACKGROUND_LOG`` is deliberately kept: once the pid is dead
+        that key is the only pointer to the log the dead server wrote, which is
+        exactly what a post-mortem `comfy logs` needs. Dropping it used to send
+        resolution back to the hard-coded default port, serving the wrong file
+        (or none) while the crash output sat elsewhere. Staleness is now reported
+        as `comfy logs` metadata (``source`` / ``mtime`` / ``port_mismatch``)
+        instead of enforced by deleting the pointer.
+        """
+        self.config["DEFAULT"].pop(constants.CONFIG_KEY_BACKGROUND, None)
         self.write_config()
         self.background = None
+
+    def remove_background(self):
+        """Clear the background server record (`comfy stop`, dead-pid cleanup).
+
+        Preserves the logfile pointer — see :meth:`clear_background_process`.
+        """
+        self.clear_background_process()
 
     def get_cli_version(self):
         # Note: this approach should work for users installing the CLI via

--- a/comfy_cli/schemas/logs.json
+++ b/comfy_cli/schemas/logs.json
@@ -2,9 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/logs.json",
   "title": "comfy logs --json data payload",
-  "description": "Tail of the background ComfyUI log captured by `comfy launch --background`.",
+  "description": "Tail of a captured ComfyUI log — the one recorded by `comfy launch --background`, or ComfyUI-Manager's own `user/comfyui*.log` for a server started outside it.",
   "type": "object",
-  "required": ["lines", "path", "truncated"],
+  "required": ["lines", "path", "truncated", "source", "port_mismatch"],
   "additionalProperties": true,
   "properties": {
     "lines": {
@@ -19,6 +19,24 @@
     "truncated": {
       "type": "boolean",
       "description": "True when the line/byte cap dropped lines the caller would otherwise have received."
+    },
+    "source": {
+      "type": "string",
+      "enum": ["recorded", "derived_port", "default_port", "explicit_port", "fallback_unsuffixed", "fallback_glob"],
+      "description": "Which candidate resolved: the path recorded at launch (`recorded`), the logfile derived from the live background port (`derived_port`) or from the 8188 default (`default_port`), the port passed to `--port` (`explicit_port`), ComfyUI-Manager's unsuffixed `user/comfyui.log` (`fallback_unsuffixed`), or the newest-mtime `user/comfyui_*.log` (`fallback_glob`). Anything other than `recorded`/`derived_port`/`explicit_port` means the file was inferred — check `mtime` before trusting it as the current run.",
+      "examples": ["recorded", "fallback_unsuffixed"]
+    },
+    "mtime": {
+      "type": ["string", "null"],
+      "description": "ISO 8601 (UTC) last-modified time of the served file, or null when it could not be stat'd. A stale mtime means the log predates the run being debugged."
+    },
+    "size": {
+      "type": ["integer", "null"],
+      "description": "Size of the served file in bytes, or null when it could not be stat'd. Zero bytes alongside a live server usually means the wrong file was served — see `port_mismatch`."
+    },
+    "port_mismatch": {
+      "type": "boolean",
+      "description": "True when a background server is recorded as running and the served file's `comfyui_<port>.log` suffix names a DIFFERENT port (e.g. a failed launch attempt left a wrong-port log recorded). Retry with `comfy logs --port <the running port>`."
     }
   }
 }

--- a/comfy_cli/schemas/logs.json
+++ b/comfy_cli/schemas/logs.json
@@ -23,7 +23,7 @@
     "source": {
       "type": "string",
       "enum": ["recorded", "derived_port", "default_port", "explicit_port", "fallback_unsuffixed", "fallback_glob"],
-      "description": "Which candidate resolved: the path recorded at launch (`recorded`), the logfile derived from the live background port (`derived_port`) or from the 8188 default (`default_port`), the port passed to `--port` (`explicit_port`), ComfyUI-Manager's unsuffixed `user/comfyui.log` (`fallback_unsuffixed`), or the newest-mtime `user/comfyui_*.log` (`fallback_glob`). Anything other than `recorded`/`derived_port`/`explicit_port` means the file was inferred — check `mtime` before trusting it as the current run.",
+      "description": "Which candidate resolved: the path recorded at launch (`recorded`), the logfile derived from the live background port (`derived_port`) or from the 8188 default (`default_port`), the port passed to `--port` (`explicit_port`), ComfyUI-Manager's unsuffixed `user/comfyui.log` (`fallback_unsuffixed`), or the newest-mtime `user/comfyui_*.log` (`fallback_glob`). Anything other than `recorded`/`derived_port`/`explicit_port` means the file was inferred — check `mtime` before trusting it as the current run. `recorded` outranks the workspace-local candidates only while its background server is live or it points inside the current workspace; a leftover pointer into another workspace is tried last.",
       "examples": ["recorded", "fallback_unsuffixed"]
     },
     "mtime": {
@@ -36,7 +36,7 @@
     },
     "port_mismatch": {
       "type": "boolean",
-      "description": "True when a background server is recorded as running and the served file's `comfyui_<port>.log` suffix names a DIFFERENT port (e.g. a failed launch attempt left a wrong-port log recorded). Retry with `comfy logs --port <the running port>`."
+      "description": "True when a background server is recorded as running and the served file's `comfyui_<port>.log` suffix names a DIFFERENT port (e.g. a failed launch attempt left a wrong-port log recorded). Retry with `comfy logs --port <the running port>`. Always false when `--port` was passed, since the served file is then the port that was explicitly asked for."
     }
   }
 }

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -511,8 +511,10 @@ def test_logs_port_serves_that_ports_log(monkeypatch, tmp_path, capsys):
     assert env["data"]["path"] == str(wanted)
     assert env["data"]["source"] == "explicit_port"
     assert env["data"]["lines"] == ["port 8189\n"]
-    # The served file's port differs from the live background server's.
-    assert env["data"]["port_mismatch"] is True
+    # The served file's port differs from the live background server's, but the
+    # user asked for it explicitly — flagging that as a mismatch (and advising a
+    # retry on 8188) would contradict the request.
+    assert env["data"]["port_mismatch"] is False
 
 
 def test_logs_port_falls_back_to_unsuffixed(monkeypatch, tmp_path, capsys):
@@ -584,3 +586,189 @@ def test_resolve_glob_handles_workspace_with_glob_metacharacters(monkeypatch, tm
     _fake_env(monkeypatch, workspace=workspace)
 
     assert launch.resolve_background_log_path() == (str(log), "fallback_glob")
+
+
+# --------------------------------------------------------------------------- #
+# staleness / cross-workspace guards on the `recorded` pointer
+# --------------------------------------------------------------------------- #
+
+
+def test_stale_cross_workspace_recorded_log_does_not_shadow_local(monkeypatch, tmp_path, capsys):
+    """A dead pointer into ANOTHER workspace must lose to this workspace's log.
+
+    `clear_background_process` keeps CONFIG_KEY_BACKGROUND_LOG so a crash log
+    stays reachable; without a workspace check that leftover pointer would be
+    served from any other workspace, with no live server for `port_mismatch` to
+    flag it.
+    """
+    _force_json_renderer()
+    other_ws = tmp_path / "other"
+    other_ws.mkdir()
+    stale = _write_log(other_ws, "comfyui_9000.log", "someone else's log\n")
+
+    this_ws = tmp_path / "here"
+    this_ws.mkdir()
+    mine = _write_log(this_ws, "comfyui_8188.log", "my own log\n")
+
+    _fake_env(monkeypatch, workspace=this_ws, recorded=str(stale), background=None)
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["data"]["path"] == str(mine)
+    assert env["data"]["source"] == "default_port"
+    assert env["data"]["lines"] == ["my own log\n"]
+
+
+def test_cross_workspace_recorded_log_still_last_resort(monkeypatch, tmp_path):
+    """Demoted, not dropped: with no local log at all it is still served."""
+    other_ws = tmp_path / "other"
+    other_ws.mkdir()
+    stale = _write_log(other_ws, "comfyui_9000.log", "last resort\n")
+    this_ws = tmp_path / "here"
+    this_ws.mkdir()
+
+    _fake_env(monkeypatch, workspace=this_ws, recorded=str(stale), background=None)
+
+    candidates = launch.candidate_log_paths()
+    assert candidates[-1] == (str(stale), "recorded")
+    assert launch.resolve_background_log_path() == (str(stale), "recorded")
+
+
+def test_live_background_keeps_recorded_first_even_cross_workspace(monkeypatch, tmp_path):
+    """A LIVE server's pointer is authoritative wherever it points."""
+    other_ws = tmp_path / "other"
+    other_ws.mkdir()
+    live_log = _write_log(other_ws, "comfyui_9000.log", "live\n")
+    this_ws = tmp_path / "here"
+    this_ws.mkdir()
+    _write_log(this_ws, "comfyui_8188.log", "local\n")
+
+    _fake_env(
+        monkeypatch,
+        workspace=this_ws,
+        recorded=str(live_log),
+        background=("127.0.0.1", 9000, 1234),
+    )
+
+    assert launch.candidate_log_paths()[0] == (str(live_log), "recorded")
+    assert launch.resolve_background_log_path() == (str(live_log), "recorded")
+
+
+def test_same_workspace_recorded_crash_log_stays_first(monkeypatch, tmp_path):
+    """The crash-surviving pointer keeps priority inside its own workspace."""
+    crash = _write_log(tmp_path, "comfyui_8189.log", "Traceback\n")
+    _write_log(tmp_path, "comfyui_8188.log", "older default-port log\n")
+    _fake_env(monkeypatch, workspace=tmp_path, recorded=str(crash), background=None)
+
+    assert launch.resolve_background_log_path() == (str(crash), "recorded")
+
+
+def test_glob_fallback_skips_symlinks(monkeypatch, tmp_path):
+    """A planted symlink must not be followed, even as the newest match.
+
+    Read-side counterpart of `_open_log_for_write`'s O_NOFOLLOW: on a shared host
+    `<workspace>/user` may be writable by an attacker who links a `comfyui_*.log`
+    name at a file outside the workspace.
+    """
+    secret = tmp_path / "id_rsa"
+    secret.write_text("PRIVATE KEY\n")
+    real = _write_log(tmp_path, "comfyui_9001.log", "the real log\n")
+    link = tmp_path / "user" / "comfyui_9999.log"
+    link.symlink_to(secret)
+    os.utime(real, (1_600_000_000, 1_600_000_000))
+    # The link is the newest match — it must still lose.
+    os.utime(link, (1_900_000_000, 1_900_000_000), follow_symlinks=False)
+
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    assert launch.resolve_background_log_path() == (str(real), "fallback_glob")
+
+
+def test_explicit_port_still_serves_a_deliberate_symlink(monkeypatch, tmp_path):
+    """The symlink guard is scoped to the untrusted auto-scan, not to `--port`.
+
+    Skipping symlinks in the newest-mtime glob must not take away a user's own
+    deliberately symlinked logfile: naming it explicitly still resolves, because
+    only the attacker-controllable "pick whatever is newest in this directory"
+    step needs the guard.
+    """
+    real = tmp_path / "elsewhere.log"
+    real.write_text("a deliberately symlinked log\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    (user_dir / "comfyui_9001.log").symlink_to(real)
+
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    # Guarded: the auto-scan will not follow it...
+    assert launch.resolve_background_log_path() is None
+    # ...but asking for that port by name still does.
+    assert launch.resolve_background_log_path(9001) == (
+        str(user_dir / "comfyui_9001.log"),
+        "explicit_port",
+    )
+
+
+def test_logs_metadata_survives_out_of_range_mtime(monkeypatch, tmp_path, capsys):
+    """A corrupt st_mtime degrades to null metadata, it does not crash."""
+    _force_json_renderer()
+    log = _write_log(tmp_path, "comfyui_8188.log", "abc\n")
+    _fake_env(monkeypatch, workspace=tmp_path, background=("127.0.0.1", 8188, 1234))
+
+    real_stat = os.stat
+
+    class _BadStat:
+        # st_mode is real so the isfile() candidate check still works; only the
+        # timestamp is corrupt.
+        st_mode = real_stat(log).st_mode
+        st_mtime = 1e30  # out of range for datetime.fromtimestamp
+        st_size = 4
+
+    monkeypatch.setattr(os, "stat", lambda p, *a, **k: _BadStat() if str(p) == str(log) else real_stat(p, *a, **k))
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["data"]["mtime"] is None
+    assert env["data"]["size"] is None
+    assert env["data"]["lines"] == ["abc\n"]
+
+
+def test_logs_pretty_no_mismatch_warning_for_explicit_port(monkeypatch, tmp_path, capsys):
+    """`--port 8189` while 8188 runs must not advise retrying on 8188."""
+    _write_log(tmp_path, "comfyui_8189.log", "asked for this\n")
+    _fake_env(monkeypatch, workspace=tmp_path, background=("127.0.0.1", 8188, 1234))
+
+    launch.logs(tail=10, port=8189)
+
+    out = capsys.readouterr().out
+    assert "asked for this\n" in out
+    assert "8188" not in out
+    assert "Warning" not in out
+
+
+def test_logs_pretty_warns_when_explicit_port_falls_back_to_unsuffixed(monkeypatch, tmp_path, capsys):
+    """The unsuffixed fallback encodes no port, so say so instead of staying silent."""
+    _write_log(tmp_path, "comfyui.log", "no --port in argv\n")
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    launch.logs(tail=10, port=8189)
+
+    out = capsys.readouterr().out
+    assert "comfyui_8189.log was found" in out
+    assert "does not" in out and "record which port" in out
+    assert "no --port in argv\n" in out
+
+
+def test_logs_pretty_warning_does_not_swallow_markup_in_path(monkeypatch, tmp_path, capsys):
+    """A workspace path holding Rich-style tags must survive verbatim."""
+    workspace = tmp_path / "ws[bold red]"
+    workspace.mkdir()
+    _write_log(workspace, "comfyui.log", "line\n")
+    _fake_env(monkeypatch, workspace=workspace)
+
+    launch.logs(tail=10, port=8189)
+
+    out = capsys.readouterr().out
+    assert "ws[bold red]" in out

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -82,6 +82,20 @@ def _fake_env(
     monkeypatch.setattr(launch, "ConfigManager", lambda: _FakeConfigManager(recorded, background))
 
 
+def _symlink_or_skip(link, target) -> None:
+    """``link -> target``, skipping the test where the OS forbids symlinks.
+
+    Windows only grants SeCreateSymbolicLinkPrivilege under Developer Mode or
+    elevation, so an unprivileged runner raises OSError here. The behaviour under
+    test (never follow a symlink out of the glob scan) is a shared-host POSIX
+    concern, so skipping is the right degradation rather than failing the suite.
+    """
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as e:  # pragma: no cover - platform dependent
+        pytest.skip(f"cannot create symlinks on this platform: {e}")
+
+
 def _write_log(workspace, name: str, text: str = "hello\n"):
     user_dir = workspace / "user"
     user_dir.mkdir(exist_ok=True)
@@ -674,11 +688,12 @@ def test_glob_fallback_skips_symlinks(monkeypatch, tmp_path):
     secret = tmp_path / "id_rsa"
     secret.write_text("PRIVATE KEY\n")
     real = _write_log(tmp_path, "comfyui_9001.log", "the real log\n")
-    link = tmp_path / "user" / "comfyui_9999.log"
-    link.symlink_to(secret)
+    _symlink_or_skip(tmp_path / "user" / "comfyui_9999.log", secret)
     os.utime(real, (1_600_000_000, 1_600_000_000))
-    # The link is the newest match — it must still lose.
-    os.utime(link, (1_900_000_000, 1_900_000_000), follow_symlinks=False)
+    # Backdate the real log and forward-date the link's TARGET: that is what the
+    # pre-guard code compared (it stat'd through the link), so the link was the
+    # newest match and won. It must now lose regardless.
+    os.utime(secret, (1_900_000_000, 1_900_000_000))
 
     _fake_env(monkeypatch, workspace=tmp_path)
 
@@ -697,7 +712,7 @@ def test_explicit_port_still_serves_a_deliberate_symlink(monkeypatch, tmp_path):
     real.write_text("a deliberately symlinked log\n")
     user_dir = tmp_path / "user"
     user_dir.mkdir()
-    (user_dir / "comfyui_9001.log").symlink_to(real)
+    _symlink_or_skip(user_dir / "comfyui_9001.log", real)
 
     _fake_env(monkeypatch, workspace=tmp_path)
 

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
 
+from comfy_cli import constants
 from comfy_cli.caller import Caller
 from comfy_cli.command import launch
 from comfy_cli.output.renderer import (
@@ -50,6 +53,41 @@ def _envelope(capsys: pytest.CaptureFixture[str]) -> dict[str, Any]:
     out = capsys.readouterr().out
     assert out.strip(), "no envelope on stdout"
     return json.loads(out.strip().splitlines()[-1])
+
+
+class _FakeConfigManager:
+    """Just the surface `comfy logs` resolution reads off ConfigManager."""
+
+    def __init__(self, recorded: str | None, background: tuple[str, int, int] | None):
+        self._recorded = recorded
+        self.background = background
+
+    def get(self, key: str):
+        return self._recorded if key == constants.CONFIG_KEY_BACKGROUND_LOG else None
+
+
+def _fake_env(
+    monkeypatch,
+    *,
+    workspace=None,
+    recorded: str | None = None,
+    background: tuple[str, int, int] | None = None,
+):
+    """Point log resolution at a tmp workspace + a synthetic config state."""
+    monkeypatch.setattr(
+        launch.workspace_manager,
+        "workspace_path",
+        str(workspace) if workspace is not None else None,
+    )
+    monkeypatch.setattr(launch, "ConfigManager", lambda: _FakeConfigManager(recorded, background))
+
+
+def _write_log(workspace, name: str, text: str = "hello\n"):
+    user_dir = workspace / "user"
+    user_dir.mkdir(exist_ok=True)
+    path = user_dir / name
+    path.write_text(text)
+    return path
 
 
 # --------------------------------------------------------------------------- #
@@ -129,8 +167,7 @@ def test_read_log_tail_single_huge_line_kept_byte_truncated(tmp_path):
 
 def test_logs_no_file_emits_clean_error(monkeypatch, tmp_path, capsys):
     _force_json_renderer()
-    missing = tmp_path / "user" / "comfyui_8188.log"
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(missing))
+    _fake_env(monkeypatch, workspace=tmp_path)  # empty workspace — no candidate exists
 
     with pytest.raises(typer.Exit) as exc:
         launch.logs(tail=50)
@@ -145,7 +182,7 @@ def test_logs_no_file_emits_clean_error(monkeypatch, tmp_path, capsys):
 
 def test_logs_no_workspace_emits_error(monkeypatch, capsys):
     _force_json_renderer()
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: None)
+    _fake_env(monkeypatch, workspace=None)
 
     with pytest.raises(typer.Exit):
         launch.logs(tail=50)
@@ -153,13 +190,15 @@ def test_logs_no_workspace_emits_error(monkeypatch, capsys):
     env = _envelope(capsys)
     assert env["ok"] is False
     assert env["error"]["code"] == "no_log_file"
+    # Nothing recorded and no workspace → nothing was checked, so no path list.
+    assert "Looked for" not in env["error"]["message"]
 
 
 def test_logs_success_envelope(monkeypatch, tmp_path, capsys):
     _force_json_renderer()
     log = tmp_path / "comfyui_8188.log"
     log.write_text("".join(f"line {i}\n" for i in range(5)))
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     launch.logs(tail=3)
 
@@ -175,7 +214,7 @@ def test_logs_success_envelope(monkeypatch, tmp_path, capsys):
 def test_logs_rejects_non_local_where(monkeypatch, tmp_path, capsys):
     _force_json_renderer()
     # resolve should never be reached, but guard anyway.
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(tmp_path / "x.log"))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(tmp_path / "x.log"), "recorded"))
 
     with pytest.raises(typer.Exit):
         launch.logs(tail=50, where="cloud")
@@ -189,7 +228,7 @@ def test_logs_where_local_is_accepted(monkeypatch, tmp_path, capsys):
     _force_json_renderer()
     log = tmp_path / "comfyui_8188.log"
     log.write_text("hello\n")
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     launch.logs(tail=10, where="local")
 
@@ -202,7 +241,7 @@ def test_logs_read_error_emits_clean_error(monkeypatch, tmp_path, capsys):
     _force_json_renderer()
     log = tmp_path / "comfyui_8188.log"
     log.write_text("hello\n")
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     def boom(*args, **kwargs):
         raise OSError("permission denied")
@@ -223,7 +262,7 @@ def test_logs_pretty_honors_large_tail_past_line_cap(monkeypatch, tmp_path, caps
     log = tmp_path / "comfyui_8188.log"
     n = launch.LOGS_MAX_LINES + 50
     log.write_text("".join(f"line {i}\n" for i in range(n)))
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     launch.logs(tail=n)
 
@@ -236,7 +275,7 @@ def test_logs_pretty_writes_raw_lines(monkeypatch, tmp_path, capsys):
     # Default renderer is pretty; log text with '[...]' must not be reinterpreted.
     log = tmp_path / "comfyui_8188.log"
     log.write_text("[INFO] hello [world]\nplain\n")
-    monkeypatch.setattr(launch, "resolve_background_log_path", lambda: str(log))
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     launch.logs(tail=10)
 
@@ -286,8 +325,6 @@ def test_launch_and_monitor_redirects_to_logfile_and_records_path(
     # stdout points at the workspace logfile; stderr is folded into it.
     assert captured["kwargs"]["stderr"] is subprocess.STDOUT
     log_path = str(tmp_path / "user" / "comfyui_8188.log")
-    from comfy_cli import constants
-
     assert cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] == log_path
     assert "8188" in cfg.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND]
     # Written twice: the log path is recorded up front (so a crash log is
@@ -295,3 +332,255 @@ def test_launch_and_monitor_redirects_to_logfile_and_records_path(
     assert cfg.write_config.call_count == 2
     # The logfile the child wrote is on disk with both lines.
     assert "To see the GUI go to:" in (tmp_path / "user" / "comfyui_8188.log").read_text()
+
+
+# --------------------------------------------------------------------------- #
+# candidate-based resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_candidate_paths_ordering_with_live_background(monkeypatch, tmp_path):
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded="/recorded/comfyui_9000.log",
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    assert launch.candidate_log_paths() == [
+        ("/recorded/comfyui_9000.log", "recorded"),
+        (str(tmp_path / "user" / "comfyui_8188.log"), "derived_port"),
+        (str(tmp_path / "user" / "comfyui.log"), "fallback_unsuffixed"),
+        (str(tmp_path / "user" / "comfyui_*.log"), "fallback_glob"),
+    ]
+
+
+def test_candidate_paths_without_background_uses_default_port(monkeypatch, tmp_path):
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    sources = dict((source, path) for path, source in launch.candidate_log_paths())
+
+    assert "recorded" not in sources
+    assert sources["default_port"] == str(tmp_path / "user" / f"comfyui_{launch.DEFAULT_LOG_PORT}.log")
+
+
+def test_candidate_paths_with_port_is_restricted(monkeypatch, tmp_path):
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded="/recorded/comfyui_9000.log",
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    # --port ignores the recorded/derived/glob candidates entirely.
+    assert launch.candidate_log_paths(8189) == [
+        (str(tmp_path / "user" / "comfyui_8189.log"), "explicit_port"),
+        (str(tmp_path / "user" / "comfyui.log"), "fallback_unsuffixed"),
+    ]
+
+
+def test_resolve_skips_missing_recorded_and_derived(monkeypatch, tmp_path):
+    unsuffixed = _write_log(tmp_path, "comfyui.log")
+    _fake_env(monkeypatch, workspace=tmp_path, recorded=str(tmp_path / "user" / "gone.log"))
+
+    assert launch.resolve_background_log_path() == (str(unsuffixed), "fallback_unsuffixed")
+
+
+def test_resolve_glob_picks_newest_and_skips_prev_rotations(monkeypatch, tmp_path):
+    old = _write_log(tmp_path, "comfyui_9001.log", "old\n")
+    newest = _write_log(tmp_path, "comfyui_9002.log", "new\n")
+    rotated = _write_log(tmp_path, "comfyui_9003.prev.log", "rotated\n")
+    rotated2 = _write_log(tmp_path, "comfyui_9004.prev2.log", "rotated2\n")
+    os.utime(old, (1_600_000_000, 1_600_000_000))
+    os.utime(newest, (1_700_000_000, 1_700_000_000))
+    # The rotations are the NEWEST files on disk — they must still be skipped.
+    os.utime(rotated, (1_800_000_000, 1_800_000_000))
+    os.utime(rotated2, (1_900_000_000, 1_900_000_000))
+
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    assert launch.resolve_background_log_path() == (str(newest), "fallback_glob")
+
+
+def test_logs_serves_unsuffixed_manager_log(monkeypatch, tmp_path, capsys):
+    """A server started outside `comfy launch --background` logs only here."""
+    _force_json_renderer()
+    unsuffixed = _write_log(tmp_path, "comfyui.log", "manager line\n")
+    _fake_env(monkeypatch, workspace=tmp_path)  # nothing recorded, no background
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["ok"] is True
+    assert env["data"]["path"] == str(unsuffixed)
+    assert env["data"]["source"] == "fallback_unsuffixed"
+    assert env["data"]["lines"] == ["manager line\n"]
+    assert env["data"]["port_mismatch"] is False
+
+
+def test_logs_serves_recorded_crash_log_after_dead_pid(monkeypatch, tmp_path, capsys):
+    """The recorded pointer survives a crash, so the crash log is still served."""
+    _force_json_renderer()
+    crash = _write_log(tmp_path, "comfyui_8189.log", "Traceback (most recent call last):\n")
+    # Dead pid → ConfigManager cleared `background` but KEPT the log pointer.
+    _fake_env(monkeypatch, workspace=tmp_path, recorded=str(crash), background=None)
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["data"]["path"] == str(crash)
+    assert env["data"]["source"] == "recorded"
+    assert env["data"]["port_mismatch"] is False  # no live server to mismatch against
+
+
+def test_logs_reports_port_mismatch_for_stale_record(monkeypatch, tmp_path, capsys):
+    """A failed launch attempt leaves an empty wrong-port log recorded."""
+    _force_json_renderer()
+    stale = _write_log(tmp_path, "comfyui_8189.log", "")
+    _write_log(tmp_path, "comfyui_8188.log", "the real live log\n")
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded=str(stale),
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["data"]["path"] == str(stale)
+    assert env["data"]["source"] == "recorded"
+    assert env["data"]["port_mismatch"] is True
+    assert env["data"]["size"] == 0
+    assert env["data"]["mtime"]
+
+
+def test_logs_metadata_reports_mtime_and_size(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    log = _write_log(tmp_path, "comfyui_8188.log", "abc\n")
+    os.utime(log, (1_700_000_000, 1_700_000_000))
+    _fake_env(monkeypatch, workspace=tmp_path, background=("127.0.0.1", 8188, 1234))
+
+    launch.logs(tail=10)
+
+    env = _envelope(capsys)
+    assert env["data"]["source"] == "derived_port"
+    assert env["data"]["size"] == 4
+    assert env["data"]["mtime"] == datetime.fromtimestamp(1_700_000_000, tz=timezone.utc).isoformat()
+    assert env["data"]["port_mismatch"] is False
+
+
+def test_logs_no_log_file_lists_every_candidate(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded="/recorded/comfyui_9000.log",
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    with pytest.raises(typer.Exit):
+        launch.logs(tail=10)
+
+    message = _envelope(capsys)["error"]["message"]
+    assert "/recorded/comfyui_9000.log" in message
+    assert str(tmp_path / "user" / "comfyui_8188.log") in message
+    assert str(tmp_path / "user" / "comfyui.log") in message
+    assert str(tmp_path / "user" / "comfyui_*.log") in message
+
+
+# --------------------------------------------------------------------------- #
+# `comfy logs --port N`
+# --------------------------------------------------------------------------- #
+
+
+def test_logs_port_serves_that_ports_log(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    wanted = _write_log(tmp_path, "comfyui_8189.log", "port 8189\n")
+    _write_log(tmp_path, "comfyui_8188.log", "port 8188\n")
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded=str(tmp_path / "user" / "comfyui_8188.log"),
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    launch.logs(tail=10, port=8189)
+
+    env = _envelope(capsys)
+    assert env["data"]["path"] == str(wanted)
+    assert env["data"]["source"] == "explicit_port"
+    assert env["data"]["lines"] == ["port 8189\n"]
+    # The served file's port differs from the live background server's.
+    assert env["data"]["port_mismatch"] is True
+
+
+def test_logs_port_falls_back_to_unsuffixed(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    unsuffixed = _write_log(tmp_path, "comfyui.log", "no --port in argv\n")
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    launch.logs(tail=10, port=8189)
+
+    env = _envelope(capsys)
+    assert env["data"]["path"] == str(unsuffixed)
+    assert env["data"]["source"] == "fallback_unsuffixed"
+
+
+def test_logs_port_with_no_match_errors_listing_both_candidates(monkeypatch, tmp_path, capsys):
+    _force_json_renderer()
+    _write_log(tmp_path, "comfyui_8188.log", "not the requested port\n")
+    _fake_env(monkeypatch, workspace=tmp_path)
+
+    with pytest.raises(typer.Exit):
+        launch.logs(tail=10, port=8189)
+
+    env = _envelope(capsys)
+    assert env["error"]["code"] == "no_log_file"
+    message = env["error"]["message"]
+    assert str(tmp_path / "user" / "comfyui_8189.log") in message
+    assert str(tmp_path / "user" / "comfyui.log") in message
+    # The restricted walk must not silently widen back to the other port's log.
+    assert "comfyui_8188.log" not in message
+
+
+def test_logs_pretty_warns_on_port_mismatch(monkeypatch, tmp_path, capsys):
+    stale = _write_log(tmp_path, "comfyui_8189.log", "stale\n")
+    _fake_env(
+        monkeypatch,
+        workspace=tmp_path,
+        recorded=str(stale),
+        background=("127.0.0.1", 8188, 1234),
+    )
+
+    launch.logs(tail=10)
+
+    out = capsys.readouterr().out
+    assert "8189" in out and "8188" in out
+    assert "stale\n" in out
+
+
+def test_logs_payload_matches_published_schema(monkeypatch, tmp_path, capsys):
+    """The `--json` payload is a published contract (`comfy --json discover`)."""
+    import jsonschema
+
+    from comfy_cli import discovery
+
+    _force_json_renderer()
+    _write_log(tmp_path, "comfyui_8188.log", "line\n")
+    _fake_env(monkeypatch, workspace=tmp_path, background=("127.0.0.1", 8188, 1234))
+
+    launch.logs(tail=10)
+
+    schema = discovery.load_all_schemas()["logs"]
+    jsonschema.Draft202012Validator(schema).validate(_envelope(capsys)["data"])
+
+
+def test_resolve_glob_handles_workspace_with_glob_metacharacters(monkeypatch, tmp_path):
+    # A workspace path like `/Users/a[1]/comfy` must not be treated as a pattern.
+    workspace = tmp_path / "ws[1]"
+    workspace.mkdir()
+    log = _write_log(workspace, "comfyui_9001.log", "found me\n")
+    _fake_env(monkeypatch, workspace=workspace)
+
+    assert launch.resolve_background_log_path() == (str(log), "fallback_glob")

--- a/tests/comfy_cli/test_config_manager.py
+++ b/tests/comfy_cli/test_config_manager.py
@@ -63,6 +63,20 @@ class TestLoad:
         assert mgr.background is None
         assert constants.CONFIG_KEY_BACKGROUND not in mgr.config["DEFAULT"]
 
+    def test_keeps_background_log_path_when_stale_pid(self, tmp_path):
+        # A dead pid usually means a CRASH — the recorded logfile is the pointer
+        # to the crash log, so init must not throw it away with the pid record.
+        config_dir = tmp_path / "comfy-cli"
+        config_dir.mkdir()
+        (config_dir / "config.ini").write_text(
+            f"[DEFAULT]\n"
+            f"{constants.CONFIG_KEY_BACKGROUND} = ('localhost', 8188, 99999)\n"
+            f"{constants.CONFIG_KEY_BACKGROUND_LOG} = /ws/user/comfyui_8188.log\n"
+        )
+        mgr = _make_config_manager(config_dir, is_running_val=False)
+        assert mgr.background is None
+        assert mgr.get(constants.CONFIG_KEY_BACKGROUND_LOG) == "/ws/user/comfyui_8188.log"
+
 
 class TestWriteConfig:
     def test_creates_directory_if_missing(self, tmp_path):
@@ -160,11 +174,18 @@ class TestRemoveBackground:
         assert config_mgr.background is None
         assert constants.CONFIG_KEY_BACKGROUND not in config_mgr.config["DEFAULT"]
 
-    def test_clears_background_log_path(self, config_mgr):
-        # The recorded logfile path must be dropped too, so `comfy logs` stops
-        # surfacing a stopped/dead server's stale log.
+    def test_preserves_background_log_path(self, config_mgr):
+        # The recorded logfile path must SURVIVE — after a stop or a crash it is
+        # the only pointer to the log that server wrote, and `comfy logs` reports
+        # staleness as metadata rather than by dropping the pointer.
         config_mgr.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND] = "('h', 1, 2)"
         config_mgr.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] = "/ws/user/comfyui_8188.log"
         config_mgr.background = ("h", 1, 2)
         config_mgr.remove_background()
-        assert constants.CONFIG_KEY_BACKGROUND_LOG not in config_mgr.config["DEFAULT"]
+        assert config_mgr.config["DEFAULT"][constants.CONFIG_KEY_BACKGROUND_LOG] == "/ws/user/comfyui_8188.log"
+
+    def test_is_idempotent_when_no_background_recorded(self, config_mgr):
+        # `comfy stop` races and the dead-pid cleanup can both reach this with
+        # the key already gone; it must not raise.
+        config_mgr.clear_background_process()
+        assert config_mgr.background is None


### PR DESCRIPTION
## ELI-5

`comfy logs` only knew how to look in one place. If ComfyUI was started any other way — foreground, the desktop app, or without an explicit `--port` — its log went somewhere else and `comfy logs` said "no log file" while a perfectly good live log sat on disk. And if ComfyUI *crashed*, the CLI helpfully deleted its own note of where the crash log was, then showed you an empty file from the wrong port. This PR makes `comfy logs` check every place a log could be, in order, and tell you which one it found and how stale it is.

## What changed

**Candidate-based resolution** (`comfy_cli/command/launch.py`). `resolve_background_log_path()` now returns `(path, source)` and walks an ordered candidate list, skipping files that don't exist:

1. `recorded` — the path recorded by `comfy launch --background`, if the file exists.
2. `derived_port` / `default_port` — `user/comfyui_<port>.log` from the live background port, else the 8188 default.
3. `fallback_unsuffixed` — ComfyUI-Manager's `user/comfyui.log`. Manager only appends `_<port>` when `--port` is in ComfyUI's argv, so this is where a foreground/desktop server logs. `comfy install` installs Manager, so it's present on a default install.
4. `fallback_glob` — the newest-mtime `user/comfyui_*.log`, skipping Manager's `.prev` / `.prev2` rotations.

A separate `candidate_log_paths()` returns the full ordered list (existing or not), so the `no_log_file` error now lists **every** path checked instead of just one.

**The crash-log pointer survives** (`comfy_cli/config_manager.py`). `remove_background()` is split: `clear_background_process()` clears `CONFIG_KEY_BACKGROUND` but keeps `CONFIG_KEY_BACKGROUND_LOG`. Both the dead-pid cleanup at load and `comfy stop` go through it — after a crash that key is the only pointer to the crash log, and post-mortems are exactly when you want it.

**Staleness metadata.** The `--json` payload gains `source`, `mtime` (ISO 8601 UTC), `size`, and `port_mismatch` — the last is true when a background server is recorded as running and the served file's `comfyui_<N>.log` suffix names a different port. Pretty output prints a matching one-line warning pointing at `comfy logs --port <running port>`. `comfy_cli/schemas/logs.json` documents all four (it's published via `comfy --json discover`), and a new test validates the real emitted payload against it.

**`comfy logs --port N`** restricts resolution to `[user/comfyui_<N>.log, user/comfyui.log]` — the unsuffixed fallback covers a server on port N started without an explicit `--port` argv flag.

`read_log_tail` and all line/byte-cap behavior are untouched.

## Chesterton's Fence — the guard this PR removes

`remove_background()` used to drop `CONFIG_KEY_BACKGROUND_LOG` with the comment "so `comfy logs` doesn't keep surfacing the previous run's stale log." `git log -L` traces that line to c6d5e64 (#491), the same PR that introduced `comfy logs` — its intent was staleness, not crash-log hygiene, and the two goals turned out to conflict. This PR deliberately reverses that tradeoff: staleness is now *reported* (`source` / `mtime` / `size` / `port_mismatch`) rather than *enforced by destroying the pointer*, because deletion made the crash log — the single most valuable log there is — unreachable. That's the ticket's explicit direction, backed by QA.

## Verification

- `uv run pytest` — 2792 passed, 37 skipped.
- `uv run ruff check` on every touched file — clean. (Repo-wide `ruff check .` reports 15 pre-existing `UP038` errors and one pre-existing unformatted file, `tests/comfy_cli/command/github/test_pr.py`; both are identical on `main` and untouched here.)
- New tests cover: the unsuffixed fallback, the crash-surviving pointer (both at the `ConfigManager` layer and end-to-end through `comfy logs`), the stale wrong-port record reporting `port_mismatch: true`, the glob fallback picking newest-mtime and skipping `.prev`/`.prev2`, `no_log_file` listing all candidates, `--port N`, `--port` falling back to the unsuffixed file, `--port` not silently widening back to another port's log, mtime/size metadata, and payload/schema conformance.

## Judgment calls

- **`explicit_port` as a sixth `source` value.** The ticket enumerates five source strings but doesn't name one for the `--port` path; a distinct value keeps "the user pinned this" distinguishable from "we guessed the port."
- **`port_mismatch` is always emitted as a boolean** rather than omitted when false. The ticket allowed either; a stable key is friendlier for the agent/MCP consumers this payload exists for.
- **Pretty-mode mismatch warning.** Not in the ticket, which specifies the JSON payload only. Added because the QA symptom was a human staring at an empty file with no explanation — the metadata fixes that for machines, and this fixes it for people. Easy to drop if unwanted.
- **`glob.escape` on the directory half of the glob pattern.** Not in the ticket. A workspace path containing glob metacharacters (`/Users/a[1]/comfy`) makes the unescaped pattern match nothing, silently disabling the glob fallback. Verified as a real failure, not a hypothetical, and covered by a test.
- **`comfy_cli/schemas/logs.json` updated.** Not in the ticket, but the payload is a published contract surfaced through `comfy --json discover`; extending the payload without the schema would ship a stale contract.

## Negative-claim falsification

Not applicable — this change adds no capability denial. It strictly *widens* what `comfy logs` can find (three new candidate sources plus a new `--port` flag) and adds no throw/deny dead-end path. The only denial string in the file, `no_log_file`, is pre-existing and this PR makes it strictly *less* likely to fire; no test was flipped to assert a dead-end.
