### PR TITLE
fix: point CLI copy at commands that exist + lint it (BE-2996)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,36 @@ the bisect tool can help you pinpoint the custom node that causes the issue.
 
   `comfy model list ?[--relative-path <PATH>]`
 
+### Running on Comfy Cloud (`--where cloud`)
+
+Comfy Cloud runs your workflow on Comfy's GPUs — no local ComfyUI install and no GPU required. The same verbs you use locally take `--where cloud`; the only extra step is signing in once.
+
+Prerequisites — a Comfy account with a credit balance ([add credits](https://docs.comfy.org/interface/credits); cloud runs are metered per GPU-second):
+
+```bash
+comfy cloud login                   # opens your browser (OAuth + PKCE), stores a session
+comfy cloud whoami                  # confirm who you're signed in as
+```
+
+Then submit, watch, and collect:
+
+```bash
+comfy run --workflow my_workflow_api.json --where cloud   # submits, prints a prompt_id, returns
+comfy jobs ls --where cloud                               # queue + history for your account
+comfy jobs status <prompt_id> --where cloud               # one job's state
+comfy jobs watch <prompt_id> --where cloud                # live progress until it finishes
+comfy download <prompt_id> --where cloud                  # fetch the outputs
+```
+
+Notes:
+
+- `--where cloud` is per-invocation. Make it the default with `comfy set-default --where cloud`; every command then honors it without the flag, and `--where local` overrides it for one call. Clear it again with `comfy set-default --clear-where`.
+- Add `--wait` to `comfy run` to block until the job completes instead of returning immediately.
+- `comfy run --prompt "<text>"` (no `--workflow`) runs a bundled default text2img graph. **That graph loads the SD1.5 checkpoint `v1-5-pruned-emaonly.ckpt`, which comfy-cli does not download for you** — install it into `models/checkpoints`, or point the graph at a checkpoint you do have with `comfy run --prompt "…" --set checkpoint=<name>`. The same applies on cloud, where the checkpoint must exist in your cloud assets.
+- `comfy download` also reads a `prompt_id` from piped stdin, so `comfy run ... --where cloud | comfy download --where cloud` works.
+- Models and custom nodes must exist on the cloud side. `comfy models search --where cloud` lists the cloud asset catalog, and `comfy nodes ls --where cloud` lists the node classes cloud can run.
+- Sign out with `comfy cloud logout`. If a run fails with `cloud_unauthorized`, your session expired — re-run `comfy cloud login`.
+
 ### Calling partner nodes (`comfy generate`)
 
 `comfy generate` calls Comfy's partner nodes directly from the terminal — no

--- a/comfy_cli/__main__.py
+++ b/comfy_cli/__main__.py
@@ -11,7 +11,7 @@ shell/CI/agent downstream.
 
 The exit 0 is only ever granted to a command that *succeeded*. A closed reader
 on a command that failed still exits with the failure's code — `comfy --json
-some-failing-cmd | head` is a failure that happened to be piped, not a success.
+<failing-cmd> | head` is a failure that happened to be piped, not a success.
 Absorbing the broken pipe there would launder a genuine error into 0, which is
 the one outcome worse than the exit 1 this wrapper exists to remove.
 

--- a/comfy_cli/cloud/__init__.py
+++ b/comfy_cli/cloud/__init__.py
@@ -20,7 +20,7 @@ def _resolve_base_url() -> str:
     override = os.environ.get("COMFY_CLOUD_BASE_URL")
     if override:
         return override.rstrip("/")
-    # Persisted config (set via `comfy auth set-base-url <url>`).
+    # Persisted config (set via `comfy cloud set-base-url <url>`).
     try:
         from comfy_cli.config_manager import ConfigManager
 

--- a/comfy_cli/cloud/oauth.py
+++ b/comfy_cli/cloud/oauth.py
@@ -473,12 +473,12 @@ def run_login(
         if not got:
             raise OAuthTimeout(
                 f"timed out waiting for browser callback after {int(timeout_s)}s",
-                hint="re-run `comfy auth login` and complete the sign-in in your browser",
+                hint="re-run `comfy cloud login` and complete the sign-in in your browser",
             )
         if capture.error or not capture.code:
             raise OAuthAuthorizeError(
                 f"authorization failed: {capture.error or 'no code returned'}",
-                hint="re-run `comfy auth login` and check for typos or browser blockers",
+                hint="re-run `comfy cloud login` and check for typos or browser blockers",
                 details={
                     "oauth_error": capture.error,
                     "oauth_error_description": capture.error_description,
@@ -561,7 +561,7 @@ def exchange_code(
     except _HTTPFail as e:
         raise OAuthTokenError(
             f"token exchange failed: {e}",
-            hint="re-run `comfy auth login` to start a fresh authorization",
+            hint="re-run `comfy cloud login` to start a fresh authorization",
             details={"status": e.status, "body": e.body},
         ) from None
     return _token_set_from_response(resp)
@@ -589,7 +589,7 @@ def refresh_tokens(
     except _HTTPFail as e:
         raise OAuthRefreshError(
             f"refresh failed: {e}",
-            hint="run `comfy auth login` to sign in again",
+            hint="run `comfy cloud login` to sign in again",
             details={"status": e.status, "body": e.body},
         ) from None
     return _token_set_from_response(resp)

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -554,8 +554,16 @@ def install(
         rprint("[bold red]--nvidia is not available on macOS. Use --m-series (Apple Silicon) or --cpu.[/bold red]")
         raise typer.Exit(code=1)
 
-    if platform != constants.OS.MACOS and m_series:
-        rprint(f"[bold yellow]--m-series is a macOS option; detected platform is {platform}.[/bold yellow]")
+    if m_series and platform != constants.OS.MACOS:
+        # Warning-only here used to fall through to `elif m_series:` below and
+        # set GPU_OPTION.MAC_M_SERIES, which installs the nightly CPU torch
+        # wheels — silently giving a Linux/Windows user a CPU-only nightly and
+        # no GPU support. Exit like the symmetric --nvidia-on-macOS check.
+        rprint(
+            f"[bold red]--m-series is a macOS (Apple Silicon) option; detected platform is {platform}.[/bold red]\n"
+            "[bold red]Use --nvidia, --amd or --intel-arc for a GPU install, or --cpu for CPU-only.[/bold red]"
+        )
+        raise typer.Exit(code=1)
 
     gpu = None
 
@@ -867,11 +875,18 @@ def run(
             if ckpt and renderer.is_pretty():
                 from rich.markup import escape as _escape
 
+                # The checkpoint has to exist wherever the run is routed, so
+                # name that environment: pointing a `--where cloud` run at the
+                # local models/checkpoints sends the user to fix the wrong box.
+                if decision.target is where_module.WhereTarget.CLOUD:
+                    where_ckpt = "in your cloud assets (`comfy models search --where cloud`)"
+                else:
+                    where_ckpt = "in models/checkpoints"
                 # `--set checkpoint=…` puts a user string here; escape it so a
                 # value containing [brackets] can't be read as rich markup.
                 rprint(
                     f"[dim]Using the bundled default text2img workflow — it needs the[/dim] "
-                    f"[bold]{_escape(ckpt)}[/bold] [dim]checkpoint in models/checkpoints. "
+                    f"[bold]{_escape(ckpt)}[/bold] [dim]checkpoint {where_ckpt}. "
                     f"Override it with --set checkpoint=<name>.[/dim]"
                 )
         elif workflow is None:

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -551,11 +551,11 @@ def install(
         return None
 
     if nvidia and platform == constants.OS.MACOS:
-        rprint("[bold red]Nvidia GPU is never on MacOS. What are you smoking? 🤔[/bold red]")
+        rprint("[bold red]--nvidia is not available on macOS. Use --m-series (Apple Silicon) or --cpu.[/bold red]")
         raise typer.Exit(code=1)
 
     if platform != constants.OS.MACOS and m_series:
-        rprint(f"[bold red]You are on {platform} bruh [/bold red]")
+        rprint(f"[bold yellow]--m-series is a macOS option; detected platform is {platform}.[/bold yellow]")
 
     gpu = None
 
@@ -690,7 +690,10 @@ def run(
             show_default=False,
             help=(
                 "Positive text prompt for the bundled default text2img workflow "
-                "(used when --workflow is omitted). Cannot be combined with --workflow."
+                "(used when --workflow is omitted). Cannot be combined with --workflow. "
+                "The bundled graph loads an SD1.5 checkpoint (v1-5-pruned-emaonly.ckpt) "
+                "that is NOT downloaded for you — install it, or point elsewhere with "
+                "--set checkpoint=<name>."
             ),
         ),
     ] = None,
@@ -844,7 +847,11 @@ def run(
                     hint="drop --workflow to use the bundled default, or edit the workflow file directly",
                 )
                 raise typer.Exit(code=1)
-            from comfy_cli.cql.default_workflow import PromptInjectionError, build_default_workflow
+            from comfy_cli.cql.default_workflow import (
+                PromptInjectionError,
+                build_default_workflow,
+                default_checkpoint,
+            )
 
             try:
                 injected = build_default_workflow(prompt=prompt, overrides=set_overrides)
@@ -852,6 +859,21 @@ def run(
                 renderer.error(code=e.code, message=str(e), hint=e.hint)
                 raise typer.Exit(code=1) from e
             preloaded = (injected, "default_text2img", False)
+            # The bundled graph pins an SD1.5 checkpoint that comfy-cli neither
+            # ships nor auto-downloads. Without it the run dies server-side on a
+            # bare validation error, so state the dependency up front. Pretty
+            # output only — the JSON dialects carry a fixed event contract.
+            ckpt = default_checkpoint(injected)
+            if ckpt and renderer.is_pretty():
+                from rich.markup import escape as _escape
+
+                # `--set checkpoint=…` puts a user string here; escape it so a
+                # value containing [brackets] can't be read as rich markup.
+                rprint(
+                    f"[dim]Using the bundled default text2img workflow — it needs the[/dim] "
+                    f"[bold]{_escape(ckpt)}[/bold] [dim]checkpoint in models/checkpoints. "
+                    f"Override it with --set checkpoint=<name>.[/dim]"
+                )
         elif workflow is None:
             renderer.error(
                 code="prompt_rejected",
@@ -1624,7 +1646,6 @@ def agent_review(
     )
 
 
-@app.command(hidden=True)
 @app.command(
     help="Given an existing installation of comfy core and any custom nodes, installs any needed python dependencies"
 )
@@ -1692,7 +1713,11 @@ def standalone(
 
 
 generate_command.register_with(app)
-app.add_typer(models_command.app, name="model", help="Manage models.")
+app.add_typer(
+    models_command.app,
+    name="model",
+    help="Manage the model files in this workspace — download, list, remove. (Search/discovery lives under `comfy models`.)",
+)
 app.add_typer(
     models_search_command.app,
     name="models",

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -277,7 +277,7 @@ def enable_gui():
     print("[dim]ComfyUI will launch with: --enable-manager[/dim]")
 
 
-@manager_app.command("disable-gui", help="Enable ComfyUI-Manager without GUI")
+@manager_app.command("disable-gui", help="Disable the ComfyUI-Manager GUI (Manager stays enabled, headless)")
 @tracking.track_command("node")
 def disable_gui():
     """Enable ComfyUI-Manager but disable its GUI."""

--- a/comfy_cli/command/generate/spec.py
+++ b/comfy_cli/command/generate/spec.py
@@ -334,7 +334,7 @@ def _registry() -> dict[str, Endpoint]:
         path = PROXY_PREFIX + endpoint_id
         node = paths.get(path)
         if not node:
-            continue  # spec drift — skip silently, surfaced via `comfy api models`
+            continue  # spec drift — skip silently, surfaced via `comfy generate list`
         # All image endpoints are POST; pick the first defined method anyway.
         method = "post" if "post" in node else next(iter(node.keys()))
         op = node[method]

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -356,7 +356,7 @@ def ls_cmd(
     limit: Annotated[int, typer.Option(help="How many history entries to include.")] = 10,
     where: Annotated[
         str | None,
-        typer.Option("--where", help="'local' (default) or 'cloud'. Cloud requires `comfy auth login`."),
+        typer.Option("--where", help="'local' (default) or 'cloud'. Cloud requires `comfy cloud login`."),
     ] = None,
     local_only: Annotated[
         bool,
@@ -1094,7 +1094,7 @@ def _cloud_cancel(prompt_id: str) -> None:
         renderer.error(
             code="cloud_http_error",
             message=f"cancel failed: {e}",
-            hint="check network / `comfy auth whoami`",
+            hint="check network / `comfy cloud whoami`",
         )
         raise typer.Exit(code=1) from e
 
@@ -1439,7 +1439,7 @@ def _cloud_client():
         return Client(target, clear_session_on_auth_failure=False)
     except Unauthenticated as e:
         renderer = get_renderer()
-        renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy auth login")
+        renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy cloud login")
         raise typer.Exit(code=1) from e
 
 

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -854,7 +854,7 @@ def download_cancel(
     renderer.emit(payload, command="model download-cancel", changed=True)
 
 
-@app.command()
+@app.command(help="Remove downloaded model files, by name or through an interactive picker.")
 @tracking.track_command("model")
 def remove(
     ctx: typer.Context,
@@ -931,7 +931,7 @@ def list_models(path: pathlib.Path) -> list[pathlib.Path]:
     return sorted(f for f in path.rglob("*") if f.is_file())
 
 
-@app.command("list")
+@app.command("list", help="List the models downloaded into this workspace, as a table.")
 @tracking.track_command("model")
 def list_command(
     ctx: typer.Context,

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -173,7 +173,7 @@ def list_folders_cmd(
             renderer=renderer,
             target=target,
             message=f"HTTP {e.code} from {url}",
-            hint="run `comfy auth whoami` to verify auth"
+            hint="run `comfy cloud whoami` to verify auth"
             if target.is_cloud
             else "run `comfy launch` to start a local server",
         )
@@ -483,7 +483,7 @@ def search_cmd(
             renderer=renderer,
             target=target,
             message=f"HTTP {e.code} during models search",
-            hint="check auth (`comfy auth whoami`) or network",
+            hint="check auth (`comfy cloud whoami`) or network",
         )
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
         renderer.error(

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -746,7 +746,7 @@ def execute_cloud(
     try:
         client = Client(target, timeout=float(timeout))
     except Unauthenticated as e:
-        renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy auth login")
+        renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy cloud login")
         raise typer.Exit(code=1) from e
 
     client_id = str(uuid.uuid4())

--- a/comfy_cli/command/run_cli.py
+++ b/comfy_cli/command/run_cli.py
@@ -429,26 +429,18 @@ def _build_steps(state: _DemoState) -> list[Step]:
             ],
         ),
         Step(
-            title="query — CQL against the live node graph",
+            # Was a "query" subcommand that has never been registered, so this
+            # step failed on every run. `comfy nodes ls` is the CQL engine's real
+            # query surface (comfy_cli.cql.engine.Graph).
+            title="nodes ls — CQL against the live node graph",
             invocations=[
                 Invocation(
-                    argv=[
-                        *comfy,
-                        "query",
-                        "-q",
-                        "from nodes where name in ('EmptyImage','ImageInvert','SaveImage') select name, category",
-                    ],
-                    label="comfy query",
+                    argv=[*comfy, "nodes", "ls", "--category", "image*", "--limit", "5"],
+                    label="comfy nodes ls",
                 ),
                 Invocation(
-                    argv=[
-                        *comfy,
-                        "--json",
-                        "query",
-                        "-q",
-                        "from nodes where name in ('EmptyImage','ImageInvert','SaveImage') select name, category",
-                    ],
-                    label="comfy --json query",
+                    argv=[*comfy, "--json", "nodes", "ls", "--category", "image*", "--limit", "5"],
+                    label="comfy --json nodes ls",
                 ),
             ],
         ),
@@ -516,13 +508,13 @@ def _build_steps(state: _DemoState) -> list[Step]:
             custom=_fleet_step,
         ),
         Step(
-            title="auth whoami — Comfy Cloud sign-in state",
-            desc="Same commands work against Comfy Cloud via --where cloud (after `comfy auth login`).",
+            title="cloud whoami — Comfy Cloud sign-in state",
+            desc="Same commands work against Comfy Cloud via --where cloud (after `comfy cloud login`).",
             invocations=[
-                Invocation(argv=[*comfy, "auth", "whoami"], label="comfy auth whoami", optional=True),
+                Invocation(argv=[*comfy, "cloud", "whoami"], label="comfy cloud whoami", optional=True),
                 Invocation(
-                    argv=[*comfy, "--json", "auth", "whoami"],
-                    label="comfy --json auth whoami",
+                    argv=[*comfy, "--json", "cloud", "whoami"],
+                    label="comfy --json cloud whoami",
                     optional=True,
                 ),
             ],
@@ -561,9 +553,9 @@ def execute(*, pause_seconds: float, no_cleanup: bool, show_agent: bool) -> int:
 
     _print_banner("Done")
     pprint(
-        "[bold]Capabilities shown:[/bold] env · which · discover · query · "
+        "[bold]Capabilities shown:[/bold] env · which · discover · nodes ls · "
         "run (sync/verbose/json/async) · jobs (ls/status/watch) · "
-        f"parallel fleet ×{FLEET_SIZE} · auth whoami."
+        f"parallel fleet ×{FLEET_SIZE} · cloud whoami."
     )
 
     paths_to_clean = [wf_path, *state.fleet_workflow_paths]

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -687,7 +687,7 @@ def _handle_cloud_http_error(renderer, e, *, operation: str, workflow_id: str | 
         renderer.error(
             code="cloud_http_error",
             message=f"{operation} failed: {e}",
-            hint="check network / `comfy auth whoami`",
+            hint="check network / `comfy cloud whoami`",
         )
     return typer.Exit(code=1)
 

--- a/comfy_cli/command_mentions.py
+++ b/comfy_cli/command_mentions.py
@@ -13,9 +13,13 @@ runs it over the repo as a guardrail.
 The resolver is deliberately biased toward false NEGATIVES: it stops scanning at
 the first token it cannot confidently classify as a subcommand (an option, a
 placeholder, a path, a quoted value), because a lint that cries wolf on
-``comfy run --prompt 'a fox'`` gets disabled. What it does catch is the exact
-failure mode above: a word that *looks* like a subcommand, sitting where the
-tree has no such subcommand.
+``comfy run --prompt 'a fox'`` gets disabled. The one exception is the root
+callback's own options, which are legal only *before* the subcommand and are
+skipped rather than treated as the end of the scan — otherwise prefixing the
+bad command with ``--json`` would hide it from the lint entirely.
+
+What it does catch is the exact failure mode above: a word that *looks* like a
+subcommand, sitting where the tree has no such subcommand.
 """
 
 from __future__ import annotations
@@ -32,6 +36,15 @@ _RUN_PREFIX = re.compile(r"(?:^|[\s\"'(])run:?\s+(?P<cmd>comfy\s+[a-z0-9 _-]+)")
 # ``label="comfy cloud whoami"`` used by the run-cli tour. Restricted to
 # command-shaped words so prose sentences beginning with "comfy" don't match.
 _QUOTED_INVOCATION = re.compile(r"""(?P<q>['"])(?P<cmd>comfy(?:\s+-{1,2}[a-z0-9-]+|\s+[a-z][a-z0-9-]*)+)(?P=q)""")
+
+# A Markdown fenced code block. The README's primary examples live in ```bash
+# fences as bare shell lines with no backticks of their own, so none of the
+# patterns above see them — the guardrail would skip the very copy users are
+# most likely to paste.
+_FENCE_BLOCK = re.compile(r"^```[^\n]*\n(?P<body>.*?)^```", re.MULTILINE | re.DOTALL)
+# One shell line inside such a block: an optional `$ ` prompt marker, the
+# invocation, and an optional trailing `# comment`.
+_FENCED_LINE = re.compile(r"^[ \t]*(?:\$[ \t]+)?(?P<cmd>comfy(?:[ \t]+[^\s#]+)*)[ \t]*(?:#.*)?$", re.MULTILINE)
 
 # A token we are willing to treat as a subcommand name. Anything else (options,
 # <PLACEHOLDERS>, paths, quoted values, ALLCAPS) ends the scan.
@@ -62,33 +75,87 @@ class Violation:
         )
 
 
+def _iter_spans(text: str):
+    """Yield ``(command text, offset of the command itself)`` for every mention.
+
+    The offset is that of the ``cmd`` group, not of the whole match: the
+    ``run:`` pattern's leading boundary class can swallow the preceding
+    newline, and anchoring the line number on ``match.start()`` would then
+    report the violation one line too high.
+    """
+    for pattern in (_BACKTICK_SPAN, _RUN_PREFIX, _QUOTED_INVOCATION):
+        for match in pattern.finditer(text):
+            yield match.group("cmd"), match.start("cmd")
+    for block in _FENCE_BLOCK.finditer(text):
+        body, base = block.group("body"), block.start("body")
+        for match in _FENCED_LINE.finditer(body):
+            yield match.group("cmd"), base + match.start("cmd")
+
+
 def extract_mentions(text: str, *, path: str) -> list[Mention]:
     """Return every ``comfy …`` invocation mentioned in ``text``."""
     out: list[Mention] = []
     seen: set[tuple[str, int]] = set()
-    for pattern in (_BACKTICK_SPAN, _RUN_PREFIX, _QUOTED_INVOCATION):
-        for match in pattern.finditer(text):
-            span = " ".join(match.group("cmd").split())
-            line = text.count("\n", 0, match.start()) + 1
-            if (span, line) in seen:
-                continue
-            seen.add((span, line))
-            out.append(Mention(text=span, path=path, line=line))
+    for raw, offset in _iter_spans(text):
+        span = " ".join(raw.split())
+        line = text.count("\n", 0, offset) + 1
+        if (span, line) in seen:
+            continue
+        seen.add((span, line))
+        out.append(Mention(text=span, path=path, line=line))
     return sorted(out, key=lambda m: (m.line, m.text))
 
 
-def check_mention(mention: Mention, tree: dict[str, Any]) -> Violation | None:
+def global_options(help_doc: dict[str, Any]) -> dict[str, bool]:
+    """Map each root-callback option flag to whether it consumes a following value.
+
+    Derived from the live tree rather than hardcoded so the set cannot drift as
+    root options are added or renamed. ``help_doc`` is the whole document from
+    :func:`comfy_cli.help_json.build_help_json`.
+    """
+    out: dict[str, bool] = {}
+    for param in help_doc.get("root", {}).get("params") or []:
+        if param.get("param_kind") != "option":
+            continue
+        takes_value = not param.get("is_flag")
+        for flag in param.get("flags") or []:
+            out[flag] = takes_value
+    return out
+
+
+def check_mention(
+    mention: Mention,
+    tree: dict[str, Any],
+    *,
+    globals_: dict[str, bool] | None = None,
+) -> Violation | None:
     """Resolve one mention against ``tree`` (a ``help_json`` command map).
 
     ``tree`` is the ``commands`` map from :func:`comfy_cli.help_json.build_help_json`
-    — ``{name: {"subcommands": {...}}}``. Returns ``None`` when the mention is
-    valid or too ambiguous to judge.
+    — ``{name: {"subcommands": {...}}}``. ``globals_`` is :func:`global_options`;
+    without it a leading global option ends the scan and the subcommand after it
+    is never checked. Returns ``None`` when the mention is valid or too
+    ambiguous to judge.
     """
     tokens = mention.text.split()[1:]  # drop the "comfy" program name
     node: dict[str, Any] = {"subcommands": tree}
     resolved = "comfy"
+    known_globals = globals_ or {}
 
-    for token in tokens:
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        i += 1
+        # Root-callback options are only legal before the subcommand, so skip
+        # them only while nothing has resolved yet. Bailing at the first `-`
+        # would wave through a `--json`-prefixed spelling of the very dead-end
+        # this module exists to catch (see the auth-login case below).
+        if resolved == "comfy" and token.startswith("-"):
+            name, eq, _value = token.partition("=")
+            if name in known_globals:
+                if known_globals[name] and not eq:
+                    i += 1  # the option consumes the next token as its value
+                continue
         if token.startswith("-") or not _SUBCOMMAND_TOKEN.match(token):
             # An option, a placeholder, a path, a quoted value: from here on we
             # can no longer tell subcommands from argument values. Stop clean.
@@ -108,6 +175,14 @@ def check_mention(mention: Mention, tree: dict[str, Any]) -> Violation | None:
     return None
 
 
-def check_text(text: str, *, path: str, tree: dict[str, Any]) -> list[Violation]:
+def check_text(
+    text: str,
+    *,
+    path: str,
+    tree: dict[str, Any],
+    globals_: dict[str, bool] | None = None,
+) -> list[Violation]:
     """Extract and check every mention in one file's ``text``."""
-    return [v for m in extract_mentions(text, path=path) if (v := check_mention(m, tree)) is not None]
+    return [
+        v for m in extract_mentions(text, path=path) if (v := check_mention(m, tree, globals_=globals_)) is not None
+    ]

--- a/comfy_cli/command_mentions.py
+++ b/comfy_cli/command_mentions.py
@@ -1,0 +1,113 @@
+"""Lint the ``comfy …`` command strings we hand users, against the real command tree.
+
+Help text, error hints, the README and the bundled agent skills are full of
+copy-pasteable invocations (``run `comfy cloud login```). Nothing binds them to
+the Typer tree, so they rot silently: an audit found eight sites telling users to
+run an ``auth login`` subcommand that has never existed (the real one is
+`comfy cloud login`) — a dead end for every human and agent that followed it.
+
+This module extracts those mentions and resolves each against the live tree
+built by :mod:`comfy_cli.help_json`. ``tests/comfy_cli/test_command_mentions.py``
+runs it over the repo as a guardrail.
+
+The resolver is deliberately biased toward false NEGATIVES: it stops scanning at
+the first token it cannot confidently classify as a subcommand (an option, a
+placeholder, a path, a quoted value), because a lint that cries wolf on
+``comfy run --prompt 'a fox'`` gets disabled. What it does catch is the exact
+failure mode above: a word that *looks* like a subcommand, sitting where the
+tree has no such subcommand.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# A backtick-quoted span that starts with the program name, e.g. `comfy cloud login`.
+# Also matches the bare `run: comfy cloud login` shape used in some hints.
+_BACKTICK_SPAN = re.compile(r"`(?P<cmd>comfy\s+[^`]*)`")
+_RUN_PREFIX = re.compile(r"(?:^|[\s\"'(])run:?\s+(?P<cmd>comfy\s+[a-z0-9 _-]+)")
+# A whole string literal that is nothing but an invocation, e.g. the
+# ``label="comfy cloud whoami"`` used by the run-cli tour. Restricted to
+# command-shaped words so prose sentences beginning with "comfy" don't match.
+_QUOTED_INVOCATION = re.compile(r"""(?P<q>['"])(?P<cmd>comfy(?:\s+-{1,2}[a-z0-9-]+|\s+[a-z][a-z0-9-]*)+)(?P=q)""")
+
+# A token we are willing to treat as a subcommand name. Anything else (options,
+# <PLACEHOLDERS>, paths, quoted values, ALLCAPS) ends the scan.
+_SUBCOMMAND_TOKEN = re.compile(r"[a-z][a-z0-9-]*\Z")
+
+
+@dataclass(frozen=True)
+class Mention:
+    """One ``comfy …`` string found in a source file."""
+
+    text: str
+    path: str
+    line: int
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A mention whose command path does not exist in the CLI."""
+
+    mention: Mention
+    resolved: str
+    unknown_token: str
+
+    def __str__(self) -> str:  # pragma: no cover - formatting only
+        return (
+            f"{self.mention.path}:{self.mention.line}: `{self.mention.text}` — "
+            f"{self.resolved!r} has no subcommand {self.unknown_token!r}"
+        )
+
+
+def extract_mentions(text: str, *, path: str) -> list[Mention]:
+    """Return every ``comfy …`` invocation mentioned in ``text``."""
+    out: list[Mention] = []
+    seen: set[tuple[str, int]] = set()
+    for pattern in (_BACKTICK_SPAN, _RUN_PREFIX, _QUOTED_INVOCATION):
+        for match in pattern.finditer(text):
+            span = " ".join(match.group("cmd").split())
+            line = text.count("\n", 0, match.start()) + 1
+            if (span, line) in seen:
+                continue
+            seen.add((span, line))
+            out.append(Mention(text=span, path=path, line=line))
+    return sorted(out, key=lambda m: (m.line, m.text))
+
+
+def check_mention(mention: Mention, tree: dict[str, Any]) -> Violation | None:
+    """Resolve one mention against ``tree`` (a ``help_json`` command map).
+
+    ``tree`` is the ``commands`` map from :func:`comfy_cli.help_json.build_help_json`
+    — ``{name: {"subcommands": {...}}}``. Returns ``None`` when the mention is
+    valid or too ambiguous to judge.
+    """
+    tokens = mention.text.split()[1:]  # drop the "comfy" program name
+    node: dict[str, Any] = {"subcommands": tree}
+    resolved = "comfy"
+
+    for token in tokens:
+        if token.startswith("-") or not _SUBCOMMAND_TOKEN.match(token):
+            # An option, a placeholder, a path, a quoted value: from here on we
+            # can no longer tell subcommands from argument values. Stop clean.
+            return None
+        subs = node.get("subcommands") or {}
+        if token in subs:
+            node = subs[token]
+            resolved = f"{resolved} {token}"
+            continue
+        if subs:
+            # A group with no such subcommand: this is the BE-2996 auth-login
+            # bug — the word reads as a subcommand but is really an unparsed
+            # positional the group will reject.
+            return Violation(mention=mention, resolved=resolved, unknown_token=token)
+        # A leaf command; the leftover words are its positional arguments.
+        return None
+    return None
+
+
+def check_text(text: str, *, path: str, tree: dict[str, Any]) -> list[Violation]:
+    """Extract and check every mention in one file's ``text``."""
+    return [v for m in extract_mentions(text, path=path) if (v := check_mention(m, tree)) is not None]

--- a/comfy_cli/cql/default_workflow.py
+++ b/comfy_cli/cql/default_workflow.py
@@ -88,6 +88,26 @@ def load_default_workflow() -> dict:
         ) from e
 
 
+def default_checkpoint(workflow: dict | None = None) -> str:
+    """Return the ``ckpt_name`` the bundled default graph loads (``""`` if absent).
+
+    ``comfy run --prompt`` silently depends on this checkpoint already being
+    present in the target's ``models/checkpoints`` — comfy-cli neither bundles
+    it nor downloads it on demand, so the run fails server-side with a bare
+    validation error when it is missing. Callers surface the requirement up
+    front instead. Pass an already-built graph to avoid re-reading the bundle.
+    """
+    graph = load_default_workflow() if workflow is None else workflow
+    node = graph.get(CHECKPOINT_LOADER_ID)
+    if not isinstance(node, dict):
+        return ""
+    inputs = node.get("inputs")
+    if not isinstance(inputs, dict):
+        return ""
+    name = inputs.get("ckpt_name")
+    return name if isinstance(name, str) else ""
+
+
 def _coerce(value: str, existing):
     """Coerce a string CLI value to the API-format type it should carry.
 

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -722,7 +722,7 @@ class Graph:
 
         for node_id, node_data in workflow.items():
             # `_meta` is the compose/run provenance block (schema/blueprint/items),
-            # stripped before submit — not a node and not a mistake. `comfy compose`
+            # stripped before submit — not a node and not a mistake. `comfy workflow compose`
             # adds it itself, so warning here is self-inflicted noise.
             if node_id == "_meta":
                 continue

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -104,6 +104,9 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy assets push": "assets",
     # config
     "comfy set-default": "set_default",
+    # Not a subcommand: the root `--version` flag emits `command="version"`,
+    # and this map is keyed by "comfy <emit name>". Verified by
+    # tests/comfy_cli/output/test_discovery.py.
     "comfy version": "version",
     # installed-vs-latest report
     "comfy outdated": "outdated",

--- a/comfy_cli/help_json.py
+++ b/comfy_cli/help_json.py
@@ -26,9 +26,9 @@ HELP_EXAMPLES: dict[str, list[str]] = {
         "comfy --json discover",
         "comfy --json discover --schemas-only",
     ],
-    "comfy query": [
-        "comfy --json query --query 'from nodes select name'",
-        "comfy query --input object_info.json --query 'from nodes where category=\"loaders\"'",
+    "comfy nodes ls": [
+        "comfy --json nodes ls --produces MODEL",
+        "comfy nodes ls --input object_info.json --category 'loaders*'",
     ],
     "comfy auth": ["comfy auth list", "comfy auth set civitai --key ..."],
     "comfy auth set": ["comfy auth set comfy-cloud --key sk-…"],

--- a/comfy_cli/skills/command.py
+++ b/comfy_cli/skills/command.py
@@ -139,7 +139,7 @@ def install_cmd(
         list[str] | None,
         typer.Option(
             "--skill",
-            help="Install only the named skill(s). Repeatable. Default: all 4 bundled skills (see `comfy skills list`).",
+            help="Install only the named skill(s). Repeatable. Default: all bundled skills (see `comfy skills list`).",
         ),
     ] = None,
     dry_run: Annotated[
@@ -311,7 +311,7 @@ def list_cmd():
 def show_cmd(
     name: Annotated[
         str,
-        typer.Argument(help="Which bundled skill to print (see `comfy skills list` for all 4)."),
+        typer.Argument(help="Which bundled skill to print (see `comfy skills list` for the full set)."),
     ] = "comfy",
 ):
     renderer = get_renderer()

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -262,14 +262,16 @@ def _get_providers() -> list[TelemetryProvider]:
 app = typer.Typer()
 
 
-@app.command()
+@app.command(help="Opt in to anonymous usage analytics.")
 def enable():
+    """Opt in to anonymous usage analytics."""
     init_tracking(True)
     typer.echo("Tracking is now enabled.")
 
 
-@app.command()
+@app.command(help="Opt out of anonymous usage analytics.")
 def disable():
+    """Opt out of anonymous usage analytics."""
     init_tracking(False)
     typer.echo("Tracking is now disabled.")
 

--- a/tests/comfy_cli/command/test_run_cli.py
+++ b/tests/comfy_cli/command/test_run_cli.py
@@ -41,7 +41,7 @@ class TestStepBuilders:
             "jobs status",
             "jobs watch",
             "fleet",
-            "auth",
+            "cloud whoami",
         ]:
             assert needle in titles, f"missing coverage for: {needle}"
 

--- a/tests/comfy_cli/command/test_run_prompt.py
+++ b/tests/comfy_cli/command/test_run_prompt.py
@@ -131,3 +131,40 @@ class TestRunCliWiring:
         with pytest.raises(typer.Exit) as e:
             self._call_run(prompt="fox", set_overrides=["bogus=1"])
         assert e.value.exit_code == 1
+
+
+class TestDefaultCheckpointNotice:
+    """The bundled graph's checkpoint is not downloaded for you, so `run` says so.
+
+    The notice has to name the environment the run was ROUTED to: telling a
+    `--where cloud` user to drop a file in the local ``models/checkpoints``
+    points them at the wrong machine (the README says cloud runs need it in
+    cloud assets).
+    """
+
+    def _run(self, where: str, capsys):
+        renderer = MagicMock()
+        renderer.is_pretty.return_value = True
+        with (
+            patch("comfy_cli.cmdline.tracking.track_event"),
+            patch("comfy_cli.cmdline.get_renderer", return_value=renderer),
+            patch("comfy_cli.cmdline.where_module.cloud_preflight", return_value=None),
+            patch("comfy_cli.command.run.execute"),
+            patch("comfy_cli.command.run.execute_cloud"),
+        ):
+            run_command(where=where, prompt="a red fox in snow")
+        return capsys.readouterr().out
+
+    def test_local_run_points_at_the_local_model_dir(self, capsys):
+        out = self._run("local", capsys)
+        assert "models/checkpoints" in out
+        assert "cloud assets" not in out
+
+    def test_cloud_run_points_at_cloud_assets(self, capsys):
+        out = self._run("cloud", capsys)
+        assert "cloud assets" in out
+        assert "models/checkpoints" not in out
+
+    def test_notice_names_the_checkpoint(self, capsys):
+        out = self._run("local", capsys)
+        assert "v1-5-pruned-emaonly.ckpt" in out

--- a/tests/comfy_cli/output/test_branding.py
+++ b/tests/comfy_cli/output/test_branding.py
@@ -191,7 +191,7 @@ def test_intro_banner_signed_out_includes_wordmark_and_login_hint():
     assert "Quick start" in out
     assert "comfy install" in out
     assert "comfy launch" in out
-    assert "comfy auth login" in out or "comfy cloud login" in out
+    assert "comfy cloud login" in out
     assert "comfy discover" in out
     assert "comfy --help" in out
     assert "not signed in" in out
@@ -229,5 +229,5 @@ def test_intro_banner_signed_in_shows_check_and_host():
 def test_signed_out_banner_points_at_login():
     out = _render(signed_out_banner(base_url="https://testcloud.comfy.org"))
     assert "not signed in" in out
-    assert "comfy auth login" in out or "comfy cloud login" in out
+    assert "comfy cloud login" in out
     assert "testcloud.comfy.org" in out

--- a/tests/comfy_cli/test_command_mentions.py
+++ b/tests/comfy_cli/test_command_mentions.py
@@ -1,0 +1,181 @@
+"""Guardrail: every ``comfy …`` we print must be a command that exists (BE-2996).
+
+The audit found eight help/hint strings pointing users at ``comfy auth login``,
+which has never been a command — the real one is ``comfy cloud login``. Nothing
+caught it because help text is just string literals. This test walks the shipped
+source, the README and the bundled agent skills, and resolves every mention
+against the live Typer tree.
+
+If this fails, the mention is wrong (or the command was renamed) — fix the
+string, don't loosen the lint. See :mod:`comfy_cli.command_mentions` for why the
+resolver is deliberately conservative.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cmdline import app
+from comfy_cli.command_mentions import Mention, check_mention, check_text, extract_mentions
+from comfy_cli.help_json import build_help_json
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "comfy_cli"
+
+# ``discovery.py`` holds no prose — it is a ``"comfy <emit name>" -> schema`` map,
+# and envelope names are not all subcommands (the root ``--version`` flag emits
+# ``command="version"``). Its keys get the stronger structural check below
+# instead of the prose scan.
+PROSE_SCAN_EXCLUDED = {PACKAGE_ROOT / "discovery.py"}
+
+
+@pytest.fixture(scope="module")
+def tree() -> dict:
+    return build_help_json(app)["commands"]
+
+
+def _scanned_files() -> list[Path]:
+    """Python sources plus the user-facing prose that ships with the package."""
+    files = [p for p in PACKAGE_ROOT.rglob("*.py") if "__pycache__" not in p.parts and p not in PROSE_SCAN_EXCLUDED]
+    files += sorted(PACKAGE_ROOT.rglob("*.md"))
+    readme = REPO_ROOT / "README.md"
+    if readme.exists():
+        files.append(readme)
+    return files
+
+
+def _all_command_paths() -> set[str]:
+    """Every command path in the tree, groups included (``iter_command_paths`` gives leaves only)."""
+    paths: set[str] = set()
+
+    def walk(subs: dict, prefix: str) -> None:
+        for name, child in subs.items():
+            path = f"{prefix} {name}"
+            paths.add(path)
+            walk(child.get("subcommands") or {}, path)
+
+    walk(build_help_json(app)["commands"], "comfy")
+    return paths
+
+
+def test_scan_covers_the_expected_surface():
+    """A silently-empty scan would make this whole guardrail a no-op."""
+    files = _scanned_files()
+    assert len(files) > 50
+    assert any(p.name == "cmdline.py" for p in files)
+    assert any(p.name == "SKILL.md" for p in files)
+
+
+def test_no_mentions_of_nonexistent_commands(tree):
+    violations = []
+    for path in _scanned_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        violations += check_text(text, path=str(path.relative_to(REPO_ROOT)), tree=tree)
+    assert not violations, "help/hint strings reference commands that do not exist:\n" + "\n".join(
+        str(v) for v in violations
+    )
+
+
+# --- the machine-readable catalogs keyed by command path ---
+
+
+def test_help_examples_keys_are_real_commands():
+    """A stale ``HELP_EXAMPLES`` key is silently dropped — the command loses its examples."""
+    from comfy_cli.help_json import HELP_EXAMPLES
+
+    stale = sorted(k for k in HELP_EXAMPLES if k not in _all_command_paths())
+    assert not stale, f"HELP_EXAMPLES keys that are not commands (their examples never render): {stale}"
+
+
+def test_command_schema_keys_are_commands_or_emitted_envelopes():
+    """``COMMAND_SCHEMAS`` ships verbatim in ``comfy discover``.
+
+    Its keys are ``"comfy <envelope command name>"``. Most are real command
+    paths; a few name an envelope emitted by a root flag (``--version``). A key
+    that is neither advertises a schema for something no agent can ever invoke.
+    """
+    import ast
+
+    from comfy_cli.discovery import COMMAND_SCHEMAS, STREAM_EVENT_SCHEMAS
+
+    emitted: set[str] = set()
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            module = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(module):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "emit"):
+                continue
+            for kw in node.keywords:
+                if kw.arg == "command" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    emitted.add(f"comfy {kw.value.value}")
+
+    known = _all_command_paths() | emitted
+    for name, catalog in (("COMMAND_SCHEMAS", COMMAND_SCHEMAS), ("STREAM_EVENT_SCHEMAS", STREAM_EVENT_SCHEMAS)):
+        stale = sorted(k for k in catalog if k not in known)
+        assert not stale, f"{name} keys that are neither a command nor an emitted envelope: {stale}"
+
+
+# --- resolver unit tests: the lint is only as good as its false-positive rate ---
+
+
+def _check(text: str, tree: dict):
+    return check_mention(Mention(text=text, path="<test>", line=1), tree)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "comfy cloud login",
+        "comfy install --nvidia",
+        "comfy run --prompt 'a red fox in snow'",
+        "comfy model download --url https://example.com/x.safetensors",
+        "comfy --json env",  # stops at the global option; no false positive
+        "comfy node show installed",  # positional argument to a leaf command
+        "comfy manager disable-gui",
+        "comfy",
+        "comfy auth",  # a bare group mention is fine
+    ],
+)
+def test_valid_mentions_pass(text, tree):
+    assert _check(text, tree) is None
+
+
+@pytest.mark.parametrize(
+    ("text", "unknown"),
+    [
+        ("comfy auth login", "login"),  # the BE-2996 regression itself
+        ("comfy cloud singin", "singin"),
+        ("comfy nope", "nope"),
+        ("comfy model downlaod --url x", "downlaod"),
+    ],
+)
+def test_invalid_mentions_are_flagged(text, unknown, tree):
+    violation = _check(text, tree)
+    assert violation is not None
+    assert violation.unknown_token == unknown
+
+
+def test_extract_finds_backticked_and_run_prefixed_mentions():
+    text = "first line\nrun: comfy cloud login\nand `comfy jobs ls` too\n"
+    found = {m.text for m in extract_mentions(text, path="<test>")}
+    assert "comfy cloud login" in found
+    assert "comfy jobs ls" in found
+
+
+def test_extract_finds_bare_quoted_invocations(tree):
+    """The run-cli tour labels invocations as plain string literals, not backticks."""
+    text = 'Invocation(argv=[*comfy, "auth", "whoami"], label="comfy auth whoami")\n'
+    found = extract_mentions(text, path="<test>")
+    assert [m.text for m in found] == ["comfy auth whoami"]
+    assert check_mention(found[0], tree).unknown_token == "whoami"
+
+
+def test_extract_ignores_non_command_comfy_words():
+    text = "`comfy-cli` installs things and writes `comfy.yaml`."
+    assert extract_mentions(text, path="<test>") == []

--- a/tests/comfy_cli/test_command_mentions.py
+++ b/tests/comfy_cli/test_command_mentions.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 
 from comfy_cli.cmdline import app
-from comfy_cli.command_mentions import Mention, check_mention, check_text, extract_mentions
+from comfy_cli.command_mentions import Mention, check_mention, check_text, extract_mentions, global_options
 from comfy_cli.help_json import build_help_json
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -34,6 +34,11 @@ PROSE_SCAN_EXCLUDED = {PACKAGE_ROOT / "discovery.py"}
 @pytest.fixture(scope="module")
 def tree() -> dict:
     return build_help_json(app)["commands"]
+
+
+@pytest.fixture(scope="module")
+def globals_() -> dict:
+    return global_options(build_help_json(app))
 
 
 def _scanned_files() -> list[Path]:
@@ -68,11 +73,24 @@ def test_scan_covers_the_expected_surface():
     assert any(p.name == "SKILL.md" for p in files)
 
 
-def test_no_mentions_of_nonexistent_commands(tree):
+def test_scan_reaches_the_readmes_fenced_examples():
+    """The README's copy-pasteable examples are bare lines in ```bash fences.
+
+    They carry no backticks of their own, so they are invisible to the
+    backtick/quoted patterns — if fenced extraction regresses, the guardrail
+    stops covering the most-copied surface in the repo while still passing.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    found = {m.text for m in extract_mentions(readme, path="README.md")}
+    assert "comfy cloud login" in found
+    assert "comfy generate list" in found
+
+
+def test_no_mentions_of_nonexistent_commands(tree, globals_):
     violations = []
     for path in _scanned_files():
         text = path.read_text(encoding="utf-8", errors="replace")
-        violations += check_text(text, path=str(path.relative_to(REPO_ROOT)), tree=tree)
+        violations += check_text(text, path=str(path.relative_to(REPO_ROOT)), tree=tree, globals_=globals_)
     assert not violations, "help/hint strings reference commands that do not exist:\n" + "\n".join(
         str(v) for v in violations
     )
@@ -124,8 +142,8 @@ def test_command_schema_keys_are_commands_or_emitted_envelopes():
 # --- resolver unit tests: the lint is only as good as its false-positive rate ---
 
 
-def _check(text: str, tree: dict):
-    return check_mention(Mention(text=text, path="<test>", line=1), tree)
+def _check(text: str, tree: dict, globals_: dict | None = None):
+    return check_mention(Mention(text=text, path="<test>", line=1), tree, globals_=globals_)
 
 
 @pytest.mark.parametrize(
@@ -135,15 +153,18 @@ def _check(text: str, tree: dict):
         "comfy install --nvidia",
         "comfy run --prompt 'a red fox in snow'",
         "comfy model download --url https://example.com/x.safetensors",
-        "comfy --json env",  # stops at the global option; no false positive
+        "comfy --json env",  # global option skipped, then a real command
+        "comfy --where cloud jobs ls",  # value-taking global; 'cloud' is its value, not a subcommand
+        "comfy --where=cloud jobs ls",  # inline value form
         "comfy node show installed",  # positional argument to a leaf command
         "comfy manager disable-gui",
         "comfy",
         "comfy auth",  # a bare group mention is fine
+        "comfy --not-a-real-flag auth login",  # unknown option: stop clean rather than guess
     ],
 )
-def test_valid_mentions_pass(text, tree):
-    assert _check(text, tree) is None
+def test_valid_mentions_pass(text, tree, globals_):
+    assert _check(text, tree, globals_) is None
 
 
 @pytest.mark.parametrize(
@@ -153,12 +174,27 @@ def test_valid_mentions_pass(text, tree):
         ("comfy cloud singin", "singin"),
         ("comfy nope", "nope"),
         ("comfy model downlaod --url x", "downlaod"),
+        # A leading global option must not end the scan before the subcommand.
+        ("comfy --json auth login", "login"),
+        ("comfy --where cloud cloud singin", "singin"),
     ],
 )
-def test_invalid_mentions_are_flagged(text, unknown, tree):
-    violation = _check(text, tree)
+def test_invalid_mentions_are_flagged(text, unknown, tree, globals_):
+    violation = _check(text, tree, globals_)
     assert violation is not None
     assert violation.unknown_token == unknown
+
+
+def test_global_options_are_derived_from_the_live_root_callback(globals_):
+    """Hardcoding the set would silently rot as root options change."""
+    assert globals_["--json"] is False  # a flag: consumes no value
+    assert globals_["--where"] is True  # takes a value
+    assert "--help-json" in globals_
+
+
+def test_without_globals_the_resolver_still_stops_at_the_first_option(tree):
+    """Default (no ``globals_``) keeps the old conservative behaviour."""
+    assert _check("comfy --json auth login", tree) is None
 
 
 def test_extract_finds_backticked_and_run_prefixed_mentions():
@@ -179,3 +215,26 @@ def test_extract_finds_bare_quoted_invocations(tree):
 def test_extract_ignores_non_command_comfy_words():
     text = "`comfy-cli` installs things and writes `comfy.yaml`."
     assert extract_mentions(text, path="<test>") == []
+
+
+def test_extract_reads_markdown_fenced_code_blocks():
+    """The README's primary examples are bare shell lines inside ```bash fences."""
+    text = "Sign in:\n\n```bash\ncomfy cloud login                   # opens your browser\n$ comfy jobs ls --where cloud\n```\n"
+    found = {m.text for m in extract_mentions(text, path="<test>")}
+    assert "comfy cloud login" in found
+    assert "comfy jobs ls --where cloud" in found
+
+
+def test_fenced_mentions_report_their_own_line():
+    text = "intro\n\n```bash\ncomfy auth login\n```\n"
+    (mention,) = extract_mentions(text, path="<test>")
+    assert mention.line == 4
+    assert text.splitlines()[mention.line - 1] == "comfy auth login"
+
+
+def test_run_prefixed_mention_at_line_start_reports_its_own_line():
+    """``_RUN_PREFIX``'s boundary class eats the preceding newline; the line must not shift."""
+    text = "first line\nsecond line\nrun: comfy cloud login\n"
+    (mention,) = extract_mentions(text, path="<test>")
+    assert mention.line == 3
+    assert text.splitlines()[mention.line - 1] == "run: comfy cloud login"

--- a/tests/comfy_cli/test_install_gpu_flags.py
+++ b/tests/comfy_cli/test_install_gpu_flags.py
@@ -1,0 +1,66 @@
+"""``comfy install`` must reject a GPU flag that its platform cannot honor.
+
+``--m-series`` selects ``GPU_OPTION.MAC_M_SERIES``, which installs the nightly
+CPU torch wheels. That is right on Apple Silicon and wrong everywhere else: on
+Linux/Windows it silently hands the user a CPU-only nightly build and no GPU
+support. The check used to print a warning and fall through, so the bad install
+still happened — it now exits like the symmetric ``--nvidia``-on-macOS guard.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import constants
+from comfy_cli.cmdline import app, g_exclusivity, g_gpu_exclusivity
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_install_env():
+    """Neutralize everything ``install`` touches before the platform checks."""
+    # The mutual-exclusivity validators are module-level and accumulate across
+    # in-process CliRunner invocations; without this the second GPU flag in the
+    # file fails as "mutually exclusive" with the first test's.
+    g_exclusivity.reset_for_testing()
+    g_gpu_exclusivity.reset_for_testing()
+    with (
+        patch("comfy_cli.cmdline.EnvChecker") as checker,
+        patch("comfy_cli.cmdline.workspace_manager.get_workspace_path", return_value=("/tmp/ComfyUI", None)),
+        patch("comfy_cli.cmdline.check_comfy_repo", return_value=(False, None)),
+        patch("comfy_cli.cmdline.install_inner.execute") as execute,
+    ):
+        checker.return_value.python_version = MagicMock(major=3, minor=12)
+        yield execute
+
+
+@pytest.mark.parametrize("plat", [constants.OS.LINUX, constants.OS.WINDOWS])
+def test_m_series_on_non_macos_exits_without_installing(stub_install_env, plat):
+    with patch("comfy_cli.cmdline.utils.get_os", return_value=plat):
+        result = runner.invoke(app, ["install", "--m-series", "--skip-manager"])
+
+    assert result.exit_code == 1
+    # The whole point: no install runs with the Apple-Silicon GPU option.
+    stub_install_env.assert_not_called()
+    # The message must name the paths that do work, not just deny the flag.
+    assert "--cpu" in result.output
+
+
+def test_m_series_on_macos_still_installs(stub_install_env):
+    with patch("comfy_cli.cmdline.utils.get_os", return_value=constants.OS.MACOS):
+        result = runner.invoke(app, ["install", "--m-series", "--skip-manager"])
+
+    assert result.exit_code == 0
+    stub_install_env.assert_called_once()
+    assert stub_install_env.call_args.kwargs["gpu"] is constants.GPU_OPTION.MAC_M_SERIES
+
+
+def test_nvidia_on_macos_exits_without_installing(stub_install_env):
+    """The guard --m-series is now symmetric with."""
+    with patch("comfy_cli.cmdline.utils.get_os", return_value=constants.OS.MACOS):
+        result = runner.invoke(app, ["install", "--nvidia", "--skip-manager"])
+
+    assert result.exit_code == 1
+    stub_install_env.assert_not_called()


### PR DESCRIPTION
## ELI-5

The CLI kept telling people to run commands that don't exist — eight places said `comfy auth login`, but the real command is `comfy cloud login`. This fixes those (and several more the audit missed), and adds a test that walks every `comfy …` string we print and checks it against the real command tree, so this class of rot can't come back.

## What changed

**Commands that don't exist → commands that do.** All eight `comfy auth login` sites now say `comfy cloud login`. The lint then surfaced six more the audit didn't list, all fixed: `comfy auth whoami` ×5 → `comfy cloud whoami`, `comfy auth set-base-url` → `comfy cloud set-base-url`, `comfy compose` → `comfy workflow compose`, `comfy api models` → `comfy generate list`.

**The guardrail (`comfy_cli/command_mentions.py` + `tests/comfy_cli/test_command_mentions.py`).** Extracts every `comfy …` invocation from help text, hints, the README and the bundled agent skills, and resolves it against the live Typer tree from `help_json`. Two structural companions check that the machine catalogs (`HELP_EXAMPLES`, `COMMAND_SCHEMAS`, `STREAM_EVENT_SCHEMAS`) are keyed by commands that actually exist. The resolver is deliberately biased toward false negatives — it stops at the first token it can't confidently classify (an option, a placeholder, a quoted value), because a lint that fires on `comfy run --prompt 'a fox'` gets disabled. 9 positive + 4 negative unit cases pin that behaviour.

**Dead references the lint caught.** `comfy run-cli` had a whole demo step invoking `comfy query -q "from nodes …"` — a command that has never been registered, so that step failed on every run of the tour. Replaced with `comfy nodes ls`, which is the same CQL engine's real query surface (`comfy_cli.cql.engine.Graph`). The tour also invoked `comfy auth whoami`, also nonexistent; now `comfy cloud whoami`. `HELP_EXAMPLES` had a stale `comfy query` key whose examples could never render.

**Copy fixes.** `manager disable-gui`'s help said "Enable ComfyUI-Manager without GUI" (verb contradicted the command name). `model remove` / `model list` / `tracking enable` / `tracking disable` had no explicit help. Skills help hardcoded "all 4 bundled skills" — there are 5; rewritten to be count-free so it can't drift again (`comfy skills list` already derives the list from `BUNDLED_SKILLS`). The two jokey install errors ("What are you smoking? 🤔", "You are on {platform} bruh") are now plain messages that say what to do instead.

**De-dup.** `dependency` carried a stray `@app.command(hidden=True)` stacked on top of its real `@app.command(help=…)`. Because decorators apply bottom-up, the hidden registration won — so a command whose original PR ([#188](https://github.com/Comfy-Org/comfy-cli/pull/188), "added `dependency` command to top level cli") gave a help string was invisible in `comfy --help`. Dropping the stray decorator realises the original intent; verified before/after against `comfy --help`.

**`model` vs `models`.** Kept both — they are not duplicates: `model` manages files in the workspace, `models` is discovery over folders and the cloud asset catalog. The `models` "dead stub" in the audit is no longer dead (it has `search` / `show` / `list-folder` / `list-folders`). Clarified `model`'s group help to name the split rather than renaming either group, which would be a breaking change.

**`comfy run --prompt` silently needs SD1.5.** The bundled default graph pins `v1-5-pruned-emaonly.ckpt`, which comfy-cli neither ships nor downloads; without it the run dies server-side on a bare validation error. Now named in `--prompt`'s help, in the README, and printed as a one-line advisory before submitting. Gated on `renderer.is_pretty()` so the `--json` / `--json-stream` event contract is untouched — verified by hand in both modes. The value is `rich.markup.escape`d because `--set checkpoint=…` can put a user string there.

**README.** New "Running on Comfy Cloud (`--where cloud`)" section documenting the full path: login → run → jobs ls/status/watch → download, plus credits, the `set-default --where` persistent default, and sign-out/expiry. Every command and flag in it was verified against `--help` before writing (this is why the section says `comfy nodes ls --where cloud` and not something invented).

## Testing

`uvx ruff@0.15.15 format --check .` and `check .` clean; `pytest` **2963 passed, 37 skipped**. Note the 15 `UP038` findings from a locally-installed ruff 0.12.7 are pre-existing on `main` and absent under the version `.pre-commit-config.yaml` pins (0.15.15) — verified by stashing.

## Judgment calls

- **Chesterton's Fence on `COMMAND_SCHEMAS["comfy version"]`.** I removed it as a stale key; `tests/.../test_discovery.py` correctly failed, because the root `--version` flag really does emit `command="version"` and that map is keyed by envelope name, not subcommand path. Restored it with a comment explaining why, and the new structural test encodes the actual rule (a key must be a real command path **or** a name passed to `renderer.emit(command=…)`) rather than an arbitrary allowlist. `discovery.py` is excluded from the prose scan for the same reason — it holds no prose, and the structural test is the stronger check for it.
- **Two `test_run_cli.py` coverage needles updated**, not loosened: `"cql"` still matches (the new step title is "nodes ls — CQL against the live node graph", and `nodes ls` is genuinely CQL-backed), and `"auth"` became `"cloud whoami"` because the command the step demos moved groups. Neither test was weakened — both still assert the step exists.
- **Negative-claim falsification.** The diff removes/redirects references to `comfy query` and `comfy version`, so I attempted both before touching anything: `comfy query --help` → `No such command 'query'`, `comfy version` → `No such command 'version'`, and neither appears in `iter_command_paths(app)`. There is no CQL text-query command anywhere in the tree (`grep` for `"-q"` / `"--query"` finds only `templates` and `generate`). So this is not a capability denial — it is removing pointers to capabilities that were already absent, and redirecting to the ones that work (`comfy nodes ls`, the `--version` flag).

## Not done (out of scope for this PR)

**"Automate the CQL catalogs duplicated across both repos."** That is cross-repo work (comfy-cli ↔ comfy-cloud-mcp-server) requiring a shared source-of-truth and a sync mechanism, and the audit doc linked on the ticket is a Linear upload I can't read. It needs its own design and its own PR; shipping a guess here would have been worse than leaving it. Everything else on the ticket is covered above.

One thing this PR **surfaces but does not fix**: `comfy nodes ls` is CQL-backed but the CLI has no general CQL query verb, while `comfy discover` still advertises `capabilities.cql: true`. That may be intentional (the engine powers `validate` / `nodes` / `workflow`), so I left it alone rather than change a public discovery contract unasked.
