### PR TITLE
test: regression sweep for real subgraphed gallery templates (BE-4877)

### DIFF
--- a/tests/comfy_cli/fixtures/gallery/02_qwen_Image_edit_subgraphed.json
+++ b/tests/comfy_cli/fixtures/gallery/02_qwen_Image_edit_subgraphed.json
@@ -1,0 +1,1603 @@
+{
+  "id": "91f6bbe2-ed41-4fd6-bac7-71d5b5864ecb",
+  "revision": 0,
+  "last_node_id": 145,
+  "last_link_id": 295,
+  "nodes": [
+    {
+      "id": 78,
+      "type": "LoadImage",
+      "pos": [
+        -890,
+        30
+      ],
+      "size": [
+        580,
+        450
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            292
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.50",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "image": true,
+            "upload": true
+          }
+        }
+      },
+      "widgets_values": [
+        "02_qwen_Image_edit_subgraphed_input_image.png",
+        "image"
+      ]
+    },
+    {
+      "id": 60,
+      "type": "SaveImage",
+      "pos": [
+        130,
+        10
+      ],
+      "size": [
+        970,
+        630
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 269
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            295
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.65"
+      },
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 119,
+      "type": "MarkdownNote",
+      "pos": [
+        -1590,
+        30
+      ],
+      "size": [
+        660,
+        1430
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: how to use this workflow",
+      "properties": {},
+      "widgets_values": [
+        "[Tutorial](https://docs.comfy.org/tutorials/image/qwen/qwen-image-edit) \n\n## About Qwen Image Edit model\n\n**Qwen Image Edit** is an image-editing model. It supports image editing tasks such as changing the background of an image, replacing something on it, changing a character's outfit, and so on.\n\nIt supports up to 3 images as input. So, you can use one image as the main image, and the others as style references, background, or something.\n\n**Qwen Image Edit 2509 (subgraph)** node is a subgraph, which is converted from the Qwen-Image workflow.\n\n## For Comfy Cloud Users\n\nIf you are using [cloud.comfy.org](https://cloud.comfy.org/):\n\n1. Since the workflow in the Cloud will have the input image ready, for the first run, you can just click the run button to see what happens. \n\n2. Update the text (prompt) in the **Qwen Image Edit 2509 (subgraph)** node. Try the following prompts:\n  - \"Remove the yellow balloon\"\n  - \"Change the balloon's color to blue.\"\n  - \"Replace the man with a child, keep the same oil-painting style.\" \n\n3. Try to upload your own image and then try to apply some changes to it.\n\n## For Local Users\n\nThis workflow requires high VRAM(More than 16GB). If you are using the ComfyUI for the first time, you can get started here: [Basic text-to-image workflow for beginners\n](https://docs.comfy.org/tutorials/basic/text-to-image)\n\n## Model links\n\nYou can find all the models on [Comfy-Org/Qwen-Image_ComfyUI](https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/tree/main) and  [Comfy-Org/Qwen-Image-Edit_ComfyUI](https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI) \n\n**Diffusion model**\n\n- [qwen_image_edit_2509_fp8_e4m3fn.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2509_fp8_e4m3fn.safetensors)\n\n**LoRA**\n\n- [Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors](https://huggingface.co/lightx2v/Qwen-Image-Lightning/resolve/main/Qwen-Image-Edit-2509/Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors)\n\n**Text encoder**\n\n- [qwen_2.5_vl_7b_fp8_scaled.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors)\n\n**VAE**\n\n- [qwen_image_vae.safetensors](https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors)\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 diffusion_models/\n│   │   └── qwen_image_edit_2509_fp8_e4m3fn.safetensors\n│   ├── 📂 loras/\n│   │   └── Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors\n│   ├── 📂 vae/\n│   │   └── qwen_image_vae.safetensors\n│   └── 📂 text_encoders/\n│       └── qwen_2.5_vl_7b_fp8_scaled.safetensors\n```\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 141,
+      "type": "6b4b0518-e42a-4e8b-a377-f0da6dacfcac",
+      "pos": [
+        -280,
+        20
+      ],
+      "size": [
+        350,
+        490
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 293
+        },
+        {
+          "name": "image2",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "name": "image3",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "positive_prompt",
+          "name": "prompt",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt"
+          },
+          "link": null
+        },
+        {
+          "label": "negative_prompt",
+          "name": "prompt_1",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt_1"
+          },
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 290
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 291
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            269
+          ]
+        }
+      ],
+      "properties": {
+        "previewExposures": []
+      },
+      "widgets_values": [
+        "Change the style of the image to a realistic style. The cloud in the background is realistic and fluffy. The balloon is yellow and reflective. ",
+        "",
+        2560,
+        1440,
+        392667428726572,
+        "qwen_image_edit_2509_fp8_e4m3fn.safetensors",
+        "Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors",
+        "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+        "qwen_image_vae.safetensors"
+      ]
+    },
+    {
+      "id": 143,
+      "type": "ResizeImageMaskNode",
+      "pos": [
+        -580,
+        540
+      ],
+      "size": [
+        270,
+        142
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "input",
+          "type": "IMAGE,MASK",
+          "link": 292
+        }
+      ],
+      "outputs": [
+        {
+          "name": "resized",
+          "type": "IMAGE",
+          "links": [
+            289,
+            293,
+            294
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ResizeImageMaskNode"
+      },
+      "widgets_values": [
+        "scale total pixels",
+        1,
+        "area"
+      ]
+    },
+    {
+      "id": 144,
+      "type": "GetImageSize",
+      "pos": [
+        -550,
+        730
+      ],
+      "size": [
+        230,
+        162
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 289
+        }
+      ],
+      "outputs": [
+        {
+          "name": "width",
+          "type": "INT",
+          "links": [
+            290
+          ]
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": [
+            291
+          ]
+        },
+        {
+          "name": "batch_size",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetImageSize"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 145,
+      "type": "ImageCompare",
+      "pos": [
+        1130,
+        20
+      ],
+      "size": [
+        590,
+        610
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image_a",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 294
+        },
+        {
+          "name": "image_b",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 295
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "ImageCompare"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      269,
+      141,
+      0,
+      60,
+      0,
+      "IMAGE"
+    ],
+    [
+      289,
+      143,
+      0,
+      144,
+      0,
+      "IMAGE"
+    ],
+    [
+      290,
+      144,
+      0,
+      141,
+      5,
+      "INT"
+    ],
+    [
+      291,
+      144,
+      1,
+      141,
+      6,
+      "INT"
+    ],
+    [
+      292,
+      78,
+      0,
+      143,
+      0,
+      "IMAGE"
+    ],
+    [
+      293,
+      143,
+      0,
+      141,
+      0,
+      "IMAGE"
+    ],
+    [
+      294,
+      143,
+      0,
+      145,
+      0,
+      "IMAGE"
+    ],
+    [
+      295,
+      60,
+      0,
+      145,
+      1,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "6b4b0518-e42a-4e8b-a377-f0da6dacfcac",
+        "version": 1,
+        "state": {
+          "lastGroupId": 4,
+          "lastNodeId": 145,
+          "lastLinkId": 295,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "New Subgraph",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1270,
+            820,
+            143.044921875,
+            288
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            970,
+            1331,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "ee295cae-b6e2-4931-9d8e-1d9aaa70989c",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              277,
+              278
+            ],
+            "localized_name": "image",
+            "pos": [
+              -1150.955078125,
+              844
+            ]
+          },
+          {
+            "id": "29c4d805-e604-4ca2-95c3-1ed97c9adcf3",
+            "name": "image2",
+            "type": "IMAGE",
+            "linkIds": [
+              272,
+              273
+            ],
+            "pos": [
+              -1150.955078125,
+              864
+            ]
+          },
+          {
+            "id": "035bdbb0-6cbc-4190-83e0-0cd4bd79d725",
+            "name": "image3",
+            "type": "IMAGE",
+            "linkIds": [
+              274,
+              275
+            ],
+            "pos": [
+              -1150.955078125,
+              884
+            ]
+          },
+          {
+            "id": "5a38a6d9-c09e-46da-b132-48edb1bf69d0",
+            "name": "prompt",
+            "type": "STRING",
+            "linkIds": [
+              279
+            ],
+            "label": "positive_prompt",
+            "pos": [
+              -1150.955078125,
+              904
+            ]
+          },
+          {
+            "id": "5549ce5b-f24a-48a3-bcfe-68d799253bb3",
+            "name": "prompt_1",
+            "type": "STRING",
+            "linkIds": [
+              280
+            ],
+            "label": "negative_prompt",
+            "pos": [
+              -1150.955078125,
+              924
+            ]
+          },
+          {
+            "id": "52addb47-d171-442e-bfe1-f5082e422328",
+            "name": "width",
+            "type": "INT",
+            "linkIds": [
+              282
+            ],
+            "pos": [
+              -1150.955078125,
+              944
+            ]
+          },
+          {
+            "id": "57951689-8b15-4fc8-acea-0a1e6363236e",
+            "name": "height",
+            "type": "INT",
+            "linkIds": [
+              283
+            ],
+            "pos": [
+              -1150.955078125,
+              964
+            ]
+          },
+          {
+            "id": "d97478f9-276c-4350-bdde-24c46b63faa8",
+            "name": "seed",
+            "type": "INT",
+            "linkIds": [
+              284
+            ],
+            "pos": [
+              -1150.955078125,
+              984
+            ]
+          },
+          {
+            "id": "1acc56af-5828-462a-bb64-5f4780e4975e",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              285
+            ],
+            "pos": [
+              -1150.955078125,
+              1004
+            ]
+          },
+          {
+            "id": "07c18e17-6bc3-48f4-903e-5563f0211014",
+            "name": "lora_name",
+            "type": "COMBO",
+            "linkIds": [
+              286
+            ],
+            "pos": [
+              -1150.955078125,
+              1024
+            ]
+          },
+          {
+            "id": "b681674b-c87f-4c79-8423-aa7c53448d62",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              287
+            ],
+            "pos": [
+              -1150.955078125,
+              1044
+            ]
+          },
+          {
+            "id": "9828f1c8-07de-4bae-a2fc-e74018d1bd1b",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              288
+            ],
+            "pos": [
+              -1150.955078125,
+              1064
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "9061aff8-476c-486b-9aa7-5106ec2178b8",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              264
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              994,
+              1355
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 124,
+            "type": "CFGNorm",
+            "pos": [
+              330,
+              790
+            ],
+            "size": [
+              290,
+              140
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 248
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "patched_model",
+                "name": "patched_model",
+                "type": "MODEL",
+                "links": [
+                  253
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CFGNorm",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.50",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "ue_properties": {
+                "widget_ue_connectable": {
+                  "strength": true
+                }
+              }
+            },
+            "widgets_values": [
+              1,
+              false
+            ]
+          },
+          {
+            "id": 125,
+            "type": "VAELoader",
+            "pos": [
+              -660,
+              1260
+            ],
+            "size": [
+              330,
+              80
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 288
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "slot_index": 0,
+                "links": [
+                  250,
+                  259,
+                  262
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "models": [
+                {
+                  "name": "qwen_image_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/vae/qwen_image_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "qwen_image_vae.safetensors"
+            ]
+          },
+          {
+            "id": 126,
+            "type": "CLIPLoader",
+            "pos": [
+              -660,
+              1050
+            ],
+            "size": [
+              330,
+              140
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 287
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "slot_index": 0,
+                "links": [
+                  258,
+                  261
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "models": [
+                {
+                  "name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/resolve/main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+              "qwen_image",
+              "default"
+            ]
+          },
+          {
+            "id": 127,
+            "type": "UNETLoader",
+            "pos": [
+              -660,
+              680
+            ],
+            "size": [
+              330,
+              110
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 285
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  252
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "models": [
+                {
+                  "name": "qwen_image_edit_2509_fp8_e4m3fn.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI/resolve/main/split_files/diffusion_models/qwen_image_edit_2509_fp8_e4m3fn.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "qwen_image_edit_2509_fp8_e4m3fn.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 128,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -190,
+              1090
+            ],
+            "size": [
+              400,
+              220
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 258
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 259
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 277
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 273
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 275
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 280
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  255
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.59"
+            },
+            "widgets_values": [
+              ""
+            ],
+            "color": "#223",
+            "bgcolor": "#335"
+          },
+          {
+            "id": 131,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              330,
+              650
+            ],
+            "size": [
+              290,
+              80
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 251
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  248
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              3
+            ]
+          },
+          {
+            "id": 132,
+            "type": "TextEncodeQwenImageEditPlus",
+            "pos": [
+              -190,
+              690
+            ],
+            "size": [
+              400,
+              220
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 261
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 262
+              },
+              {
+                "localized_name": "image1",
+                "name": "image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 278
+              },
+              {
+                "localized_name": "image2",
+                "name": "image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 272
+              },
+              {
+                "localized_name": "image3",
+                "name": "image3",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 274
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 279
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  254
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeQwenImageEditPlus",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.59"
+            },
+            "widgets_values": [
+              "Change the style of the image to a realistic style. The cloud in the background is realistic and fluffy. The balloon is yellow and reflective. "
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 137,
+            "type": "KSampler",
+            "pos": [
+              330,
+              990
+            ],
+            "size": [
+              300,
+              480
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 253
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 254
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 255
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 281
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 284
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  249
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              1118877715456453,
+              "randomize",
+              4,
+              1,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 138,
+            "type": "VAEDecode",
+            "pos": [
+              680,
+              660
+            ],
+            "size": [
+              230,
+              80
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 249
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 250
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  264
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.48",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 140,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              -650,
+              850
+            ],
+            "size": [
+              310,
+              140
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 252
+              },
+              {
+                "localized_name": "lora_name",
+                "name": "lora_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "lora_name"
+                },
+                "link": 286
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  251
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.50",
+              "models": [
+                {
+                  "name": "Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors",
+                  "url": "https://huggingface.co/lightx2v/Qwen-Image-Lightning/resolve/main/Qwen-Image-Edit-2509/Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors",
+                  "directory": "loras"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65,
+              "ue_properties": {
+                "widget_ue_connectable": {
+                  "lora_name": true,
+                  "strength_model": true
+                }
+              }
+            },
+            "widgets_values": [
+              "Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors",
+              1
+            ]
+          },
+          {
+            "id": 142,
+            "type": "EmptySD3LatentImage",
+            "pos": [
+              -630,
+              1430
+            ],
+            "size": [
+              270,
+              150
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 282
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 283
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  281
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptySD3LatentImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.59"
+            },
+            "widgets_values": [
+              2560,
+              1440,
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Step1 - Load models",
+            "bounding": [
+              -680,
+              610,
+              380,
+              750
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step 4 - Prompt",
+            "bounding": [
+              -280,
+              610,
+              560,
+              750
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 248,
+            "origin_id": 131,
+            "origin_slot": 0,
+            "target_id": 124,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 258,
+            "origin_id": 126,
+            "origin_slot": 0,
+            "target_id": 128,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 259,
+            "origin_id": 125,
+            "origin_slot": 0,
+            "target_id": 128,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 251,
+            "origin_id": 140,
+            "origin_slot": 0,
+            "target_id": 131,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 261,
+            "origin_id": 126,
+            "origin_slot": 0,
+            "target_id": 132,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 262,
+            "origin_id": 125,
+            "origin_slot": 0,
+            "target_id": 132,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 253,
+            "origin_id": 124,
+            "origin_slot": 0,
+            "target_id": 137,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 254,
+            "origin_id": 132,
+            "origin_slot": 0,
+            "target_id": 137,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 255,
+            "origin_id": 128,
+            "origin_slot": 0,
+            "target_id": 137,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 249,
+            "origin_id": 137,
+            "origin_slot": 0,
+            "target_id": 138,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 250,
+            "origin_id": 125,
+            "origin_slot": 0,
+            "target_id": 138,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 252,
+            "origin_id": 127,
+            "origin_slot": 0,
+            "target_id": 140,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 264,
+            "origin_id": 138,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 272,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 132,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 273,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 128,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 274,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 132,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 275,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 128,
+            "target_slot": 4,
+            "type": "IMAGE"
+          },
+          {
+            "id": 277,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 128,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 278,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 132,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 279,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 132,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 280,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 128,
+            "target_slot": 5,
+            "type": "STRING"
+          },
+          {
+            "id": 281,
+            "origin_id": 142,
+            "origin_slot": 0,
+            "target_id": 137,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 282,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 142,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 283,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 142,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 284,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 137,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 285,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 127,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 286,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 140,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 287,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 126,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 288,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 125,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.2659463528922607,
+      "offset": [
+        2527.172897620484,
+        839.7595153308597
+      ]
+    },
+    "frontendVersion": "1.47.7",
+    "workflowRendererVersion": "LG",
+    "ue_links": [],
+    "links_added_by_ue": [],
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/05_audio_ace_step_1_t2a_song_subgraphed.json
+++ b/tests/comfy_cli/fixtures/gallery/05_audio_ace_step_1_t2a_song_subgraphed.json
@@ -1,0 +1,1428 @@
+{
+  "id": "88ac5dad-efd7-40bb-84fe-fbaefdee1fa9",
+  "revision": 0,
+  "last_node_id": 127,
+  "last_link_id": 289,
+  "nodes": [
+    {
+      "id": 59,
+      "type": "SaveAudioMP3",
+      "pos": [
+        1402.2839931804533,
+        -271.1075075319548
+      ],
+      "size": [
+        499.96875,
+        210.65625
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 289
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveAudioMP3",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.34"
+      },
+      "widgets_values": [
+        "audio/ComfyUI",
+        "V0"
+      ]
+    },
+    {
+      "id": 77,
+      "type": "MarkdownNote",
+      "pos": [
+        70.15182995168391,
+        345.44789104617723
+      ],
+      "size": [
+        608.328125,
+        1011.640625
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "About ACE Step and Multi-language Input",
+      "properties": {},
+      "widgets_values": [
+        "Currently, multi-language support in ACE-Step V1 is implemented by uniformly converting all languages to English characters. At present, in ComfyUI, we haven't implemented the step of converting multiple languages into English. This is because if we need to implement the corresponding conversion, we have to add additional ComfyUI core dependencies, which may lead to unresolved dependency conflicts.\n\nSo, currently, if you need to input multi-language text, you have to convert it into English characters to complete this process manually. Then, at the beginning of the corresponding `lyrics`, input the abbreviation of the corresponding language code.\n\nFor example, use `[zh]` for Chinese, `[ja]` for Japanese, `[ko]` for Korean, and so on. For specific language input, please check the examples in the instructions. \n\nFor example, Chinese `[zh]`, Japanese `[ja]`, Korean `[ko]`, etc.\n\nExample:\n\n```\n[verse]\n\n[zh]wo3zou3guo4shen1ye4de5jie1dao4\n[zh]leng3feng1chui1luan4si1nian4de5piao4liang4wai4tao4\n[zh]ni3de5wei1xiao4xiang4xing1guang1hen3xuan4yao4\n[zh]zhao4liang4le5wo3gu1du2de5mei3fen1mei3miao3\n\n[chorus]\n\n[verse]​\n[ko]hamkke si-kkeuleo-un sesang-ui sodong-eul pihae​\n[ko]honja ogsang-eseo dalbich-ui eolyeompus-ileul balaboda​\n[ko]niga salang-eun lideum-i ganghan eum-ag gatdago malhaess-eo​\n[ko]han ta han tamada ma-eum-ui ondoga eolmana heojeonhanji ijge hae\n\n[bridge]\n[es]cantar mi anhelo por ti sin ocultar\n[es]como poesía y pintura, lleno de anhelo indescifrable\n[es]tu sombra es tan terca como el viento, inborrable\n[es]persiguiéndote en vuelo, brilla como cruzar una mar de nubes\n\n[chorus]\n[fr]que tu sois le vent qui souffle sur ma main\n[fr]un contact chaud comme la douce pluie printanière\n[fr]que tu sois le vent qui s'entoure de mon corps\n[fr]un amour profond qui ne s'éloignera jamais\n\n```\n\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 75,
+      "type": "MarkdownNote",
+      "pos": [
+        67.2220367408969,
+        -283.87520808793926
+      ],
+      "size": [
+        610,
+        553.265625
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: how to use this workflow",
+      "properties": {},
+      "widgets_values": [
+        "[Tutorial](https://docs.comfy.org/tutorials/audio/ace-step/ace-step-v1) \n\nThe AceStep requires `tags` and `lyrics` to generate music. `Tags` are for the music rhythm and type, and `lyrics` literally mean the words of the song.\n \n## For Comfy Cloud users\n\nIf you are using [cloud.comfy.org](https://cloud.comfy.org/):\n1. For the first run, you can just click the run button to see what happens. \n\n2. Try to updating the `tags(top one)`, and `lyrics(bottom one)` to have fun with it\n\n## For Local Users\n\nDownload the following model and save it to the **ComfyUI/models/checkpoints** folder.\n[ace_step_v1_3.5b.safetensors](https://huggingface.co/Comfy-Org/ACE-Step_ComfyUI_repackaged/blob/main/all_in_one/ace_step_v1_3.5b.safetensors)\n\n## Report Issues\n\nIf you have any problems running this workflow, please report template-related issues via this link: [report the template issue here](https://github.com/Comfy-Org/workflow_templates/issues)"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 127,
+      "type": "f2e2ae00-c892-4af3-81bd-68de1e31fa9b",
+      "pos": [
+        735.3840701929829,
+        -272.1477447655758
+      ],
+      "size": [
+        561.84375,
+        743.71875
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "duration",
+          "name": "value",
+          "type": "FLOAT",
+          "widget": {
+            "name": "value"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            289
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "124",
+            "tags"
+          ],
+          [
+            "124",
+            "lyrics"
+          ],
+          [
+            "124",
+            "timesignature"
+          ],
+          [
+            "124",
+            "language"
+          ],
+          [
+            "124",
+            "keyscale"
+          ],
+          [
+            "124",
+            "generate_audio_codes"
+          ],
+          [
+            "124",
+            "cfg_scale"
+          ],
+          [
+            "110",
+            "value"
+          ],
+          [
+            "125",
+            "unet_name"
+          ],
+          [
+            "105",
+            "clip_name1"
+          ],
+          [
+            "105",
+            "clip_name2"
+          ],
+          [
+            "106",
+            "vae_name"
+          ]
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      289,
+      127,
+      0,
+      59,
+      0,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "f2e2ae00-c892-4af3-81bd-68de1e31fa9b",
+        "version": 1,
+        "state": {
+          "lastGroupId": 16,
+          "lastNodeId": 127,
+          "lastLinkId": 289,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Audio (ACE-Step 1.5)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -660,
+            -560,
+            167.458984375,
+            280
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1504.8375,
+            -410,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "ebc79d17-2e65-4e0f-855a-c9f2466a5fbf",
+            "name": "tags",
+            "type": "STRING",
+            "linkIds": [
+              264
+            ],
+            "pos": [
+              -512.541015625,
+              -540
+            ]
+          },
+          {
+            "id": "230afdb4-a647-4fb7-a68c-a2204fd5d570",
+            "name": "lyrics",
+            "type": "STRING",
+            "linkIds": [
+              265
+            ],
+            "pos": [
+              -512.541015625,
+              -520
+            ]
+          },
+          {
+            "id": "efdcbb48-231c-4757-b343-4458c011a283",
+            "name": "timesignature",
+            "type": "COMBO",
+            "linkIds": [
+              266
+            ],
+            "pos": [
+              -512.541015625,
+              -500
+            ]
+          },
+          {
+            "id": "811579c1-2979-4721-a1e1-7d9352616e7b",
+            "name": "language",
+            "type": "COMBO",
+            "linkIds": [
+              267
+            ],
+            "pos": [
+              -512.541015625,
+              -480
+            ]
+          },
+          {
+            "id": "76a68b0d-7a5f-43dc-873d-d78adf32895f",
+            "name": "keyscale",
+            "type": "COMBO",
+            "linkIds": [
+              268
+            ],
+            "pos": [
+              -512.541015625,
+              -460
+            ]
+          },
+          {
+            "id": "11bb3297-272d-4c56-873a-2c974581e838",
+            "name": "generate_audio_codes",
+            "type": "BOOLEAN",
+            "linkIds": [
+              269
+            ],
+            "pos": [
+              -512.541015625,
+              -440
+            ]
+          },
+          {
+            "id": "e5a30400-a8b0-422a-a0f3-21739727ab03",
+            "name": "cfg_scale",
+            "type": "FLOAT",
+            "linkIds": [
+              270
+            ],
+            "pos": [
+              -512.541015625,
+              -420
+            ]
+          },
+          {
+            "id": "91a37ca5-e0d1-42c5-8248-419b850661a0",
+            "name": "value",
+            "type": "FLOAT",
+            "linkIds": [
+              284
+            ],
+            "label": "duration",
+            "pos": [
+              -512.541015625,
+              -400
+            ]
+          },
+          {
+            "id": "30f69f59-e916-48ab-9a5d-ae445b8d8a63",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              285
+            ],
+            "pos": [
+              -512.541015625,
+              -380
+            ]
+          },
+          {
+            "id": "1af0e8df-6fa7-4df2-b1b4-9c356a8f30a6",
+            "name": "clip_name1",
+            "type": "COMBO",
+            "linkIds": [
+              286
+            ],
+            "pos": [
+              -512.541015625,
+              -360
+            ]
+          },
+          {
+            "id": "c7195505-9e83-4f87-b8d7-7747d808577d",
+            "name": "clip_name2",
+            "type": "COMBO",
+            "linkIds": [
+              287
+            ],
+            "pos": [
+              -512.541015625,
+              -340
+            ]
+          },
+          {
+            "id": "ca4bd68f-e7c1-4d87-9914-cfe15c63b96e",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              288
+            ],
+            "pos": [
+              -512.541015625,
+              -320
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "bfd748f6-f9ac-4588-81fa-41bde07a58fa",
+            "name": "AUDIO",
+            "type": "AUDIO",
+            "linkIds": [
+              263
+            ],
+            "localized_name": "AUDIO",
+            "pos": [
+              1524.8375,
+              -390
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 105,
+            "type": "DualCLIPLoader",
+            "pos": [
+              -160,
+              -660
+            ],
+            "size": [
+              380,
+              130
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name1",
+                "name": "clip_name1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name1"
+                },
+                "link": 286
+              },
+              {
+                "localized_name": "clip_name2",
+                "name": "clip_name2",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name2"
+                },
+                "link": 287
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  261
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "DualCLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "models": [
+                {
+                  "name": "qwen_0.6b_ace15.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/ace_step_1.5_ComfyUI_files/resolve/main/split_files/text_encoders/qwen_0.6b_ace15.safetensors",
+                  "directory": "text_encoders"
+                },
+                {
+                  "name": "qwen_4b_ace15.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/ace_step_1.5_ComfyUI_files/resolve/main/split_files/text_encoders/qwen_4b_ace15.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_0.6b_ace15.safetensors",
+              "qwen_4b_ace15.safetensors",
+              "ace",
+              "default"
+            ]
+          },
+          {
+            "id": 106,
+            "type": "VAELoader",
+            "pos": [
+              -160,
+              -470
+            ],
+            "size": [
+              380,
+              60
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 288
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  262
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "models": [
+                {
+                  "name": "ace_1.5_vae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/ace_step_1.5_ComfyUI_files/resolve/main/split_files/vae/ace_1.5_vae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "ace_1.5_vae.safetensors"
+            ]
+          },
+          {
+            "id": 122,
+            "type": "EmptyAceStep1.5LatentAudio",
+            "pos": [
+              -150,
+              10
+            ],
+            "size": [
+              320,
+              90
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "seconds",
+                "name": "seconds",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "seconds"
+                },
+                "link": 279
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  249
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptyAceStep1.5LatentAudio",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              120,
+              1
+            ]
+          },
+          {
+            "id": 47,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              670,
+              50
+            ],
+            "size": [
+              210,
+              30
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 255
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  119
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ConditioningZeroOut",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 3,
+            "type": "KSampler",
+            "pos": [
+              930,
+              -680
+            ],
+            "size": [
+              330,
+              270
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 175
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 254
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 119
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 249
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 258
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  256
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              561594583201063,
+              "fixed",
+              8,
+              1,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 78,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              930,
+              -810
+            ],
+            "size": [
+              330,
+              60
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 260
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  175
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3
+            ]
+          },
+          {
+            "id": 123,
+            "type": "VAEDecodeAudio",
+            "pos": [
+              1280,
+              -800
+            ],
+            "size": [
+              170,
+              50
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 256
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 262
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  263
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecodeAudio",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 124,
+            "type": "TextEncodeAceStepAudio1.5",
+            "pos": [
+              270,
+              -790
+            ],
+            "size": [
+              620,
+              680
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 261
+              },
+              {
+                "localized_name": "tags",
+                "name": "tags",
+                "type": "STRING",
+                "widget": {
+                  "name": "tags"
+                },
+                "link": 264
+              },
+              {
+                "localized_name": "lyrics",
+                "name": "lyrics",
+                "type": "STRING",
+                "widget": {
+                  "name": "lyrics"
+                },
+                "link": 265
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 257
+              },
+              {
+                "localized_name": "duration",
+                "name": "duration",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "duration"
+                },
+                "link": 280
+              },
+              {
+                "localized_name": "timesignature",
+                "name": "timesignature",
+                "type": "COMBO",
+                "widget": {
+                  "name": "timesignature"
+                },
+                "link": 266
+              },
+              {
+                "localized_name": "language",
+                "name": "language",
+                "type": "COMBO",
+                "widget": {
+                  "name": "language"
+                },
+                "link": 267
+              },
+              {
+                "localized_name": "keyscale",
+                "name": "keyscale",
+                "type": "COMBO",
+                "widget": {
+                  "name": "keyscale"
+                },
+                "link": 268
+              },
+              {
+                "localized_name": "generate_audio_codes",
+                "name": "generate_audio_codes",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "generate_audio_codes"
+                },
+                "link": 269
+              },
+              {
+                "localized_name": "cfg_scale",
+                "name": "cfg_scale",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg_scale"
+                },
+                "link": 270
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  254,
+                  255
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "TextEncodeAceStepAudio1.5",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "synthwave, techno, synthpop, futuristic, electro, with liquid drum & bass drive.\nRestless, confident, dreamy mood at 128 BPM.\nAnalog bass, pulsating arps, percussive synth stabs, gated drums.\nQuick build,  then explosive drum burst, then clean fade.\nBreathy, rhythmic female vocals, minimal emotion, metallic echo.",
+              "Verse\nNeon rain on my screen,\nDreams compile in silver sheen.\nNo weight, just motion,\nI’m plugged into emotion.\n\nChorus\nComfy Cloud — breathing light,\nCode and color, spark and wire.\nDrift through data, feel alive,\nIn your circuits, I arrive.",
+              561594583201063,
+              "fixed",
+              190,
+              120,
+              "4",
+              "en",
+              "E minor",
+              true,
+              2,
+              0.85,
+              0.9,
+              0,
+              0
+            ]
+          },
+          {
+            "id": 125,
+            "type": "UNETLoader",
+            "pos": [
+              -170,
+              -790
+            ],
+            "size": [
+              380,
+              90
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 285
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  260
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.11.1",
+              "models": [
+                {
+                  "name": "acestep_v1.5_turbo.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/ace_step_1.5_ComfyUI_files/resolve/main/split_files/diffusion_models/acestep_v1.5_turbo.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "acestep_v1.5_turbo.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 126,
+            "type": "PrimitiveNode",
+            "pos": [
+              -120,
+              -130
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "INT",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "links": [
+                  257,
+                  258
+                ]
+              }
+            ],
+            "title": "seed",
+            "properties": {
+              "Run widget replace on values": false
+            },
+            "widgets_values": [
+              561594583201063,
+              "randomize"
+            ]
+          },
+          {
+            "id": 110,
+            "type": "PrimitiveFloat",
+            "pos": [
+              -120,
+              -280
+            ],
+            "size": [
+              270,
+              60
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 284
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": [
+                  279,
+                  280
+                ]
+              }
+            ],
+            "title": "Song Duration",
+            "properties": {
+              "Node name for S&R": "PrimitiveFloat",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.12.3",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              120
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Step 1 - Load Models",
+            "bounding": [
+              -180,
+              -860,
+              405,
+              461.6
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Step 2 - Duration",
+            "bounding": [
+              -180,
+              -370,
+              400,
+              170
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step3 - Prompt",
+            "bounding": [
+              260,
+              -860,
+              640,
+              960
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 255,
+            "origin_id": 124,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 175,
+            "origin_id": 78,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 254,
+            "origin_id": 124,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 119,
+            "origin_id": 47,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 249,
+            "origin_id": 122,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 258,
+            "origin_id": 126,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 260,
+            "origin_id": 125,
+            "origin_slot": 0,
+            "target_id": 78,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 256,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 123,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 262,
+            "origin_id": 106,
+            "origin_slot": 0,
+            "target_id": 123,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 261,
+            "origin_id": 105,
+            "origin_slot": 0,
+            "target_id": 124,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 257,
+            "origin_id": 126,
+            "origin_slot": 0,
+            "target_id": 124,
+            "target_slot": 3,
+            "type": "INT"
+          },
+          {
+            "id": 263,
+            "origin_id": 123,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 264,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 124,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 265,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 124,
+            "target_slot": 2,
+            "type": "STRING"
+          },
+          {
+            "id": 266,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 124,
+            "target_slot": 5,
+            "type": "COMBO"
+          },
+          {
+            "id": 267,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 124,
+            "target_slot": 6,
+            "type": "COMBO"
+          },
+          {
+            "id": 268,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 124,
+            "target_slot": 7,
+            "type": "COMBO"
+          },
+          {
+            "id": 269,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 124,
+            "target_slot": 8,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 270,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 124,
+            "target_slot": 9,
+            "type": "FLOAT"
+          },
+          {
+            "id": 279,
+            "origin_id": 110,
+            "origin_slot": 0,
+            "target_id": 122,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 280,
+            "origin_id": 110,
+            "origin_slot": 0,
+            "target_id": 124,
+            "target_slot": 4,
+            "type": "FLOAT"
+          },
+          {
+            "id": 284,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 110,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 285,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 125,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 286,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 105,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 287,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 105,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 288,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 106,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ds": {
+            "scale": 0.9575633843910519,
+            "offset": [
+              -950.8014851321678,
+              872.1540230582457
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7256247279787457,
+      "offset": [
+        -309.3356095934124,
+        752.4521114186003
+      ]
+    },
+    "frontendVersion": "1.41.13",
+    "node_versions": {
+      "comfy-core": "0.3.34",
+      "ace-step": "06f751d65491c9077fa2bc9b06d2c6f2a90e4c56"
+    },
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "workflowRendererVersion": "Vue-corrected"
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/README.md
+++ b/tests/comfy_cli/fixtures/gallery/README.md
@@ -1,0 +1,22 @@
+# Gallery template fixtures
+
+Real subgraphed gallery templates, copied **verbatim** from
+[Comfy-Org/workflow_templates](https://github.com/Comfy-Org/workflow_templates)
+`templates/`. They back `tests/comfy_cli/test_subgraph_gallery_templates.py`,
+the regression sweep that proves `convert_ui_to_api` fully expands real
+subgraph instances and `Graph.get_template_schema` surfaces their interior
+slots.
+
+Refresh with:
+
+```bash
+cd tests/comfy_cli/fixtures/gallery
+for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed; do
+  curl -sfL "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/${f}.json" -o "${f}.json"
+done
+```
+
+`qwen_object_info.json` is NOT a template — it is a purpose-built minimal
+`/object_info` covering only the node types the qwen fixture uses (frontend-only
+`MarkdownNote` excluded, matching a real server response), used to exercise slot
+extraction. If a refresh changes the qwen template's node set, extend it to match.

--- a/tests/comfy_cli/fixtures/gallery/qwen_object_info.json
+++ b/tests/comfy_cli/fixtures/gallery/qwen_object_info.json
@@ -1,0 +1,248 @@
+{
+  "LoadImage": {
+    "input": {
+      "required": {
+        "image": [["02_qwen_Image_edit_subgraphed_input_image.png"], {"image_upload": true}]
+      }
+    },
+    "input_order": {"required": ["image"]},
+    "output": ["IMAGE", "MASK"],
+    "output_name": ["IMAGE", "MASK"],
+    "category": "image",
+    "display_name": "Load Image",
+    "python_module": "nodes"
+  },
+  "SaveImage": {
+    "input": {
+      "required": {
+        "images": "IMAGE",
+        "filename_prefix": ["STRING", {"default": "ComfyUI"}]
+      }
+    },
+    "input_order": {"required": ["images", "filename_prefix"]},
+    "output": [],
+    "output_name": [],
+    "category": "image",
+    "display_name": "Save Image",
+    "output_node": true,
+    "python_module": "nodes"
+  },
+  "GetImageSize": {
+    "input": {
+      "required": {
+        "image": "IMAGE"
+      }
+    },
+    "input_order": {"required": ["image"]},
+    "output": ["INT", "INT", "INT"],
+    "output_name": ["width", "height", "batch_size"],
+    "category": "image",
+    "display_name": "Get Image Size",
+    "python_module": "nodes"
+  },
+  "ImageCompare": {
+    "input": {
+      "required": {
+        "image_a": "IMAGE",
+        "image_b": "IMAGE"
+      }
+    },
+    "input_order": {"required": ["image_a", "image_b"]},
+    "output": [],
+    "output_name": [],
+    "category": "image",
+    "display_name": "Image Compare",
+    "output_node": true,
+    "python_module": "nodes"
+  },
+  "ResizeImageMaskNode": {
+    "input": {
+      "required": {
+        "resize_type": [["scale total pixels", "scale by ratio", "resize to dimensions"]],
+        "scale": ["FLOAT", {"default": 1.0, "min": 0.01, "max": 100.0, "step": 0.01}],
+        "interpolation": [["area", "nearest-exact", "bilinear", "bicubic", "lanczos"]]
+      },
+      "optional": {
+        "image": "IMAGE",
+        "mask": "MASK"
+      }
+    },
+    "input_order": {"required": ["resize_type", "scale", "interpolation"], "optional": ["image", "mask"]},
+    "output": ["IMAGE", "MASK"],
+    "output_name": ["IMAGE", "MASK"],
+    "category": "transform",
+    "display_name": "Resize Image/Mask",
+    "python_module": "nodes"
+  },
+  "UNETLoader": {
+    "input": {
+      "required": {
+        "unet_name": [["qwen_image_edit_2509_fp8_e4m3fn.safetensors"]],
+        "weight_dtype": [["default", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e5m2"]]
+      }
+    },
+    "input_order": {"required": ["unet_name", "weight_dtype"]},
+    "output": ["MODEL"],
+    "output_name": ["MODEL"],
+    "category": "advanced/loaders",
+    "display_name": "Load Diffusion Model",
+    "python_module": "nodes"
+  },
+  "CLIPLoader": {
+    "input": {
+      "required": {
+        "clip_name": [["qwen_2.5_vl_7b_fp8_scaled.safetensors"]],
+        "type": [["stable_diffusion", "sd3", "flux", "wan", "hidream", "chroma", "ace", "omnigen2", "qwen_image"]]
+      },
+      "optional": {
+        "device": [["default", "cpu"], {"advanced": true}]
+      }
+    },
+    "input_order": {"required": ["clip_name", "type"], "optional": ["device"]},
+    "output": ["CLIP"],
+    "output_name": ["CLIP"],
+    "category": "advanced/loaders",
+    "display_name": "Load CLIP",
+    "python_module": "nodes"
+  },
+  "VAELoader": {
+    "input": {
+      "required": {
+        "vae_name": [["qwen_image_vae.safetensors"]]
+      }
+    },
+    "input_order": {"required": ["vae_name"]},
+    "output": ["VAE"],
+    "output_name": ["VAE"],
+    "category": "loaders",
+    "display_name": "Load VAE",
+    "python_module": "nodes"
+  },
+  "LoraLoaderModelOnly": {
+    "input": {
+      "required": {
+        "model": "MODEL",
+        "lora_name": [["Qwen-Image-Edit-2509-Lightning-4steps-V1.0-bf16.safetensors"]],
+        "strength_model": ["FLOAT", {"default": 1.0, "min": -100.0, "max": 100.0, "step": 0.01}]
+      }
+    },
+    "input_order": {"required": ["model", "lora_name", "strength_model"]},
+    "output": ["MODEL"],
+    "output_name": ["MODEL"],
+    "category": "loaders",
+    "display_name": "LoraLoaderModelOnly",
+    "python_module": "nodes"
+  },
+  "TextEncodeQwenImageEditPlus": {
+    "input": {
+      "required": {
+        "clip": "CLIP",
+        "prompt": ["STRING", {"multiline": true, "dynamicPrompts": true}]
+      },
+      "optional": {
+        "vae": "VAE",
+        "image1": "IMAGE",
+        "image2": "IMAGE",
+        "image3": "IMAGE"
+      }
+    },
+    "input_order": {"required": ["clip", "prompt"], "optional": ["vae", "image1", "image2", "image3"]},
+    "output": ["CONDITIONING"],
+    "output_name": ["CONDITIONING"],
+    "category": "advanced/conditioning",
+    "display_name": "TextEncodeQwenImageEditPlus",
+    "python_module": "nodes"
+  },
+  "ModelSamplingAuraFlow": {
+    "input": {
+      "required": {
+        "model": "MODEL",
+        "shift": ["FLOAT", {"default": 3.0, "min": 0.0, "max": 100.0, "step": 0.01}]
+      }
+    },
+    "input_order": {"required": ["model", "shift"]},
+    "output": ["MODEL"],
+    "output_name": ["MODEL"],
+    "category": "advanced/model",
+    "display_name": "ModelSamplingAuraFlow",
+    "python_module": "nodes"
+  },
+  "CFGNorm": {
+    "input": {
+      "required": {
+        "model": "MODEL",
+        "strength": ["FLOAT", {"default": 1.0, "min": 0.0, "max": 100.0, "step": 0.01}]
+      }
+    },
+    "input_order": {"required": ["model", "strength"]},
+    "output": ["MODEL"],
+    "output_name": ["patched_model"],
+    "category": "advanced/guidance",
+    "display_name": "CFGNorm",
+    "python_module": "nodes"
+  },
+  "EmptySD3LatentImage": {
+    "input": {
+      "required": {
+        "width": ["INT", {"default": 1024, "min": 16, "max": 16384, "step": 8}],
+        "height": ["INT", {"default": 1024, "min": 16, "max": 16384, "step": 8}],
+        "batch_size": ["INT", {"default": 1, "min": 1, "max": 4096}]
+      }
+    },
+    "input_order": {"required": ["width", "height", "batch_size"]},
+    "output": ["LATENT"],
+    "output_name": ["LATENT"],
+    "category": "latent/sd3",
+    "display_name": "EmptySD3LatentImage",
+    "python_module": "nodes"
+  },
+  "KSampler": {
+    "input": {
+      "required": {
+        "model": "MODEL",
+        "seed": ["INT", {"default": 0, "min": 0, "max": 18446744073709551615, "control_after_generate": true}],
+        "steps": ["INT", {"default": 20, "min": 1, "max": 10000}],
+        "cfg": ["FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "step": 0.1}],
+        "sampler_name": [["euler", "euler_ancestral", "dpmpp_2m", "res_multistep"]],
+        "scheduler": [["normal", "karras", "simple", "sgm_uniform"]],
+        "positive": "CONDITIONING",
+        "negative": "CONDITIONING",
+        "latent_image": "LATENT",
+        "denoise": ["FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}]
+      }
+    },
+    "input_order": {
+      "required": [
+        "model",
+        "seed",
+        "steps",
+        "cfg",
+        "sampler_name",
+        "scheduler",
+        "positive",
+        "negative",
+        "latent_image",
+        "denoise"
+      ]
+    },
+    "output": ["LATENT"],
+    "output_name": ["LATENT"],
+    "category": "sampling",
+    "display_name": "KSampler",
+    "python_module": "nodes"
+  },
+  "VAEDecode": {
+    "input": {
+      "required": {
+        "samples": "LATENT",
+        "vae": "VAE"
+      }
+    },
+    "input_order": {"required": ["samples", "vae"]},
+    "output": ["IMAGE"],
+    "output_name": ["IMAGE"],
+    "category": "latent",
+    "display_name": "VAE Decode",
+    "python_module": "nodes"
+  }
+}

--- a/tests/comfy_cli/test_subgraph_gallery_templates.py
+++ b/tests/comfy_cli/test_subgraph_gallery_templates.py
@@ -1,0 +1,115 @@
+"""Regression sweep over REAL subgraphed gallery templates.
+
+BE-3223 showed subgraph gallery templates must convert fully through
+``convert_ui_to_api`` and expose their interior slots via
+``Graph.get_template_schema``, but the existing subgraph tests only use small
+synthetic shapes. These tests pin that behavior against verbatim copies of
+templates from Comfy-Org/workflow_templates (see ``fixtures/gallery/README.md``
+for provenance + refresh command). Everything here is pure-Python and offline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql.engine import Graph
+from comfy_cli.workflow_to_api import convert_ui_to_api, is_subgraph_uuid
+
+_GALLERY = Path(__file__).resolve().parent / "fixtures" / "gallery"
+
+# Auto-discovered so a newly committed *_subgraphed.json fixture joins the sweep
+# without editing this list; the explicit assert keeps the glob honest.
+GALLERY_TEMPLATES = sorted(p.name for p in _GALLERY.glob("*_subgraphed.json"))
+assert {"02_qwen_Image_edit_subgraphed.json", "05_audio_ace_step_1_t2a_song_subgraphed.json"} <= set(
+    GALLERY_TEMPLATES
+), f"expected gallery fixtures missing from {_GALLERY}: found {GALLERY_TEMPLATES}"
+
+QWEN = "02_qwen_Image_edit_subgraphed.json"
+
+
+def _load_template(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _iter_subgraph_defs(workflow_or_def: dict):
+    """Yield every subgraph def reachable from a workflow or def's definitions."""
+    definitions = workflow_or_def.get("definitions")
+    if not isinstance(definitions, dict):
+        return
+    for sg in definitions.get("subgraphs") or []:
+        if isinstance(sg, dict):
+            yield sg
+            yield from _iter_subgraph_defs(sg)
+
+
+@pytest.mark.parametrize("template_name", GALLERY_TEMPLATES)
+class TestGalleryTemplateConversion:
+    def test_converts_with_empty_object_info(self, template_name):
+        """The structural path (no object_info) must convert without raising."""
+        wf = _load_template(template_name)
+        api = convert_ui_to_api(wf, {})
+        assert isinstance(api, dict)
+        assert api, f"{template_name} converted to an empty prompt"
+
+    def test_every_subgraph_instance_expanded(self, template_name):
+        """No UUID class_type may survive conversion — expansion must be total."""
+        wf = _load_template(template_name)
+        # Sanity: the fixture really exercises subgraphs (a refresh that drops
+        # them would silently gut this sweep).
+        instance_types = {
+            n.get("type") for n in wf.get("nodes", []) if isinstance(n, dict) and is_subgraph_uuid(n.get("type"))
+        }
+        assert instance_types, f"{template_name} no longer contains any subgraph instance"
+
+        api = convert_ui_to_api(wf, {})
+        unexpanded = {nid: n.get("class_type") for nid, n in api.items() if is_subgraph_uuid(n.get("class_type"))}
+        assert not unexpanded, f"{template_name} left unexpanded subgraph instances in the API prompt: {unexpanded}"
+        # Interior nodes surface under '<instance>:<interior>' ids — their
+        # presence proves the instances were expanded, not just dropped.
+        assert any(":" in nid for nid in api), (
+            f"{template_name} produced no subgraph-interior nodes; "
+            "subgraph instances appear to have been dropped instead of expanded"
+        )
+
+    def test_no_nested_definitions_blind_spot(self, template_name):
+        """_collect_subgraph_defs reads only the workflow's top-level
+        definitions.subgraphs. A def carrying its OWN nested definitions block
+        would NOT be expanded today. No gallery fixture does this yet — if one
+        ever does, _collect_subgraph_defs (comfy_cli/workflow_to_api.py) needs
+        recursive collection before that fixture can be trusted to convert."""
+        wf = _load_template(template_name)
+        for sg in _iter_subgraph_defs(wf):
+            nested = (sg.get("definitions") or {}).get("subgraphs") if isinstance(sg.get("definitions"), dict) else None
+            assert not nested, (
+                f"{template_name} subgraph def {sg.get('id')!r} carries nested definitions.subgraphs — "
+                "_collect_subgraph_defs only reads top-level definitions and must learn to collect recursively"
+            )
+
+
+class TestGalleryTemplateSlots:
+    """Slot extraction over the qwen fixture with a minimal realistic object_info."""
+
+    @pytest.fixture(scope="class")
+    def qwen_schema(self) -> dict:
+        oi = json.loads((_GALLERY / "qwen_object_info.json").read_text(encoding="utf-8"))
+        graph = Graph.from_object_info(oi)
+        return graph.get_template_schema(QWEN, _load_template(QWEN))
+
+    def test_surfaces_subgraph_interior_slots(self, qwen_schema):
+        interior = [s for s in qwen_schema["slots"] if "/" in s["address"]]
+        assert interior, f"no subgraph-interior slots surfaced; got {[s['address'] for s in qwen_schema['slots']]}"
+
+    def test_interior_prompt_and_seed_are_addressable(self, qwen_schema):
+        """The slots an agent actually edits: the prompt + seed inside the
+        opaque 'Qwen Image Edit 2509' subgraph instance (node 141)."""
+        by_addr = {s["address"]: s for s in qwen_schema["slots"]}
+        assert "141/132.prompt" in by_addr, f"missing interior prompt slot; got {sorted(by_addr)}"
+        assert by_addr["141/132.prompt"]["current_value"].startswith("Change the style")
+        assert by_addr["141/137.seed"]["current_value"] == 1118877715456453
+
+    def test_top_level_slots_still_present(self, qwen_schema):
+        by_addr = {s["address"]: s for s in qwen_schema["slots"]}
+        assert by_addr["60.filename_prefix"]["current_value"] == "ComfyUI"


### PR DESCRIPTION
## ELI-5

The template gallery ships workflows whose guts are hidden inside "subgraphs" (a box-of-nodes with a UUID name). comfy-cli has to unpack those boxes to run the workflow and to let agents edit the knobs inside them. That unpacking worked, but nothing tested it against *real* gallery templates — only tiny hand-made ones — so a change in how the frontend saves templates could break every gallery workflow without any test going red. This PR commits two real gallery templates as fixtures and adds tests that prove the boxes get fully unpacked and the inner knobs (prompt, seed) stay reachable.

## What

- Commit `02_qwen_Image_edit_subgraphed.json` and `05_audio_ace_step_1_t2a_song_subgraphed.json` verbatim from Comfy-Org/workflow_templates `templates/` (shasums verified identical to upstream `main`) under `tests/comfy_cli/fixtures/gallery/`, with a README documenting provenance + the refresh command.
- New `tests/comfy_cli/test_subgraph_gallery_templates.py` (9 tests, ~0.6s, fully offline):
  - `convert_ui_to_api(wf, {})` on each fixture must not raise, must return a non-empty prompt, must leave **zero** `is_subgraph_uuid` class_types, and must actually emit subgraph-interior nodes (`<instance>:<interior>` ids) — so the tests fail whether expansion passes instances through *or* silently drops them.
  - Blind-spot tripwire: recursively asserts no fixture carries nested `definitions.subgraphs` inside a subgraph def; the failure message points at `_collect_subgraph_defs` needing recursive collection if the save format ever evolves that way.
  - Slot coverage: `Graph.from_object_info(...).get_template_schema(...)` on the qwen fixture surfaces subgraph-interior slots (`/` addresses), including the concrete `141/132.prompt` and `141/137.seed` an agent actually edits, using a new purpose-built `qwen_object_info.json` covering only that template's node types.

## Verification

- `uv run pytest tests/comfy_cli/test_subgraph_gallery_templates.py` → 9 passed in 0.63s (offline, pure Python).
- Acceptance mutation checks run locally: making `_collect_subgraph_defs` return `{}` → 2 failures; deleting the body of `_expand_subgraphs` → 2 failures. Source restored after each.
- Full suite: 2952 passed, 37 skipped. `ruff check` / `ruff format --check` / pre-commit on the new files: clean.

## Judgment calls

- The README lives at `tests/comfy_cli/fixtures/gallery/README.md` (next to the fixtures) rather than as a line in the parent fixtures dir, which had no README to append to.
- Reused nothing from `subgraph_object_info.json` — its node types (Gemini/Regex/etc.) don't overlap the qwen template at all, so per the ticket's "or" branch I built the minimal `qwen_object_info.json` instead. Frontend-only `MarkdownNote` is intentionally absent, matching a real server's `/object_info`.
- Added the interior-node-presence assertion (`:` ids) beyond the ticket's letter — without it, an expansion regression that *drops* instances instead of passing them through would slip past the zero-UUID check.
- The qwen template upstream is currently ~41 KB (the ticket's ~46 KB reflects an older revision); verbatim-from-main is what's committed.
