### PR TITLE
fix(env): detect legacy ComfyUI-Manager clones and reconcile stale manager_gui_mode (BE-4768)

### DIFF
--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -25,19 +25,11 @@ _dependency_cmds = {
 }
 
 
-@lru_cache(maxsize=1)
-def find_cm_cli() -> bool:
-    """Check if cm_cli module is available in the workspace Python.
-
-    First checks the workspace venv Python (primary path — matches the Python
-    used by execute_cm_cli). Falls back to the current Python environment only
-    when the workspace Python is the same as sys.executable.
-
-    Results are cached for the session lifetime.
-    """
-    ws = workspace_manager.workspace_path
-    if ws:
-        python = resolve_workspace_python(ws)
+@lru_cache(maxsize=8)
+def _probe_cm_cli(workspace_path: str | None) -> bool:
+    """Probe for the ``cm_cli`` module for one workspace. Cached per workspace path."""
+    if workspace_path:
+        python = resolve_workspace_python(workspace_path)
         if python != sys.executable:
             # Workspace uses a different Python — check that one
             try:
@@ -54,25 +46,28 @@ def find_cm_cli() -> bool:
     return importlib.util.find_spec("cm_cli") is not None
 
 
-@lru_cache(maxsize=1)
-def find_legacy_manager_clone() -> bool:
-    """Check if ComfyUI-Manager exists as a plain git clone under ``custom_nodes/``.
+def find_cm_cli() -> bool:
+    """Check if cm_cli module is available in the workspace Python.
 
-    This is the pre-pip-package install shape: the Manager repo cloned straight
-    into ``custom_nodes/``. It is invisible to :func:`find_cm_cli`, which only
-    tests whether the ``cm_cli`` module imports in the workspace Python.
+    First checks the workspace venv Python (primary path — matches the Python
+    used by execute_cm_cli). Falls back to the current Python environment only
+    when the workspace Python is the same as sys.executable.
 
-    Detection is by marker file, not directory name — users clone the Manager
-    under arbitrary names. Directories ending in ``.disabled`` (the Manager's own
-    disable convention) are skipped.
-
-    Results are cached for the session lifetime.
+    Results are cached per workspace path, so resolving (or switching) the
+    workspace after a first call re-probes instead of returning a stale answer.
     """
     ws = workspace_manager.workspace_path
-    if not ws:
-        return False
+    return _probe_cm_cli(str(ws) if ws else None)
 
-    custom_nodes = os.path.join(ws, "custom_nodes")
+
+# Preserve the ``lru_cache`` API callers rely on to force a re-probe.
+find_cm_cli.cache_clear = _probe_cm_cli.cache_clear
+
+
+@lru_cache(maxsize=8)
+def _scan_for_legacy_manager_clone(workspace_path: str) -> bool:
+    """Scan one workspace's ``custom_nodes/`` for a Manager clone. Cached per path."""
+    custom_nodes = os.path.join(workspace_path, "custom_nodes")
     try:
         entries = os.listdir(custom_nodes)
     except OSError:
@@ -93,6 +88,30 @@ def find_legacy_manager_clone() -> bool:
             continue
 
     return False
+
+
+def find_legacy_manager_clone() -> bool:
+    """Check if ComfyUI-Manager exists as a plain git clone under ``custom_nodes/``.
+
+    This is the pre-pip-package install shape: the Manager repo cloned straight
+    into ``custom_nodes/``. It is invisible to :func:`find_cm_cli`, which only
+    tests whether the ``cm_cli`` module imports in the workspace Python.
+
+    Detection is by marker file, not directory name — users clone the Manager
+    under arbitrary names. Directories ending in ``.disabled`` (the Manager's own
+    disable convention) are skipped.
+
+    Results are cached per workspace path, so an unresolved workspace on the
+    first call does not poison the answer for the rest of the session.
+    """
+    ws = workspace_manager.workspace_path
+    if not ws:
+        return False
+    return _scan_for_legacy_manager_clone(str(ws))
+
+
+# Preserve the ``lru_cache`` API callers rely on to force a re-scan.
+find_legacy_manager_clone.cache_clear = _scan_for_legacy_manager_clone.cache_clear
 
 
 def detect_manager_installation() -> str:

--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -54,6 +54,61 @@ def find_cm_cli() -> bool:
     return importlib.util.find_spec("cm_cli") is not None
 
 
