### PR TITLE
fix(models): accept spaces/Unicode in user-supplied model folder names (BE-4792)

### DIFF
--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -64,7 +64,30 @@ def _is_walkable_folder_name(value: str) -> bool:
     the URL, so spaces, ``?``/``#``, and control characters can't alter the
     request.
     """
-    return bool(value) and ".." not in value and "/" not in value and "\\" not in value
+    if not value or "/" in value or "\\" in value:
+        return False
+    # Only the *exact* segments `.` and `..` are rewritten by a URL resolver
+    # (RFC 3986 remove_dot_segments); `..` merely *inside* a name (`model..v2`)
+    # is an ordinary run of characters and must stay usable. `quote` leaves `.`
+    # unencoded, so a bare `.` would otherwise reach the server as `/models/.`
+    # and normalize back to the `/models` collection.
+    if value in (".", ".."):
+        return False
+    try:
+        # argv can carry undecodable bytes as lone surrogates (PEP 383
+        # `surrogateescape`), and a JSON `"\udcff"` escape does the same for
+        # server-advertised names. `quote(..., safe="")` raises
+        # `UnicodeEncodeError` on those — a `ValueError` that no call site's
+        # handler catches, so it would surface as an uncaught traceback.
+        # Rejecting costs no reachable capability: `quote(..., errors=
+        # "surrogateescape")` would encode the raw bytes instead, but a backend's
+        # folder names are config-defined `str` keys (`folder_names_and_paths`,
+        # `extra_model_paths.yaml`) that are always valid UTF-8, so such a segment
+        # can never match one — it would only turn this clear error into a 404.
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
 
 
 def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
@@ -73,7 +96,10 @@ def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
         renderer.error(
             code="invalid_argument",
             message=f"{kind} {value!r} is not usable as a single path segment",
-            hint=f"a {kind} name must be non-empty and must not contain `..`, `/`, or `\\`",
+            hint=(
+                f"a {kind} name must be non-empty, must not be `.` or `..`, must not contain "
+                "`/` or `\\`, and must be valid UTF-8"
+            ),
         )
         raise typer.Exit(code=1)
 

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -27,7 +27,6 @@ Local-mode caveats:
 from __future__ import annotations
 
 import json
-import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -46,45 +45,35 @@ app = typer.Typer(no_args_is_help=True, help="Discover models — folders, files
 # a misconfigured backend or hostile and would only serve to OOM the CLI.
 _MAX_RESPONSE_BYTES = 64 * 1024 * 1024
 
-# Folder + asset-name arguments are interpolated into URL paths or query
-# strings. We disallow path-traversal sequences and control characters so a
-# crafted argument can't escape the intended endpoint. The set of legitimate
-# folder names (loras, checkpoints, …) is alphanumeric + ``_``/`-`/`.`; the
-# regex below is permissive enough for real-world filenames while rejecting
-# the obvious attack shapes.
-_PATH_SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]*$")
-
-
-def _is_safe_path_segment(value: str) -> bool:
-    """True if ``value`` can be interpolated into a URL path as a single segment."""
-    return (
-        bool(value) and ".." not in value and "/" not in value and "\\" not in value and bool(_PATH_SAFE.match(value))
-    )
+# Folder names are interpolated into URL paths, so they must stay a *single*
+# path segment. Only genuine traversal shapes are refused; everything else is
+# percent-encoded before it reaches the URL (see `_is_walkable_folder_name`).
 
 
 def _is_walkable_folder_name(value: str) -> bool:
-    """True if a *server-advertised* folder name is safe to walk.
+    """True if ``value`` is usable as a single URL path segment.
 
-    Deliberately laxer than :func:`_is_safe_path_segment`, which gates
-    user-supplied arguments and stays strict-ASCII on purpose. Real installs
-    configure folders like ``my loras``, ``SDXL (base)``, or non-ASCII names;
-    holding those to the strict regex silently skipped them, so every model
-    inside them stayed unfindable by ``models search`` — the exact bug this
-    command is meant to fix. Only genuine traversal shapes are refused here;
-    everything else is percent-encoded by :func:`_local_folder_matches` before
-    it reaches the URL, so spaces, ``?``/``#``, and control characters can't
-    alter the request.
+    Applies to both server-advertised folder names (the ``models search
+    --where local`` walk) and user-supplied ones (``models list-folder <folder>``,
+    ``models search --type``). Real installs configure folders like ``my loras``,
+    ``SDXL (base)``, or non-ASCII names; holding those to a strict-ASCII regex
+    silently skipped them on the walk and rejected them outright on user input,
+    leaving every model inside them unreachable even though ComfyUI serves the
+    folder fine. Only genuine traversal shapes are refused here; every call site
+    percent-encodes the segment with ``quote(..., safe="")`` before it reaches
+    the URL, so spaces, ``?``/``#``, and control characters can't alter the
+    request.
     """
     return bool(value) and ".." not in value and "/" not in value and "\\" not in value
 
 
 def _reject_unsafe_path_segment(value: str, *, kind: str, renderer) -> None:
     """Exit with an `invalid_argument` error if ``value`` isn't safe as a path segment."""
