### PR TITLE
feat(node): add `comfy node deps` read-only per-pack dependency report (BE-4773)

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -24,6 +24,7 @@ from comfy_cli.file_utils import (
     zip_files,
 )
 from comfy_cli.output import rprint as print  # context-aware: stderr in JSON mode
+from comfy_cli.output.renderer import get_renderer
 from comfy_cli.registry import (
     RegistryAPI,
     extract_node_configuration,
@@ -469,6 +470,26 @@ def node_completer(incomplete: str) -> list[str]:
         with open(tmp_path, encoding="UTF-8", errors="ignore") as cache_file:
             return [node_id for node_id in cache_file.readlines() if node_id.startswith(incomplete)]
 
+    except Exception:
+        return []
+
+
+def installed_pack_completer(incomplete: str) -> list[str]:
+    """Complete against *installed pack directory names*.
+
+    Deliberately not ``node_completer``: that one serves the registry node-id
+    cache, and a git-cloned pack's directory name is its repo name, not its
+    registry id. ``comfy node deps`` matches on directory name.
+    """
+    try:
+        from comfy_cli.command.pack_scan import iter_pack_dirs
+
+        workspace = workspace_manager.workspace_path
+        if not workspace:
+            return []
+        return [
+            p.name for p in iter_pack_dirs(pathlib.Path(workspace) / "custom_nodes") if p.name.startswith(incomplete)
+        ]
     except Exception:
         return []
 
@@ -965,6 +986,28 @@ def deps_in_workflow(
         channel,
         mode=mode,
     )
+
+
+@app.command(
+    "deps",
+    help="Report each pack's declared Python requirements vs the versions installed in the workspace venv (read-only).",
+)
+@tracking.track_command("node")
+def deps(
+    pack_names: Annotated[
+        list[str] | None,
+        typer.Argument(
+            show_default=False,
+            help="Pack directory names to report on (case-insensitive). Omit to report every installed pack.",
+            autocompletion=installed_pack_completer,
+        ),
+    ] = None,
+):
+    # Native + read-only on purpose: no cm-cli, no pip install, no network, so
+    # it works on a workspace that never installed ComfyUI-Manager.
+    from comfy_cli.command import node_deps
+
+    node_deps.execute(get_renderer(), workspace_manager.workspace_path, pack_names)
 
 
 def validate_node_for_publishing():

--- a/comfy_cli/command/node_deps.py
+++ b/comfy_cli/command/node_deps.py
@@ -1,0 +1,422 @@
+"""``comfy node deps`` — read-only per-pack Python dependency report.
+
+For every installed custom node pack (or just the ones named on the command
+line), reports the pack's *declared* Python requirements — from its
+``requirements.txt`` and/or its ``pyproject.toml`` ``[project] dependencies``
+— alongside the version actually installed in the workspace venv and a
+computed status per requirement.
+
+Read-only by construction: it never installs anything, never shells out to
+``cm-cli``, and never touches the network. The only subprocess it runs is a
+single ``<workspace python> -m pip list --format=json`` for the whole report
+(not once per pack).
+
+Statuses:
+
+- ``satisfied``   — installed, and the declared specifier accepts that version
+  (a bare name with no specifier is satisfied by any installed version);
+- ``mismatch``    — installed, but the specifier rejects that version (both
+  versions are reported);
+- ``missing``     — not present in the workspace venv at all;
+- ``unparseable`` — a pip option (``--extra-index-url``, ``-r other.txt``), a
+  bare VCS/URL line, or anything else :class:`packaging.requirements.Requirement`
+  rejects. Kept in the report rather than dropped silently;
+- ``unknown``     — the comparison could not be made: either the ``pip list``
+  probe failed (accompanied by an ``installed_versions_unavailable`` warning on
+  the report) or the installed dist records a version that isn't PEP 440.
+
+Known caveat: pyproject dependencies are read through the shared registry
+parser (:func:`comfy_cli.command.pack_scan.read_pyproject`), which drops the
+``comfyui-frontend-package`` pin from ``[project] dependencies``. Such a pin is
+a core-ComfyUI concern rather than a pack dependency, so it will not appear in
+this report even though it is declared.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from comfy_cli.command.pack_scan import iter_pack_dirs, read_pyproject
+
+PIP_LIST_TIMEOUT_SECONDS = 60
+
+# Same comment rules as ``uv.py::parse_req_file``: a ``#`` at line start or
+# preceded by whitespace begins a comment. VCS URL fragments like
+# ``#subdirectory=pkg`` / ``#egg=foo`` survive because they are not preceded by
+# whitespace.
+_INLINE_COMMENT_RE = re.compile(r"(^|\s+)#.*$")
+
+# Every status a requirement row can carry; the per-pack summary always reports
+# all of them so consumers can index without a KeyError.
+STATUSES = ("satisfied", "mismatch", "missing", "unparseable", "unknown")
+
+SOURCE_REQUIREMENTS_TXT = "requirements.txt"
+SOURCE_PYPROJECT = "pyproject.toml"
+
+
+# ---------------------------------------------------------------------------
+# Installed versions
+# ---------------------------------------------------------------------------
+
+
+def pip_list(python: str) -> tuple[dict[str, str] | None, str | None]:
+    """Return ``(canonical_name -> version, error)`` for the workspace venv.
+
+    Runs ``<python> -m pip list --format=json`` exactly once. On any failure
+    the map is ``None`` and the second element carries a human-readable reason
+    — a report that can't see the venv is still a useful report.
+    """
+    from packaging.utils import canonicalize_name
+
+    try:
+        proc = subprocess.run(
+            [python, "-m", "pip", "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            timeout=PIP_LIST_TIMEOUT_SECONDS,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        detail = (e.stderr or "").strip().splitlines()
+        return None, f"`pip list` exited {e.returncode}" + (f": {detail[-1]}" if detail else "")
+    except (subprocess.SubprocessError, OSError) as e:
+        return None, f"could not run `pip list`: {e}"
+
+    try:
+        rows = json.loads(proc.stdout)
+    except ValueError as e:
+        return None, f"could not parse `pip list --format=json` output: {e}"
+    if not isinstance(rows, list):
+        return None, "`pip list --format=json` did not return a list"
+
+    versions: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name, version = row.get("name"), row.get("version")
+        if isinstance(name, str) and name:
+            versions[canonicalize_name(name)] = str(version) if version is not None else ""
+    return versions, None
+
+
+# ---------------------------------------------------------------------------
+# Declared requirements
+# ---------------------------------------------------------------------------
+
+
+def _requirements_txt_lines(path: Path) -> tuple[list[str], str | None]:
+    """Return ``(lines, error)`` for a pack ``requirements.txt``.
+
+    Mirrors ``uv.py::parse_req_file``'s comment/blank handling, but keeps pip
+    option lines (``--extra-index-url``, ``-r base.txt``) instead of splitting
+    them off — this report surfaces them as ``unparseable`` rather than
+    dropping them.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return [], f"could not read {path}: {e}"
+
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = _INLINE_COMMENT_RE.sub("", raw_line).strip()
+        if line:
+            lines.append(line)
+    return lines, None
+
+
+def _pyproject_lines(path: Path) -> list[str]:
+    cfg = read_pyproject(str(path))
+    if cfg is None:
+        return []
+    deps = getattr(cfg.project, "dependencies", None) or []
+    return [d.strip() for d in deps if isinstance(d, str) and d.strip()]
+
+
+def _classify(raw: str, installed_versions: dict[str, str] | None) -> dict[str, Any]:
+    """Turn one declared requirement line into a report row."""
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
+
+    row: dict[str, Any] = {
+        "raw": raw,
+        "name": None,
+        "specifier": None,
+        "installed": None,
+        "status": "unparseable",
+    }
+
+    # A leading ``-`` is a pip option (``-r``, ``-e``, ``--extra-index-url``),
+    # never a requirement — `Requirement` would either reject it or, worse,
+    # misread it. Short-circuit so the reason is unambiguous.
+    if raw.startswith("-"):
+        return row
+
+    try:
+        req = Requirement(raw)
+    except InvalidRequirement:
+        # Bare VCS/URL lines (``git+https://…``, ``https://…/x.whl``) land here.
+        return row
+
+    row["name"] = req.name
+    row["specifier"] = str(req.specifier)
+    if req.marker is not None:
+        # Markers are NOT evaluated: the relevant environment is the workspace
+        # venv's, not this CLI process's. Surfaced so a consumer can tell why a
+        # platform-specific pin reads as `missing`.
+        row["marker"] = str(req.marker)
+
+    if installed_versions is None:
+        row["status"] = "unknown"
+        return row
+
+    installed = installed_versions.get(canonicalize_name(req.name))
+    row["installed"] = installed
+    if installed is None:
+        row["status"] = "missing"
+    elif not req.specifier:
+        # A bare name is satisfied by any installed version.
+        row["status"] = "satisfied"
+    else:
+        from packaging.version import InvalidVersion
+
+        try:
+            contains = req.specifier.contains(installed, prereleases=True)
+        except InvalidVersion:
+            # A dist whose recorded version isn't PEP 440 (rare, but a broken
+            # `.dist-info` will do it) can't be compared. Say so rather than
+            # letting the exception abort the whole report.
+            row["status"] = "unknown"
+            return row
+        row["status"] = "satisfied" if contains else "mismatch"
+    return row
+
+
+def _pack_report(pack_dir: Path, workspace: Path, installed_versions: dict[str, str] | None) -> tuple[dict, list[str]]:
+    """Build one pack's report row. Returns ``(row, warnings)``."""
+    warnings: list[str] = []
+    requirement_files: list[str] = []
+    # ``raw`` line -> row, so a line declared in BOTH files is reported once
+    # (requirements.txt wins the ``source`` attribution, being read first).
+    rows: dict[str, dict[str, Any]] = {}
+
+    req_txt = pack_dir / "requirements.txt"
+    if req_txt.is_file():
+        requirement_files.append(SOURCE_REQUIREMENTS_TXT)
+        lines, err = _requirements_txt_lines(req_txt)
+        if err:
+            warnings.append(err)
+        for line in lines:
+            if line not in rows:
+                rows[line] = {**_classify(line, installed_versions), "source": SOURCE_REQUIREMENTS_TXT}
+
+    pyproject = pack_dir / "pyproject.toml"
+    if pyproject.is_file():
+        lines = _pyproject_lines(pyproject)
+        # Only advertise pyproject as a requirement file when it actually
+        # declares dependencies — most packs ship one purely for registry
+        # metadata.
+        if lines:
+            requirement_files.append(SOURCE_PYPROJECT)
+        for line in lines:
+            if line not in rows:
+                rows[line] = {**_classify(line, installed_versions), "source": SOURCE_PYPROJECT}
+
+    requirements = list(rows.values())
+    summary = {status: 0 for status in STATUSES}
+    for row in requirements:
+        summary[row["status"]] += 1
+
+    try:
+        rel_path = str(pack_dir.relative_to(workspace))
+    except ValueError:
+        rel_path = str(pack_dir)
+
+    return (
+        {
+            "pack": pack_dir.name,
+            "path": rel_path,
+            "status": "installed",
+            "requirement_files": requirement_files,
+            "requirements": requirements,
+            "summary": summary,
+        },
+        warnings,
+    )
+
+
+def _not_installed_row(name: str) -> dict[str, Any]:
+    return {
+        "pack": name,
+        "path": None,
+        "status": "not_installed",
+        "requirement_files": [],
+        "requirements": [],
+        "summary": dict.fromkeys(STATUSES, 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    comfy_path: str | None,
+    pack_names: list[str] | None = None,
+    *,
+    python: str | None = None,
+) -> tuple[dict[str, Any] | None, list[dict[str, str]]]:
+    """Build the per-pack dependency report.
+
+    Returns ``(report, warnings)``. ``report`` is ``None`` when *comfy_path*
+    resolves to no usable workspace — the caller turns that into a
+    ``not_in_workspace`` error envelope. Each warning is
+    ``{"code": ..., "message": ...}``.
+    """
+    from comfy_cli.resolve_python import resolve_workspace_python
+
+    warnings: list[dict[str, str]] = []
+    if not comfy_path or not os.path.isdir(comfy_path):
+        return None, warnings
+
+    workspace = Path(comfy_path)
+    python = python or resolve_workspace_python(comfy_path)
+
+    installed_versions, pip_error = pip_list(python)
+    if installed_versions is None:
+        warnings.append(
+            {
+                "code": "installed_versions_unavailable",
+                "message": (
+                    f"could not read installed packages from {python}"
+                    + (f" ({pip_error})" if pip_error else "")
+                    + " — every parseable requirement is reported with status 'unknown'"
+                ),
+            }
+        )
+
+    pack_dirs = iter_pack_dirs(workspace / "custom_nodes")
+    packs: list[dict[str, Any]] = []
+    if pack_names:
+        by_lower = {p.name.lower(): p for p in pack_dirs}
+        for requested in pack_names:
+            match = by_lower.get(requested.strip().lower())
+            if match is None:
+                packs.append(_not_installed_row(requested))
+                continue
+            row, pack_warnings = _pack_report(match, workspace, installed_versions)
+            packs.append(row)
+            warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
+    else:
+        for pack_dir in pack_dirs:
+            row, pack_warnings = _pack_report(pack_dir, workspace, installed_versions)
+            packs.append(row)
+            warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
+
+    compiled = workspace / "requirements.compiled"
+    compiled_present = compiled.is_file()
+    report = {
+        "workspace": str(workspace),
+        "python": python,
+        "compiled_lock": {
+            "present": compiled_present,
+            # Presence + path only in v1 — the lock is never parsed or diffed.
+            "path": str(compiled) if compiled_present else None,
+        },
+        "packs": packs,
+    }
+    return report, warnings
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+_STATUS_STYLE = {
+    "satisfied": "[green]satisfied[/green]",
+    "mismatch": "[bold red]mismatch[/bold red]",
+    "missing": "[bold yellow]missing[/bold yellow]",
+    "unparseable": "[dim]unparseable[/dim]",
+    "unknown": "[dim]unknown[/dim]",
+}
+
+
+def _render_pretty(renderer, report: dict[str, Any]) -> None:
+    from rich.markup import escape
+    from rich.table import Table
+
+    console = renderer.console()
+    for pack in report["packs"]:
+        title = escape(pack["pack"])
+        if pack["status"] == "not_installed":
+            renderer.print(f"[bold]{title}[/bold] — [yellow]not installed[/yellow]")
+            continue
+        if not pack["requirements"]:
+            renderer.print(f"[bold]{title}[/bold] — [dim]no declared requirements[/dim]")
+            continue
+
+        tbl = Table(show_header=True, header_style="bold", title=title, title_justify="left")
+        tbl.add_column("requirement")
+        tbl.add_column("source")
+        tbl.add_column("installed")
+        tbl.add_column("status")
+        for req in pack["requirements"]:
+            # Values come from pack-controlled files; escape so a spec like
+            # ``foo[/]`` can't raise a rich MarkupError and crash the report.
+            installed = escape(req["installed"]) if req["installed"] is not None else "[dim]-[/dim]"
+            tbl.add_row(
+                escape(req["raw"]),
+                escape(req["source"]),
+                installed,
+                _STATUS_STYLE.get(req["status"], escape(req["status"])),
+            )
+        console.print(tbl)
+
+    totals = dict.fromkeys(STATUSES, 0)
+    for pack in report["packs"]:
+        for status, count in pack["summary"].items():
+            totals[status] = totals.get(status, 0) + count
+    renderer.print(
+        "[bold]totals[/bold]: "
+        + ", ".join(f"{count} {status}" for status, count in totals.items() if count)
+        + (" — nothing declared" if not any(totals.values()) else "")
+    )
+    if report["compiled_lock"]["present"]:
+        renderer.print(f"[dim]compiled lock: {escape(report['compiled_lock']['path'])}[/dim]")
+
+
+def execute(renderer, comfy_path: str | None, pack_names: list[str] | None = None) -> None:
+    """Entry point wired from ``comfy node deps``."""
+    from rich.markup import escape
+
+    report, warnings = build_report(comfy_path, pack_names)
+    if report is None:
+        import typer
+
+        renderer.error(
+            code="not_in_workspace",
+            message=(
+                "ComfyUI workspace not found"
+                + (f" at {comfy_path!r}" if comfy_path else "")
+                + ". Run 'comfy install', run 'comfy' from a ComfyUI directory, or pass '--workspace'."
+            ),
+            hint="run: comfy install   (or pass --workspace /path/to/ComfyUI)",
+            command="node deps",
+        )
+        # Mirrors the `comfy which` convention: renderer.error records the code,
+        # typer.Exit is what actually makes the process exit non-zero.
+        raise typer.Exit(code=1)
+
+    if renderer.is_pretty():
+        _render_pretty(renderer, report)
+    for warning in warnings:
+        renderer.warn(escape(warning["message"]))
+    # Warnings ride along in the payload too: a JSON consumer reads only stdout.
+    report["warnings"] = warnings
+    renderer.emit(report, command="node deps")

--- a/comfy_cli/command/outdated.py
+++ b/comfy_cli/command/outdated.py
@@ -34,19 +34,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from comfy_cli.registry import RegistryAPI, extract_node_configuration
-
-
-def _read_pyproject(path: str):
-    """Parse a pack/core ``pyproject.toml`` via the shared registry parser.
-
-    ``extract_node_configuration`` emits its own validation warnings through
-    ``typer.echo``/rich to *stdout*; in JSON mode that would corrupt the single
-    envelope on stdout. Route those side-messages to stderr where they belong.
-    """
-    with contextlib.redirect_stdout(sys.stderr):
-        return extract_node_configuration(path)
-
+from comfy_cli.command.pack_scan import iter_pack_dirs as _iter_pack_dirs
+from comfy_cli.command.pack_scan import read_pyproject as _read_pyproject
+from comfy_cli.registry import RegistryAPI
 
 CACHE_TTL_SECONDS = 3600  # 1 hour
 GIT_TIMEOUT_SECONDS = 10
@@ -283,19 +273,6 @@ def _core_latest(cache: dict[str, Any], refresh: bool, warn: Callable[[str], Non
 # ---------------------------------------------------------------------------
 # Custom node packs
 # ---------------------------------------------------------------------------
-
-
-def _iter_pack_dirs(custom_nodes_dir: Path) -> list[Path]:
-    if not custom_nodes_dir.is_dir():
-        return []
-    packs = []
-    for entry in sorted(custom_nodes_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        if entry.name.startswith(".") or entry.name == "__pycache__":
-            continue
-        packs.append(entry)
-    return packs
 
 
 def _registry_latest(

--- a/comfy_cli/command/pack_scan.py
+++ b/comfy_cli/command/pack_scan.py
@@ -1,0 +1,44 @@
+"""Shared read-only helpers for scanning installed custom node packs.
+
+Extracted from :mod:`comfy_cli.command.outdated` so every read-only pack
+report (``comfy outdated``, ``comfy node deps``, …) agrees on *what counts as
+an installed pack* and on how a pack ``pyproject.toml`` is parsed. Nothing
+here mutates the workspace.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from pathlib import Path
+
+from comfy_cli.registry import extract_node_configuration
+
+
+def iter_pack_dirs(custom_nodes_dir: Path) -> list[Path]:
+    """Return the pack directories under *custom_nodes_dir*, sorted by name.
+
+    Dotfiles and ``__pycache__`` are skipped; ``.disabled`` packs are kept
+    (they are still installed, just not loaded).
+    """
+    if not custom_nodes_dir.is_dir():
+        return []
+    packs = []
+    for entry in sorted(custom_nodes_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(".") or entry.name == "__pycache__":
+            continue
+        packs.append(entry)
+    return packs
+
+
+def read_pyproject(path: str):
+    """Parse a pack/core ``pyproject.toml`` via the shared registry parser.
+
+    ``extract_node_configuration`` emits its own validation warnings through
+    ``typer.echo``/rich to *stdout*; in JSON mode that would corrupt the single
+    envelope on stdout. Route those side-messages to stderr where they belong.
+    """
+    with contextlib.redirect_stdout(sys.stderr):
+        return extract_node_configuration(path)

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -99,6 +99,8 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy version": "version",
     # installed-vs-latest report
     "comfy outdated": "outdated",
+    # per-pack declared-vs-installed Python dependency report
+    "comfy node deps": "node_deps",
     # background server logs
     "comfy logs": "logs",
 }

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -594,6 +594,22 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy feedback` was run in JSON/non-interactive mode without an inline message.",
         'comfy feedback "your feedback here"',
     ),
+    # --- custom node dependency report (`comfy node deps`) --------------------
+    ErrorCode(
+        "installed_versions_unavailable",
+        "`comfy node deps` could not read the workspace venv's installed packages (`pip list --format=json` "
+        "failed, timed out, or returned unparseable output), so every parseable requirement is reported with "
+        '`status: "unknown"`. Surfaced in `data.warnings[]` (not as an error envelope) so the declared '
+        "requirements are still reported.",
+        "check the workspace venv has pip (`comfy env`), then re-run",
+    ),
+    ErrorCode(
+        "pack_read_error",
+        "A pack's `requirements.txt` existed but could not be read (permissions, I/O). That pack's row omits "
+        "the unreadable file's requirements. Surfaced in `data.warnings[]` (not as an error envelope) so the "
+        "rest of the report still succeeds.",
+        "check the file's permissions under `custom_nodes/<pack>/`",
+    ),
 )
 
 

--- a/comfy_cli/schemas/node_deps.json
+++ b/comfy_cli/schemas/node_deps.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "comfy node deps",
+  "description": "Per-pack Python dependency report: each installed custom node pack's declared requirements (requirements.txt and/or pyproject.toml [project] dependencies) against the versions installed in the workspace venv. Read-only: no installs, no cm-cli, no network. Exit code is 0 even when requirements are missing or mismatched — this is a report, not a check.",
+  "type": "object",
+  "properties": {
+    "workspace": { "type": "string", "description": "Resolved ComfyUI workspace path." },
+    "python": {
+      "type": "string",
+      "description": "Interpreter whose site-packages were probed (`pip list --format=json`, run once for the whole report)."
+    },
+    "compiled_lock": {
+      "type": "object",
+      "description": "Presence + path of the workspace `requirements.compiled` written by the uv-compile install path. Never parsed or diffed in v1.",
+      "properties": {
+        "present": { "type": "boolean" },
+        "path": { "type": ["string", "null"] }
+      },
+      "required": ["present", "path"]
+    },
+    "packs": {
+      "type": "array",
+      "description": "One row per reported pack, in directory-name order (or in the order requested on the command line).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "pack": { "type": "string", "description": "Pack directory name." },
+          "path": {
+            "type": ["string", "null"],
+            "description": "Pack path relative to the workspace, or null when the named pack is not installed."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["installed", "not_installed"],
+            "description": "`not_installed` when a name given on the command line matched no pack directory."
+          },
+          "requirement_files": {
+            "type": "array",
+            "description": "Which declaration files contributed requirements.",
+            "items": { "type": "string", "enum": ["requirements.txt", "pyproject.toml"] }
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "raw": { "type": "string", "description": "The declared line, verbatim (comments stripped)." },
+                "name": {
+                  "type": ["string", "null"],
+                  "description": "Requirement name, or null when the line is unparseable."
+                },
+                "specifier": {
+                  "type": ["string", "null"],
+                  "description": "PEP 440 specifier (empty string for a bare name), or null when unparseable."
+                },
+                "marker": {
+                  "type": "string",
+                  "description": "PEP 508 environment marker, when declared. NOT evaluated — the relevant environment is the workspace venv's, not the CLI's."
+                },
+                "source": { "type": "string", "enum": ["requirements.txt", "pyproject.toml"] },
+                "installed": {
+                  "type": ["string", "null"],
+                  "description": "Version found in the workspace venv, or null when missing/unparseable/unknown."
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["satisfied", "mismatch", "missing", "unparseable", "unknown"],
+                  "description": "`unparseable` covers pip options (-r, --extra-index-url) and bare VCS/URL lines; `unknown` means the comparison could not be made (the pip probe failed, or the installed dist records a non-PEP-440 version)."
+                }
+              },
+              "required": ["raw", "name", "specifier", "source", "installed", "status"]
+            }
+          },
+          "summary": {
+            "type": "object",
+            "description": "Per-status counts for this pack. Every status key is always present.",
+            "properties": {
+              "satisfied": { "type": "integer" },
+              "mismatch": { "type": "integer" },
+              "missing": { "type": "integer" },
+              "unparseable": { "type": "integer" },
+              "unknown": { "type": "integer" }
+            },
+            "required": ["satisfied", "mismatch", "missing", "unparseable", "unknown"]
+          }
+        },
+        "required": ["pack", "path", "status", "requirement_files", "requirements", "summary"]
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "description": "Non-fatal problems. `installed_versions_unavailable` means the pip probe failed, so every requirement is `unknown`.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "required": ["code", "message"]
+      }
+    }
+  },
+  "required": ["workspace", "python", "compiled_lock", "packs"]
+}

--- a/tests/comfy_cli/command/test_node_deps.py
+++ b/tests/comfy_cli/command/test_node_deps.py
@@ -1,0 +1,476 @@
+"""Tests for ``comfy node deps`` — per-pack declared-vs-installed dependencies.
+
+Builds a fixture workspace with fake ``custom_nodes/<pack>/requirements.txt`` +
+``pyproject.toml`` under tmp_path and mocks the single ``pip list --format=json``
+subprocess to a fixed payload, so nothing touches a real venv or the network.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import node_deps as node_deps_cmd
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+# What the mocked workspace venv has installed. ``Pillow`` is deliberately
+# capitalized to exercise canonicalization against a lowercase declaration.
+INSTALLED = [
+    {"name": "opencv-python", "version": "4.9.0.80"},
+    {"name": "Pillow", "version": "10.2.0"},
+    {"name": "numpy", "version": "1.26.4"},
+]
+
+
+@pytest.fixture(autouse=True)
+def _renderer_isolation():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+class _FakePipList:
+    """Stand-in for ``subprocess.run``; records every invocation."""
+
+    def __init__(self, payload=INSTALLED, returncode: int = 0, stdout: str | None = None):
+        self.calls: list[list[str]] = []
+        self._payload = payload
+        self._returncode = returncode
+        self._stdout = stdout
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        stdout = self._stdout if self._stdout is not None else json.dumps(self._payload)
+        if self._returncode != 0:
+            raise subprocess.CalledProcessError(self._returncode, cmd, output=stdout, stderr="boom")
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def fake_pip(monkeypatch) -> _FakePipList:
+    fake = _FakePipList()
+    monkeypatch.setattr(node_deps_cmd.subprocess, "run", fake)
+    return fake
+
+
+def _make_pack(workspace: Path, name: str, *, requirements: str | None = None, pyproject: str | None = None) -> Path:
+    pack = workspace / "custom_nodes" / name
+    pack.mkdir(parents=True)
+    if requirements is not None:
+        (pack / "requirements.txt").write_text(requirements)
+    if pyproject is not None:
+        (pack / "pyproject.toml").write_text(pyproject)
+    return pack
+
+
+@pytest.fixture
+def workspace(tmp_path) -> Path:
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+
+    _make_pack(
+        ws,
+        "comfyui-impact-pack",
+        requirements=(
+            "# a comment line\n"
+            "\n"
+            "opencv-python>=4.7  # inline comment\n"
+            "ultralytics\n"
+            "numpy<1.20\n"
+            "pillow\n"
+            "--extra-index-url https://example.invalid/simple\n"
+            "-r other-requirements.txt\n"
+            "git+https://example.invalid/pkg.git\n"
+        ),
+    )
+    _make_pack(
+        ws,
+        "Registry-Pack",
+        pyproject=(
+            '[project]\nname = "registry-pack"\nversion = "1.0.0"\nlicense = {text = "MIT"}\n'
+            'dependencies = ["numpy>=1.20", "requests"]\n'
+        ),
+    )
+    return ws
+
+
+def _packs_by_name(report: dict) -> dict[str, dict]:
+    return {p["pack"]: p for p in report["packs"]}
+
+
+def _reqs_by_raw(pack: dict) -> dict[str, dict]:
+    return {r["raw"]: r for r in pack["requirements"]}
+
+
+# ---------------------------------------------------------------------------
+# statuses
+# ---------------------------------------------------------------------------
+
+
+def test_statuses_satisfied_mismatch_missing_unparseable(workspace, fake_pip):
+    report, warnings = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert not warnings
+    pack = _packs_by_name(report)["comfyui-impact-pack"]
+    assert pack["status"] == "installed"
+    assert pack["requirement_files"] == ["requirements.txt"]
+    reqs = _reqs_by_raw(pack)
+
+    assert reqs["opencv-python>=4.7"]["status"] == "satisfied"
+    assert reqs["opencv-python>=4.7"]["installed"] == "4.9.0.80"
+    assert reqs["opencv-python>=4.7"]["specifier"] == ">=4.7"
+
+    # installed but rejected by the specifier → both versions reported
+    assert reqs["numpy<1.20"]["status"] == "mismatch"
+    assert reqs["numpy<1.20"]["installed"] == "1.26.4"
+
+    # declared, not in the venv
+    assert reqs["ultralytics"]["status"] == "missing"
+    assert reqs["ultralytics"]["installed"] is None
+    # a bare name is satisfied by whatever is installed
+    assert reqs["pillow"]["specifier"] == ""
+
+    for raw in (
+        "--extra-index-url https://example.invalid/simple",
+        "-r other-requirements.txt",
+        "git+https://example.invalid/pkg.git",
+    ):
+        assert reqs[raw]["status"] == "unparseable", raw
+        assert reqs[raw]["name"] is None
+
+    assert pack["summary"] == {
+        "satisfied": 2,  # opencv-python, pillow
+        "mismatch": 1,  # numpy
+        "missing": 1,  # ultralytics
+        "unparseable": 3,
+        "unknown": 0,
+    }
+    # comments and blank lines are dropped, everything else is kept
+    assert len(pack["requirements"]) == 7
+
+
+def test_name_canonicalization_matches_case_insensitively(workspace, fake_pip):
+    """A lowercase ``pillow`` declaration resolves against installed ``Pillow``."""
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    pillow = _reqs_by_raw(_packs_by_name(report)["comfyui-impact-pack"])["pillow"]
+    assert pillow["installed"] == "10.2.0"
+    assert pillow["status"] == "satisfied"
+
+
+def test_pyproject_dependencies_are_reported(workspace, fake_pip):
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    pack = _packs_by_name(report)["Registry-Pack"]
+    assert pack["requirement_files"] == ["pyproject.toml"]
+    reqs = _reqs_by_raw(pack)
+    assert reqs["numpy>=1.20"]["source"] == "pyproject.toml"
+    assert reqs["numpy>=1.20"]["status"] == "satisfied"
+    assert reqs["requests"]["status"] == "missing"
+
+
+def test_both_sources_are_unioned_with_per_line_source(tmp_path, fake_pip):
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+    _make_pack(
+        ws,
+        "dual-pack",
+        requirements="numpy>=1.20\nrequests\n",
+        pyproject=(
+            '[project]\nname = "dual-pack"\nversion = "1.0.0"\nlicense = {text = "MIT"}\n'
+            # ``numpy>=1.20`` is declared in BOTH files (deduped, requirements.txt
+            # wins the source), ``pillow`` only here.
+            'dependencies = ["numpy>=1.20", "pillow"]\n'
+        ),
+    )
+
+    report, _ = node_deps_cmd.build_report(str(ws), python="/fake/python")
+    pack = _packs_by_name(report)["dual-pack"]
+
+    assert pack["requirement_files"] == ["requirements.txt", "pyproject.toml"]
+    reqs = _reqs_by_raw(pack)
+    assert len(pack["requirements"]) == 3
+    assert reqs["numpy>=1.20"]["source"] == "requirements.txt"
+    assert reqs["requests"]["source"] == "requirements.txt"
+    assert reqs["pillow"]["source"] == "pyproject.toml"
+
+
+def test_environment_marker_is_surfaced_not_evaluated(tmp_path, fake_pip):
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+    _make_pack(ws, "marker-pack", requirements='pywin32; sys_platform == "win32"\n')
+
+    report, _ = node_deps_cmd.build_report(str(ws), python="/fake/python")
+    req = _packs_by_name(report)["marker-pack"]["requirements"][0]
+
+    assert req["name"] == "pywin32"
+    assert req["marker"] == 'sys_platform == "win32"'
+    assert req["status"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# pip list behavior
+# ---------------------------------------------------------------------------
+
+
+def test_non_pep440_installed_version_is_unknown_not_a_crash(tmp_path, monkeypatch):
+    """A broken `.dist-info` version must not abort the whole report."""
+    monkeypatch.setattr(
+        node_deps_cmd.subprocess,
+        "run",
+        _FakePipList(payload=[{"name": "weirdpkg", "version": "not-a-version"}]),
+    )
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+    _make_pack(ws, "weird-pack", requirements="weirdpkg>=1.0\nweirdpkg\n")
+
+    report, _ = node_deps_cmd.build_report(str(ws), python="/fake/python")
+    reqs = _reqs_by_raw(_packs_by_name(report)["weird-pack"])
+
+    assert reqs["weirdpkg>=1.0"]["status"] == "unknown"
+    assert reqs["weirdpkg>=1.0"]["installed"] == "not-a-version"
+    # a bare name never needs a version comparison, so it stays satisfied
+    assert reqs["weirdpkg"]["status"] == "satisfied"
+
+
+def test_pip_list_runs_once_for_the_whole_report(workspace, fake_pip):
+    node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert len(fake_pip.calls) == 1, f"pip list ran {len(fake_pip.calls)}x — must be once per report"
+    assert fake_pip.calls[0] == ["/fake/python", "-m", "pip", "list", "--format=json"]
+
+
+def test_pip_list_failure_degrades_to_unknown_with_a_warning(workspace, monkeypatch):
+    monkeypatch.setattr(node_deps_cmd.subprocess, "run", _FakePipList(returncode=2))
+
+    report, warnings = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert [w["code"] for w in warnings] == ["installed_versions_unavailable"]
+    pack = _packs_by_name(report)["comfyui-impact-pack"]
+    reqs = _reqs_by_raw(pack)
+    assert reqs["opencv-python>=4.7"]["status"] == "unknown"
+    assert reqs["opencv-python>=4.7"]["installed"] is None
+    # unparseable lines stay unparseable — the pip probe can't change that
+    assert reqs["-r other-requirements.txt"]["status"] == "unparseable"
+    assert pack["summary"]["unknown"] == 4
+    assert pack["summary"]["unparseable"] == 3
+
+
+def test_pip_list_unparseable_output_degrades_to_unknown(workspace, monkeypatch):
+    monkeypatch.setattr(node_deps_cmd.subprocess, "run", _FakePipList(stdout="not json at all"))
+
+    report, warnings = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert [w["code"] for w in warnings] == ["installed_versions_unavailable"]
+    assert _packs_by_name(report)["Registry-Pack"]["requirements"][0]["status"] == "unknown"
+
+
+def test_pip_list_missing_interpreter_does_not_crash(workspace, monkeypatch):
+    def _boom(*a, **k):
+        raise FileNotFoundError("no such python")
+
+    monkeypatch.setattr(node_deps_cmd.subprocess, "run", _boom)
+
+    report, warnings = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert report is not None
+    assert [w["code"] for w in warnings] == ["installed_versions_unavailable"]
+
+
+# ---------------------------------------------------------------------------
+# pack filtering
+# ---------------------------------------------------------------------------
+
+
+def test_pack_name_filter_is_case_insensitive(workspace, fake_pip):
+    report, _ = node_deps_cmd.build_report(str(workspace), ["REGISTRY-pack"], python="/fake/python")
+
+    assert [p["pack"] for p in report["packs"]] == ["Registry-Pack"]
+    assert report["packs"][0]["status"] == "installed"
+
+
+def test_unknown_pack_name_reports_not_installed(workspace, fake_pip):
+    report, _ = node_deps_cmd.build_report(str(workspace), ["nope-pack", "comfyui-impact-pack"], python="/fake/python")
+
+    rows = _packs_by_name(report)
+    assert rows["nope-pack"]["status"] == "not_installed"
+    assert rows["nope-pack"]["path"] is None
+    assert rows["nope-pack"]["requirements"] == []
+    assert rows["comfyui-impact-pack"]["status"] == "installed"
+
+
+def test_no_names_reports_every_pack(workspace, fake_pip):
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+
+    assert sorted(p["pack"] for p in report["packs"]) == ["Registry-Pack", "comfyui-impact-pack"]
+
+
+def test_unreadable_requirements_file_warns_instead_of_crashing(tmp_path, fake_pip, monkeypatch):
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+    _make_pack(ws, "locked-pack", requirements="numpy\n")
+
+    real_read_text = Path.read_text
+
+    def _deny(self, *a, **k):
+        if self.name == "requirements.txt":
+            raise PermissionError("denied")
+        return real_read_text(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", _deny)
+
+    report, warnings = node_deps_cmd.build_report(str(ws), python="/fake/python")
+
+    assert [w["code"] for w in warnings] == ["pack_read_error"]
+    assert _packs_by_name(report)["locked-pack"]["requirements"] == []
+
+
+def test_pack_without_declarations_reports_empty_requirements(tmp_path, fake_pip):
+    ws = tmp_path / "ComfyUI"
+    (ws / "custom_nodes").mkdir(parents=True)
+    _make_pack(ws, "bare-pack")
+
+    report, _ = node_deps_cmd.build_report(str(ws), python="/fake/python")
+    pack = _packs_by_name(report)["bare-pack"]
+
+    assert pack["requirement_files"] == []
+    assert pack["requirements"] == []
+    assert pack["summary"]["satisfied"] == 0
+
+
+# ---------------------------------------------------------------------------
+# workspace-level fields
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_lock_presence_and_path(workspace, fake_pip):
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+    assert report["compiled_lock"] == {"present": False, "path": None}
+
+    (workspace / "requirements.compiled").write_text("numpy==1.26.4\n")
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+    assert report["compiled_lock"]["present"] is True
+    assert report["compiled_lock"]["path"] == str(workspace / "requirements.compiled")
+
+
+def test_missing_custom_nodes_dir_is_not_an_error(tmp_path, fake_pip):
+    ws = tmp_path / "ComfyUI"
+    ws.mkdir()
+
+    report, warnings = node_deps_cmd.build_report(str(ws), python="/fake/python")
+
+    assert report["packs"] == []
+    assert not warnings
+
+
+def test_no_workspace_returns_none(tmp_path):
+    report, warnings = node_deps_cmd.build_report(str(tmp_path / "nope"), python="/fake/python")
+    assert report is None
+    assert warnings == []
+
+    report, _ = node_deps_cmd.build_report(None, python="/fake/python")
+    assert report is None
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def _force_json_renderer() -> Renderer:
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def test_cli_json_envelope_shape(workspace, fake_pip, capsys):
+    r = _force_json_renderer()
+    node_deps_cmd.execute(r, str(workspace))
+
+    out = capsys.readouterr().out.strip()
+    # Envelope contract: stdout must be exactly ONE line. The registry parser's
+    # own warnings must land on stderr, not corrupt the envelope.
+    assert len(out.splitlines()) == 1, f"stdout not a single envelope line:\n{out}"
+    envelope = json.loads(out)
+
+    assert envelope["ok"] is True
+    assert envelope["command"] == "node deps"
+    assert envelope["data"]["workspace"] == str(workspace)
+    assert isinstance(envelope["data"]["packs"], list)
+    assert envelope["data"]["warnings"] == []
+    assert r.exit_code == 0  # a report, not a check: missing deps stay exit 0
+
+
+def test_cli_no_workspace_emits_error_envelope(tmp_path, capsys):
+    import typer
+
+    r = _force_json_renderer()
+    # typer.Exit is what makes the *process* exit non-zero; renderer.error alone
+    # only records the code (see `comfy which`).
+    with pytest.raises(typer.Exit) as exc:
+        node_deps_cmd.execute(r, str(tmp_path / "nope"))
+    assert exc.value.exit_code == 1
+
+    envelope = json.loads(capsys.readouterr().out.strip())
+    assert envelope["ok"] is False
+    assert envelope["command"] == "node deps"
+    assert envelope["error"]["code"] == "not_in_workspace"
+    assert envelope["error"]["hint"]
+    assert r.exit_code == 1
+
+
+def test_cli_pretty_mode_renders_without_crashing(workspace, fake_pip, capsys):
+    reset_renderer_for_testing()
+    r = Renderer(mode=OutputMode.PRETTY)
+    set_renderer(r)
+
+    node_deps_cmd.execute(r, str(workspace))
+
+    out = capsys.readouterr().out
+    assert "comfyui-impact-pack" in out
+    assert "satisfied" in out
+
+
+def test_report_validates_against_shipped_schema(workspace, fake_pip):
+    import jsonschema
+
+    from comfy_cli import discovery
+
+    schema = discovery._read_schema("node_deps")
+    report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
+    report["warnings"] = []
+    jsonschema.validate(report, schema)
+
+    # a not-installed row and an unknown-status report must validate too
+    report_filtered, _ = node_deps_cmd.build_report(str(workspace), ["nope-pack"], python="/fake/python")
+    report_filtered["warnings"] = []
+    jsonschema.validate(report_filtered, schema)
+
+
+def test_command_registers_a_schema():
+    from comfy_cli.discovery import COMMAND_SCHEMAS
+
+    assert COMMAND_SCHEMAS["comfy node deps"] == "node_deps"
+
+
+def test_deps_command_is_registered_on_the_node_app():
+    from comfy_cli.command.custom_nodes.command import app
+
+    names = {c.name for c in app.registered_commands}
+    assert "deps" in names
+    assert {"deps-in-workflow", "install-deps"} <= names, "must not shadow the existing deps-* commands"


### PR DESCRIPTION
## ELI-5

You installed a bunch of custom node packs. Each one ships a list of Python libraries it needs. Nobody was checking whether your ComfyUI venv actually *has* those libraries at the right versions — so a pack silently half-works and you find out at node-execution time.

`comfy node deps` reads every pack's requirement list, asks the workspace venv once "what do you actually have installed?", and prints a per-requirement verdict: **satisfied**, **mismatch** (installed, but the wrong version), **missing**, or **unparseable** (a `-r other.txt` / `--extra-index-url` / bare git URL line that isn't a version-checkable requirement). It changes nothing — no pip installs, no cm-cli, no network.

## What this adds

`comfy node deps [PACK_NAMES...]` — read-only per-pack Python dependency report. With no arguments it reports every installed pack; with names it filters case-insensitively on the pack directory name. This is the CLI half of BE-4743; a comfy-local-mcp tool wraps it.

- **`comfy_cli/command/node_deps.py`** — modeled on `outdated.py`: read-only scan, `get_renderer()` envelope output, `execute(renderer, comfy_path, pack_names)` entry point. Deliberately **not** routed through `execute_cm_cli`, so it works on a workspace that never installed ComfyUI-Manager.
- **`comfy_cli/command/pack_scan.py`** — `_iter_pack_dirs` and `_read_pyproject` **extracted** out of `outdated.py` (not copy-pasted); `outdated.py` now imports them under its existing private names, so its behavior and internal API are unchanged.
- Registered on the existing `node` typer app as `deps`. `deps-in-workflow` and `install-deps` are untouched and still resolve (verified via `--help` and a test assertion).
- **`comfy_cli/schemas/node_deps.json`** + `discovery.COMMAND_SCHEMAS["comfy node deps"]`, and the two non-fatal warning codes in `error_codes.REGISTRY`. Both were *required* — the repo has ratchet tests (`test_every_emitted_command_registers_a_schema`, `test_every_raised_code_is_registered`) that fail otherwise.

Requirements come from `requirements.txt` (same comment/option rules as `uv.py::parse_req_file`) **and** `pyproject.toml` `[project] dependencies` (via the shared registry parser), unioned with a per-line `source`. Installed versions come from one `<workspace python> -m pip list --format=json` for the **whole** report (asserted by a test), keyed on `packaging.utils.canonicalize_name` so `Pillow` matches a declared `pillow`.

## Judgment calls (all deviate slightly from, or extend, the ticket text)

- **Uniform row keys.** The ticket sketches unparseable rows as `{raw, status}`. They instead carry the same keys as every other row with `name`/`specifier`/`installed` set to `null` — a superset, so JSON consumers can index without branching on shape. Same reasoning for `status: "installed" | "not_installed"` on every pack row and for `summary` always carrying all five status keys (including `unknown`).
- **`warnings` in the payload.** The ticket calls `installed_versions_unavailable` an "envelope-level warning". It goes to stderr via `renderer.warn` *and* rides in `data.warnings[]`, because a JSON consumer reads only stdout.
- **PEP 508 direct references.** A *bare* URL/VCS line (`git+https://…`) fails `Requirement` parsing → `unparseable`, as specified. A `name @ git+https://…` line **does** parse, so it is reported as a normal requirement with an empty specifier (satisfied/missing by presence). Reporting the name we successfully parsed seemed strictly more useful than discarding it; flagging in case the ticket meant otherwise.
- **Environment markers are surfaced, not evaluated.** `pywin32; sys_platform == "win32"` reports `missing` on macOS, with the marker text in a `marker` field. Evaluating it here would be *wrong* — the relevant environment is the workspace venv's, not the CLI process's.
- **Non-PEP-440 installed version → `unknown`, not a crash.** A broken `.dist-info` makes `SpecifierSet.contains()` raise `InvalidVersion`; that is caught per-requirement so one bad dist can't abort the report. This widens `unknown` slightly beyond the ticket's "pip probe failed" (documented in the schema + module docstring).
- **`typer.Exit(code=1)` on the no-workspace path.** `renderer.error()` alone records the code but the process still exits 0 (Typer's `SystemExit(0)` short-circuits `main()`'s rc check). Followed the `comfy which` convention and raised explicitly — verified empirically that the error envelope now exits 1 while a real report exits 0.
- **Dedicated shell completer.** `pack_names` completes against *installed pack directory names*, not `node_completer`'s registry-node-id cache — a git-cloned pack's directory is its repo name, not its registry id.

## Known caveats (not fixed here — out of scope / follow-up material)

- `read_pyproject` is the shared registry parser as the ticket specifies, and that parser **strips `comfyui-frontend-package`** from `[project] dependencies`. Such a pin therefore won't appear in the report. It's a core-ComfyUI concern rather than a pack dependency, so this seems acceptable; noted in the module docstring.
- `resolve_workspace_python` prefers `VIRTUAL_ENV` / `CONDA_PREFIX` over the workspace venv — the same behavior `custom_nodes/command.py::get_installed_packages` already has, and the ticket named that call. The report echoes the resolved `python` path so the reader can always tell which interpreter was probed.
- `compiled_lock` checks `<workspace>/requirements.compiled`. `DependencyCompiler`'s `outDir` defaults to the *process* cwd on some call paths, so a lock written from a different cwd won't be found. Presence + path only, never parsed — per the ticket.

## Testing

`tests/comfy_cli/command/test_node_deps.py` (24 tests), mirroring `test_outdated.py` conventions: tmp workspace with fake `custom_nodes/<pack>/requirements.txt` + `pyproject.toml`, `pip list` mocked to a fixed JSON payload. Covers each status, the single-pip-list-invocation guarantee, `Pillow`/`pillow` canonicalization, case-insensitive pack filtering, `not_installed` rows, both-sources union + dedup, markers, pip-failure/unparseable-output/missing-interpreter degradation, unreadable `requirements.txt`, the non-PEP-440 version guard, `compiled_lock`, the JSON envelope shape, the pretty table, the no-workspace error envelope, and schema validation.

Full suite: **2798 passed, 37 skipped, 0 failed**. `ruff check` + `ruff format --diff` clean.

Also smoke-tested against a real fixture workspace: satisfied/mismatch/missing/unparseable rows in both JSON and pretty mode, `DEMO-PACK ghost` case-insensitive filtering with a `not installed` row, and exit 0 on a report vs exit 1 on the error envelope.

## Negative-claim falsification

The diff introduces "unavailable"/"unknown"/"not installed" strings and one deny path (`not_in_workspace` + `typer.Exit(1)`), so per the falsification rule: none of these deny an existing capability. They are **report values** computed from the user's actual filesystem and venv state, and all were empirically produced against a real workspace (see smoke test above) rather than asserted. The only deny path fires when the given path genuinely is not a directory — verified that a real workspace path yields a full report at exit 0 on the same code. No existing capability is removed or routed away: `comfy node deps-in-workflow` and `comfy node install-deps` both still resolve (`--help` verified, plus a regression assertion in the test file), and `comfy outdated` is unchanged apart from importing its helpers from their new shared home.

## Out of scope (per the ticket)

Conflict resolution / auto-fix; registry lookups for uninstalled packs (follow-up ticket); parsing `requirements.compiled`.