+@lru_cache(maxsize=1)
+def find_legacy_manager_clone() -> bool:
+    """Check if ComfyUI-Manager exists as a plain git clone under ``custom_nodes/``.
+
+    This is the pre-pip-package install shape: the Manager repo cloned straight
+    into ``custom_nodes/``. It is invisible to :func:`find_cm_cli`, which only
+    tests whether the ``cm_cli`` module imports in the workspace Python.
+
+    Detection is by marker file, not directory name — users clone the Manager
+    under arbitrary names. Directories ending in ``.disabled`` (the Manager's own
+    disable convention) are skipped.
+
+    Results are cached for the session lifetime.
+    """
+    ws = workspace_manager.workspace_path
+    if not ws:
+        return False
+
+    custom_nodes = os.path.join(ws, "custom_nodes")
+    try:
+        entries = os.listdir(custom_nodes)
+    except OSError:
+        return False
+
+    for name in entries:
+        if name.endswith(".disabled"):
+            continue
+        node_dir = os.path.join(custom_nodes, name)
+        try:
+            if not os.path.isdir(node_dir):
+                continue
+            if os.path.isfile(os.path.join(node_dir, "glob", "manager_core.py")) or os.path.isfile(
+                os.path.join(node_dir, "cm-cli.py")
+            ):
+                return True
+        except OSError:
+            continue
+
+    return False
+
+
+def detect_manager_installation() -> str:
+    """Report how ComfyUI-Manager is installed for the current workspace.
+
+    Returns ``"venv-package"`` (the pip ``comfyui_manager`` package — cm-cli
+    usable), ``"legacy-clone"`` (an on-disk clone under ``custom_nodes/`` — cm-cli
+    integration unavailable), or ``"none"``.
+    """
+    if find_cm_cli():
+        return "venv-package"
+    if find_legacy_manager_clone():
+        return "legacy-clone"
+    return "none"
+
+
 def resolve_manager_gui_mode(not_installed_value: str | None = None) -> str | None:
     """Resolve manager GUI mode from config, with legacy migration.
 

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -116,7 +116,7 @@ def pip_install_comfyui_dependencies(
 
 def pip_install_manager(repo_dir, python=sys.executable):
     """Install ComfyUI-Manager via manager_requirements.txt."""
-    from comfy_cli.command.custom_nodes.cm_cli_util import find_cm_cli
+    from comfy_cli.command.custom_nodes.cm_cli_util import find_cm_cli, find_legacy_manager_clone
 
     manager_req_path = os.path.join(repo_dir, constants.MANAGER_REQUIREMENTS_FILE)
     if not os.path.exists(manager_req_path):
@@ -138,8 +138,9 @@ def pip_install_manager(repo_dir, python=sys.executable):
             rprint(f"[dim]{result.stderr.strip()}[/dim]")
         return False
 
-    # Clear cache so find_cm_cli() picks up the newly installed module
+    # Clear caches so manager detection picks up the newly installed module
     find_cm_cli.cache_clear()
+    find_legacy_manager_clone.cache_clear()
     return True
 
 

--- a/comfy_cli/schemas/env.json
+++ b/comfy_cli/schemas/env.json
@@ -32,7 +32,9 @@
       "additionalProperties": true,
       "properties": {
         "path": {"type": ["string", "null"]},
-        "type": {"type": ["string", "null"]}
+        "type": {"type": ["string", "null"]},
+        "manager_mode": {"type": ["string", "null"]},
+        "manager_detected": {"enum": ["venv-package", "legacy-clone", "none"]}
       }
     },
     "server": {

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -297,18 +297,49 @@ class WorkspaceManager:
         file_path = os.path.join(self.workspace_path, constants.COMFY_LOCK_YAML_FILE)
         save_yaml(file_path, self.metadata)
 
-    def fill_print_table(self):
-        # Lazy import to avoid circular dependency
-        from comfy_cli.command.custom_nodes.cm_cli_util import resolve_manager_gui_mode
+    def _reported_manager_state(self) -> tuple[str, str]:
+        """Reconcile the configured manager mode against what is actually installed.
 
