### PR TITLE
fix: exit 0 when stdout's reader closes early (BE-4795)

### DIFF
--- a/comfy_cli/__main__.py
+++ b/comfy_cli/__main__.py
@@ -9,6 +9,12 @@ when the failing write is the interpreter's own shutdown flush, prints an
 "Exception ignored" traceback), which reads as a command failure to every
 shell/CI/agent downstream.
 
+The exit 0 is only ever granted to a command that *succeeded*. A closed reader
+on a command that failed still exits with the failure's code — `comfy --json
+some-failing-cmd | head` is a failure that happened to be piped, not a success.
+Absorbing the broken pipe there would launder a genuine error into 0, which is
+the one outcome worse than the exit 1 this wrapper exists to remove.
+
 Output written before the pipe closed is of course truncated — a half-written
 `--json` envelope stays half-written. That is the consumer's problem by
 construction; the exit code is ours.
@@ -20,19 +26,33 @@ import sys
 from comfy_cli.cmdline import main as _cli_main
 
 
-def _exit_quietly_on_broken_pipe() -> None:
-    """Absorb a closed stdout and exit 0. Never returns."""
-    # Point fd 1 at /dev/null so that nothing between here and process death —
-    # an atexit hook, a `finally` that prints, the interpreter's own shutdown
-    # flush — can hit EPIPE a second time and turn this clean exit back into a
-    # traceback on stderr.
+def _silence_stdout() -> None:
+    """Point fd 1 at /dev/null so nothing later can hit EPIPE a second time.
+
+    Between here and process death an atexit hook, a `finally` that prints, or
+    the interpreter's own shutdown flush can all write to stdout. Once its
+    reader is gone each of those turns into a fresh `BrokenPipeError` — an
+    "Exception ignored" traceback on stderr, and (for the shutdown flush) exit
+    120 in place of whatever code we meant to report.
+    """
     try:
-        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    except OSError:  # pragma: no cover — /dev/null is not openable
+        return
+    try:
+        os.dup2(devnull_fd, sys.stdout.fileno())
     except (OSError, ValueError, AttributeError):
         # No usable fd 1 (already closed, or stdout was replaced by something
-        # without a real file descriptor). Nothing to protect — os._exit below
-        # skips Python-level flushing anyway.
+        # without a real file descriptor). Nothing to protect.
         pass
+    finally:
+        # dup2 gives fd 1 its own reference, so this one is ours to release.
+        os.close(devnull_fd)
+
+
+def _exit_quietly_on_broken_pipe() -> None:
+    """Absorb a closed stdout and exit 0. Never returns."""
+    _silence_stdout()
     # os._exit rather than sys.exit: it skips atexit handlers and stdio
     # flushing entirely, so no buffered-but-unwritable stdout can resurrect the
     # error we just absorbed. The cost is that the telemetry atexit flush in
@@ -59,40 +79,83 @@ def _broken_pipe_swallowed_by_click() -> bool:
     return isinstance(sys.stdout, PacifyFlushWrapper)
 
 
-def _flush_stdout() -> None:
-    """Flush stdout, letting only `BrokenPipeError` escape."""
+def _flush_stdout(*, unwinding: bool) -> bool:
+    """Flush stdout; return False iff the flush hit a broken pipe.
+
+    Reporting the broken pipe by return value instead of raising is what lets
+    `main` keep the two cases apart. This flush runs at a point where a real
+    exception may already be on its way out, and a `BrokenPipeError` raised
+    from here would silently *replace* it — turning a failed command's non-zero
+    exit into 0.
+
+    `unwinding` says whether that is the case. While unwinding, every other
+    flush failure is swallowed too, for the same reason: a `finally`-time flush
+    must never mask the exception it is running underneath. On the clean path
+    there is nothing to mask, so a non-broken-pipe `OSError` (a full disk, EIO)
+    is allowed to propagate — output was genuinely lost and a real traceback
+    beats the interpreter's opaque exit 120. Only the nothing-to-flush shapes
+    stay quiet either way.
+    """
     stream = sys.stdout
     if stream is None:  # stdout detached (pythonw and friends)
-        return
+        return True
     try:
         stream.flush()
     except BrokenPipeError:
-        raise
-    except (OSError, ValueError, AttributeError):
-        # Closed, detached, or non-file-like stdout (`comfy … >&-`) — nothing to
-        # flush, and not the broken-pipe case we are guarding against. Swallow
-        # it so this `finally`-time flush can never mask the real exception on
-        # its way out.
+        return False
+    except (ValueError, AttributeError):
+        # Closed or non-file-like stdout (`comfy … >&-`) — nothing to flush,
+        # and not the broken-pipe case we are guarding against.
         pass
+    except OSError:
+        if not unwinding:
+            raise
+    return True
+
+
+def _is_clean_exit(exc: SystemExit) -> bool:
+    """Whether this `SystemExit` reports success (`sys.exit(0)` / `sys.exit()`)."""
+    return exc.code is None or exc.code == 0
 
 
 def main() -> None:
     try:
-        try:
-            _cli_main()
-        finally:
-            # stdout is block-buffered when it is a pipe, so the write that
-            # actually lands on the closed reader is frequently the
-            # interpreter's shutdown flush — long after any handler here could
-            # run. Flushing inside the guard pulls that failure forward to
-            # where we can absorb it.
-            _flush_stdout()
+        _cli_main()
     except BrokenPipeError:
+        # click's standalone `main` converts every EPIPE raised inside a command
+        # into the pacified `SystemExit(1)` handled just below, so a raw
+        # `BrokenPipeError` reaching here is stdout dying outside that guard.
         _exit_quietly_on_broken_pipe()
-    except SystemExit:
+    except SystemExit as exc:
         if _broken_pipe_swallowed_by_click():
             _exit_quietly_on_broken_pipe()
+        # stdout is block-buffered when it is a pipe, so the write that actually
+        # lands on the closed reader is frequently the interpreter's shutdown
+        # flush — long after any handler here could run. Flushing now pulls that
+        # failure forward to where we can still decide what it means.
+        clean = _is_clean_exit(exc)
+        if _flush_stdout(unwinding=not clean):
+            raise
+        if clean:
+            # The command succeeded and its reader left early: that is the whole
+            # story, so exit 0.
+            _exit_quietly_on_broken_pipe()
+        # The command failed. Its exit code is the truth and outranks the closed
+        # reader; only silence fd 1 so the shutdown flush cannot re-raise what
+        # we just absorbed (which would replace that code with 120).
+        _silence_stdout()
         raise
+    except BaseException:
+        # A crash is already on its way out. Same rule: flush what we can, let
+        # nothing from the flush displace it.
+        if not _flush_stdout(unwinding=True):
+            _silence_stdout()
+        raise
+    else:
+        # `_cli_main` returned instead of exiting. click always raises in
+        # standalone mode, but `cmdline.main` can fall through on rc == 0.
+        if not _flush_stdout(unwinding=False):
+            _exit_quietly_on_broken_pipe()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/comfy_cli/__main__.py
+++ b/comfy_cli/__main__.py
@@ -1,4 +1,99 @@
-from comfy_cli.cmdline import main
+"""Console-script entrypoint for `comfy` / `comfy-cli` / `comfycli`.
+
+A thin wrapper around `comfy_cli.cmdline.main` whose only job is to make the
+process a well-behaved pipe producer. When the consumer of our stdout goes away
+early — `comfy run --wait … | head`, `comfy jobs ls | head -5` — the next write
+raises `BrokenPipeError`. The right answer is a silent exit 0: the consumer got
+exactly what it asked for. Without this wrapper the process instead exits 1 (or,
+when the failing write is the interpreter's own shutdown flush, prints an
+"Exception ignored" traceback), which reads as a command failure to every
+shell/CI/agent downstream.
+
+Output written before the pipe closed is of course truncated — a half-written
+`--json` envelope stays half-written. That is the consumer's problem by
+construction; the exit code is ours.
+"""
+
+import os
+import sys
+
+from comfy_cli.cmdline import main as _cli_main
+
+
+def _exit_quietly_on_broken_pipe() -> None:
+    """Absorb a closed stdout and exit 0. Never returns."""
+    # Point fd 1 at /dev/null so that nothing between here and process death —
+    # an atexit hook, a `finally` that prints, the interpreter's own shutdown
+    # flush — can hit EPIPE a second time and turn this clean exit back into a
+    # traceback on stderr.
+    try:
+        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+    except (OSError, ValueError, AttributeError):
+        # No usable fd 1 (already closed, or stdout was replaced by something
+        # without a real file descriptor). Nothing to protect — os._exit below
+        # skips Python-level flushing anyway.
+        pass
+    # os._exit rather than sys.exit: it skips atexit handlers and stdio
+    # flushing entirely, so no buffered-but-unwritable stdout can resurrect the
+    # error we just absorbed. The cost is that the telemetry atexit flush in
+    # comfy_cli.tracking is skipped for this invocation, which is the intended
+    # trade — a truncated pipe is not worth risking a second failure or a
+    # shutdown hang on the way out.
+    os._exit(0)
+
+
+def _broken_pipe_swallowed_by_click() -> bool:
+    """Report whether the `SystemExit` we just caught is click's EPIPE bail-out.
+
+    click's `BaseCommand.main` handles EPIPE itself: it swaps `sys.stdout` and
+    `sys.stderr` for `click.utils.PacifyFlushWrapper` and raises
+    `SystemExit(1)`. So on the common path a broken pipe never reaches us as a
+    `BrokenPipeError` at all, and the exit 1 is otherwise indistinguishable
+    from a genuine command failure. That wrapper — which click installs in this
+    branch and nowhere else — is the one reliable in-process signal.
+    """
+    try:
+        from click.utils import PacifyFlushWrapper
+    except ImportError:  # pragma: no cover — click ships as a typer dependency
+        return False
+    return isinstance(sys.stdout, PacifyFlushWrapper)
+
+
+def _flush_stdout() -> None:
+    """Flush stdout, letting only `BrokenPipeError` escape."""
+    stream = sys.stdout
+    if stream is None:  # stdout detached (pythonw and friends)
+        return
+    try:
+        stream.flush()
+    except BrokenPipeError:
+        raise
+    except (OSError, ValueError, AttributeError):
+        # Closed, detached, or non-file-like stdout (`comfy … >&-`) — nothing to
+        # flush, and not the broken-pipe case we are guarding against. Swallow
+        # it so this `finally`-time flush can never mask the real exception on
+        # its way out.
+        pass
+
+
+def main() -> None:
+    try:
+        try:
+            _cli_main()
+        finally:
+            # stdout is block-buffered when it is a pipe, so the write that
+            # actually lands on the closed reader is frequently the
+            # interpreter's shutdown flush — long after any handler here could
+            # run. Flushing inside the guard pulls that failure forward to
+            # where we can absorb it.
+            _flush_stdout()
+    except BrokenPipeError:
+        _exit_quietly_on_broken_pipe()
+    except SystemExit:
+        if _broken_pipe_swallowed_by_click():
+            _exit_quietly_on_broken_pipe()
+        raise
+
 
 if __name__ == "__main__":  # pragma: nocover
     main()

--- a/tests/comfy_cli/test_broken_pipe.py
+++ b/tests/comfy_cli/test_broken_pipe.py
@@ -22,17 +22,37 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 # workspace, network, or auth — the cheapest command that writes a lot.
 BIG_OUTPUT_CMD = [sys.executable, "-m", "comfy_cli", "--help-json"]
 
+# A stand-in for a command that writes a small `--json` envelope and *then*
+# fails. The write is small enough to stay in stdout's 8 KiB buffer, so the
+# broken pipe surfaces from the entrypoint's own exit-time flush — the one
+# window where it could displace the pending `SystemExit` and report success.
+# No real subcommand fails offline while writing to stdout, hence the stub.
+FAILING_COMMAND_STUB = """
+import sys
+from comfy_cli import __main__ as entrypoint
 
-def _run_with_stdout_reader_gone():
-    """Run the CLI with a stdout pipe whose read end is already closed.
+def _envelope_then_fail():
+    sys.stdout.write('{"schema": "envelope/1", "ok": false}')
+    sys.exit(7)
+
+entrypoint._cli_main = _envelope_then_fail
+entrypoint.main()
+"""
+
+
+def _run_with_stdout_reader_gone(cmd=None):
+    """Run `cmd` with a stdout pipe whose read end is already closed.
 
     Deterministic by construction: there is no pipe buffer left to absorb the
     output, so the very first write raises `BrokenPipeError`. (Reading a chunk
     first and *then* closing is the more literal `| head` shape, but it races
     the kernel's pipe buffer — see the `head` test below for that variant.)
     """
+    # Block-buffered stdout is the whole point of these tests; an inherited
+    # PYTHONUNBUFFERED would move the failing write somewhere else entirely.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONUNBUFFERED"}
     read_fd, write_fd = os.pipe()
-    proc = subprocess.Popen(BIG_OUTPUT_CMD, cwd=REPO_ROOT, stdout=write_fd, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd or BIG_OUTPUT_CMD, cwd=REPO_ROOT, stdout=write_fd, stderr=subprocess.PIPE, env=env)
     os.close(write_fd)
     os.close(read_fd)
     try:
@@ -96,6 +116,24 @@ class TestBrokenPipeExitCode:
         )
         assert proc.returncode != 0
 
+    def test_failure_plus_broken_pipe_still_exits_nonzero(self):
+        """`comfy --json <failing-cmd> | head`: the failure outranks the closed reader.
+
+        The case `test_real_failure_still_exits_nonzero` cannot reach — it
+        drains stdout, so no pipe ever breaks. Here both happen at once, which
+        is where an exit-time flush is able to swap a `SystemExit(7)` for a
+        `BrokenPipeError` and hand the shell a 0.
+        """
+        returncode, _ = _run_with_stdout_reader_gone([sys.executable, "-c", FAILING_COMMAND_STUB])
+        assert returncode == 7, f"expected the command's exit 7 to survive the broken pipe, got {returncode}"
+
+    def test_failure_plus_broken_pipe_is_silent(self):
+        """Preserving the exit code must not cost a shutdown-flush traceback."""
+        _, stderr = _run_with_stdout_reader_gone([sys.executable, "-c", FAILING_COMMAND_STUB])
+        text = stderr.decode(errors="replace")
+        assert "BrokenPipeError" not in text, text
+        assert "Exception ignored" not in text, text
+
 
 class TestClickPacifySignal:
     """click swallows EPIPE itself, so the guard detects it by the stream swap."""
@@ -120,32 +158,160 @@ class TestClickPacifySignal:
         assert excinfo.value.code == 3
 
 
-class TestFlushStdout:
-    def test_broken_pipe_propagates(self, monkeypatch):
-        class Exploding(io.StringIO):
-            def flush(self):
-                raise BrokenPipeError(32, "Broken pipe")
+class BrokenStdout(io.StringIO):
+    def flush(self):
+        raise BrokenPipeError(32, "Broken pipe")
 
-        monkeypatch.setattr(sys, "stdout", Exploding())
-        with pytest.raises(BrokenPipeError):
-            entrypoint._flush_stdout()
+
+class ExitedZero(BaseException):
+    """Stand-in for `_exit_quietly_on_broken_pipe`, which really `os._exit`s.
+
+    A stub that merely *returns* would let `main` run on past the call and
+    reach code the real process never does — hiding exactly the mistakes these
+    tests are here to catch.
+    """
+
+
+class TestFlushStdout:
+    def test_broken_pipe_is_reported_not_raised(self, monkeypatch):
+        """Raising here would replace whatever exception is already unwinding."""
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        assert entrypoint._flush_stdout(unwinding=False) is False
+        assert entrypoint._flush_stdout(unwinding=True) is False
 
     def test_closed_stdout_is_tolerated(self, monkeypatch):
         stream = io.StringIO()
         stream.close()
         monkeypatch.setattr(sys, "stdout", stream)
-        entrypoint._flush_stdout()  # must not raise
+        assert entrypoint._flush_stdout(unwinding=False) is True
 
     def test_detached_stdout_is_tolerated(self, monkeypatch):
         monkeypatch.setattr(sys, "stdout", None)
-        entrypoint._flush_stdout()  # must not raise
+        assert entrypoint._flush_stdout(unwinding=False) is True
 
-    def test_other_oserror_is_tolerated(self, monkeypatch):
-        """A `finally`-time flush must never mask the exception on its way out."""
+    def test_other_oserror_is_swallowed_while_unwinding(self, monkeypatch):
+        """A flush running under a live exception must never mask it."""
 
         class BadFd(io.StringIO):
             def flush(self):
                 raise OSError(9, "Bad file descriptor")
 
         monkeypatch.setattr(sys, "stdout", BadFd())
-        entrypoint._flush_stdout()  # must not raise
+        assert entrypoint._flush_stdout(unwinding=True) is True
+
+    def test_other_oserror_surfaces_on_the_clean_path(self, monkeypatch):
+        """A full disk lost output; with nothing to mask, say so properly."""
+
+        class FullDisk(io.StringIO):
+            def flush(self):
+                raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(sys, "stdout", FullDisk())
+        with pytest.raises(OSError):
+            entrypoint._flush_stdout(unwinding=False)
+
+
+class TestFailureIsNeverLaundered:
+    """A broken pipe from the exit-time flush must not outrank a real failure."""
+
+    @staticmethod
+    def _forbid_exit_zero(monkeypatch):
+        def _boom():
+            raise AssertionError("exit 0 taken for a failing command")
+
+        monkeypatch.setattr(entrypoint, "_exit_quietly_on_broken_pipe", _boom)
+
+    def test_nonzero_systemexit_survives(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: sys.exit(2))
+        self._forbid_exit_zero(monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            entrypoint.main()
+
+        assert excinfo.value.code == 2
+
+    def test_string_systemexit_survives(self, monkeypatch):
+        """`sys.exit("message")` is exit 1, not a success code."""
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: sys.exit("nope"))
+        self._forbid_exit_zero(monkeypatch)
+
+        with pytest.raises(SystemExit) as excinfo:
+            entrypoint.main()
+
+        assert excinfo.value.code == "nope"
+
+    def test_crash_survives(self, monkeypatch):
+        def _crash():
+            raise RuntimeError("real failure")
+
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", _crash)
+        self._forbid_exit_zero(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="real failure"):
+            entrypoint.main()
+
+    @staticmethod
+    def _record_exit_zero(monkeypatch):
+        def _exit_zero():
+            raise ExitedZero
+
+        monkeypatch.setattr(entrypoint, "_exit_quietly_on_broken_pipe", _exit_zero)
+
+    def test_successful_exit_still_becomes_exit_zero(self, monkeypatch):
+        """The point of the guard: a succeeded command keeps its exit 0."""
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: sys.exit(0))
+        self._record_exit_zero(monkeypatch)
+
+        with pytest.raises(ExitedZero):
+            entrypoint.main()
+
+    def test_bare_sys_exit_still_becomes_exit_zero(self, monkeypatch):
+        """`sys.exit()` carries `code is None`, which is success."""
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: sys.exit())
+        self._record_exit_zero(monkeypatch)
+
+        with pytest.raises(ExitedZero):
+            entrypoint.main()
+
+    def test_clean_return_still_becomes_exit_zero(self, monkeypatch):
+        """`cmdline.main` falls through without raising when rc == 0."""
+        monkeypatch.setattr(sys, "stdout", BrokenStdout())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: None)
+        self._record_exit_zero(monkeypatch)
+
+        with pytest.raises(ExitedZero):
+            entrypoint.main()
+
+
+class TestSilenceStdout:
+    def test_closes_its_devnull_descriptor(self, tmp_path, monkeypatch):
+        """The /dev/null fd is duplicated onto stdout's fd, not left dangling."""
+        with open(tmp_path / "out", "w") as target:
+            monkeypatch.setattr(sys, "stdout", target)
+            probe = os.open(os.devnull, os.O_WRONLY)
+            os.close(probe)
+
+            entrypoint._silence_stdout()
+
+            after = os.open(os.devnull, os.O_WRONLY)
+            os.close(after)
+        # os.open hands back the lowest free descriptor, so a leak would push
+        # this one past `probe`.
+        assert after == probe
+
+    def test_writes_go_to_devnull_afterwards(self, tmp_path, monkeypatch):
+        path = tmp_path / "out"
+        with open(path, "w") as target:
+            monkeypatch.setattr(sys, "stdout", target)
+            entrypoint._silence_stdout()
+            target.write("must not land in the file")
+        assert path.read_text() == ""
+
+    def test_stdout_without_a_descriptor_is_tolerated(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        entrypoint._silence_stdout()  # must not raise

--- a/tests/comfy_cli/test_broken_pipe.py
+++ b/tests/comfy_cli/test_broken_pipe.py
@@ -1,0 +1,151 @@
+"""BE-4795: `comfy … | head` must exit 0, not 1.
+
+A CLI whose stdout consumer closes early is not a failing CLI — the consumer got
+what it asked for. These cover both halves of the entrypoint guard in
+`comfy_cli/__main__.py`: the end-to-end process behaviour (stdout's reader gone)
+and the two in-process signals the guard keys off.
+"""
+
+import io
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from comfy_cli import __main__ as entrypoint
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# `--help-json` dumps the whole command surface (>100 KB) and needs no
+# workspace, network, or auth — the cheapest command that writes a lot.
+BIG_OUTPUT_CMD = [sys.executable, "-m", "comfy_cli", "--help-json"]
+
+
+def _run_with_stdout_reader_gone():
+    """Run the CLI with a stdout pipe whose read end is already closed.
+
+    Deterministic by construction: there is no pipe buffer left to absorb the
+    output, so the very first write raises `BrokenPipeError`. (Reading a chunk
+    first and *then* closing is the more literal `| head` shape, but it races
+    the kernel's pipe buffer — see the `head` test below for that variant.)
+    """
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(BIG_OUTPUT_CMD, cwd=REPO_ROOT, stdout=write_fd, stderr=subprocess.PIPE)
+    os.close(write_fd)
+    os.close(read_fd)
+    try:
+        assert proc.stderr is not None
+        stderr = proc.stderr.read()
+        proc.stderr.close()
+        returncode = proc.wait(timeout=120)
+    finally:
+        if proc.poll() is None:  # pragma: no cover — only if the child hangs
+            proc.kill()
+            proc.wait(timeout=30)
+    return returncode, stderr
+
+
+class TestBrokenPipeExitCode:
+    def test_closed_stdout_exits_zero(self):
+        returncode, _ = _run_with_stdout_reader_gone()
+        assert returncode == 0, f"expected exit 0 for a closed stdout, got {returncode}"
+
+    def test_closed_stdout_is_silent(self):
+        _, stderr = _run_with_stdout_reader_gone()
+        text = stderr.decode(errors="replace")
+        assert "BrokenPipeError" not in text, text
+        assert "Traceback" not in text, text
+        assert "Exception ignored" not in text, text
+        assert "Abort" not in text, text
+
+    @pytest.mark.skipif(
+        sys.platform == "win32" or not (shutil.which("bash") and shutil.which("head")),
+        reason="needs a POSIX shell with PIPESTATUS and head",
+    )
+    def test_head_pipeline_exits_zero(self):
+        """The literal ticket scenario: `comfy … | head` reads a bit, then leaves."""
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                '"$1" -m comfy_cli --help-json | head -c 100 > /dev/null; exit "${PIPESTATUS[0]}"',
+                "bash",
+                sys.executable,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=120,
+        )
+        assert proc.returncode == 0, proc.stderr.decode(errors="replace")
+
+    def test_fully_consumed_output_still_exits_zero(self):
+        """Sanity: the guard does not disturb the ordinary success path."""
+        proc = subprocess.run(BIG_OUTPUT_CMD, cwd=REPO_ROOT, capture_output=True, timeout=120)
+        assert proc.returncode == 0
+        assert proc.stdout
+
+    def test_real_failure_still_exits_nonzero(self):
+        """The guard must not launder genuine failures into exit 0."""
+        proc = subprocess.run(
+            [sys.executable, "-m", "comfy_cli", "definitely-not-a-command"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=120,
+        )
+        assert proc.returncode != 0
+
+
+class TestClickPacifySignal:
+    """click swallows EPIPE itself, so the guard detects it by the stream swap."""
+
+    def test_detects_click_pacified_stdout(self, monkeypatch):
+        from click.utils import PacifyFlushWrapper
+
+        monkeypatch.setattr(sys, "stdout", PacifyFlushWrapper(io.StringIO()))
+        assert entrypoint._broken_pipe_swallowed_by_click() is True
+
+    def test_ordinary_stdout_is_not_a_broken_pipe(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        assert entrypoint._broken_pipe_swallowed_by_click() is False
+
+    def test_systemexit_is_reraised_untouched_when_pipe_is_healthy(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        monkeypatch.setattr(entrypoint, "_cli_main", lambda: sys.exit(3))
+
+        with pytest.raises(SystemExit) as excinfo:
+            entrypoint.main()
+
+        assert excinfo.value.code == 3
+
+
+class TestFlushStdout:
+    def test_broken_pipe_propagates(self, monkeypatch):
+        class Exploding(io.StringIO):
+            def flush(self):
+                raise BrokenPipeError(32, "Broken pipe")
+
+        monkeypatch.setattr(sys, "stdout", Exploding())
+        with pytest.raises(BrokenPipeError):
+            entrypoint._flush_stdout()
+
+    def test_closed_stdout_is_tolerated(self, monkeypatch):
+        stream = io.StringIO()
+        stream.close()
+        monkeypatch.setattr(sys, "stdout", stream)
+        entrypoint._flush_stdout()  # must not raise
+
+    def test_detached_stdout_is_tolerated(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", None)
+        entrypoint._flush_stdout()  # must not raise
+
+    def test_other_oserror_is_tolerated(self, monkeypatch):
+        """A `finally`-time flush must never mask the exception on its way out."""
+
+        class BadFd(io.StringIO):
+            def flush(self):
+                raise OSError(9, "Bad file descriptor")
+
+        monkeypatch.setattr(sys, "stdout", BadFd())
+        entrypoint._flush_stdout()  # must not raise


### PR DESCRIPTION
## ELI-5

If you run `comfy jobs ls | head -5`, `head` grabs five lines and walks away — and that's fine, it got what it asked for. But when it walks away it slams the door on our output, so the next thing we print blows up and the whole command reports "I failed" (exit 1) even though nothing went wrong. Every shell script, CI job, and agent downstream believes it. This teaches the CLI to notice the door is shut, stop talking, and quietly report success.

## What changed

`comfy_cli/__main__.py` — the module all three console scripts (`comfy`, `comfy-cli`, `comfycli`) and `python -m comfy_cli` resolve to — is now a thin guard around `comfy_cli.cmdline.main`. On a closed stdout it points fd 1 at `/dev/null` (so no later flush can raise a second time) and `os._exit(0)`.

Two paths are covered, because a broken pipe can arrive in two shapes:

- **`BrokenPipeError` propagating out of the command.** Caught directly.
- **The interpreter's shutdown flush.** stdout is block-buffered when it's a pipe, so the write that actually lands on the closed reader is often the flush Python does on the way out — far too late for any handler. The guard flushes stdout inside its own `try` to pull that failure forward.

## The one deviation from the ticket's recipe, and why

The ticket prescribed `try: app() / except BrokenPipeError`. On its own **that would have been a no-op**: click's `BaseCommand.main` already handles EPIPE itself — it swaps `sys.stdout`/`sys.stderr` for `click.utils.PacifyFlushWrapper` and raises `SystemExit(1)` (click 8.1.8, `click/core.py:1100-1105`). So a `BrokenPipeError` almost never reaches the entrypoint; what reaches it is an exit 1 that is otherwise indistinguishable from a genuine command failure.

The guard therefore also inspects that `SystemExit`: if `sys.stdout` is a `PacifyFlushWrapper`, the exit 1 *is* the broken pipe. `PacifyFlushWrapper` is installed by click in exactly one place — that EPIPE branch — and nowhere else in the library (verified by grep over the installed package), and it is never uninstalled, so its presence is a sufficient condition. The import is wrapped so a click without the symbol degrades to today's behaviour rather than crashing.

I kept the direct `except BrokenPipeError` as well: it covers the shutdown-flush case and anything raised outside click's `main`.

## Judgment calls

- **`os._exit(0)` skips `atexit`,** which means the telemetry flush in `comfy_cli/tracking.py` is skipped for a pipe-truncated invocation. The ticket prescribed `os._exit(0)` and I kept it — losing one invocation's analytics is a better trade than risking a second EPIPE or a shutdown hang while bailing out. Flagging it explicitly since it is a (small) behaviour change beyond the exit code.
- **A command that genuinely failed *and* had its stdout closed now reports 0.** No information is lost that exists today: click already collapses every EPIPE to exit 1 regardless of the command's own status, so the real exit code was already gone. `test_real_failure_still_exits_nonzero` pins that an ordinary failure with a healthy stdout is untouched.
- **Truncated machine output stays truncated.** Per the ticket, a half-written `--json` envelope is the consumer's problem by construction; nothing extra is written on the way out, so a partial envelope can never be mistaken for a complete one — only the exit code changes.
- **Placed in `__main__.py`, not `cmdline.main`.** `os._exit` is a process-level action and belongs at the process boundary; `cmdline.main` stays importable/testable. All three `pyproject.toml` console scripts already point at `comfy_cli.__main__:main`, and nothing else in the tree imports `cmdline.main`, so there is no uncovered entrypoint.

## Tests

`tests/comfy_cli/test_broken_pipe.py` (12 tests). Verified red on the parent commit and green with the fix — the two end-to-end tests and the six unit tests all fail without the change.

- **`test_closed_stdout_exits_zero` / `test_closed_stdout_is_silent`** — spawn `python -m comfy_cli --help-json` with a stdout pipe whose read end is already closed; assert returncode 0 and that stderr carries no `Traceback` / `BrokenPipeError` / `Exception ignored` / `Abort`.
- **`test_head_pipeline_exits_zero`** — the literal ticket scenario through a real `bash` pipeline, checking `${PIPESTATUS[0]}`. It uses `head -c 100` rather than `head -1` because in machine mode `--help-json` emits the whole ~122 KB envelope as a *single* line, so `head -1` would consume all of it and never break the pipe. (Skipped where `bash`/`head` aren't available.)
- The first pair closes the read end outright rather than reading-then-closing, because the read-then-close shape races the kernel's pipe buffer — on macOS a 122 KB payload was absorbed whole, so that variant passed even without the fix. The `head` test keeps the realistic shape; the closed-pipe tests keep determinism.
- Unit tests cover the click-pacify detection (positive and negative), `SystemExit` pass-through with an intact exit code, and `_flush_stdout`'s contract (only `BrokenPipeError` escapes; closed/detached/`EBADF` stdout is tolerated so the `finally`-time flush can never mask a real exception).

## Verification

- `ruff format --check` and `ruff check` clean on both files.
- `pytest tests/comfy_cli tests/test_file_utils_network.py` — **2747 passed, 13 skipped**.
- Not run: `tests/e2e` and `tests/uv` (they install ComfyUI / resolve wheels over the network). The diff touches only the entrypoint wrapper and adds one test file, so exposure there is nil, but calling it out rather than implying a full-suite pass.
