### PR TITLE
fix(validate): expand dynamic-combo options so validate matches the server (BE-3777)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -915,7 +915,11 @@ def run(
 
 
 @app.command(
-    help="Validate an API-format workflow without submitting. Checks class_types, input shapes, enum values, and edge wiring."
+    help=(
+        "Validate a workflow without submitting (UI exports are converted to API format first). "
+        "Checks class_types, input shapes, enum values, edge wiring, and the dotted sub-inputs a "
+        "dynamic combo's selected option requires."
+    )
 )
 @tracking.track_command()
 def validate(

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -50,6 +50,11 @@ class Port:
     is_link: bool = False
     enum_values: list[Any] = field(default_factory=list)  # preserves the option's real type (int combos stay int)
     options: PortOptions = field(default_factory=PortOptions)
+    # The verbatim ``INPUT_TYPES`` spec this port was parsed from. Retained
+    # (by reference — no copy) because a dynamic combo's sub-input schema lives
+    # in the spec's ``options`` blocks and is NOT recoverable from the parsed
+    # fields above. Output ports carry ``None``.
+    raw_spec: Any = None
 
     @property
     def is_autogrow(self) -> bool:
@@ -57,6 +62,18 @@ class Port:
         ONE input, but the server expects autogrown slot keys —
         ``images.image0``, ``images.image1``, … one per connection."""
         return self.type.startswith("COMFY_AUTOGROW")
+
+    @property
+    def is_dynamic_combo(self) -> bool:
+        """V3 dynamic combo (e.g. ``COMFY_DYNAMICCOMBO_V3``): the schema declares
+        ONE selector input, but the option the selector names carries its own
+        ``INPUT_TYPES`` block, which the frontend — and ``convert_ui_to_api`` —
+        lower into dotted slot keys (``model.size_preset``, ``model.width``, …).
+
+        Deliberately the same test the converter applies
+        (``workflow_to_api._is_widget_input``), so validation expands exactly the
+        tree the converter lowered."""
+        return self.type.startswith("COMFY_") and "COMBO" in self.type
 
     def autogrow_slot_example(self) -> str:
         """Best-effort slot-key example for hints. The element name comes from
@@ -310,6 +327,7 @@ def _parse_inputs(raw: dict, order: list[str] | None, required: bool) -> list[Po
                 is_link=_is_link(type_id, is_enum, opts.force_input),
                 enum_values=enum_values,
                 options=opts,
+                raw_spec=spec,
             )
         )
     return ports
@@ -891,6 +909,9 @@ class Graph:
 
             errors.extend(_check_autogrow_required(node_id, autogrow_ports, autogrow_seen, node_data))
             errors.extend(_check_required_present(node_id, m, node_data))
+            dyn_errors, dyn_warnings = _check_dynamic_combos(node_id, class_type, m, node_data)
+            errors.extend(dyn_errors)
+            warnings.extend(dyn_warnings)
 
         # No-outputs check: the server rejects any prompt with zero output
         # nodes (execution.py:1155-1162, prompt_no_outputs) — including an
@@ -1124,8 +1145,9 @@ def _check_required_present(node_id: str, m: Morphism, node_data: dict) -> list[
     didn't serialize is a hard reject (required_input_missing). The per-input
     loop only inspects keys that ARE present, so this catches the absent ones.
     Skipped, because each is handled by its own path (and would otherwise
-    double-error): autogrow ports (``_check_autogrow_required``) and the dynamic
-    types COMFY_DYNAMICCOMBO / COMFY_DYNAMICSLOT (DynamicSlot is always optional
+    double-error): autogrow ports (``_check_autogrow_required``), dynamic combos
+    (``_check_dynamic_combos``, which reports the absent selector itself so it can
+    also name the valid options), and COMFY_DYNAMICSLOT (always optional
     server-side anyway). The server has NO exemption for required inputs that
     carry a default — the frontend always serializes widget values, so absence
     is a genuine authoring error; we do not skip ports with defaults.
@@ -1135,7 +1157,7 @@ def _check_required_present(node_id: str, m: Morphism, node_data: dict) -> list[
     for port in m.inputs:
         if not port.required or port.is_autogrow:
             continue
-        if port.type.startswith("COMFY_DYNAMICCOMBO") or port.type.startswith("COMFY_DYNAMICSLOT"):
+        if port.is_dynamic_combo or port.type.startswith("COMFY_DYNAMICSLOT"):
             continue
         if port.name in present:
             continue
@@ -1157,6 +1179,236 @@ def _check_required_present(node_id: str, m: Morphism, node_data: dict) -> list[
             }
         )
     return errors
+
+
+# A dynamic combo's option may declare another dynamic combo among its
+# sub-inputs. Mirrors ``workflow_to_api._MAX_DYNAMIC_COMBO_DEPTH`` so validation
+# walks the same bounded tree the converter expanded.
+_MAX_DYNAMIC_COMBO_DEPTH = 16
+
+
+def _dynamic_combo_options(spec: Any) -> list[dict]:
+    """Every option block a dynamic-combo spec declares, in schema order.
+
+    Shape: ``["COMFY_DYNAMICCOMBO_V3", {"options": [{"key": …, "inputs":
+    {"required": {…}, "optional": {…}}}, …]}]``. Non-dict entries are dropped
+    rather than raising — object_info is server-supplied and we never want a
+    malformed option block to take down validation of the whole workflow.
+    (Counterpart of ``workflow_to_api._dynamic_combo_selected_subs``, which
+    resolves the same structure for the conversion side.)
+    """
+    if not isinstance(spec, (list, tuple)) or len(spec) < 2:
+        return []
+    options_meta = spec[1] if isinstance(spec[1], dict) else {}
+    return [o for o in (options_meta.get("options") or []) if isinstance(o, dict)]
+
+
+def _check_dynamic_combos(node_id: str, class_type: str, m: Morphism, node_data: dict) -> tuple[list[dict], list[dict]]:
+    """Validate every dynamic-combo input against the option its selector names.
+
+    Mirrors the server: ``DynamicCombo._expand_schema_for_dynamic``
+    (comfy_api/latest/_io.py) reads the submitted selector, finds the option
+    whose ``key`` equals it, and folds THAT option's inputs — and only that
+    one's — into the node's finalized required/optional sets under dotted names
+    (``model.width``). ``validate_inputs`` (execution.py:886-900) then walks
+    those finalized names, so a missing one is a real ``required_input_missing``
+    and a present one gets the same type/range/enum checks as any input.
+
+    object_info never declares those dotted keys, so the driver loop skips them
+    (``port_by_name`` misses) and ``_check_required_present`` exempts the parent
+    selector. Without this walk a workflow that omits or mistypes a sub-input
+    validates clean and is then rejected at ``/prompt`` — validation giving
+    false confidence right before a paid run.
+    """
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    present = node_data.get("inputs") or {}
+    for port in m.inputs:
+        if not port.is_dynamic_combo:
+            continue
+        e, w = _check_dynamic_combo_input(node_id, class_type, port.name, port.raw_spec, port.required, present)
+        errors.extend(e)
+        warnings.extend(w)
+    return errors, warnings
+
+
+def _check_dynamic_combo_input(
+    node_id: str,
+    class_type: str,
+    name: str,
+    spec: Any,
+    required: bool,
+    present: dict,
+    depth: int = 0,
+) -> tuple[list[dict], list[dict]]:
+    """One dynamic-combo input: resolve its selected option, check its sub-inputs."""
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    options = _dynamic_combo_options(spec)
+    keys = [o.get("key") for o in options]
+
+    if name not in present:
+        # ``_check_required_present`` deliberately exempts the dynamic types
+        # ("handled by its own path") — this is that path, so the absent
+        # selector is reported here and nowhere else (no double-error).
+        #
+        # NOTE the failure is *later* than a plain missing input. With no
+        # selector the server's schema expansion is a no-op
+        # (``DynamicCombo._expand_schema_for_dynamic`` returns early), so the
+        # selector never enters ``valid_inputs`` and ``/prompt`` does NOT emit
+        # ``required_input_missing`` for it — the node's inputs are dropped and
+        # it fails at EXECUTION instead, i.e. after a paid node has been
+        # entered. Still a hard error here: the workflow cannot run.
+        if required:
+            errors.append(
+                {
+                    "node_id": node_id,
+                    "field": name,
+                    "code": "required_input_missing",
+                    "message": (
+                        f"required dynamic-combo input {name!r} is missing — the server cannot resolve "
+                        f"which option's sub-inputs apply, so this node fails at execution"
+                    ),
+                    "hint": f"set {name!r} to one of its options: "
+                    + ", ".join(str(k) for k in keys[:8])
+                    + (f" (and {len(keys) - 8} more — see valid_options)" if len(keys) > 8 else ""),
+                    "suggestions": keys[:20],
+                    "valid_options": keys,
+                }
+            )
+        return errors, warnings
+
+    selected = present[name]
+    if isinstance(selected, list) and len(selected) == 2:
+        # Wired as a link: which option expands is only known at execution time,
+        # so there is no static sub-input set to check. The edge itself is
+        # already validated by the driver loop.
+        return errors, warnings
+
+    option = next((o for o in options if o.get("key") == selected), None)
+    if option is None:
+        # Strict ``==`` on the key — the same test the server
+        # (``DynamicCombo._expand_schema_for_dynamic``) and the converter both
+        # apply, so all three agree on which option expands.
+        #
+        # Same late failure as the absent selector above: an unmatched key
+        # expands to nothing, so the server drops this node's inputs rather
+        # than rejecting the prompt, and the run dies at execution. The
+        # converter ALSO failed to expand it, silently misaligning every
+        # following widget value — surfacing that is the whole point.
+        errors.append(
+            {
+                "node_id": node_id,
+                "field": name,
+                "code": "unknown_enum_value",
+                "message": (
+                    f"{selected!r} not in {len(keys)} known options for {name} — its sub-inputs "
+                    f"cannot be resolved, so this node fails at execution"
+                ),
+                "hint": f"valid options: {', '.join(str(k) for k in keys[:8])}"
+                + (f" (and {len(keys) - 8} more — see valid_options)" if len(keys) > 8 else ""),
+                "suggestions": keys[:20],
+                "valid_options": keys,
+            }
+        )
+        return errors, warnings
+
+    if depth >= _MAX_DYNAMIC_COMBO_DEPTH:
+        return errors, warnings  # pathological nesting — the converter stops here too
+
+    sub_def = option.get("inputs")
+    if not isinstance(sub_def, dict):
+        return errors, warnings
+    for section, sub_required in (("required", True), ("optional", False)):
+        section_def = sub_def.get(section)
+        if not isinstance(section_def, dict):
+            continue
+        for sub_name, sub_spec in section_def.items():
+            e, w = _check_dynamic_combo_sub(
+                node_id, class_type, f"{name}.{sub_name}", sub_spec, sub_required, present, depth
+            )
+            errors.extend(e)
+            warnings.extend(w)
+    return errors, warnings
+
+
+def _check_dynamic_combo_sub(
+    node_id: str,
+    class_type: str,
+    dotted: str,
+    sub_spec: Any,
+    sub_required: bool,
+    present: dict,
+    depth: int,
+) -> tuple[list[dict], list[dict]]:
+    """Presence + shape + catalog checks for one expanded sub-input.
+
+    The sub-input spec is a plain ``INPUT_TYPES`` entry, so it goes through the
+    same ``_parse_input_spec`` / :class:`Port` machinery as a top-level input and
+    inherits identical shape and enum/range semantics.
+    """
+    type_id, is_enum, enum_values, opts = _parse_input_spec(sub_spec)
+    port = Port(
+        name=dotted,
+        type=type_id,
+        required=sub_required,
+        is_link=_is_link(type_id, is_enum, opts.force_input),
+        enum_values=enum_values,
+        options=opts,
+        raw_spec=sub_spec,
+    )
+
+    if port.is_dynamic_combo:
+        # Nested dynamic combo: its own selector/presence rules apply one level down.
+        return _check_dynamic_combo_input(node_id, class_type, dotted, sub_spec, sub_required, present, depth + 1)
+
+    if port.is_autogrow:
+        # An autogrow sub-input wires as `<dotted>.<slot>` keys and routinely
+        # declares `min: 0` even inside the `required` section (Seedream's
+        # `model.images`), so absence is NOT a server reject — the converter
+        # emits no key at all for a zero-slot autogrow. Nothing to presence- or
+        # shape-check here.
+        return [], []
+
+    if dotted not in present:
+        if not sub_required:
+            return [], []
+        return [
+            {
+                "node_id": node_id,
+                "field": dotted,
+                "code": "required_input_missing",
+                "message": (
+                    f"required input {dotted!r} is missing — the server will reject this node (required_input_missing)"
+                ),
+                "hint": f"add {dotted!r} to inputs"
+                + (
+                    f" (e.g. a {port.type} value)"
+                    if not port.is_link
+                    else f" (wire a {port.type} link: [<node_id>, <output_index>])"
+                ),
+            }
+        ], []
+
+    value = present[dotted]
+    if isinstance(value, list) and len(value) == 2:
+        # A wired sub-input — the driver loop already ran the dangling-edge and
+        # output-index checks on this same key.
+        return [], []
+
+    shape_err = port.validate_shape(value)
+    if shape_err:
+        return [
+            {
+                "node_id": node_id,
+                "field": dotted,
+                "code": "shape_mismatch",
+                "message": shape_err,
+                "hint": f"expected {port.type}; check the value type",
+            }
+        ], []
+
+    return _validate_catalog_value(node_id, class_type, dotted, port, value)
 
 
 def _check_autogrow_required(

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -934,7 +934,10 @@ Hard-won lessons per domain. Not a tutorial — a reference card.
 - Preprocessor output ≠ ControlNet model (two separate things)
 - Don't feed raw photos into ControlNet without preprocessing first
 - ImageCompositeMasked: mask MUST match SOURCE size, not destination
-- COMFY_DYNAMICCOMBO_V3: use flat dotted keys (`"model.max_tokens": 800`), not nested
+- COMFY_DYNAMICCOMBO_V3: use flat dotted keys (`"model.max_tokens": 800`), not nested.
+  Which dotted keys are required depends on the option the selector names, and
+  `comfy validate` expands that option — so it reports a missing/mistyped
+  sub-input instead of letting `/prompt` reject it.
 - First/last frame transitions: wire start_frame + end_frame → I2V node fills in between
 - Wiring: ControlNetApplyAdvanced takes CONDITIONING + IMAGE + CONTROL_NET → modified CONDITIONING
 

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -6,6 +6,7 @@ No I/O, no CLI invocation — just the engine in isolation.
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import pytest
@@ -995,6 +996,253 @@ class TestValidateServerParity:
         result = graph_sd15.validate_workflow(wf)
         assert result["valid"] is True, result["errors"]
         assert [e for e in result["errors"] if e.get("node_id") == "_meta"] == []
+
+
+class TestValidateDynamicCombo:
+    """Validate expands a ``COMFY_DYNAMICCOMBO_V3`` selector's chosen option and
+    checks the dotted sub-inputs the server will actually require (BE-3777).
+
+    object_info declares only the selector (``model``); the frontend and
+    ``convert_ui_to_api`` lower the selected option's own INPUT_TYPES into
+    ``model.width`` / ``model.size_preset`` / … keys. Before this, none of those
+    keys were reachable from the schema, so every one of the cases below came
+    back ``valid: true`` and was then rejected at ``/prompt`` with
+    ``required_input_missing`` / ``shape_mismatch``.
+    """
+
+    @pytest.fixture
+    def seedream_graph(self) -> Graph:
+        """The captured ByteDance Seedream catalog plus a minimal output node, so
+        a converted single-node workflow isn't drowned in prompt_no_outputs."""
+        import json
+        from pathlib import Path
+
+        fixture = Path(__file__).parent.parent / "fixtures" / "object_info_bytedance_seedream_v2.json"
+        object_info = json.loads(fixture.read_text())
+        object_info["SaveImageAdvanced"] = {
+            "input": {"required": {"images": ["IMAGE", {}]}},
+            "output": [],
+            "output_name": [],
+            "output_node": True,
+            "python_module": "nodes",
+        }
+        return Graph.from_object_info(object_info)
+
+    @pytest.fixture
+    def seedream_api(self, seedream_graph: Graph) -> dict:
+        """The ticket's repro payload: the pristine Seedream 5.0 Pro UI export,
+        lowered to API format by the same converter ``comfy run`` / ``comfy
+        validate`` use — i.e. the exact bytes that reach ``/prompt``."""
+        import json
+        from pathlib import Path
+
+        from comfy_cli.workflow_to_api import convert_ui_to_api
+
+        ui = json.loads((Path(__file__).parent.parent / "fixtures" / "seedream_5_0_pro_t2i_ui.json").read_text())
+        return convert_ui_to_api(ui, seedream_graph.object_info)
+
+    def test_converted_seedream_workflow_is_valid(self, seedream_graph: Graph, seedream_api: dict):
+        """Guard against over-strictness: the pristine template — whose
+        ``model.images`` autogrow sub-input is declared *required* with
+        ``min: 0`` and legitimately emits no key — must still validate clean."""
+        result = seedream_graph.validate_workflow(seedream_api)
+        assert result["valid"] is True, result["errors"]
+
+    def test_missing_sub_input_errors(self, seedream_graph: Graph, seedream_api: dict):
+        wf = copy.deepcopy(seedream_api)
+        del wf["1"]["inputs"]["model.width"]
+        result = seedream_graph.validate_workflow(wf)
+        assert result["valid"] is False
+        err = next(e for e in result["errors"] if e["field"] == "model.width")
+        assert err["code"] == "required_input_missing"
+        assert err["node_id"] == "1"
+
+    def test_sub_input_shape_mismatch_errors(self, seedream_graph: Graph, seedream_api: dict):
+        wf = copy.deepcopy(seedream_api)
+        wf["1"]["inputs"]["model.width"] = "wide"  # INT declared, non-numeric string given
+        result = seedream_graph.validate_workflow(wf)
+        assert result["valid"] is False
+        err = next(e for e in result["errors"] if e["field"] == "model.width")
+        assert err["code"] == "shape_mismatch"
+
+    def test_sub_input_range_and_enum_checked(self, seedream_graph: Graph, seedream_api: dict):
+        """Sub-inputs go through the same Port machinery as top-level inputs, so
+        they inherit the range and enum-membership hard errors."""
+        wf = copy.deepcopy(seedream_api)
+        wf["1"]["inputs"]["model.width"] = 8  # catalog min is 1024
+        wf["1"]["inputs"]["model.size_preset"] = "(9K) nope"
+        result = seedream_graph.validate_workflow(wf)
+        codes = {(e["field"], e["code"]) for e in result["errors"]}
+        assert ("model.width", "below_min") in codes
+        assert ("model.size_preset", "unknown_enum_value") in codes
+
+    def test_selecting_another_option_switches_the_required_set(self, seedream_graph: Graph, seedream_api: dict):
+        """Flipping the selector to ``seedream 5.0 lite`` — which declares
+        ``max_images``/``fail_on_partial`` the pro option does not — makes those
+        sub-inputs required, exactly as the server would."""
+        wf = copy.deepcopy(seedream_api)
+        wf["1"]["inputs"]["model"] = "seedream 5.0 lite"
+        result = seedream_graph.validate_workflow(wf)
+        assert result["valid"] is False
+        missing = {e["field"] for e in result["errors"] if e["code"] == "required_input_missing"}
+        assert missing == {"model.max_images", "model.fail_on_partial"}
+
+    def test_unknown_selector_errors_with_options(self, seedream_graph: Graph, seedream_api: dict):
+        """A selector naming no option is where the converter silently misaligns
+        the following widget values, so it must not pass as valid."""
+        wf = copy.deepcopy(seedream_api)
+        wf["1"]["inputs"]["model"] = "seedream 9.9 ultra"
+        result = seedream_graph.validate_workflow(wf)
+        assert result["valid"] is False
+        err = next(e for e in result["errors"] if e["field"] == "model")
+        assert err["code"] == "unknown_enum_value"
+        assert "seedream 5.0 pro" in err["valid_options"]
+
+    def test_unresolvable_selector_messages_say_execution_not_prompt(self, seedream_graph: Graph, seedream_api: dict):
+        """An unresolvable selector is a hard error, but the message must NOT
+        claim a ``/prompt`` rejection: with nothing to expand, the server never
+        adds the selector to its finalized input set, so ``/prompt`` accepts the
+        prompt and the node dies at execution — after a paid node is entered.
+        Only the *sub-input* errors are genuine ``/prompt`` rejections."""
+        for bad in ({"model": "seedream 9.9 ultra"}, {}):
+            wf = copy.deepcopy(seedream_api)
+            wf["1"]["inputs"].pop("model")
+            wf["1"]["inputs"].update(bad)
+            err = next(e for e in seedream_graph.validate_workflow(wf)["errors"] if e["field"] == "model")
+            assert "execution" in err["message"]
+            assert "will reject" not in err["message"]
+
+    def test_missing_selector_errors_once(self, seedream_graph: Graph, seedream_api: dict):
+        """The absent selector is reported by the dynamic path only —
+        ``_check_required_present`` exempts it, so exactly one error, and it
+        carries the valid options."""
+        wf = copy.deepcopy(seedream_api)
+        del wf["1"]["inputs"]["model"]
+        result = seedream_graph.validate_workflow(wf)
+        errs = [e for e in result["errors"] if e["field"] == "model"]
+        assert len(errs) == 1
+        assert errs[0]["code"] == "required_input_missing"
+        assert "seedream 5.0 pro" in errs[0]["valid_options"]
+        # No sub-input errors pile on top — the option set is unknown.
+        assert [e for e in result["errors"] if e["field"].startswith("model.")] == []
+
+    # -- synthetic catalogs for the shapes the captured fixture doesn't cover --
+
+    @staticmethod
+    def _dyn_object_info(options: list[dict]) -> dict:
+        return {
+            "DynNode": {
+                "input": {"required": {"mode": ["COMFY_DYNAMICCOMBO_V3", {"options": options}]}},
+                "output": [],
+                "output_name": [],
+                "output_node": True,
+                "python_module": "nodes",
+            },
+        }
+
+    def test_optional_sub_input_absent_is_clean(self):
+        """A sub-input in the option's ``optional`` section may be absent."""
+        g = Graph.from_object_info(
+            self._dyn_object_info(
+                [{"key": "go", "inputs": {"required": {"a": ["INT", {}]}, "optional": {"b": ["INT", {}]}}}]
+            )
+        )
+        result = g.validate_workflow({"1": {"class_type": "DynNode", "inputs": {"mode": "go", "mode.a": 1}}})
+        assert result["valid"] is True, result["errors"]
+
+    def test_optional_sub_input_present_is_still_shape_checked(self):
+        g = Graph.from_object_info(
+            self._dyn_object_info(
+                [{"key": "go", "inputs": {"required": {"a": ["INT", {}]}, "optional": {"b": ["INT", {}]}}}]
+            )
+        )
+        result = g.validate_workflow(
+            {"1": {"class_type": "DynNode", "inputs": {"mode": "go", "mode.a": 1, "mode.b": "nope"}}}
+        )
+        assert result["valid"] is False
+        assert next(e for e in result["errors"] if e["field"] == "mode.b")["code"] == "shape_mismatch"
+
+    def test_nested_dynamic_combo_expands(self):
+        """An option's sub-input can itself be a dynamic combo — the inner
+        option's own required sub-inputs are checked at ``mode.inner.leaf``."""
+        inner = ["COMFY_DYNAMICCOMBO_V3", {"options": [{"key": "deep", "inputs": {"required": {"leaf": ["INT", {}]}}}]}]
+        g = Graph.from_object_info(self._dyn_object_info([{"key": "go", "inputs": {"required": {"inner": inner}}}]))
+        wf = {"1": {"class_type": "DynNode", "inputs": {"mode": "go", "mode.inner": "deep"}}}
+        result = g.validate_workflow(wf)
+        assert result["valid"] is False
+        assert {e["field"] for e in result["errors"]} == {"mode.inner.leaf"}
+
+        wf["1"]["inputs"]["mode.inner.leaf"] = 3
+        assert g.validate_workflow(wf)["valid"] is True
+
+    def test_wired_selector_skips_expansion(self):
+        """A selector wired as a link resolves at execution time, so there is no
+        static option to expand — no phantom missing-sub-input errors."""
+        object_info = self._dyn_object_info([{"key": "go", "inputs": {"required": {"a": ["INT", {}]}}}])
+        object_info["IntSource"] = {
+            "input": {"required": {}},
+            "output": ["INT"],
+            "output_name": ["INT"],
+            "output_node": False,
+            "python_module": "nodes",
+        }
+        g = Graph.from_object_info(object_info)
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "DynNode", "inputs": {"mode": ["2", 0]}},
+                "2": {"class_type": "IntSource", "inputs": {}},
+            }
+        )
+        assert result["valid"] is True, result["errors"]
+
+    def test_wired_sub_input_is_not_presence_or_shape_flagged(self):
+        """A sub-input satisfied by a link counts as present, and its value is a
+        ``[node_id, index]`` pair — not a shape violation."""
+        object_info = self._dyn_object_info([{"key": "go", "inputs": {"required": {"a": ["INT", {}]}}}])
+        object_info["IntSource"] = {
+            "input": {"required": {}},
+            "output": ["INT"],
+            "output_name": ["INT"],
+            "output_node": False,
+            "python_module": "nodes",
+        }
+        g = Graph.from_object_info(object_info)
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "DynNode", "inputs": {"mode": "go", "mode.a": ["2", 0]}},
+                "2": {"class_type": "IntSource", "inputs": {}},
+            }
+        )
+        assert result["valid"] is True, result["errors"]
+
+    def test_malformed_option_block_does_not_crash(self):
+        """object_info is server-supplied — a junk option block degrades to
+        'no sub-inputs to check', never an exception."""
+        g = Graph.from_object_info(self._dyn_object_info([{"key": "go", "inputs": "not-a-dict"}, "junk"]))
+        result = g.validate_workflow({"1": {"class_type": "DynNode", "inputs": {"mode": "go"}}})
+        assert result["valid"] is True, result["errors"]
+
+    def test_optional_selector_absent_is_clean(self):
+        """An *optional* dynamic combo that is absent is not a missing input."""
+        object_info = {
+            "OptDyn": {
+                "input": {
+                    "optional": {
+                        "mode": [
+                            "COMFY_DYNAMICCOMBO_V3",
+                            {"options": [{"key": "go", "inputs": {"required": {"a": ["INT", {}]}}}]},
+                        ]
+                    }
+                },
+                "output": [],
+                "output_name": [],
+                "output_node": True,
+                "python_module": "nodes",
+            },
+        }
+        g = Graph.from_object_info(object_info)
+        result = g.validate_workflow({"1": {"class_type": "OptDyn", "inputs": {}}})
+        assert result["valid"] is True, result["errors"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## ELI-5

Some ComfyUI nodes have a dropdown that *changes what else the node needs*. Pick "Seedream 5.0 pro" and the node wants a width and a height; pick "5.0 lite" and it also wants `max_images`. `comfy validate` only knew about the dropdown itself, not about the extra fields the choice pulls in — so it happily said "looks good" about a workflow that the server then refused to run. This teaches validate to open the dropdown, see which extra fields the chosen option actually requires, and check them.

## The bug

A `COMFY_DYNAMICCOMBO_V3` input (Seedream's `model`, LTXV, several partner-API nodes) declares exactly ONE input in `object_info` — the selector. The option the selector names carries its own `INPUT_TYPES` block, and both the frontend and `convert_ui_to_api` lower it into dotted keys: `model.size_preset`, `model.width`, `model.height`.

Validation never expanded that. `model.width` misses `port_by_name`, so the per-input loop `continue`d past it; and `_check_required_present` exempted the parent selector outright. Every one of these came back `valid: true` against the captured Seedream catalog before this change (measured on `origin/main`):

| mutation of the pristine Seedream 5.0 Pro template | before | after |
|---|---|---|
| `model.width` deleted | `valid: true` | `required_input_missing` |
| `model.width` = `"wide"` | `valid: true` | `shape_mismatch` |
| `model.width` = `8` (catalog min 1024) | `valid: true` | `below_min` |
| `model.size_preset` = `"(9K) nope"` | `valid: true` | `unknown_enum_value` |
| `model` = `"seedream 9.9 ultra"` | `valid: true` | `unknown_enum_value` |
| `model` deleted | `valid: true` | `required_input_missing` |
| selector flipped to `"seedream 5.0 lite"` | `valid: true` | `required_input_missing` × 2 (`max_images`, `fail_on_partial`) |

## What this changes

`_check_dynamic_combos` resolves each selector's option **exactly the way the server does** and validates that option's sub-inputs through the same `_parse_input_spec` / `Port` machinery as any top-level input — so they inherit identical presence, shape, enum-membership and range semantics rather than a parallel set of rules.

- Nested dynamic combos recurse, under the same depth cap the converter uses.
- Autogrow sub-inputs are exempt: they wire as further-dotted slot keys (`model.images.image_1`) and routinely declare `min: 0` even inside the `required` section, so absence is not a rejection. Their edges are still checked by the driver loop.
- A selector or sub-input satisfied by a link is left to the existing dangling-edge / output-index checks.
- Malformed option blocks degrade to "nothing to expand" — `object_info` is server-supplied and must never take validation down.

`comfy run`'s preflight shares the engine, so both paths gain the check. No new error codes: the four emitted (`required_input_missing`, `shape_mismatch`, `unknown_enum_value`, `below_min`/`above_max`) already exist.

## Verification against the real server

I checked the premise against ComfyUI's source rather than assuming it, because a validator that hard-errors on something the server accepts is worse than the bug it replaces.

- `DynamicCombo._expand_schema_for_dynamic` (`comfy_api/latest/_io.py`) reads the submitted selector, finds the option whose `key` **strictly equals** it, and folds *only that option's* inputs into the finalized required/optional sets, prefixed into dotted names. This confirms selector-driven expansion, strict `==` matching, dotted naming, and recursion — the four load-bearing design choices here.
- `validate_inputs` (`execution.py:886-900`) then walks those finalized names: `if x not in inputs: ... "required_input_missing"`, with **no** exemption for inputs carrying a default. Missing dotted sub-inputs are genuine `/prompt` rejections.
- The same loop supplies `invalid_input_type`, `value_smaller_than_min` / `value_bigger_than_max`, and the COMBO membership check for sub-inputs that *are* present.

**One nuance I found and deliberately did not paper over.** When the selector is absent, or names no option, the server's expansion returns early — so the selector never enters `valid_inputs`, `/prompt` **accepts** the prompt, and the node instead dies at *execution* (its inputs are silently dropped), i.e. after a paid node has been entered. Those two cases are still hard errors here (the workflow genuinely cannot run, and it's the case where the converter also silently misaligns every following widget value), but their **messages say "fails at execution", not "the server will reject this node"** — I did not want validate claiming a `/prompt` rejection that does not happen. `test_unresolvable_selector_messages_say_execution_not_prompt` pins that distinction. If you'd rather these two were warnings so `valid` is byte-for-byte `/prompt` equivalence, that's a one-line change — say the word.

Over-strictness guard: `test_converted_seedream_workflow_is_valid` runs the pristine captured Seedream 5.0 Pro UI export through the real converter and asserts it still validates clean, so the new checks can't start rejecting good workflows unnoticed.

## Scope note — where this ticket actually lives

The ticket was filed against the local MCP, whose `validate_workflow` is a one-line passthrough to `comfy validate` (its `AGENTS.md` forbids implementing anything there: "New functionality belongs in comfy-cli"). The defect is in this repo's CQL engine, so it is fixed here; the MCP picks it up with no change (it shells out to whatever `comfy` is on `PATH` and pins no version). The ticket's repo label should move to `comfy-cli`.

Also worth recording: the ticket's other two named symptoms were already fixed and this PR does **not** claim them — required-input presence-checking landed in #551, and validate's UI→API auto-conversion in #553. Dynamic-combo expansion was the remaining leg, and it is what made the reporter's repro still fail after those.

## Discovered, NOT fixed here (follow-up)

`comfy validate` emits a failure envelope with `ok: false` but `error: null` — the per-node findings live in `data.errors`. An MCP-style consumer that unwraps the envelope on `ok` therefore raises with code `unknown` and loses every structured error, so an agent learns *that* the workflow is invalid but not *which* input is wrong. That predates this change and affects all validate failures, and fixing it is a contract question (how an error envelope should carry a per-node error list), so I left it out rather than mixing it in. Worth its own ticket.

## Verification

- `pytest` — 2934 passed, 37 skipped. The 2 failures in `tests/comfy_cli/test_broken_pipe.py` are pre-existing on `origin/main` (confirmed by re-running them with this change stashed) and unrelated.
- `ruff check` and `ruff format --diff` clean under CI's pinned `ruff==0.15.15`.
- Red→green proof: with the engine change stashed, 8 of the 15 new tests fail; the other 7 are the over-strictness / no-false-positive guards and pass either way by design.
- End-to-end through the real CLI in offline mode (`--input object_info.json`): the good API workflow validates `ok: true` / exit 0, the same workflow minus `model.width` returns `required_input_missing` / exit 1, and the raw UI export converts (`converted_from_ui: true`) and validates.