-        config_manager = ConfigManager()
+        Reporting-only: this never feeds ``comfy launch`` flag injection, which
+        keeps reading :func:`resolve_manager_gui_mode` directly (user intent).
+
+        The global per-user ``manager_gui_mode`` config key can drift out of sync
+        with a given workspace, so ``comfy env`` reconciles the two:
+
+        * any manager-enabling mode (``enable-gui`` / ``disable-gui`` /
+          ``enable-legacy-gui`` — ``disable-gui`` still enables the Manager, it
+          only hides its UI) with no Manager anywhere is stale config → report
+          ``"not-installed"``;
+        * ``"not-installed"`` with an on-disk legacy clone → report ``"legacy"``
+          (the Manager is present, but cm-cli venv integration is unavailable).
+
+        ``"disable"`` is user intent and is always left untouched.
+
+        Returns ``(manager_mode, manager_detected)``.
+        """
+        # Lazy import to avoid circular dependency
+        from comfy_cli.command.custom_nodes.cm_cli_util import detect_manager_installation, resolve_manager_gui_mode
+
+        detected = detect_manager_installation()
         mode = resolve_manager_gui_mode(not_installed_value="not-installed")
+
+        if mode in ("enable-gui", "disable-gui", "enable-legacy-gui") and detected == "none":
+            mode = "not-installed"
+        elif mode == "not-installed" and detected == "legacy-clone":
+            mode = "legacy"
+
+        return mode, detected
+
+    def fill_print_table(self):
+        config_manager = ConfigManager()
+        mode, _detected = self._reported_manager_state()
 
         status_map = {
             "disable": "[bold red]Disabled[/bold red]",
             "enable-gui": "[bold green]GUI Enabled[/bold green]",
             "disable-gui": "[bold yellow]GUI Disabled[/bold yellow]",
             "enable-legacy-gui": "[bold cyan]Legacy GUI[/bold cyan]",
+            "legacy": "[bold yellow]Legacy clone (cm-cli unavailable)[/bold yellow]",
             "not-installed": "[dim]Not Installed[/dim]",
         }
         manager_status = status_map.get(mode, "[bold green]GUI Enabled[/bold green]")
@@ -327,13 +358,13 @@ class WorkspaceManager:
 
     def fill_data(self) -> dict:
         """Structured workspace info for ``comfy env --json``."""
-        from comfy_cli.command.custom_nodes.cm_cli_util import resolve_manager_gui_mode
-
         config_manager = ConfigManager()
         uv_compile_value = config_manager.get(constants.CONFIG_KEY_UV_COMPILE_DEFAULT)
+        mode, detected = self._reported_manager_state()
         return {
             "path": str(self.workspace_path) if self.workspace_path else None,
             "type": self.workspace_type.value if self.workspace_type is not None else None,
-            "manager_mode": resolve_manager_gui_mode(not_installed_value="not-installed"),
+            "manager_mode": mode,
+            "manager_detected": detected,
             "uv_compile_default": (str(uv_compile_value).lower() == "true" if uv_compile_value is not None else False),
         }

--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -306,14 +306,18 @@ class WorkspaceManager:
         The global per-user ``manager_gui_mode`` config key can drift out of sync
         with a given workspace, so ``comfy env`` reconciles the two:
 
-        * any manager-enabling mode (``enable-gui`` / ``disable-gui`` /
-          ``enable-legacy-gui`` — ``disable-gui`` still enables the Manager, it
-          only hides its UI) with no Manager anywhere is stale config → report
-          ``"not-installed"``;
-        * ``"not-installed"`` with an on-disk legacy clone → report ``"legacy"``
-          (the Manager is present, but cm-cli venv integration is unavailable).
+        Every mode that expects a working Manager — the enabling modes
+        (``enable-gui`` / ``disable-gui`` / ``enable-legacy-gui``; ``disable-gui``
+        still enables the Manager, it only hides its UI) and ``"not-installed"``
+        — is reconciled against what is actually on disk:
 
-        ``"disable"`` is user intent and is always left untouched.
+        * no Manager anywhere → report ``"not-installed"``;
+        * an on-disk legacy clone → report ``"legacy"`` (the Manager is present,
+          but cm-cli venv integration is unavailable, so an ``enable-*`` config
+          overstates what works).
+
+        ``"disable"`` is user intent and is always left untouched, as is any
+        unrecognised mode string.
 
         Returns ``(manager_mode, manager_detected)``.
         """
@@ -323,10 +327,11 @@ class WorkspaceManager:
         detected = detect_manager_installation()
         mode = resolve_manager_gui_mode(not_installed_value="not-installed")
 
-        if mode in ("enable-gui", "disable-gui", "enable-legacy-gui") and detected == "none":
-            mode = "not-installed"
-        elif mode == "not-installed" and detected == "legacy-clone":
-            mode = "legacy"
+        if mode in ("enable-gui", "disable-gui", "enable-legacy-gui", "not-installed"):
+            if detected == "none":
+                mode = "not-installed"
+            elif detected == "legacy-clone":
+                mode = "legacy"
 
         return mode, detected
 