-    if not _is_safe_path_segment(value):
+    if not _is_walkable_folder_name(value):
         renderer.error(
             code="invalid_argument",
-            message=f"{kind} {value!r} contains characters that aren't allowed in a path segment",
-            hint=f"valid {kind} names are alphanumeric with `_`, `-`, or `.`",
+            message=f"{kind} {value!r} is not usable as a single path segment",
+            hint=f"a {kind} name must be non-empty and must not contain `..`, `/`, or `\\`",
         )
         raise typer.Exit(code=1)
 
@@ -260,7 +249,11 @@ def list_folder_cmd(
     renderer = get_renderer()
     _reject_unsafe_path_segment(folder, kind="folder", renderer=renderer)
     target = resolve_target(where=where)
-    url = target.url(*_models_path_parts(target), folder)
+    # Percent-encoded for the same reason `_local_folder_matches` does it: the
+    # relaxed validation above admits spaces, `?`/`#`, and non-ASCII, none of
+    # which may be allowed to alter the request. Error payloads below carry the
+    # decoded `folder` so the user sees what they typed.
+    url = target.url(*_models_path_parts(target), urllib.parse.quote(folder, safe=""))
 
     try:
         data = _http_get_json(url, target)

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -229,7 +229,7 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "invalid_argument",
         "An argument intended for a URL path failed safe-path validation.",
-        "use only alphanumerics, `_`, `-`, or `.` in path-segment arguments",
+        "a path-segment argument must be a single segment: non-empty, not `.` or `..`, and free of `/` and `\\`",
     ),
     ErrorCode(
         "folder_not_found",

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -335,6 +335,29 @@ class TestListFolder:
         assert env["error"]["code"] == "invalid_argument"
         assert calls == []
 
+    @pytest.mark.parametrize("folder", ["%2e%2e%2fetc", "%2E%2E%2Fetc", "a%00b", "a\r\nX-Evil: 1"])
+    def test_encoded_traversal_and_injection_shapes_are_neutralized(self, local_target, monkeypatch, capsys, folder):
+        """`%` and control characters are no longer charset-rejected, so encoding must defuse them.
+
+        These are the shapes the old strict regex blocked incidentally. The
+        traversal guard alone lets them through — `..` and `/` are not
+        *literally* present — so the percent-encoding in `list_folder_cmd` is
+        what keeps them inside one path segment: `%` becomes `%25`, so an
+        encoded `../` can never be decoded back into one by the server.
+        """
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        url = calls[0]["url"]
+        assert url == f"http://127.0.0.1:8188/models/{segment}"
+        # Exactly one layer of encoding: the server decodes back to the literal
+        # folder name the user asked for, never to a traversal or a new header.
+        assert urllib.parse.unquote(segment) == folder
+        # And nothing escaped the segment on the wire.
+        assert url.count("/") == 4  # http:// + /127.0.0.1:8188 + /models + /<segment>
+        assert not any(c in url for c in "\r\n\x00")
+
 
 # ---------------------------------------------------------------------------
 # search

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -358,6 +358,49 @@ class TestListFolder:
         assert url.count("/") == 4  # http:// + /127.0.0.1:8188 + /models + /<segment>
         assert not any(c in url for c in "\r\n\x00")
 
+    @pytest.mark.parametrize("folder", ["model..v2", "my..folder", "..hidden", "trailing.."])
+    def test_dots_inside_a_name_are_not_traversal(self, local_target, monkeypatch, capsys, folder):
+        """Only the exact segments `.`/`..` are dot-segments; `..` mid-name is an ordinary name.
+
+        A substring `".." not in value` guard silently skipped these on the
+        `search --where local` walk and rejected them outright here, even though
+        `/models/model..v2` resolves to exactly that folder — no resolver rewrites it.
+        """
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [c["url"] for c in calls] == [f"http://127.0.0.1:8188/models/{segment}"]
+        assert env["data"]["folder"] == folder
+
+    @pytest.mark.parametrize("folder", [".", ".."])
+    def test_bare_dot_segments_are_rejected(self, local_target, monkeypatch, capsys, folder):
+        """`.` and `..` are rewritten by a URL resolver, so they can't stay one segment.
+
+        `quote(..., safe="")` leaves `.` untouched, so a bare `.` would reach the
+        server as `/models/.` and normalize back to the `/models` *collection* —
+        rendering the folder list as if it were a file listing.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    def test_undecodable_argv_bytes_error_cleanly(self, local_target, monkeypatch, capsys):
+        """A non-UTF-8 filename from argv must be `invalid_argument`, not a traceback.
+
+        Python decodes undecodable argv bytes into lone surrogates (PEP 383
+        `surrogateescape`). `quote(..., safe="")` raises `UnicodeEncodeError` on
+        those, and it runs *before* `list_folder_cmd`'s try block — so without a
+        guard the CLI dies with an uncaught stack trace.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", "a\udcffb", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
 
 # ---------------------------------------------------------------------------
 # search
@@ -518,6 +561,40 @@ class TestSearch:
         assert env["ok"] is False, env
         assert env["error"]["code"] == "invalid_argument"
         assert calls == []
+
+    def test_local_type_undecodable_argv_bytes_error_cleanly(self, local_target, monkeypatch, capsys):
+        """`--type` reaches `quote` via `_local_folder_matches`, whose handler misses this.
+
+        `search`'s except clause catches `json.JSONDecodeError` but not bare
+        `ValueError`, so the `UnicodeEncodeError` a surrogate raises would escape
+        uncaught. The guard rejects it up front instead.
+        """
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["search", "--text", "ltx", "--type", "a\udcffb", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
+    def test_local_walk_skips_undecodable_server_folder_name(self, local_target, monkeypatch, capsys):
+        """A server-advertised name carrying a lone surrogate is skipped, not fatal.
+
+        `json.loads('"\\udcff"')` yields a lone surrogate, so this shape is
+        reachable from a malicious or buggy backend. The walk must drop just that
+        folder and still return every other folder's models.
+        """
+        routes = {
+            "127.0.0.1:8188/models/loras": [{"name": "ltx-lora-detail.safetensors", "pathIndex": 0}],
+            "127.0.0.1:8188/models": ["loras", "bad\udcffname"],
+        }
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-lora-detail.safetensors"]
+        # The undecodable folder is never fetched at all.
+        assert [c["url"] for c in calls] == [
+            "http://127.0.0.1:8188/models",
+            "http://127.0.0.1:8188/models/loras",
+        ]
 
     def test_local_non_string_entry_name_is_skipped(self, local_target, monkeypatch, capsys):
         """A server sending a non-string `name` must not crash the walk or the sort."""

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import io
 import json
 import urllib.error
+import urllib.parse
 from typing import Any
 
 import pytest
@@ -296,6 +297,44 @@ class TestListFolder:
         assert env["ok"] is False
         assert env["error"]["code"] == "folder_not_found"
 
+    def test_folder_name_with_space_is_accepted_and_encoded(self, local_target, monkeypatch, capsys):
+        """A user-configured folder like `my loras` lists, matching what `search --where local` finds."""
+        routes = {"127.0.0.1:8188/models/my%20loras": [{"name": "ltx-custom.safetensors", "pathIndex": 0}]}
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["list-folder", "my loras", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [c["url"] for c in calls] == ["http://127.0.0.1:8188/models/my%20loras"]
+        # The payload echoes the decoded name the user typed, not the wire form.
+        assert env["data"]["folder"] == "my loras"
+        assert [f["name"] for f in env["data"]["files"]] == ["ltx-custom.safetensors"]
+
+    @pytest.mark.parametrize(
+        "folder",
+        [
+            "SDXL (base)",  # parentheses
+            "モデル",  # non-ASCII
+            "_hidden",  # leading underscore — rejected by the old strict regex
+            "a?b#c",  # URL-significant characters, neutralized by percent-encoding
+        ],
+    )
+    def test_non_traversal_folder_names_are_accepted(self, local_target, monkeypatch, capsys, folder):
+        segment = urllib.parse.quote(folder, safe="")
+        calls = _patch_urlopen(monkeypatch, {f"127.0.0.1:8188/models/{segment}": []})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        # Every character that could re-shape the request is encoded away.
+        assert [c["url"] for c in calls] == [f"http://127.0.0.1:8188/models/{segment}"]
+        assert env["data"]["folder"] == folder
+
+    @pytest.mark.parametrize("folder", ["../../etc", "..", "a/b", "a\\b", ""])
+    def test_traversal_shapes_still_rejected(self, local_target, monkeypatch, capsys, folder):
+        """Relaxing the charset must not relax the traversal guard — and no request is issued."""
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["list-folder", folder, "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
+
 
 # ---------------------------------------------------------------------------
 # search
@@ -438,6 +477,24 @@ class TestSearch:
         assert [c["url"] for c in calls[1:]] == ["http://127.0.0.1:8188/models/my%20loras"]
         assert env["data"]["rows"][0]["type"] == "my loras"
         assert env["data"]["rows"][0]["tags"] == ["my loras"]
+
+    def test_local_type_with_space_scopes_to_that_folder(self, local_target, monkeypatch, capsys):
+        """`--type "my loras"` is an unmapped passthrough — it must scope, not error."""
+        routes = {"127.0.0.1:8188/models/my%20loras": [{"name": "ltx-custom.safetensors", "pathIndex": 0}]}
+        calls = _patch_urlopen(monkeypatch, routes)
+        env = _run(["search", "--text", "ltx", "--type", "my loras", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        # Scoped: the bare `/models` folder listing is never fetched.
+        assert [c["url"] for c in calls] == ["http://127.0.0.1:8188/models/my%20loras"]
+        assert [r["name"] for r in env["data"]["rows"]] == ["ltx-custom.safetensors"]
+        assert env["data"]["rows"][0]["type"] == "my loras"
+
+    def test_local_type_traversal_still_rejected(self, local_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {})
+        env = _run(["search", "--text", "ltx", "--type", "../../etc", "--where", "local"], capsys)
+        assert env["ok"] is False, env
+        assert env["error"]["code"] == "invalid_argument"
+        assert calls == []
 
     def test_local_non_string_entry_name_is_skipped(self, local_target, monkeypatch, capsys):
         """A server sending a non-string `name` must not crash the walk or the sort."""


### PR DESCRIPTION
> **STACKED — merging lands on `matt/be-4746-local-search-all-folders` (owned by @mattmillerai, PR #603), NOT `main`.** GitHub retargets this to `main` once #603 merges. Please merge #603 first; do not treat this as safe-to-merge standalone.

## ELI-5

If you name a model folder `my loras` instead of `loras`, `comfy models list-folder "my loras"` used to refuse to even try — it said the name had illegal characters, even though ComfyUI serves that folder perfectly well. Now it just works. The folder name gets URL-escaped on the way out, so a space stays a space and nothing sneaky can slip through.

## What this fixes

`_reject_unsafe_path_segment()` gated user-supplied path segments on a strict-ASCII regex, `_PATH_SAFE = ^[A-Za-z0-9][A-Za-z0-9_.\-]*$`. It guards two user inputs: the `folder` argument of `models list-folder` and `--type` on `models search`. A real install can configure folders with spaces, parentheses, or non-ASCII names (`my loras`, `SDXL (base)`), and both commands rejected those with `invalid_argument`.

That produced a contradiction a user hits directly. #603 (BE-4746) made `comfy models search --text foo --where local` walk every server-advertised folder, so it now *finds* a model inside `my loras` and reports `"type": "my loras"` — and then `comfy models list-folder "my loras"`, the obvious next command, errored out.

## What changed

This applies the same two-part treatment #603 used on the server-advertised walk, to the user-input path:

1. **`_reject_unsafe_path_segment()` now reuses `_is_walkable_folder_name()`** — it refuses only genuine traversal shapes (empty, `..`, `/`, `\`) rather than a charset. The error `code` stays `invalid_argument`; the message and hint no longer promise "alphanumeric with `_`, `-`, or `.`".
2. **`list_folder_cmd` percent-encodes the segment** with `quote(folder, safe="")` before building the URL, so the relaxed input cannot alter the request. This was the only call site that still needed it — local `--type` already goes through `_local_folder_matches` (which encodes), and cloud `--type` goes through `urlencode`.
3. **`_is_safe_path_segment` and `_PATH_SAFE` are deleted** — they had no remaining callers — along with the now-unused `re` import.

## Why the security property still holds

This diff *relaxes an existing guard*, so it deserves the scrutiny. The old regex's stated intent was "a crafted argument can't escape the intended endpoint." That property is preserved, just enforced by encoding instead of by charset — the same trade #603 already made and shipped on this file one commit earlier.

Enumerating what the regex used to block and where it lands now:

| Input | Now | Why it's safe |
|---|---|---|
| `..`, `/`, `\` | still rejected | traversal guard is unchanged |
| empty | still rejected | traversal guard is unchanged |
| `?`, `#`, `&` | accepted | encoded to `%3F`/`%23`/`%26` — cannot split path from query |
| `%` | accepted | encoded to `%25`, so `%2e%2e%2f` becomes `%252e%252e%252f` and can never be decoded back into `../` |
| `\r`, `\n`, NUL | accepted | encoded to `%0D`/`%0A`/`%00` — no request-line or header injection |
| spaces, non-ASCII | accepted | encoded; this is the whole point of the ticket |

The `%` row is the sharp one: the traversal guard alone would let `%2e%2e%2fetc` through, because `..` and `/` are not *literally* present. The percent-encoding is what actually stops it, so that is pinned by a test rather than left to reasoning.

One behavior note that is now newly reachable: `--type` values containing a **comma** on the cloud path. Cloud's `include_tags` is comma-delimited per its OpenAPI contract (`style: form, explode: false`), so `--type "a,b"` is sent as two tags. Commas were incidentally blocked by the old regex. I did not add escaping — the cloud tag API has no escape mechanism for commas, so a comma-containing tag simply isn't expressible on that wire contract, and inventing one here would be guessing at a contract I can't verify. Flagging it rather than silently papering over it.

## Tests

`tests/comfy_cli/command/models/test_search.py`, following `TestSearch::test_local_folder_name_with_space_is_walked_and_encoded` as the model:

- `list-folder "my loras"` succeeds and hits `/models/my%20loras`, with the payload echoing the decoded name.
- `list-folder` accepts `SDXL (base)`, `モデル`, `_hidden` (leading underscore — rejected by the old regex), and `a?b#c`, each encoded correctly.
- `list-folder "../../etc"`, `..`, `a/b`, `a\b`, and `""` still return `invalid_argument`, and issue **no** HTTP request.
- `%2e%2e%2fetc`, `%2E%2E%2Fetc`, `a%00b`, and a CRLF-bearing name stay inside one path segment — asserted structurally (one layer of encoding, segment count, no raw control characters).
- `models search --type "my loras" --where local` scopes to that folder and never fetches the bare `/models` listing.
- `models search --type "../../etc"` still returns `invalid_argument`.

**These are real gates, not tautologies:** reverting just the `quote()` call fails 8 of them, including all four encoded-traversal cases. I checked that explicitly rather than assuming.

Full suite: **2800 passed, 37 skipped**. `ruff check` + `ruff format --diff` clean at the CI-pinned 0.15.15.

## Judgment calls

- **Stacked on #603 rather than gated behind it.** `_is_walkable_folder_name()` exists only on that branch, and acceptance criterion (c) depends on #603's multi-folder local walk. Building on `main` would have meant reimplementing the helper against a stale base.
- **Kept the name `_is_walkable_folder_name`** even though it now gates user input too, rather than renaming to something like `_is_single_path_segment`. A rename would churn #603's diff for no behavior change; the docstring is updated to state both roles. Happy to rename if you'd prefer.
- **No capability is denied by this change** — it removes a denial. The diff adds no deny/dead-end path and flips no test to assert one, so the negative-claim falsification requirement doesn't apply here.
