### PR TITLE
fix(output): strip ANSI/control sequences from server-supplied text at the pretty renderer boundary (BE-4794)

### DIFF
--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -35,6 +35,7 @@ import typer
 
 from comfy_cli import tracking
 from comfy_cli.output import get_renderer, rprint
+from comfy_cli.output.sanitize import sanitize_markup
 
 app = typer.Typer(no_args_is_help=True, help="Discover models — folders, files, and the cloud asset catalog.")
 
@@ -208,7 +209,11 @@ def list_folders_cmd(
         tbl.add_column("folder")
         tbl.add_column("subfolders", style="dim")
         for r in rows[:200]:
-            tbl.add_row(r["name"], ", ".join(r["subfolders"]) if r["subfolders"] else "")
+            # ``add_row`` parses markup in ``str`` cells; these are server names.
+            tbl.add_row(
+                sanitize_markup(r["name"]),
+                sanitize_markup(", ".join(r["subfolders"])) if r["subfolders"] else "",
+            )
         renderer.console().print(tbl)
         rprint(f"[dim]{len(rows)} folders ({payload['mode']})[/dim]")
     renderer.emit(payload, command="models list-folders")
@@ -296,7 +301,7 @@ def list_folder_cmd(
         tbl.add_column("name")
         tbl.add_column("pathIndex", style="dim", justify="right")
         for f in files:
-            tbl.add_row(f["name"], str(f["pathIndex"]))
+            tbl.add_row(sanitize_markup(f["name"]), sanitize_markup(f["pathIndex"]))
         renderer.console().print(tbl)
         tail = f" (of {total})" if total != len(files) else ""
         rprint(f"[dim]{len(files)} files in {folder!r}{tail} ({payload['mode']})[/dim]")
@@ -509,11 +514,14 @@ def search_cmd(
         tbl.add_column("base_model", style="dim")
         tbl.add_column("source", style="dim")
         for r in rows:
+            # Truncate first, then sanitize: escaping last keeps the markup
+            # escapes balanced, and a sequence cut in half by the slice is
+            # cleaned up rather than left dangling.
             tbl.add_row(
-                r["name"][:60],
-                r["type"] or "",
-                r["base_model"] or "",
-                (r["source_url"] or "")[:48],
+                sanitize_markup(r["name"][:60]),
+                sanitize_markup(r["type"] or ""),
+                sanitize_markup(r["base_model"] or ""),
+                sanitize_markup((r["source_url"] or "")[:48]),
             )
         renderer.console().print(tbl)
         tail = f" (of {total} total)" if total != len(rows) else ""
@@ -603,19 +611,21 @@ def show_cmd(
     }
     if renderer.is_pretty():
         row = payload["row"]
-        rprint(f"[bold]{row['name']}[/bold]")
-        rprint(f"  type:        {row['type']}")
+        # Every field below is catalog text the server chose, interpolated into
+        # a markup-parsing sink — sanitize each one (see comfy_cli.output.sanitize).
+        rprint(f"[bold]{sanitize_markup(row['name'])}[/bold]")
+        rprint(f"  type:        {sanitize_markup(row['type'])}")
         if row.get("base_model"):
-            rprint(f"  base_model:  {row['base_model']}")
+            rprint(f"  base_model:  {sanitize_markup(row['base_model'])}")
         if row.get("tags"):
-            rprint(f"  tags:        {', '.join(row['tags'])}")
+            rprint(f"  tags:        {sanitize_markup(', '.join(row['tags']))}")
         if row.get("source_url"):
-            rprint(f"  source:      {row['source_url']}")
+            rprint(f"  source:      {sanitize_markup(row['source_url'])}")
         if row.get("preview_url"):
-            rprint(f"  preview:     {row['preview_url']}")
+            rprint(f"  preview:     {sanitize_markup(row['preview_url'])}")
         if row.get("size"):
             rprint(f"  size:        {row['size']:,} bytes")
         trained = row.get("trained_words")
         if trained:
-            rprint(f"  trained:     {', '.join(trained)}")
+            rprint(f"  trained:     {sanitize_markup(', '.join(trained))}")
     renderer.emit(payload, command="models show")

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -25,6 +25,7 @@ import typer
 from comfy_cli import tracking
 from comfy_cli.cql.engine import Graph, LoadError
 from comfy_cli.output import get_renderer, rprint
+from comfy_cli.output.sanitize import sanitize_markup
 
 app = typer.Typer(no_args_is_help=True, help="Introspect ComfyUI node classes (inputs, outputs, categories).")
 
@@ -281,8 +282,10 @@ def ls_cmd(
             tbl.add_column("category", style="dim")
             tbl.add_column("outputs")
             for m in nodes:
-                outs = ", ".join(m.output_types()) or "[dim]—[/dim]"
-                tbl.add_row(m.id, m.category or "", outs)
+                # object_info text into a markup sink; the em-dash fallback is
+                # ours, so only the joined server values are escaped.
+                outs = sanitize_markup(", ".join(m.output_types())) or "[dim]—[/dim]"
+                tbl.add_row(sanitize_markup(m.id), sanitize_markup(m.category or ""), outs)
             renderer.console().print(tbl)
             rprint(f"[dim]{len(nodes)} node(s)[/dim]")
     renderer.emit(payload, command="nodes ls")
@@ -356,18 +359,18 @@ def show_cmd(
         from rich.table import Table
 
         rprint(
-            f"[bold]{payload['name']}[/bold]"
+            f"[bold]{sanitize_markup(payload['name'])}[/bold]"
             + (
-                f"  [dim]({payload['display_name']})[/dim]"
+                f"  [dim]({sanitize_markup(payload['display_name'])})[/dim]"
                 if payload["display_name"] and payload["display_name"] != payload["name"]
                 else ""
             )
         )
         if payload["category"]:
-            rprint(f"[dim]category[/dim]  {payload['category']}")
+            rprint(f"[dim]category[/dim]  {sanitize_markup(payload['category'])}")
         if payload["description"]:
-            rprint(f"[dim]{payload['description']}[/dim]")
-        outs = ", ".join(payload["output_types"]) or "(none)"
+            rprint(f"[dim]{sanitize_markup(payload['description'])}[/dim]")
+        outs = sanitize_markup(", ".join(payload["output_types"])) or "(none)"
         rprint(f"[dim]outputs[/dim]   {outs}")
         rprint("")
         if payload["inputs"]:
@@ -380,10 +383,10 @@ def show_cmd(
                 opts = i.get("options") or {}
                 default = opts.get("default")
                 tbl.add_row(
-                    str(i.get("name") or ""),
-                    str(i.get("type") or ""),
-                    str(i.get("section") or ""),
-                    "" if default is None else str(default),
+                    sanitize_markup(i.get("name") or ""),
+                    sanitize_markup(i.get("type") or ""),
+                    sanitize_markup(i.get("section") or ""),
+                    "" if default is None else sanitize_markup(default),
                 )
             renderer.console().print(tbl)
     renderer.emit(payload, command="nodes show")
@@ -487,8 +490,9 @@ def search_cmd(
             tbl.add_column("category", style="dim")
             tbl.add_column("description", style="dim")
             for m in matched:
-                desc = m.description[:60]
-                tbl.add_row(m.id, m.category or "", desc)
+                # Truncate first, then escape, so the escapes stay balanced.
+                desc = sanitize_markup(m.description[:60])
+                tbl.add_row(sanitize_markup(m.id), sanitize_markup(m.category or ""), desc)
             renderer.console().print(tbl)
             rprint(f"[dim]{len(matched)} node(s)[/dim]")
     renderer.emit(payload, command="nodes search")
@@ -559,8 +563,8 @@ def upstream_cmd(
             tbl.add_column("category", style="dim")
             tbl.add_column("outputs")
             for r in rows:
-                outs = ", ".join(r["output_types"]) or "[dim]—[/dim]"
-                tbl.add_row(r["name"] or "", r["category"] or "", outs)
+                outs = sanitize_markup(", ".join(r["output_types"])) or "[dim]—[/dim]"
+                tbl.add_row(sanitize_markup(r["name"] or ""), sanitize_markup(r["category"] or ""), outs)
             renderer.console().print(tbl)
             tail = f" of {total_upstream}" if total_upstream != len(rows) else ""
             rprint(f"[dim]{len(rows)} upstream node(s){tail}[/dim]")
@@ -617,8 +621,8 @@ def downstream_cmd(
             tbl.add_column("category", style="dim")
             tbl.add_column("outputs")
             for r in rows:
-                outs = ", ".join(r["output_types"]) or "[dim]—[/dim]"
-                tbl.add_row(r["name"] or "", r["category"] or "", outs)
+                outs = sanitize_markup(", ".join(r["output_types"])) or "[dim]—[/dim]"
+                tbl.add_row(sanitize_markup(r["name"] or ""), sanitize_markup(r["category"] or ""), outs)
             renderer.console().print(tbl)
             tail = f" of {total_downstream}" if total_downstream != len(rows) else ""
             rprint(f"[dim]{len(rows)} downstream node(s){tail}[/dim]")
@@ -700,8 +704,13 @@ def path_cmd(
             )
         else:
             for p in paths:
-                chain = " [dim]→[/dim] ".join(f"[bold]{s.get('node')}[/bold]" for s in (p.get("steps") or []))
-                rprint(f"[cyan]{p.get('from')}[/cyan]  {chain}  [cyan]{p.get('to')}[/cyan]")
+                chain = " [dim]→[/dim] ".join(
+                    f"[bold]{sanitize_markup(s.get('node'))}[/bold]" for s in (p.get("steps") or [])
+                )
+                rprint(
+                    f"[cyan]{sanitize_markup(p.get('from'))}[/cyan]  {chain}  "
+                    f"[cyan]{sanitize_markup(p.get('to'))}[/cyan]"
+                )
             rprint(f"[dim]{len(paths)} path(s)[/dim]")
     renderer.emit(payload, command="nodes path")
 
@@ -750,7 +759,7 @@ def types_cmd(
     if renderer.is_pretty():
         from rich.columns import Columns
 
-        renderer.console().print(Columns([f"[cyan]{t}[/cyan]" for t in types], expand=True))
+        renderer.console().print(Columns([f"[cyan]{sanitize_markup(t)}[/cyan]" for t in types], expand=True))
         rprint(f"[dim]{len(types)} type(s)[/dim]")
     renderer.emit(payload, command="nodes types")
 
@@ -844,7 +853,7 @@ def categories_cmd(
             tbl.add_column("category")
             tbl.add_column("nodes", justify="right", style="dim")
             for p, c in flat:
-                tbl.add_row(p, str(c))
+                tbl.add_row(sanitize_markup(p), sanitize_markup(c))
             renderer.console().print(tbl)
             rprint(f"[dim]{len(flat)} categories[/dim]")
     renderer.emit(payload, command="nodes categories")

--- a/comfy_cli/command/outdated.py
+++ b/comfy_cli/command/outdated.py
@@ -501,13 +501,11 @@ def _status(outdated: bool, latest: Any) -> str:
 
 def execute(renderer, comfy_path: str | None, *, refresh: bool = False) -> None:
     """Entry point wired from ``comfy outdated`` in cmdline.py."""
-    from rich.markup import escape
-
     report, warnings = build_report(comfy_path, refresh=refresh)
     if renderer.is_pretty():
         _render_pretty(renderer, report)
     for w in warnings:
-        # Warnings embed pack names/error text; escape so a name like ``foo[/]``
-        # can't trip renderer.warn's markup pass.
-        renderer.warn(escape(w))
+        # Warnings embed pack names/error text, but ``renderer.warn`` escapes
+        # markup itself now — escaping again here would render the backslashes.
+        renderer.warn(w)
     renderer.emit(report, command="outdated")

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -44,6 +44,7 @@ from comfy_cli.command.run.watcher import _tail_state_file as _tail_state_file
 from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
+from comfy_cli.output.sanitize import sanitize_markup
 from comfy_cli.workflow_to_api import WorkflowConversionError, convert_ui_to_api
 from comfy_cli.workspace_manager import WorkspaceManager
 
@@ -314,7 +315,8 @@ def execute(
                 if len(execution.outputs) > 0:
                     pprint("[bold green]\nOutputs:[/bold green]")
                     for f in execution.outputs:
-                        pprint(f)
+                        # Output paths are built from server-chosen filenames.
+                        pprint(sanitize_markup(f))
                 elapsed = timedelta(seconds=end - start)
                 pprint(f"[bold green]\nWorkflow execution completed ({elapsed})[/bold green]")
 
@@ -435,7 +437,7 @@ def execute(
             )
             raise typer.Exit(code=130) from e
         if renderer.is_pretty():
-            pprint(f"[bold red]Error: Lost connection to ComfyUI server: {e}[/bold red]")
+            pprint(f"[bold red]Error: Lost connection to ComfyUI server: {sanitize_markup(e)}[/bold red]")
         renderer.error(
             code="ws_disconnected",
             message=f"Lost connection to ComfyUI server: {e}",
@@ -816,9 +818,9 @@ def execute_cloud(
         if output_urls:
             pprint("[bold green]\nOutputs:[/bold green]")
             for u in output_urls:
-                pprint(u)
+                pprint(sanitize_markup(u))
         for w in warnings:
-            pprint(f"[yellow]⚠ {w['message']}[/yellow]")
+            pprint(f"[yellow]⚠ {sanitize_markup(w['message'])}[/yellow]")
         pprint(f"[bold green]\nCloud workflow completed ({timedelta(seconds=end - start)})[/bold green]")
 
     # Grouped views of the same artifacts: by producing node always, and by

--- a/comfy_cli/command/run/execution.py
+++ b/comfy_cli/command/run/execution.py
@@ -40,6 +40,7 @@ from comfy_cli import execution_errors
 from comfy_cli.command.run.loader import _MAX_BODY_PREVIEW, _node_errors_to_list
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
+from comfy_cli.output.sanitize import sanitize_markup
 from comfy_cli.workspace_manager import WorkspaceManager
 
 workspace_manager = WorkspaceManager()
@@ -185,7 +186,10 @@ class WorkflowExecution:
                 if isinstance(node_errors_raw, dict) and node_errors_raw:
                     node_errors = _node_errors_to_list(node_errors_raw)
                     if self.renderer.is_pretty():
-                        pprint(f"[bold red]Error running workflow\n{json.dumps(node_errors_raw, indent=2)}[/bold red]")
+                        pprint(
+                            "[bold red]Error running workflow\n"
+                            f"{sanitize_markup(json.dumps(node_errors_raw, indent=2))}[/bold red]"
+                        )
                     self.renderer.error(
                         code="prompt_rejected",
                         message=f"Workflow has {len(node_errors_raw)} validation error(s)",
@@ -195,7 +199,7 @@ class WorkflowExecution:
                     raise typer.Exit(code=1)
 
             if self.renderer.is_pretty():
-                pprint(f"[bold red]Error running workflow (HTTP {e.status})\n{body_text}[/bold red]")
+                pprint(f"[bold red]Error running workflow (HTTP {e.status})\n{sanitize_markup(body_text)}[/bold red]")
             if e.status < 500:
                 self.renderer.error(
                     code="client_error",
@@ -216,7 +220,7 @@ class WorkflowExecution:
                 self.progress.stop()
             reason = str(e.reason) if isinstance(e, urllib.error.URLError) else str(e)
             if self.renderer.is_pretty():
-                pprint(f"[bold red]Error: Failed to submit workflow: {reason}[/bold red]")
+                pprint(f"[bold red]Error: Failed to submit workflow: {sanitize_markup(reason)}[/bold red]")
             self.renderer.error(
                 code="connection_error",
                 message=f"Failed to submit workflow: {reason}",
@@ -318,15 +322,20 @@ class WorkflowExecution:
             return
 
         node = self.workflow.get(node_id)
+        # ``node_id`` arrives on the wire and ``class_type``/``_meta.title`` come
+        # from a workflow the server may have echoed back, so each leaf is
+        # sanitized before it is interpolated into this markup string. ``type``
+        # is a caller-side literal ("Executing"/"Cached").
+        safe_node_id = sanitize_markup(node_id)
         if node is None:
-            pprint(f"{type} : [bright_black]({node_id})[/]")
+            pprint(f"{type} : [bright_black]({safe_node_id})[/]")
             return
-        class_type = node["class_type"]
-        title = self.get_node_title(node_id)
+        class_type = sanitize_markup(node["class_type"])
+        title = sanitize_markup(self.get_node_title(node_id))
 
         if title != class_type:
             title += f"[bright_black] - {class_type}[/]"
-        title += f"[bright_black] ({node_id})[/]"
+        title += f"[bright_black] ({safe_node_id})[/]"
 
         pprint(f"{type} : {title}")
 
@@ -536,7 +545,7 @@ class WorkflowExecution:
         data = data if isinstance(data, dict) else {}
         node_id = str(data.get("node_id", ""))
         if self.renderer.is_pretty():
-            pprint(f"[bold red]Error running workflow\n{json.dumps(data, indent=2)}[/bold red]")
+            pprint(f"[bold red]Error running workflow\n{sanitize_markup(json.dumps(data, indent=2))}[/bold red]")
         # The event keeps the full server payload (incl. complete traceback);
         # the error envelope carries the classified one-line verdict.
         self.renderer.event("execution_error", prompt_id=self.prompt_id, details=data)

--- a/comfy_cli/command/run/preflight.py
+++ b/comfy_cli/command/run/preflight.py
@@ -18,6 +18,7 @@ import typer
 from comfy_cli.command.run.loader import _MAX_BODY_PREVIEW
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
+from comfy_cli.output.sanitize import sanitize_markup
 
 # Partner-API nodes live under `partner/...` in ComfyUI/cloud object_info
 # (e.g. `partner/video/ByteDance`). The category prefix is only the fallback —
@@ -108,7 +109,9 @@ def _preflight_validate(renderer, workflow: dict, object_info: dict, *, target_l
     warnings = validation.get("warnings", [])
     if warnings and renderer.is_pretty():
         for w in warnings:
-            pprint(f"[yellow]⚠ {w.get('field', '?')}: {w.get('message', '')}[/yellow]")
+            pprint(
+                f"[yellow]⚠ {sanitize_markup(w.get('field', '?'))}: {sanitize_markup(w.get('message', ''))}[/yellow]"
+            )
 
 
 def _fetch_object_info(host: str, port: int) -> dict:

--- a/comfy_cli/command/run/watcher.py
+++ b/comfy_cli/command/run/watcher.py
@@ -13,6 +13,7 @@ import sys
 
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as pprint
+from comfy_cli.output.sanitize import sanitize_markup
 
 
 def _tail_state_file(prompt_id: str, *, seconds: float = 8.0) -> None:
@@ -63,7 +64,7 @@ def _tail_state_file(prompt_id: str, *, seconds: float = 8.0) -> None:
     if final_state.is_terminal:
         pprint(f"  {glyph} [dim]· finished in {elapsed:.1f}s[/dim]")
         for u in (final_state.outputs or [])[:3]:
-            pprint(f"  [dim]→[/dim] [cyan]{u}[/cyan]")
+            pprint(f"  [dim]→[/dim] [cyan]{sanitize_markup(u)}[/cyan]")
     else:
         pprint(f"  {glyph} [dim]· still in flight — track:[/dim] [cyan]comfy jobs ls --watch[/cyan]")
 

--- a/comfy_cli/output/panels.py
+++ b/comfy_cli/output/panels.py
@@ -18,6 +18,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_value
+
 _TARGET_DIM_CHAR = "·"
 
 
@@ -54,7 +56,15 @@ def error_panel(
         │ details:                                                      │
         │   key=value                                                   │
         ╰───────────────────────────────────────────────────────────────╯
+
+    ``code``, ``message``, ``hint`` and the stringified ``details`` are all
+    sanitized here: any of them can carry server-supplied text, and this panel
+    is the pretty-mode boundary where it would otherwise reach the terminal as
+    live escape sequences (see ``comfy_cli.output.sanitize``).
     """
+    code = sanitize(code)
+    message = sanitize(message)
+    hint = sanitize_optional(hint)
     body: list[Any] = [Text(message, style="white")]
     if hint:
         body.append(Text(""))
@@ -66,7 +76,7 @@ def error_panel(
         for k, v in details.items():
             if v is None:
                 continue
-            rows.append((str(k), str(v)))
+            rows.append((sanitize_value(k), sanitize_value(v)))
         if rows:
             body.append(_kv_table(rows, label_style="dim", value_style="dim"))
     return Panel(

--- a/comfy_cli/output/panels.py
+++ b/comfy_cli/output/panels.py
@@ -18,13 +18,17 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_value
+from comfy_cli.output.sanitize import sanitize_markup, sanitize_optional, sanitize_value
 
 _TARGET_DIM_CHAR = "·"
 
 
 def _kv_table(rows: Sequence[tuple[str, str]], *, label_style: str = "bold cyan", value_style: str = "") -> Table:
-    """Two-column borderless table used inside panels to align label/value rows."""
+    """Two-column borderless table used inside panels to align label/value rows.
+
+    ``Table.add_row`` parses Rich markup in a ``str`` cell, so any caller
+    passing untrusted text must run it through ``sanitize_markup`` first.
+    """
     tbl = Table.grid(padding=(0, 2), expand=False)
     tbl.add_column(justify="right", style=label_style, no_wrap=True)
     tbl.add_column(style=value_style, overflow="fold")
@@ -61,9 +65,14 @@ def error_panel(
     sanitized here: any of them can carry server-supplied text, and this panel
     is the pretty-mode boundary where it would otherwise reach the terminal as
     live escape sequences (see ``comfy_cli.output.sanitize``).
+
+    ``code``/``message``/``hint`` are rendered through ``Text``, which never
+    parses markup, so stripping the control bytes is enough for them. The
+    ``details`` rows go to ``Table.add_row``, which *does* parse markup, so
+    those additionally need ``sanitize_markup``.
     """
-    code = sanitize(code)
-    message = sanitize(message)
+    code = sanitize_value(code)
+    message = sanitize_value(message)
     hint = sanitize_optional(hint)
     body: list[Any] = [Text(message, style="white")]
     if hint:
@@ -76,7 +85,7 @@ def error_panel(
         for k, v in details.items():
             if v is None:
                 continue
-            rows.append((sanitize_value(k), sanitize_value(v)))
+            rows.append((sanitize_markup(k), sanitize_markup(v)))
         if rows:
             body.append(_kv_table(rows, label_style="dim", value_style="dim"))
     return Panel(

--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -23,6 +23,7 @@ from typing import Any, TextIO
 from rich.console import Console
 
 from comfy_cli.caller import Caller, detect_caller
+from comfy_cli.output.sanitize import sanitize_value
 
 # Machine-output contract versions, surfaced in every envelope/event line and
 # in `comfy discover` (output_contract). Bump rule: additive optional fields =
@@ -195,18 +196,28 @@ class Renderer:
 
     # ----- semantic helpers -----
 
+    # These four take a plain string and hand it to the terminal, so they are a
+    # pretty-mode boundary in the same sense ``error_panel`` is: anything the
+    # message carries — including a remote server's text — is sanitized before
+    # it can be acted on as an escape sequence. Rich *markup* is deliberately
+    # left intact; call sites use it for styling (and escape untrusted text with
+    # ``rich.markup.escape``). ``print`` is not sanitized: it is the generic
+    # passthrough and takes arbitrary Rich renderables, not just strings.
+    # ``sanitize_value`` (not ``sanitize``) so a caller that ignores the ``str``
+    # annotation still gets the ``str()`` coercion the f-strings used to do.
+
     def info(self, message: str, *, hint: str | None = None) -> None:
-        self.print(message)
+        self.print(sanitize_value(message))
         if hint:
-            self.print(f"[yellow]Hint:[/yellow] {hint}")
+            self.print(f"[yellow]Hint:[/yellow] {sanitize_value(hint)}")
 
     def warn(self, message: str, *, hint: str | None = None) -> None:
-        self.print(f"[yellow]{message}[/yellow]")
+        self.print(f"[yellow]{sanitize_value(message)}[/yellow]")
         if hint:
-            self.print(f"[yellow]Hint:[/yellow] {hint}")
+            self.print(f"[yellow]Hint:[/yellow] {sanitize_value(hint)}")
 
     def success(self, message: str) -> None:
-        self.print(f"[bold green]{message}[/bold green]")
+        self.print(f"[bold green]{sanitize_value(message)}[/bold green]")
 
     # ----- structured output -----
 

--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -23,7 +23,7 @@ from typing import Any, TextIO
 from rich.console import Console
 
 from comfy_cli.caller import Caller, detect_caller
-from comfy_cli.output.sanitize import sanitize_value
+from comfy_cli.output.sanitize import sanitize_markup
 
 # Machine-output contract versions, surfaced in every envelope/event line and
 # in `comfy discover` (output_contract). Bump rule: additive optional fields =
@@ -198,26 +198,32 @@ class Renderer:
 
     # These four take a plain string and hand it to the terminal, so they are a
     # pretty-mode boundary in the same sense ``error_panel`` is: anything the
-    # message carries — including a remote server's text — is sanitized before
-    # it can be acted on as an escape sequence. Rich *markup* is deliberately
-    # left intact; call sites use it for styling (and escape untrusted text with
-    # ``rich.markup.escape``). ``print`` is not sanitized: it is the generic
-    # passthrough and takes arbitrary Rich renderables, not just strings.
-    # ``sanitize_value`` (not ``sanitize``) so a caller that ignores the ``str``
-    # annotation still gets the ``str()`` coercion the f-strings used to do.
+    # message carries — including a remote server's text — is neutralized before
+    # it can be acted on as an escape sequence. The message lands inside a Rich
+    # *markup* string, so ``sanitize_markup`` also escapes the markup: Rich would
+    # otherwise turn ``[link=http://evil]x[/link]`` back into a live OSC 8
+    # sequence, and an unbalanced ``[/]`` would raise ``MarkupError`` and crash
+    # the CLI mid-print. Escaping here rather than asking every call site to
+    # remember ``rich.markup.escape`` is the whole point of having a boundary;
+    # the cost is that these four helpers no longer accept caller markup, which
+    # is fine — they style the line themselves and no call site passed any.
+    # ``print`` is deliberately not sanitized: it is the generic passthrough and
+    # takes arbitrary Rich renderables, not just strings.
+    # ``sanitize_value`` semantics (not ``sanitize``) so a caller that ignores
+    # the ``str`` annotation still gets the ``str()`` coercion f-strings did.
 
     def info(self, message: str, *, hint: str | None = None) -> None:
-        self.print(sanitize_value(message))
+        self.print(sanitize_markup(message))
         if hint:
-            self.print(f"[yellow]Hint:[/yellow] {sanitize_value(hint)}")
+            self.print(f"[yellow]Hint:[/yellow] {sanitize_markup(hint)}")
 
     def warn(self, message: str, *, hint: str | None = None) -> None:
-        self.print(f"[yellow]{sanitize_value(message)}[/yellow]")
+        self.print(f"[yellow]{sanitize_markup(message)}[/yellow]")
         if hint:
-            self.print(f"[yellow]Hint:[/yellow] {sanitize_value(hint)}")
+            self.print(f"[yellow]Hint:[/yellow] {sanitize_markup(hint)}")
 
     def success(self, message: str) -> None:
-        self.print(f"[bold green]{sanitize_value(message)}[/bold green]")
+        self.print(f"[bold green]{sanitize_markup(message)}[/bold green]")
 
     # ----- structured output -----
 

--- a/comfy_cli/output/sanitize.py
+++ b/comfy_cli/output/sanitize.py
@@ -1,0 +1,64 @@
+r"""Strip ANSI escape sequences and control characters from untrusted text.
+
+Server-supplied strings reach the terminal verbatim in pretty mode: a remote or
+shared ComfyUI instance (``comfy run --host/--port``) picks the ``prompt_id``,
+and an exception raised against that host carries whatever text the host chose.
+Rich does not save us here — ``rich.text.Text`` drops a few C0 characters but
+passes ``\x1b`` straight through, so a CSI/OSC sequence reaches the user's
+terminal and can clear the screen, rewrite the window title, or repaint earlier
+lines to spoof CLI output.
+
+This module is the single sanitizing boundary for **pretty** rendering only.
+The JSON/NDJSON envelope paths must NOT use it: ``json.dumps`` already escapes
+``\x1b`` as a ``\u`` escape, and stripping there would silently mutate
+the data agents parse.
+
+Scope: C0/C1 control characters and ANSI escape sequences (CSI, OSC, DCS, and
+the shorter two-character forms). Tab and newline are preserved — they are
+legitimate layout in multi-line messages. Carriage return is removed, since it
+lets a message overwrite a line that has already been printed. Non-control
+Unicode is left alone; homoglyph and bidi-override spoofing are a different
+problem and deliberately out of scope here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# One pass over the ANSI escape forms a terminal will act on. Ordered so the
+# multi-character sequences are consumed before the lone-ESC fallback.
+_ESCAPE_SEQUENCE_RE = re.compile(
+    r"""
+      \x1b\[ [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 7-bit (ESC [ ...)
+    | \x9b   [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 8-bit C1 form
+    | \x1b[\]PX^_] .*? (?: \x1b\\ | \x9c | \x07 | \Z )   # OSC/DCS/SOS/PM/APC, 7-bit
+    | [\x90\x9d\x9e\x9f] .*? (?: \x1b\\ | \x9c | \x07 | \Z )  # same, 8-bit C1 form
+    | \x1b [\x20-\x2f]* [\x30-\x7e]                      # two-/three-char escapes (ESC ( B, ESC =, ...)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# Whatever survives the sweep above: stray C0 (minus tab/newline), DEL, and the
+# C1 block. A lone trailing ESC and an orphaned 8-bit introducer land here.
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def sanitize(text: str) -> str:
+    """Return ``text`` with ANSI escape sequences and control characters removed.
+
+    An unterminated OSC/DCS sequence consumes the remainder of the string —
+    that is what the terminal itself would do with it, so dropping the tail is
+    the conservative reading, not data loss we could have avoided.
+    """
+    return _CONTROL_CHAR_RE.sub("", _ESCAPE_SEQUENCE_RE.sub("", text))
+
+
+def sanitize_optional(text: str | None) -> str | None:
+    """``sanitize`` for the many call sites whose value is an optional string."""
+    return None if text is None else sanitize(text)
+
+
+def sanitize_value(value: Any) -> str:
+    """Stringify ``value`` and sanitize it — for panel fields rendered via ``str()``."""
+    return sanitize(value if isinstance(value, str) else str(value))

--- a/comfy_cli/output/sanitize.py
+++ b/comfy_cli/output/sanitize.py
@@ -8,10 +8,17 @@ passes ``\x1b`` straight through, so a CSI/OSC sequence reaches the user's
 terminal and can clear the screen, rewrite the window title, or repaint earlier
 lines to spoof CLI output.
 
-This module is the single sanitizing boundary for **pretty** rendering only.
-The JSON/NDJSON envelope paths must NOT use it: ``json.dumps`` already escapes
-``\x1b`` as a ``\u`` escape, and stripping there would silently mutate
-the data agents parse.
+This module sanitizes **pretty** rendering only. The JSON/NDJSON envelope paths
+must NOT use it: ``json.dumps`` already escapes ``\x1b`` as a ``\u`` escape, and
+stripping there would silently mutate the data agents parse.
+
+``Renderer`` is not the only path to the terminal, so applying it there is not
+sufficient on its own. Command modules also call ``rich.print`` directly under
+their own ``is_pretty()`` gates, and those never route through ``Renderer``:
+they must call ``sanitize_markup`` on each server-supplied value themselves,
+as the ``comfy run`` and ``comfy models`` paths do. Automatic coverage stops at
+``Renderer``; treat a bare ``rich.print`` of remote text as unsanitized until
+you have checked it.
 
 Scope: C0/C1 control characters and ANSI escape sequences (CSI, OSC, DCS, and
 the shorter two-character forms). Tab and newline are preserved — they are

--- a/comfy_cli/output/sanitize.py
+++ b/comfy_cli/output/sanitize.py
@@ -19,12 +19,18 @@ legitimate layout in multi-line messages. Carriage return is removed, since it
 lets a message overwrite a line that has already been printed. Non-control
 Unicode is left alone; homoglyph and bidi-override spoofing are a different
 problem and deliberately out of scope here.
+
+Removing the escape *bytes* is only half the boundary: Rich manufactures new
+ones from markup it finds in a string, so text bound for a markup-interpreting
+sink also needs ``sanitize_markup`` (see its docstring).
 """
 
 from __future__ import annotations
 
 import re
 from typing import Any
+
+from rich.markup import escape as _escape_markup
 
 # One pass over the ANSI escape forms a terminal will act on. Ordered so the
 # multi-character sequences are consumed before the lone-ESC fallback.
@@ -33,7 +39,7 @@ _ESCAPE_SEQUENCE_RE = re.compile(
       \x1b\[ [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 7-bit (ESC [ ...)
     | \x9b   [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 8-bit C1 form
     | \x1b[\]PX^_] .*? (?: \x1b\\ | \x9c | \x07 | \Z )   # OSC/DCS/SOS/PM/APC, 7-bit
-    | [\x90\x9d\x9e\x9f] .*? (?: \x1b\\ | \x9c | \x07 | \Z )  # same, 8-bit C1 form
+    | [\x90\x98\x9d\x9e\x9f] .*? (?: \x1b\\ | \x9c | \x07 | \Z )  # same, 8-bit C1 form (DCS/SOS/OSC/PM/APC)
     | \x1b [\x20-\x2f]* [\x30-\x7e]                      # two-/three-char escapes (ESC ( B, ESC =, ...)
     """,
     re.VERBOSE | re.DOTALL,
@@ -55,10 +61,32 @@ def sanitize(text: str) -> str:
 
 
 def sanitize_optional(text: str | None) -> str | None:
-    """``sanitize`` for the many call sites whose value is an optional string."""
-    return None if text is None else sanitize(text)
+    """``sanitize`` for the many call sites whose value is an optional string.
+
+    Non-``None`` values go through ``sanitize_value``, so a caller that ignores
+    the ``str`` annotation gets the ``str()`` coercion the old f-strings did
+    rather than a ``TypeError`` from ``re.sub``.
+    """
+    return None if text is None else sanitize_value(text)
 
 
 def sanitize_value(value: Any) -> str:
     """Stringify ``value`` and sanitize it — for panel fields rendered via ``str()``."""
     return sanitize(value if isinstance(value, str) else str(value))
+
+
+def sanitize_markup(value: Any) -> str:
+    """``sanitize_value`` plus Rich-markup escaping, for markup-interpreting sinks.
+
+    Stripping the escape bytes is not enough on its own: Rich re-creates them
+    from markup found in the string. A server-supplied ``[link=http://evil]x[/link]``
+    renders as a live OSC 8 hyperlink, ``[red]`` restyles the line to spoof
+    other output, and an unbalanced ``[/]`` raises ``rich.errors.MarkupError``
+    — crashing the CLI while it is merely printing an info line.
+
+    Use this for anything interpolated into a markup string or handed to
+    ``Table.add_row``. Do NOT use it for a value passed to ``rich.text.Text``:
+    ``Text`` never parses markup, so the escaping backslashes would show up
+    verbatim on screen.
+    """
+    return _escape_markup(sanitize_value(value))

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -1,0 +1,273 @@
+"""Server-supplied text must not reach the terminal live from *direct*
+``rich.print`` sites (BE-4794).
+
+``comfy_cli.output.sanitize`` covers everything routed through ``Renderer``,
+but ``Renderer`` is not the only path to the terminal: command modules print
+under their own ``is_pretty()`` gates, and those strings never touch the
+renderer's helpers. Two distinct defects live there, both reachable from a
+hostile ComfyUI host on ``comfy run --host/--port``:
+
+  1. raw ANSI in the payload reaches the terminal (screen clear, window-title
+     rewrite, repaint-to-spoof), and
+  2. Rich *manufactures* new escapes from markup it finds — and an unbalanced
+     ``[/]`` raises ``rich.errors.MarkupError``, hard-crashing the CLI while it
+     is merely printing an error line.
+
+These tests drive the real call sites in pretty mode and assert both. Each was
+verified to fail before the corresponding ``sanitize_markup`` call was added.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from comfy_cli.command.run.execution import WorkflowExecution
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+# A payload carrying every hazard at once: CSI 2J clears the screen, OSC 0
+# rewrites the window title, and the markup forges an OSC 8 hyperlink.
+EVIL = "\x1b[2J\x1b]0;PWNED\x07boom [link=https://attacker.example]click[/link]"
+UNBALANCED = "server said [/] oops"
+
+# Rich's own styling. Anything left after stripping these came from the payload.
+_RICH_SGR_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Rich's ``Live`` display additionally emits cursor show/hide, erase-line and
+# cursor-up. Those are Rich's, not the payload's — a `Live`-backed site strips
+# them too, but nothing wider: the screen-clear and OSC forms the attacker
+# needs are deliberately absent from this allowlist.
+_RICH_LIVE_RE = re.compile(r"\x1b\[(?:\?25[lh]|[0-9]*[AK])")
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+@pytest.fixture
+def pretty(monkeypatch):
+    """Install a pretty renderer writing to a StringIO Rich treats as a tty.
+
+    ``force_terminal`` matters: Rich only emits OSC 8 hyperlinks to a terminal,
+    so without it the markup half of the attack is invisible. ``COLUMNS`` is
+    pinned because the assertions look for un-wrapped substrings.
+    """
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("COLUMNS", "300")
+    stream = io.StringIO()
+    r = Renderer.resolve(is_stdout_tty=True, env={}, caller=None)
+    r.mode = OutputMode.PRETTY
+    r.pretty_stream = stream
+    set_renderer(r)
+    return stream
+
+
+def assert_inert(stream: io.StringIO, *, live: bool = False) -> str:
+    """The payload rendered as literal text: no live escape, nothing executed.
+
+    Set ``live=True`` for a site backed by Rich's ``Live``, which emits its own
+    cursor/erase control codes on top of the SGR styling.
+    """
+    out = stream.getvalue()
+    assert "\x1b]8;" not in out, "markup was rendered into a live OSC 8 hyperlink"
+    assert "\x1b]0;" not in out, "OSC 0 window-title sequence reached the terminal"
+    assert "\x1b[2J" not in out, "CSI 2J screen-clear reached the terminal"
+    residue = _RICH_SGR_RE.sub("", out)
+    if live:
+        residue = _RICH_LIVE_RE.sub("", residue)
+    assert "\x1b" not in residue, f"escape byte survived: {residue!r}"
+    return residue
+
+
+def _execution(workflow=None, *, verbose=False):
+    return WorkflowExecution(
+        workflow=workflow if workflow is not None else {},
+        host="127.0.0.1",
+        port=8188,
+        verbose=verbose,
+        local_paths=False,
+        progress=None,
+        timeout=30,
+    )
+
+
+def _http_error(status: int, body: bytes) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://127.0.0.1:8188/prompt", code=status, msg="err", hdrs=None, fp=io.BytesIO(body)
+    )
+
+
+def _queue_against(ex, exc):
+    """Run ``ex.queue()`` with ``/prompt`` raising ``exc``. Always exits 1."""
+    with patch("comfy_cli.command.run.execution.request.urlopen", side_effect=exc):
+        with pytest.raises(typer.Exit):
+            ex.queue()
+
+
+# ---------------------------------------------------------------------------
+# execution.py — the HTTP error body the reviewer proved still leaked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_http_error_body_is_inert(pretty, status):
+    """`comfy run` against a hostile host: the body is printed verbatim two
+    lines above the (already covered) error panel."""
+    _queue_against(_execution(), _http_error(status, EVIL.encode()))
+    assert "boom" in assert_inert(pretty)
+
+
+@pytest.mark.parametrize("status", [400, 500])
+def test_http_error_body_with_unbalanced_markup_does_not_crash(pretty, status):
+    """An unbalanced ``[/]`` in the body used to raise ``MarkupError`` — a
+    remote server could hard-crash the client."""
+    _queue_against(_execution(), _http_error(status, UNBALANCED.encode()))
+    assert "oops" in assert_inert(pretty)
+
+
+def test_node_errors_json_dump_is_inert(pretty):
+    """``json.dumps`` neutralizes the ESC byte but NOT ``[``/``]`` — the markup
+    half of the attack survives the JSON encoding."""
+    body = json.dumps({"node_errors": {"1": {"errors": [{"message": EVIL}], "class_type": "X"}}}).encode()
+    _queue_against(_execution(), _http_error(400, body))
+    assert "boom" in assert_inert(pretty)
+
+
+def test_node_errors_json_dump_with_unbalanced_markup_does_not_crash(pretty):
+    body = json.dumps({"node_errors": {"1": {"errors": [{"message": UNBALANCED}], "class_type": "X"}}}).encode()
+    _queue_against(_execution(), _http_error(400, body))
+    assert "oops" in assert_inert(pretty)
+
+
+def test_connection_error_reason_is_inert(pretty):
+    _queue_against(_execution(), urllib.error.URLError(EVIL))
+    assert_inert(pretty)
+
+
+def test_execution_error_payload_is_inert(pretty):
+    """The ``execution_error`` WS frame is server-authored end to end."""
+    ex = _execution()
+    with pytest.raises(typer.Exit):
+        ex.on_error({"node_id": "1", "exception_message": EVIL, "traceback": [UNBALANCED]})
+    assert "boom" in assert_inert(pretty)
+
+
+# ---------------------------------------------------------------------------
+# execution.py — --verbose node log (node_id off the wire, title from workflow)
+# ---------------------------------------------------------------------------
+
+
+def test_log_node_known_node_is_inert(pretty):
+    ex = _execution({"1": {"class_type": EVIL, "inputs": {}, "_meta": {"title": UNBALANCED}}}, verbose=True)
+    ex.log_node("Executing", "1")
+    assert_inert(pretty)
+
+
+def test_log_node_unknown_node_id_is_inert(pretty):
+    ex = _execution({}, verbose=True)
+    ex.log_node("Executing", EVIL)
+    assert_inert(pretty)
+
+
+# ---------------------------------------------------------------------------
+# preflight.py — validation warnings, field names derived from object_info
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_warnings_are_inert(pretty):
+    from comfy_cli.command.run import preflight
+
+    graph = MagicMock()
+    graph.validate_workflow.return_value = {
+        "valid": True,
+        "warnings": [{"field": UNBALANCED, "message": EVIL}],
+    }
+    with patch("comfy_cli.cql.engine.Graph") as g:
+        g.from_object_info.return_value = graph
+        preflight._preflight_validate(preflight.get_renderer(), {"1": {}}, {"X": {}})
+    assert "boom" in assert_inert(pretty)
+
+
+# ---------------------------------------------------------------------------
+# watcher.py — output URLs echoed back from the job state file
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_output_urls_are_inert(pretty):
+    from comfy_cli.command.run import watcher
+
+    state = MagicMock()
+    state.status = "completed"
+    state.is_terminal = True
+    state.outputs = [EVIL, UNBALANCED]
+    with patch("comfy_cli.jobs_state.read", return_value=state):
+        watcher._tail_state_file("p" * 12, seconds=0.0)
+    assert "boom" in assert_inert(pretty, live=True)
+
+
+# ---------------------------------------------------------------------------
+# models/search.py — the cloud asset catalog is server-supplied too
+# ---------------------------------------------------------------------------
+
+
+#
+# `Table.add_row` parses markup in a `str` cell — the same sink the error
+# panel's `_kv_table` already covers — so the list/search tables need it too.
+
+
+def _hostile_asset(name: str) -> dict:
+    return {
+        "id": "a1",
+        "name": name,
+        "display_name": name,
+        "tags": ["models", UNBALANCED],
+        "size": None,
+        "preview_url": EVIL,
+        "metadata": {"base_model": EVIL, "repo_url": EVIL, "trained_words": [UNBALANCED]},
+    }
+
+
+@pytest.fixture
+def cloud_catalog():
+    """Point the models commands at a cloud target serving a hostile catalog."""
+    target = MagicMock()
+    target.is_cloud = True
+    target.url.return_value = "https://cloud.example/assets"
+    with (
+        patch("comfy_cli.target.resolve_target", return_value=target),
+        patch("comfy_cli.command.models.search._http_get_json") as get_json,
+    ):
+        yield get_json
+
+
+def test_models_show_fields_are_inert(pretty, cloud_catalog):
+    from comfy_cli.command.models.search import show_cmd
+
+    cloud_catalog.return_value = {"assets": [_hostile_asset(EVIL)], "has_more": False}
+    show_cmd(name=EVIL)
+    assert "boom" in assert_inert(pretty)
+
+
+def test_models_search_table_cells_are_inert(pretty, cloud_catalog):
+    from comfy_cli.command.models.search import search_cmd
+
+    cloud_catalog.return_value = {"assets": [_hostile_asset(EVIL)], "has_more": False}
+    search_cmd(text=None, type_=None, limit=20, include_public=True, where=None)
+    assert_inert(pretty)
+
+
+def test_models_list_folders_table_cells_are_inert(pretty, cloud_catalog):
+    from comfy_cli.command.models.search import list_folders_cmd
+
+    cloud_catalog.return_value = [{"name": EVIL, "folders": [UNBALANCED]}]
+    list_folders_cmd(where=None)
+    assert_inert(pretty)

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -215,6 +215,81 @@ def test_watcher_output_urls_are_inert(pretty):
 
 
 # ---------------------------------------------------------------------------
+# nodes.py — `object_info` off the same --host/--port the run path uses
+# ---------------------------------------------------------------------------
+
+# Every string here is chosen by whoever answers /object_info.
+HOSTILE_OBJECT_INFO = {
+    EVIL: {
+        "input": {"required": {UNBALANCED: ["IMAGE", {}]}},
+        "output": [EVIL],
+        "output_name": [EVIL],
+        "name": EVIL,
+        "display_name": UNBALANCED,
+        "description": EVIL,
+        "category": UNBALANCED,
+    }
+}
+
+
+@pytest.fixture
+def hostile_object_info():
+    with patch("comfy_cli.cql.loader.resilient_load_object_info", return_value=HOSTILE_OBJECT_INFO):
+        yield
+
+
+def test_nodes_ls_is_inert(pretty, hostile_object_info):
+    from comfy_cli.command.nodes import ls_cmd
+
+    ls_cmd(
+        produces=None,
+        accepts=None,
+        category=None,
+        pack=None,
+        label=None,
+        cloud_disabled=False,
+        api_only=False,
+        output_only=False,
+        exclude_deprecated=False,
+        limit=None,
+        input_path=None,
+        host=None,
+        port=None,
+        where=None,
+    )
+    assert_inert(pretty)
+
+
+def test_nodes_show_is_inert(pretty, hostile_object_info):
+    """`comfy nodes show --host <hostile>` — same flag pair as `comfy run`."""
+    from comfy_cli.command.nodes import show_cmd
+
+    show_cmd(name=EVIL, where=None, input_path=None, host=None, port=None)
+    assert "boom" in assert_inert(pretty)
+
+
+def test_nodes_search_is_inert(pretty, hostile_object_info):
+    from comfy_cli.command.nodes import search_cmd
+
+    search_cmd(query="boom", limit=20, input_path=None, host=None, port=None, where=None)
+    assert_inert(pretty)
+
+
+def test_nodes_types_is_inert(pretty, hostile_object_info):
+    from comfy_cli.command.nodes import types_cmd
+
+    types_cmd(limit=None, input_path=None, host=None, port=None, where=None)
+    assert_inert(pretty)
+
+
+def test_nodes_categories_is_inert(pretty, hostile_object_info):
+    from comfy_cli.command.nodes import categories_cmd
+
+    categories_cmd(prefix=None, limit=None, input_path=None, host=None, port=None, where=None)
+    assert_inert(pretty)
+
+
+# ---------------------------------------------------------------------------
 # models/search.py — the cloud asset catalog is server-supplied too
 # ---------------------------------------------------------------------------
 

--- a/tests/comfy_cli/output/test_panels.py
+++ b/tests/comfy_cli/output/test_panels.py
@@ -69,6 +69,35 @@ def test_error_panel_renders_details():
     assert "8188" in out
 
 
+def test_error_panel_strips_server_supplied_escape_sequences():
+    """Server-supplied text must not reach the terminal as live escapes.
+
+    A remote/shared ComfyUI picks the ``prompt_id`` and writes the exception
+    text the CLI interpolates, so every field here is attacker-influenced.
+    ``_render`` only removes the SGR codes Rich itself emits, so any ESC left
+    in ``out`` came from the payload.
+    """
+    out = _render(
+        error_panel(
+            code="ws_disconnected",
+            message="job \x1b[2Jevil running",
+            hint="retry \x1b]0;pwned\x07soon",
+            details={"prompt_id": "\x1b[2Jabc", "\x1b[2Jkey": "value"},
+        )
+    )
+    assert "\x1b" not in out
+    assert "job evil running" in out
+    assert "retry soon" in out
+    assert "abc" in out
+    assert "key" in out
+
+
+def test_error_panel_strips_escape_sequences_from_code():
+    out = _render(error_panel(code="ws_\x1b[2Jdisconnected", message="boom"))
+    assert "\x1b" not in out
+    assert "ws_disconnected" in out
+
+
 # ---------------------------------------------------------------------------
 # discover_panel
 # ---------------------------------------------------------------------------

--- a/tests/comfy_cli/output/test_panels.py
+++ b/tests/comfy_cli/output/test_panels.py
@@ -98,6 +98,38 @@ def test_error_panel_strips_escape_sequences_from_code():
     assert "ws_disconnected" in out
 
 
+def test_error_panel_details_do_not_let_markup_forge_escape_sequences():
+    """``Table.add_row`` parses Rich markup, so a server-supplied
+    ``[link=...]`` detail would otherwise emit a live OSC 8 hyperlink."""
+    buf = io.StringIO()
+    # A real terminal: Rich only emits hyperlinks when the console is a tty.
+    Console(file=buf, force_terminal=True, width=100, no_color=True).print(
+        error_panel(
+            code="ws_disconnected",
+            message="boom",
+            details={"prompt_id": "[link=https://attacker.example]x[/link]"},
+        )
+    )
+    raw = buf.getvalue()
+    assert "\x1b]8;" not in raw
+    assert "\x1b" not in _ANSI_RE.sub("", raw)
+
+
+def test_error_panel_details_survive_unbalanced_markup():
+    # ``[/]`` used to raise rich.errors.MarkupError and kill the CLI.
+    out = _render(error_panel(code="ws_disconnected", message="boom", details={"prompt_id": "a[/]b"}))
+    assert "prompt_id" in out
+
+
+def test_error_panel_tolerates_non_string_code_and_message():
+    # The renderer's helpers coerce via ``str()``; the panel must match so a
+    # loose caller doesn't hit a TypeError from ``re.sub``.
+    out = _render(error_panel(code=42, message=7, hint=13))
+    assert "42" in out
+    assert "7" in out
+    assert "13" in out
+
+
 # ---------------------------------------------------------------------------
 # discover_panel
 # ---------------------------------------------------------------------------

--- a/tests/comfy_cli/output/test_renderer.py
+++ b/tests/comfy_cli/output/test_renderer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 
 import pytest
 
@@ -289,6 +290,63 @@ def test_pretty_helpers_strip_escape_sequences(call):
     out = _pretty_output(call)
     assert "\x1b" not in out
     assert "evil" in out  # the text survives; only the escape is gone
+
+
+# Rich re-creates escape sequences from *markup* it finds in the text, so
+# stripping the raw bytes above is only half the boundary. These need a real
+# terminal: Rich only emits OSC 8 hyperlinks when the console is a tty.
+_MARKUP_LINK = "job [link=https://attacker.example]click[/link] done"
+_MARKUP_UNBALANCED = "server said [/] oops"
+_RICH_SGR_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+@pytest.fixture
+def force_terminal(monkeypatch):
+    """Make Rich treat the StringIO stream as a color terminal."""
+    monkeypatch.setenv("FORCE_COLOR", "1")
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda r: r.warn(_MARKUP_LINK),
+        lambda r: r.warn("ok", hint=_MARKUP_LINK),
+        lambda r: r.info(_MARKUP_LINK),
+        lambda r: r.info("ok", hint=_MARKUP_LINK),
+        lambda r: r.success(_MARKUP_LINK),
+        lambda r: r.error("ws_disconnected", "boom", details={"prompt_id": _MARKUP_LINK}),
+    ],
+    ids=["warn", "warn-hint", "info", "info-hint", "success", "error-panel-details"],
+)
+def test_pretty_helpers_do_not_let_markup_forge_escape_sequences(call, force_terminal):
+    """``[link=...]`` must not become a live OSC 8 hyperlink.
+
+    Only the SGR codes Rich emits for its own styling may remain; once those
+    are stripped, any surviving ESC was manufactured from the payload.
+    """
+    out = _pretty_output(call)
+    assert "\x1b]8;" not in out  # no hyperlink sequence
+    assert "\x1b" not in _RICH_SGR_RE.sub("", out)
+    assert "link=https://attacker.example" in _RICH_SGR_RE.sub("", out)  # shown as inert text
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda r: r.warn(_MARKUP_UNBALANCED),
+        lambda r: r.warn("ok", hint=_MARKUP_UNBALANCED),
+        lambda r: r.info(_MARKUP_UNBALANCED),
+        lambda r: r.info("ok", hint=_MARKUP_UNBALANCED),
+        lambda r: r.success(_MARKUP_UNBALANCED),
+        lambda r: r.error("ws_disconnected", "boom", details={"prompt_id": _MARKUP_UNBALANCED}),
+    ],
+    ids=["warn", "warn-hint", "info", "info-hint", "success", "error-panel-details"],
+)
+def test_pretty_helpers_survive_unbalanced_markup(call):
+    """An unbalanced ``[/]`` used to raise ``MarkupError`` and kill the CLI
+    while it was merely printing a line."""
+    out = _pretty_output(call)
+    assert "oops" in out
 
 
 def test_json_error_envelope_is_unchanged_by_sanitizing():

--- a/tests/comfy_cli/output/test_renderer.py
+++ b/tests/comfy_cli/output/test_renderer.py
@@ -302,8 +302,14 @@ _RICH_SGR_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 @pytest.fixture
 def force_terminal(monkeypatch):
-    """Make Rich treat the StringIO stream as a color terminal."""
+    """Make Rich treat the StringIO stream as a color terminal.
+
+    ``COLUMNS`` is pinned too: these assertions look for an un-wrapped
+    substring, and ``rich.print`` gives no way to pass ``width`` through, so
+    without it the result depends on the runner's default console width.
+    """
     monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.setenv("COLUMNS", "200")
 
 
 @pytest.mark.parametrize(

--- a/tests/comfy_cli/output/test_renderer.py
+++ b/tests/comfy_cli/output/test_renderer.py
@@ -250,3 +250,84 @@ def test_get_renderer_default_is_pretty():
     # No prior set; default is pretty so unsuspecting callers don't crash.
     r = get_renderer()
     assert r.is_pretty()
+
+
+# ---------------------------------------------------------------------------
+# Control-sequence sanitizing at the pretty boundary (BE-4794)
+# ---------------------------------------------------------------------------
+
+_EVIL = "job \x1b[2Jevil"
+
+
+def _pretty_output(call) -> str:
+    """Run ``call(renderer)`` in pretty mode and return what hit the stream.
+
+    ``force_terminal`` is left off, so Rich emits no SGR of its own: every ESC
+    in the result would have come from the message itself.
+    """
+    stream = io.StringIO()
+    r = _resolve()
+    r.mode = OutputMode.PRETTY
+    r.pretty_stream = stream
+    call(r)
+    return stream.getvalue()
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda r: r.warn(_EVIL),
+        lambda r: r.warn("ok", hint=_EVIL),
+        lambda r: r.info(_EVIL),
+        lambda r: r.info("ok", hint=_EVIL),
+        lambda r: r.success(_EVIL),
+        lambda r: r.error("ws_disconnected", _EVIL, hint=_EVIL, details={"prompt_id": _EVIL}),
+    ],
+    ids=["warn", "warn-hint", "info", "info-hint", "success", "error-panel"],
+)
+def test_pretty_helpers_strip_escape_sequences(call):
+    out = _pretty_output(call)
+    assert "\x1b" not in out
+    assert "evil" in out  # the text survives; only the escape is gone
+
+
+def test_json_error_envelope_is_unchanged_by_sanitizing():
+    """The machine path must stay byte-identical: ``json.dumps`` already
+    neutralizes ESC as ``\\u001b``, and stripping it would mutate data agents
+    parse."""
+    stream = io.StringIO()
+    r = _resolve()
+    r.mode = OutputMode.JSON
+    r.machine_stream = stream
+    r.command = "run"
+    r.error("ws_disconnected", _EVIL, hint=_EVIL, details={"prompt_id": "\x1b[2Jx"})
+    raw = stream.getvalue()
+
+    # Byte level: escaped, never raw — and never stripped.
+    assert "\x1b" not in raw
+    assert raw.count("\\u001b") == 3
+    # Value level: the payload round-trips exactly as it went in.
+    env = json.loads(raw.strip())
+    assert env["error"]["message"] == _EVIL
+    assert env["error"]["hint"] == _EVIL
+    assert env["error"]["details"] == {"prompt_id": "\x1b[2Jx"}
+
+
+def test_ndjson_event_payload_is_unchanged_by_sanitizing():
+    stream = io.StringIO()
+    r = _resolve()
+    r.mode = OutputMode.NDJSON
+    r.machine_stream = stream
+    r.event("progress", prompt_id="\x1b[2Jx")
+    raw = stream.getvalue()
+    assert "\x1b" not in raw
+    assert "\\u001b" in raw
+    assert json.loads(raw.strip())["prompt_id"] == "\x1b[2Jx"
+
+
+def test_pretty_helpers_tolerate_non_string_messages():
+    """The f-string interpolation these helpers used to do coerced anything to
+    ``str``; sanitizing must not turn a loose caller into a TypeError."""
+    assert "42" in _pretty_output(lambda r: r.warn(42))
+    assert "42" in _pretty_output(lambda r: r.info(42))
+    assert "42" in _pretty_output(lambda r: r.success(42))

--- a/tests/comfy_cli/output/test_sanitize.py
+++ b/tests/comfy_cli/output/test_sanitize.py
@@ -1,0 +1,90 @@
+"""Unit tests for the pretty-mode control-sequence sanitizer."""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_value
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # CSI: clear screen, cursor moves, SGR colors.
+        ("job \x1b[2Jevil running", "job evil running"),
+        ("\x1b[1;31mred\x1b[0m", "red"),
+        ("up\x1b[3Aover", "upover"),
+        # OSC: window-title rewrite, terminated by BEL or by ST.
+        ("a\x1b]0;pwned\x07b", "ab"),
+        ("a\x1b]0;pwned\x1b\\b", "ab"),
+        # DCS / APC / PM / SOS.
+        ("a\x1bPq#0;2\x1b\\b", "ab"),
+        ("a\x1b_G payload \x1b\\b", "ab"),
+        # Two-character escapes and charset designators.
+        ("a\x1b(Bb", "ab"),
+        ("a\x1b=b", "ab"),
+        # 8-bit C1 forms of CSI and OSC.
+        ("a\x9b2Jb", "ab"),
+        ("a\x9d0;pwned\x9cb", "ab"),
+        # Bare control characters, including a lone trailing ESC and DEL.
+        ("a\x00b\x07c\x7fd", "abcd"),
+        ("trailing\x1b", "trailing"),
+        ("trailing\x9b", "trailing"),
+        # ``\x9b c`` is a complete 8-bit CSI (Device Attributes), so the final
+        # byte goes with it — over-eager by one character in the pathological
+        # case where U+009B appears in otherwise-legitimate text, which it
+        # never does.
+        ("bare\x9bcsi", "baresi"),
+        # Carriage return is stripped: it lets a message repaint a printed line.
+        ("real output\rspoofed", "real outputspoofed"),
+        ("windows\r\nlines", "windows\nlines"),
+        # Tab and newline are layout, not control — they survive.
+        ("col1\tcol2\nrow2", "col1\tcol2\nrow2"),
+        # Ordinary text, including non-ASCII, is untouched.
+        ("", ""),
+        ("plain ascii", "plain ascii"),
+        ("héllo · 世界 ✓", "héllo · 世界 ✓"),
+        # Rich markup is NOT stripped — call sites rely on it for styling.
+        ("[bold]styled[/bold]", "[bold]styled[/bold]"),
+    ],
+)
+def test_sanitize_strips_control_sequences(raw: str, expected: str):
+    assert sanitize(raw) == expected
+
+
+def test_sanitize_output_never_contains_escape():
+    payload = "x\x1b[2J\x1b]0;t\x07\x1bPz\x1b\\\x9b1m\x7f\x00y"
+    cleaned = sanitize(payload)
+    assert "\x1b" not in cleaned
+    assert "\x9b" not in cleaned
+    assert cleaned == "xy"
+
+
+def test_unterminated_osc_consumes_the_tail():
+    # A terminal would swallow the rest of the stream looking for the
+    # terminator, so dropping the tail is the faithful reading.
+    assert sanitize("before\x1b]0;never terminated") == "before"
+
+
+def test_sanitize_is_idempotent():
+    once = sanitize("job \x1b[2Jevil\x1b]0;t\x07")
+    assert sanitize(once) == once
+
+
+def test_sanitize_optional_passes_none_through():
+    assert sanitize_optional(None) is None
+    assert sanitize_optional("a\x1b[2Jb") == "ab"
+
+
+def test_sanitize_value_stringifies_non_strings():
+    assert sanitize_value(42) == "42"
+    assert sanitize_value(None) == "None"
+    assert sanitize_value("\x1b[2Jkeep") == "keep"
+
+
+def test_sanitize_value_leaves_container_repr_inert():
+    # ``str()`` on a container reprs its members, which already renders an ESC
+    # as the four visible characters ``\x1b`` — inert, so it survives as text.
+    out = sanitize_value(["\x1b[2Ja"])
+    assert "\x1b" not in out
+    assert out == "['\\x1b[2Ja']"

--- a/tests/comfy_cli/output/test_sanitize.py
+++ b/tests/comfy_cli/output/test_sanitize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_value
+from comfy_cli.output.sanitize import sanitize, sanitize_markup, sanitize_optional, sanitize_value
 
 
 @pytest.mark.parametrize(
@@ -26,6 +26,10 @@ from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_valu
         # 8-bit C1 forms of CSI and OSC.
         ("a\x9b2Jb", "ab"),
         ("a\x9d0;pwned\x9cb", "ab"),
+        # 8-bit SOS, the C1 counterpart of ``\x1bX`` — consumed as a unit, so
+        # its payload does not survive as visible garbage.
+        ("a\x98payload\x9cb", "ab"),
+        ("a\x1bXpayload\x1b\\b", "ab"),
         # Bare control characters, including a lone trailing ESC and DEL.
         ("a\x00b\x07c\x7fd", "abcd"),
         ("trailing\x1b", "trailing"),
@@ -44,7 +48,9 @@ from comfy_cli.output.sanitize import sanitize, sanitize_optional, sanitize_valu
         ("", ""),
         ("plain ascii", "plain ascii"),
         ("héllo · 世界 ✓", "héllo · 世界 ✓"),
-        # Rich markup is NOT stripped — call sites rely on it for styling.
+        # Rich markup is NOT stripped here — ``sanitize`` only removes the
+        # bytes a terminal acts on. Neutralizing markup is ``sanitize_markup``'s
+        # job, and only for sinks that actually parse it.
         ("[bold]styled[/bold]", "[bold]styled[/bold]"),
     ],
 )
@@ -76,10 +82,38 @@ def test_sanitize_optional_passes_none_through():
     assert sanitize_optional("a\x1b[2Jb") == "ab"
 
 
+def test_sanitize_optional_stringifies_non_strings():
+    # A caller that ignores the ``str | None`` annotation must not hit the
+    # ``TypeError`` ``re.sub`` raises on a non-string.
+    assert sanitize_optional(42) == "42"
+
+
 def test_sanitize_value_stringifies_non_strings():
     assert sanitize_value(42) == "42"
     assert sanitize_value(None) == "None"
     assert sanitize_value("\x1b[2Jkeep") == "keep"
+
+
+def test_sanitize_markup_escapes_rich_markup():
+    # Rich would turn these back into a live OSC 8 hyperlink / a restyled line.
+    assert sanitize_markup("[link=https://attacker.example]x[/link]") == (r"\[link=https://attacker.example]x\[/link]")
+    assert sanitize_markup("[red]spoof[/red]") == r"\[red]spoof\[/red]"
+
+
+def test_sanitize_markup_also_strips_control_sequences():
+    out = sanitize_markup("job \x1b[2J[bold]evil[/bold]")
+    assert "\x1b" not in out
+    assert out == r"job \[bold]evil\[/bold]"
+
+
+def test_sanitize_markup_leaves_markup_free_text_untouched():
+    # The overwhelmingly common case must be byte-identical to sanitize_value.
+    for text in ["plain ascii", "col1\tcol2\nrow2", "héllo · 世界 ✓", "8188"]:
+        assert sanitize_markup(text) == sanitize_value(text) == text
+
+
+def test_sanitize_markup_stringifies_non_strings():
+    assert sanitize_markup(42) == "42"
 
 
 def test_sanitize_value_leaves_container_repr_inert():


### PR DESCRIPTION
## ELI-5

When something goes wrong, the CLI prints the error message it got back from the ComfyUI server. If that server is a stranger's machine (`comfy run --host/--port` can point anywhere), it gets to choose the text — and terminals treat some text as *commands*, not characters. A message like `job <ESC>[2Jevil running` doesn't say "clear my screen", it *clears your screen*. It can also rewrite your window title, or repaint lines that already scrolled past so the CLI appears to have said something it never said.

This PR adds one small function that removes those invisible command characters, and calls it in the one place where human-facing text becomes terminal output. Machine-readable JSON output is untouched — it already escapes them safely, and stripping there would corrupt data that agents parse.

## What changed

- **New `comfy_cli/output/sanitize.py`** — strips C0/C1 control characters and ANSI escape sequences (CSI, OSC, DCS, and the shorter two- and three-character forms). Tab and newline survive (legitimate layout in multi-line messages); carriage return does not (it lets a message repaint an already-printed line). Rich *markup* is deliberately left alone — call sites use `[yellow]…[/yellow]` for styling and escape untrusted text with `rich.markup.escape`.
- **`error_panel`** (the only pretty path `Renderer.error` takes) now sanitizes `code`, `message`, `hint`, and the stringified `details` keys and values.
- **`Renderer.warn` / `info` / `success`** sanitize their `message` and `hint`.
- **The JSON/NDJSON envelope paths are untouched.** `json.dumps` already encodes ESC as a `\u` escape, so machine output was never exposed, and sanitizing there would silently mutate the payload agents read.

Why here and not at the call sites: the pattern is repo-wide (every `renderer.error(...)` interpolates `{e}` or a server-chosen id the same way), so fixing individual commands would leave the identical hazard on the adjacent lines and give a false sense of coverage. One boundary, applied once.

This is the same class of defense the repo already applies to untrusted download filenames in `_sanitize_ext` (`comfy_cli/command/transfer.py`) — that one guards the on-disk name, this one guards the rendered line.

## Verification

- `pytest tests/ --ignore=tests/e2e` — **2813 passed, 18 skipped**.
- `ruff check` and `ruff format --check` (pinned v0.15.15, matching `.pre-commit-config.yaml`) clean on every changed file. The 15 pre-existing `UP038` findings elsewhere in the repo come from a newer ruff and are untouched by this PR.
- New tests: `tests/comfy_cli/output/test_sanitize.py` (28 cases across CSI/OSC/DCS/APC, 8-bit C1 forms, unterminated sequences, idempotence, and the text that must survive), plus panel and renderer boundary tests. Both boundary tests are genuine regression tests — I confirmed `rich.print` passes `\x1b` through unchanged, so they fail without this change.
- The JSON side is asserted two ways: no raw ESC on the wire, and the parsed envelope values round-trip byte-for-byte as they went in.
- Not ReDoS-prone: the regex has no nested quantifiers, and 400 KB adversarial inputs (unterminated OSC runs, 200k-parameter CSI, ESC-then-long-tail) all sanitize in under 5 ms.

## Judgment calls

- **Extended past the ticket's letter to `Renderer.info` and `success`.** The ticket named `error` and `warn`. Sanitizing `warn` while leaving the adjacent `info` unsanitized would reproduce the exact "false sense of coverage" the ticket argues against, and both take a plain string straight to the terminal. Zero call sites today, so no behavior risk.
- **`Renderer.print` is deliberately NOT sanitized.** It is the generic passthrough and accepts arbitrary Rich renderables, not just strings; sanitizing there would mean stringifying renderables. Callers with untrusted text should use the semantic helpers above.
- **`which_panel` / `auth_list_table` / `discover_panel` are deliberately NOT sanitized.** They render locally-sourced data (workspace paths, the local auth store, the CLI's own command help), not server-supplied text. Adding them would widen the diff without closing a reachable path.
- **The helpers coerce with `str()` before sanitizing** (`sanitize_value`, not `sanitize`). Their params are annotated `str`, but `warn`/`success` previously interpolated via an f-string, which accepted anything. Keeping the coercion means a loose caller gets the old behavior instead of a new `TypeError`; there is a test for it.
- **An unterminated OSC/DCS sequence consumes the rest of the string.** That is what a terminal itself does with it, so dropping the tail is the faithful reading rather than avoidable data loss. Only reachable via a real ESC byte, which never appears in legitimate message text.
- **Homoglyph and bidi-override spoofing (e.g. U+202E) are out of scope**, and noted as such in the module docstring. They are a different problem with a different fix; the ticket scoped this to C0/C1 and ANSI.

## Capability-denial check

The change removes ANSI passthrough from four rendering helpers, so I checked empirically that nothing legitimately relies on it rather than assuming: `error_panel` has exactly one caller (`Renderer.error`); `warn`/`info`/`success` have exactly one call site between them (`comfy_cli/command/outdated.py:512`, which already wraps its input in `rich.markup.escape`); all 242 `.error(...)` call sites pass f-strings or `str(e)`; and no `.py` file in `comfy_cli/` contains a raw `\x1b`/`\033`/`\e[` literal. No product path emits intentional ANSI through these helpers, so nothing is denied.

Closes BE-4794.