--- a/tests/comfy_cli/command/test_cm_cli_util.py
+++ b/tests/comfy_cli/command/test_cm_cli_util.py
@@ -146,6 +146,27 @@ class TestFindCmCli:
             mock_spec.return_value = MagicMock()
             assert cm_cli_util.find_cm_cli() is True
 
+    def test_cache_is_keyed_on_workspace_path(self):
+        """Probing before the workspace resolves must not poison the later answer."""
+        with (
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.importlib.util.find_spec", return_value=None),
+            patch.object(cm_cli_util.workspace_manager, "workspace_path", None),
+        ):
+            assert cm_cli_util.find_cm_cli() is False
+
+        with (
+            patch.object(cm_cli_util.workspace_manager, "workspace_path", "/fake/workspace"),
+            patch(
+                "comfy_cli.command.custom_nodes.cm_cli_util.resolve_workspace_python",
+                return_value="/fake/venv/python",
+            ),
+            patch(
+                "comfy_cli.command.custom_nodes.cm_cli_util.subprocess.run",
+                return_value=MagicMock(returncode=0),
+            ),
+        ):
+            assert cm_cli_util.find_cm_cli() is True
+
     def test_returns_false_on_subprocess_timeout(self):
         """When workspace Python check times out, returns False (not fallback to cli)."""
         with (
@@ -206,6 +227,40 @@ class TestFindLegacyManagerClone:
 
         with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
             assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_cache_is_keyed_on_workspace_path(self, tmp_path):
+        """A first call before the workspace resolves must not poison later calls."""
+        custom_nodes = tmp_path / "custom_nodes"
+        custom_nodes.mkdir()
+        _make_clone(custom_nodes, "ComfyUI-Manager")
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", None):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is True
+
+    def test_distinct_workspaces_get_distinct_answers(self, tmp_path):
+        with_clone = tmp_path / "with_clone"
+        (with_clone / "custom_nodes").mkdir(parents=True)
+        _make_clone(with_clone / "custom_nodes", "ComfyUI-Manager")
+        without_clone = tmp_path / "without_clone"
+        (without_clone / "custom_nodes").mkdir(parents=True)
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(with_clone)):
+            assert cm_cli_util.find_legacy_manager_clone() is True
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(without_clone)):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_result_is_cached_per_workspace(self, tmp_path):
+        (tmp_path / "custom_nodes").mkdir()
+        with (
+            patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)),
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.os.listdir", return_value=[]) as mock_listdir,
+        ):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+            assert cm_cli_util.find_legacy_manager_clone() is False
+            mock_listdir.assert_called_once()
 
     def test_ignores_unrelated_custom_nodes(self, tmp_path):
         custom_nodes = tmp_path / "custom_nodes"

--- a/tests/comfy_cli/command/test_cm_cli_util.py
+++ b/tests/comfy_cli/command/test_cm_cli_util.py
@@ -20,8 +20,10 @@ def _make_mock_proc(returncode, stdout_lines=None, stderr_lines=None):
 @pytest.fixture(autouse=True)
 def _clear_find_cm_cli_cache():
     cm_cli_util.find_cm_cli.cache_clear()
+    cm_cli_util.find_legacy_manager_clone.cache_clear()
     yield
     cm_cli_util.find_cm_cli.cache_clear()
+    cm_cli_util.find_legacy_manager_clone.cache_clear()
 
 
 @pytest.fixture()
@@ -158,6 +160,84 @@ class TestFindCmCli:
             ),
         ):
             assert cm_cli_util.find_cm_cli() is False
+
+
+def _make_clone(custom_nodes, name, marker="glob/manager_core.py"):
+    """Create a fake custom node dir containing the given manager marker file."""
+    marker_path = custom_nodes / name / marker
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("# fake manager marker\n", encoding="utf-8")
+
+
+class TestFindLegacyManagerClone:
+    def test_returns_false_without_workspace(self):
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", None):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_returns_false_when_custom_nodes_missing(self, tmp_path):
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_returns_false_for_empty_custom_nodes(self, tmp_path):
+        (tmp_path / "custom_nodes").mkdir()
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_detects_clone_under_arbitrary_name(self, tmp_path):
+        custom_nodes = tmp_path / "custom_nodes"
+        custom_nodes.mkdir()
+        _make_clone(custom_nodes, "SomeName")
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is True
+
+    def test_detects_clone_via_cm_cli_script_marker(self, tmp_path):
+        custom_nodes = tmp_path / "custom_nodes"
+        custom_nodes.mkdir()
+        _make_clone(custom_nodes, "ComfyUI-Manager", marker="cm-cli.py")
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is True
+
+    def test_ignores_disabled_clone(self, tmp_path):
+        custom_nodes = tmp_path / "custom_nodes"
+        custom_nodes.mkdir()
+        _make_clone(custom_nodes, "ComfyUI-Manager.disabled")
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+    def test_ignores_unrelated_custom_nodes(self, tmp_path):
+        custom_nodes = tmp_path / "custom_nodes"
+        (custom_nodes / "SomeOtherNode").mkdir(parents=True)
+        (custom_nodes / "SomeOtherNode" / "__init__.py").write_text("", encoding="utf-8")
+        (custom_nodes / "loose_file.py").write_text("", encoding="utf-8")
+
+        with patch.object(cm_cli_util.workspace_manager, "workspace_path", str(tmp_path)):
+            assert cm_cli_util.find_legacy_manager_clone() is False
+
+
+class TestDetectManagerInstallation:
+    def test_venv_package_wins(self):
+        with (
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_cm_cli", return_value=True),
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_legacy_manager_clone", return_value=True),
+        ):
+            assert cm_cli_util.detect_manager_installation() == "venv-package"
+
+    def test_legacy_clone_when_no_package(self):
+        with (
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_cm_cli", return_value=False),
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_legacy_manager_clone", return_value=True),
+        ):
+            assert cm_cli_util.detect_manager_installation() == "legacy-clone"
+
+    def test_none_when_nothing_installed(self):
+        with (
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_cm_cli", return_value=False),
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_legacy_manager_clone", return_value=False),
+        ):
+            assert cm_cli_util.detect_manager_installation() == "none"
 
 
 class TestResolveManagerGuiMode:

--- a/tests/comfy_cli/command/test_manager_gui.py
+++ b/tests/comfy_cli/command/test_manager_gui.py
@@ -1026,6 +1026,16 @@ class TestManagerModeReconciliation:
             ("enable-gui", False, False, "not-installed", "none"),
             ("disable-gui", False, False, "not-installed", "none"),
             ("enable-legacy-gui", False, False, "not-installed", "none"),
+            # Stale global config claiming the manager is enabled, but only a
+            # legacy clone is on disk — cm-cli is unavailable, so report "legacy".
+            ("enable-gui", False, True, "legacy", "legacy-clone"),
+            ("disable-gui", False, True, "legacy", "legacy-clone"),
+            ("enable-legacy-gui", False, True, "legacy", "legacy-clone"),
+            # An enabling config that matches reality is left alone.
+            ("enable-gui", True, False, "enable-gui", "venv-package"),
+            ("disable-gui", True, False, "disable-gui", "venv-package"),
+            # An unrecognised mode string is passed through untouched.
+            ("some-future-mode", False, False, "some-future-mode", "none"),
             # "disable" is user intent — never rewritten.
             ("disable", True, False, "disable", "venv-package"),
             ("disable", False, True, "disable", "legacy-clone"),
@@ -1064,6 +1074,15 @@ class TestManagerModeReconciliation:
 
         assert result[1][0] == "Manager"
         assert "Not Installed" in result[1][1]
+
+    def test_fill_print_table_does_not_claim_gui_enabled_for_legacy_clone(self):
+        """A stale enable-gui config plus a clone must not render as "GUI Enabled"."""
+        with self._env(configured_mode="enable-gui", has_cm_cli=False, has_legacy_clone=True) as ws:
+            result = ws.fill_print_table()
+
+        assert result[1][0] == "Manager"
+        assert "Legacy clone (cm-cli unavailable)" in result[1][1]
+        assert "GUI Enabled" not in result[1][1]
 
 
 class TestResolveUvCompile:

--- a/tests/comfy_cli/command/test_manager_gui.py
+++ b/tests/comfy_cli/command/test_manager_gui.py
@@ -1,3 +1,4 @@
+import contextlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -808,6 +809,21 @@ class TestFillPrintTable:
             mock_cls.return_value = instance
             yield instance
 
+    @pytest.fixture(autouse=True)
+    def _manager_installed(self):
+        """Default these mode-rendering tests to "Manager is pip-installed".
+
+        fill_print_table() reconciles the configured mode against what is actually
+        installed; without this the real detector would run against the fake
+        workspace path and rewrite every enable-* mode to "not-installed". The
+        reconciliation itself is covered by TestManagerModeReconciliation.
+        """
+        with patch(
+            "comfy_cli.command.custom_nodes.cm_cli_util.detect_manager_installation",
+            return_value="venv-package",
+        ):
+            yield
+
     @patch("comfy_cli.command.custom_nodes.cm_cli_util.resolve_manager_gui_mode", return_value="disable")
     def test_fill_print_table_disable_mode(self, mock_resolve, mock_workspace_config_manager):
         """When mode is 'disable', status should show Disabled."""
@@ -950,6 +966,104 @@ class TestFillPrintTable:
 
         assert result[2][0] == "UV Compile Default"
         assert "Disabled" in result[2][1]
+
+
+class TestManagerModeReconciliation:
+    """`comfy env` reconciles the global manager_gui_mode config against reality."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_detection_caches(self):
+        from comfy_cli.command.custom_nodes import cm_cli_util
+
+        cm_cli_util.find_cm_cli.cache_clear()
+        cm_cli_util.find_legacy_manager_clone.cache_clear()
+        yield
+        cm_cli_util.find_cm_cli.cache_clear()
+        cm_cli_util.find_legacy_manager_clone.cache_clear()
+
+    @contextlib.contextmanager
+    def _env(self, *, configured_mode, has_cm_cli, has_legacy_clone):
+        """Set up a workspace with the given config key + on-disk manager state."""
+
+        def _get(key):
+            if key == constants.CONFIG_KEY_MANAGER_GUI_MODE:
+                return configured_mode
+            return None
+
+        cm_cli_config = MagicMock()
+        cm_cli_config.get.side_effect = _get
+        workspace_config = MagicMock()
+        workspace_config.get.return_value = None
+
+        with (
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.ConfigManager", return_value=cm_cli_config),
+            patch("comfy_cli.workspace_manager.ConfigManager", return_value=workspace_config),
+            patch("comfy_cli.command.custom_nodes.cm_cli_util.find_cm_cli", return_value=has_cm_cli),
+            patch(
+                "comfy_cli.command.custom_nodes.cm_cli_util.find_legacy_manager_clone",
+                return_value=has_legacy_clone,
+            ),
+        ):
+            from comfy_cli.workspace_manager import WorkspaceManager
+
+            # WorkspaceManager is a @singleton, so restore what we clobber.
+            ws = WorkspaceManager()
+            previous_path = ws.workspace_path
+            ws.workspace_path = "/fake/workspace"
+            try:
+                yield ws
+            finally:
+                ws.workspace_path = previous_path
+
+    @pytest.mark.parametrize(
+        ("configured_mode", "has_cm_cli", "has_legacy_clone", "expected_mode", "expected_detected"),
+        [
+            # No config at all — detection drives the answer.
+            (None, True, False, "enable-gui", "venv-package"),
+            (None, False, True, "legacy", "legacy-clone"),
+            (None, False, False, "not-installed", "none"),
+            # Stale global config claiming the manager is enabled, nothing installed.
+            ("enable-gui", False, False, "not-installed", "none"),
+            ("disable-gui", False, False, "not-installed", "none"),
+            ("enable-legacy-gui", False, False, "not-installed", "none"),
+            # "disable" is user intent — never rewritten.
+            ("disable", True, False, "disable", "venv-package"),
+            ("disable", False, True, "disable", "legacy-clone"),
+            ("disable", False, False, "disable", "none"),
+        ],
+    )
+    def test_fill_data_reconciliation_matrix(
+        self, configured_mode, has_cm_cli, has_legacy_clone, expected_mode, expected_detected
+    ):
+        with self._env(configured_mode=configured_mode, has_cm_cli=has_cm_cli, has_legacy_clone=has_legacy_clone) as ws:
+            data = ws.fill_data()
+
+        assert data["manager_mode"] == expected_mode
+        assert data["manager_detected"] == expected_detected
+
+    def test_fill_data_keeps_existing_fields(self):
+        """`manager_detected` is additive — the pre-existing payload keys stay put."""
+        with self._env(configured_mode=None, has_cm_cli=True, has_legacy_clone=False) as ws:
+            data = ws.fill_data()
+
+        assert set(data) == {"path", "type", "manager_mode", "manager_detected", "uv_compile_default"}
+        assert data["path"] == "/fake/workspace"
+        assert data["uv_compile_default"] is False
+
+    def test_fill_print_table_reports_legacy_clone(self):
+        """The table view matches the JSON view for the legacy-clone case."""
+        with self._env(configured_mode=None, has_cm_cli=False, has_legacy_clone=True) as ws:
+            result = ws.fill_print_table()
+
+        assert result[1][0] == "Manager"
+        assert "Legacy clone (cm-cli unavailable)" in result[1][1]
+
+    def test_fill_print_table_reports_stale_enable_config_as_not_installed(self):
+        with self._env(configured_mode="enable-gui", has_cm_cli=False, has_legacy_clone=False) as ws:
+            result = ws.fill_print_table()
+
+        assert result[1][0] == "Manager"
+        assert "Not Installed" in result[1][1]
 
 
 class TestResolveUvCompile:

--- a/tests/comfy_cli/test_custom_nodes_python_resolution.py
+++ b/tests/comfy_cli/test_custom_nodes_python_resolution.py
@@ -145,6 +145,12 @@ class TestUpdateNodeIdCache:
                 "comfy_cli.command.custom_nodes.command.resolve_workspace_python",
                 return_value="/resolved/python",
             ),
+            # update_node_id_cache() hard-fails on `not find_cm_cli()`. That guard is
+            # incidental to what this test asserts (that the resolved workspace Python
+            # is the interpreter invoked), and the on-disk cm-cli.py above never
+            # satisfies it — find_cm_cli() probes for the importable `cm_cli` module,
+            # not a clone's script. Stub the guard so the test stands on its own.
+            patch("comfy_cli.command.custom_nodes.command.find_cm_cli", return_value=True),
             patch.object(command.workspace_manager, "workspace_path", str(tmp_path)),
             patch("comfy_cli.command.custom_nodes.command.ConfigManager") as MockConfig,
             patch("comfy_cli.command.custom_nodes.command.subprocess.run") as mock_run,


### PR DESCRIPTION
## ELI-5

If you installed ComfyUI-Manager the old way — `git clone` into `custom_nodes/` — `comfy env` flatly told you it wasn't installed, because it only ever checked whether the `cm_cli` Python package could be imported and never looked at the disk. And because a single global config key overrode detection entirely, `comfy env` could also claim the Manager was enabled on a machine that has never had it. This PR makes `comfy env` look at both and report what's actually there. Nothing about `comfy launch` changes.

## What changed

- **`find_legacy_manager_clone()`** (`cm_cli_util.py`) — scans `<workspace>/custom_nodes/` for a directory containing the Manager marker file `glob/manager_core.py` **or** `cm-cli.py` at its root. Detection is by marker, not directory name, because people clone the Manager under arbitrary names; directories ending in `.disabled` are skipped. Returns `False` on a missing workspace or any `OSError`. Cached **per workspace path** (it delegates to an `@lru_cache`d `_scan_for_legacy_manager_clone(workspace_path)`), and cleared alongside the existing `find_cm_cli.cache_clear()` in `pip_install_manager()`.
- **`find_cm_cli()` caches keyed per workspace too** — it was `@lru_cache(maxsize=1)` on an argument-less function whose answer depends on the mutable global `workspace_manager.workspace_path`, so one cached answer served every workspace and an unresolved workspace on the first call poisoned the session. It now delegates to `_probe_cm_cli(workspace_path)`. Behaviour for a single fixed workspace is unchanged; both functions still expose `.cache_clear()`.
- **`detect_manager_installation()`** — `"venv-package"` if `find_cm_cli()`, else `"legacy-clone"` if `find_legacy_manager_clone()`, else `"none"`.
- **Reconciliation in the reporting path only** — a new `WorkspaceManager._reported_manager_state()` helper shared by `fill_data()` and `fill_print_table()` so the JSON and table views can't drift apart. The manager-enabling modes (`enable-gui` / `disable-gui` / `enable-legacy-gui`) and `"not-installed"` share one reconciliation branch: with `detected == "none"` they report `"not-installed"`; with an on-disk clone they report the new `"legacy"` value. **`"disable"` is user intent and is never rewritten, nor is any unrecognised mode string.**
- **`manager_detected`** — new additive field on the `comfy env --json` `workspace` payload, alongside the existing `manager_mode`. No existing field was renamed or removed. `schemas/env.json` gains declarations for both (`workspace` was already `additionalProperties: true`, so this documents the contract rather than gating it).
- **`fill_print_table()`** gains `"legacy": "[bold yellow]Legacy clone (cm-cli unavailable)[/bold yellow]"`.

## Launch is untouched (plan item 5)

`comfy launch` flag injection is byte-for-byte unchanged. `_get_manager_flags()` (`launch.py:28-51`) calls `resolve_manager_gui_mode(not_installed_value=None)`, and `resolve_manager_gui_mode()` was not modified — the diff touches `launch.py` not at all. `find_cm_cli()` was refactored to key its cache per workspace path, which changes no answer for a single fixed workspace and so leaves the flags launch injects identical. Its unknown-mode fallback at line 50 can never see `"legacy"`, because `"legacy"` is produced only inside `_reported_manager_state()`, which is called exclusively from `fill_data()` / `fill_print_table()`.

## Verification

`ruff check` + `ruff format --diff` clean; `pytest tests/comfy_cli tests/uv` → **2732 passed, 18 skipped**.

Beyond unit tests, both acceptance criteria were reproduced end-to-end against a scratch ComfyUI workspace with a real `custom_nodes/ComfyUI-Manager/` clone and an isolated `HOME` (so the real user config was untouched):

**QA repro — legacy clone, no pip package, no config keys:**
```
$ comfy --workspace <ws> env          # non-TTY → JSON
"workspace": { "manager_mode": "legacy", "manager_detected": "legacy-clone", ... }
$ comfy --no-json --workspace <ws> env
│ Manager   │ Legacy clone (cm-cli unavailable) │
```
(pre-change this reported `"not-installed"` / `Not Installed`)

**Stale `manager_gui_mode=enable-gui`, no Manager anywhere:**
```
"workspace": { "manager_mode": "not-installed", "manager_detected": "none", ... }
│ Manager   │ Not Installed │
```

### Falsification of the "cm-cli unavailable" claim

This PR adds a user-facing string asserting cm-cli is unavailable for a legacy clone, so I went and checked rather than assuming. With the clone on disk:

```
$ python -c "import cm_cli"
ModuleNotFoundError: No module named 'cm_cli'
$ comfy --workspace <ws> node show installed
ComfyUI-Manager not found. 'cm-cli' command is not available.
```

Every cm-cli entry point in the codebase routes through `execute_cm_cli()`, which runs `[python, "-m", "cm_cli"]` and is gated on `find_cm_cli()`; `grep` confirms no code path invokes a clone's `cm-cli.py` script directly, and `cm-cli.py` (hyphen) is not importable as a module regardless. Note this denial is **pre-existing and untouched** — `execute_cm_cli()`'s hard-fail is unchanged by this diff. The PR does not add a dead-end; it removes a wronger one (`comfy env` previously claimed the Manager was absent entirely).

## Judgment calls

- **`enable-gui` config + legacy clone on disk reports `manager_mode: "legacy"`.** An earlier revision of this PR followed the plan's two literal reconciliation rules and left this case reporting `"enable-gui"`; review ([r3661548777](https://github.com/Comfy-Org/comfy-cli/pull/609#discussion_r3661548777)) correctly called that a contradictory pair (`manager_mode="enable-gui"` + `manager_detected="legacy-clone"`, table saying "GUI Enabled" while cm-cli is unavailable), and `9ea65df` merged the enabling modes into the same branch as `"not-installed"`. An `enable-*` config backed only by a clone overstates what actually works; `manager_detected` still exposes the ground truth for a consumer that needs to distinguish.
- **Reconciliation lives in a shared `_reported_manager_state()` helper** rather than being duplicated into `fill_data()` and `fill_print_table()`. The plan describes the logic twice; duplicating it invites the JSON and table views to drift, which is what item 4 explicitly asks to prevent.
- **`schemas/env.json` was updated** (not called for in the plan). It's purely additive documentation of the two fields — `workspace` already allowed additional properties, so nothing that validated before stops validating. `manager_detected` is declared as an enum of the three values `detect_manager_installation()` can return, which makes a future value addition fail loudly instead of silently escaping the contract.
- **`disable-gui` is included in the stale-config rewrite list.** Despite the name it *enables* the Manager (`--enable-manager --disable-manager-ui`) and only hides the UI, so reporting it with nothing installed would be just as misleading as `enable-gui`. This matches the plan's list.
- One test fixture leaks less than its neighbors: `WorkspaceManager` is a `@singleton`, so the new reconciliation tests save and restore `workspace_path` instead of clobbering the shared instance the way the surrounding `TestFillPrintTable` tests do. I did not retrofit the pre-existing tests — out of scope.

No unmet acceptance criteria.
- **`TestUpdateNodeIdCache::test_uses_resolved_python` needed a `find_cm_cli` stub.** Keying the caches per workspace removed the cross-test `lru_cache` pollution that this test had been relying on (`TestFindCmCli` primed the single global slot with `True` earlier in the suite), so it started failing in CI. It was already broken standalone on `main` — verified by running it against `main`'s `cm_cli_util.py`, where it fails the same way. The guard is incidental to what the test asserts, so it is stubbed rather than the assertion weakened. Caught by @bigcat88 ([r3666335561](https://github.com/Comfy-Org/comfy-cli/pull/609#discussion_r3666335561)).
