### PR TITLE
fix(tracking): shape-validate $POSTHOG_API_KEY and quiet the posthog logger (BE-4931)

### DIFF
--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -23,15 +23,40 @@ if TYPE_CHECKING:
 # Ignore logs from urllib3 that Mixpanel/PostHog use.
 logginglib.getLogger("urllib3").setLevel(logginglib.ERROR)
 
+# posthog-python reports every failed upload at ERROR on the "posthog" logger
+# (it never logs above ERROR). Telemetry is best-effort by contract — a failed
+# upload must not look like a product failure on the user's stderr — so silence
+# it entirely unless the user is explicitly debugging (LOG_LEVEL=DEBUG).
+if os.environ.get("LOG_LEVEL", "").upper() != "DEBUG":
+    logginglib.getLogger("posthog").setLevel(logginglib.CRITICAL)
+
 MIXPANEL_TOKEN = "93aeab8962b622d431ac19800ccc9f67"
 
 # phc_* are public client-side write keys designed for embedding — safe to commit, same as MIXPANEL_TOKEN above.
-# Override with $POSTHOG_API_KEY.
-POSTHOG_TOKEN = os.environ.get(
-    "POSTHOG_API_KEY",
-    "phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO",
-)
+# Override with $POSTHOG_API_KEY (see _resolve_posthog_token for the accepted shapes).
+_POSTHOG_DEFAULT_TOKEN = "phc_iKfK86id4xVYws9LybMje0h44eGtfwFgRPIBehmy8rO"
 POSTHOG_HOST = "https://t.comfy.org"
+
+
+def _resolve_posthog_token() -> str:
+    """Resolve the PostHog project write key, guarding against the
+    $POSTHOG_API_KEY name collision: PostHog's own tooling uses that name for a
+    personal (phx_) API key, which the ingestion endpoint rejects with a 401.
+    Only a phc_* project write key is accepted as an override; an empty string
+    still disables the provider (existing escape hatch); anything else is
+    ignored in favor of the committed default.
+    """
+    raw = os.environ.get("POSTHOG_API_KEY")
+    if raw is None:
+        return _POSTHOG_DEFAULT_TOKEN
+    if raw == "" or raw.startswith("phc_"):
+        return raw
+    logging.warning(
+        "Ignoring $POSTHOG_API_KEY: not a phc_* project write key "
+        "(personal phx_ keys cannot ingest events); using the built-in key."
+    )
+    return _POSTHOG_DEFAULT_TOKEN
+
 
 # Only these events get the tracing_id --> workflow_run_id alias on PostHog.
 EXECUTION_EVENTS = frozenset({"execution_start", "execution_success", "execution_error"})
@@ -249,7 +274,7 @@ def _get_providers() -> list[TelemetryProvider]:
                 built = []
                 for name, factory in (
                     ("MixpanelProvider", lambda: MixpanelProvider(MIXPANEL_TOKEN)),
-                    ("PostHogProvider", lambda: PostHogProvider(POSTHOG_TOKEN, POSTHOG_HOST)),
+                    ("PostHogProvider", lambda: PostHogProvider(_resolve_posthog_token(), POSTHOG_HOST)),
                 ):
                     try:
                         built.append(factory())

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -51,7 +51,10 @@ def _resolve_posthog_token() -> str:
         return _POSTHOG_DEFAULT_TOKEN
     if raw == "" or raw.startswith("phc_"):
         return raw
-    logging.warning(
+    # ERROR, not WARNING: the CLI's default LOG_LEVEL is ERROR (see
+    # logging.setup_logging), so a WARNING here would be silently dropped and
+    # the user would never learn their override was ignored.
+    logging.error(
         "Ignoring $POSTHOG_API_KEY: not a phc_* project write key "
         "(personal phx_ keys cannot ingest events); using the built-in key."
     )

--- a/tests/comfy_cli/test_tracking_lazy_import.py
+++ b/tests/comfy_cli/test_tracking_lazy_import.py
@@ -94,7 +94,7 @@ def test_broken_sdk_import_degrades_instead_of_crashing_the_command():
         "builtins.__import__ = boom\n"
         "import comfy_cli.tracking as t\n"
         "t.MIXPANEL_TOKEN = 'tok'\n"
-        "t.POSTHOG_TOKEN = 'tok'\n"
+        "t._POSTHOG_DEFAULT_TOKEN = 'tok'\n"
         # The send path must survive: _get_providers() is called in _dispatch's loop
         # header, outside the per-provider try/except that only guards .track().
         "t._dispatch('evt', {}, distinct_id='abc')\n"
@@ -118,7 +118,7 @@ def test_one_broken_sdk_does_not_silence_the_other():
         "builtins.__import__ = boom\n"
         "import comfy_cli.tracking as t\n"
         "t.MIXPANEL_TOKEN = 'tok'\n"
-        "t.POSTHOG_TOKEN = 'tok'\n"
+        "t._POSTHOG_DEFAULT_TOKEN = 'tok'\n"
         "providers = t._get_providers()\n"
         "names = [type(p).__name__ for p in providers]\n"
         "assert names == ['MixpanelProvider'], f'lost the healthy provider: {names!r}'\n"

--- a/tests/comfy_cli/test_tracking_providers.py
+++ b/tests/comfy_cli/test_tracking_providers.py
@@ -6,6 +6,8 @@ with the standard CLI properties and aliases ``tracing_id`` to
 ``workflow_run_id`` on the canonical execution lifecycle events.
 """
 
+import importlib
+import logging
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -368,3 +370,138 @@ class TestAtexitFlush:
             fast.flush.assert_called_once()
         finally:
             release.set()
+
+
+def _override_warnings(caplog):
+    """The $POSTHOG_API_KEY-was-ignored warnings captured so far."""
+    return [r for r in caplog.records if "POSTHOG_API_KEY" in r.getMessage()]
+
+
+class TestPostHogTokenResolution:
+    """BE-4931: $POSTHOG_API_KEY is also what posthog-cli calls a *personal*
+    (``phx_``) API key, which the ingestion endpoint rejects with a 401. Only a
+    ``phc_`` project write key may override the committed default."""
+
+    def test_unset_env_uses_the_committed_default(self, monkeypatch):
+        import comfy_cli.tracking as tracking_mod
+
+        monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+        assert tracking_mod._resolve_posthog_token() == tracking_mod._POSTHOG_DEFAULT_TOKEN
+
+    def test_phc_override_is_honored_without_warning(self, monkeypatch, caplog):
+        import comfy_cli.tracking as tracking_mod
+
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_custom")
+        with caplog.at_level(logging.WARNING):
+            assert tracking_mod._resolve_posthog_token() == "phc_custom"
+        assert _override_warnings(caplog) == []
+
+    def test_empty_override_still_disables_the_provider(self, monkeypatch, caplog):
+        # The pre-existing escape hatch: an empty string opts the PostHog pipe
+        # out entirely (PostHogProvider.__init__ returns early on a falsy token —
+        # see test_posthog_with_empty_token_is_disabled_and_silent).
+        import comfy_cli.tracking as tracking_mod
+
+        monkeypatch.setenv("POSTHOG_API_KEY", "")
+        with caplog.at_level(logging.WARNING):
+            assert tracking_mod._resolve_posthog_token() == ""
+        assert _override_warnings(caplog) == []
+
+        provider = PostHogProvider(tracking_mod._resolve_posthog_token(), tracking_mod.POSTHOG_HOST)
+        assert provider.enabled is False
+
+    @pytest.mark.parametrize("bad_value", ["phx_test", "not-a-key", "phc-typo"])
+    def test_non_phc_override_warns_and_falls_back(self, monkeypatch, caplog, bad_value):
+        import comfy_cli.tracking as tracking_mod
+
+        monkeypatch.setenv("POSTHOG_API_KEY", bad_value)
+        with caplog.at_level(logging.WARNING):
+            assert tracking_mod._resolve_posthog_token() == tracking_mod._POSTHOG_DEFAULT_TOKEN
+
+        warnings = _override_warnings(caplog)
+        assert len(warnings) == 1
+        assert warnings[0].levelno == logging.WARNING
+
+
+class _FakePosthogClient:
+    """Stands in for ``posthog.Posthog`` so provider construction records the
+    token it was handed without starting a real consumer thread."""
+
+    def __init__(self, *, project_api_key, host, **_kwargs):
+        self.api_key = project_api_key
+        self.host = host
+        self.join = MagicMock()
+        self.capture = MagicMock()
+        self.flush = MagicMock()
+
+
+class TestPostHogTokenResolutionThroughProviderBuild:
+    def test_phx_env_still_builds_a_provider_on_the_default_key(self, monkeypatch, caplog):
+        """End to end: a developer with a personal key exported gets working
+        telemetry and exactly one warning, no matter how many events fire —
+        the resolve happens inside the once-only provider factory."""
+        import comfy_cli.tracking as tracking_mod
+
+        monkeypatch.setenv("POSTHOG_API_KEY", "phx_test")
+        monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+        monkeypatch.delenv("COMFY_NO_TELEMETRY", raising=False)
+
+        with (
+            # Both SDKs are imported lazily inside the providers, so patch the
+            # source modules rather than a tracking attribute.
+            patch("posthog.Posthog", _FakePosthogClient),
+            patch("mixpanel.Mixpanel", return_value=MagicMock()),
+            patch.object(tracking_mod, "PROVIDERS", None),
+            patch.object(tracking_mod, "_session_only_tracking", True),
+            patch.object(tracking_mod, "user_id", "test-distinct-id"),
+            caplog.at_level(logging.WARNING),
+        ):
+            tracking_mod.track_event("first_event")
+            tracking_mod.track_event("second_event")
+            providers = list(tracking_mod.PROVIDERS)
+
+        posthog_providers = [p for p in providers if type(p).__name__ == "PostHogProvider"]
+        assert len(posthog_providers) == 1
+        posthog_provider = posthog_providers[0]
+        assert posthog_provider.enabled is True
+        assert posthog_provider.client.api_key == tracking_mod._POSTHOG_DEFAULT_TOKEN
+        # Two events, one build, one warning.
+        assert len(_override_warnings(caplog)) == 1
+        assert posthog_provider.client.capture.call_count == 2
+
+
+class TestPostHogLoggerIsQuiet:
+    """posthog-python logs every failed upload — 401, offline, DNS, 5xx — at
+    ERROR on the single ``posthog`` logger, which comfy-cli's root handler
+    prints in red. Telemetry is best-effort, so that must not reach stderr."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_module_state(self, monkeypatch):
+        posthog_logger = logging.getLogger("posthog")
+        original_level = posthog_logger.level
+        yield
+        # Undo the reloads: leave the module (and the logger) exactly as a
+        # normal import would, so test ordering can't leak either one.
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        import comfy_cli.tracking as tracking_mod
+
+        importlib.reload(tracking_mod)
+        posthog_logger.setLevel(original_level)
+
+    def test_import_silences_the_posthog_logger(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        import comfy_cli.tracking as tracking_mod
+
+        logging.getLogger("posthog").setLevel(logging.NOTSET)
+        importlib.reload(tracking_mod)
+
+        assert logging.getLogger("posthog").level == logging.CRITICAL
+
+    def test_log_level_debug_leaves_the_posthog_logger_alone(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "debug")  # setup_logging upper()s it too
+        import comfy_cli.tracking as tracking_mod
+
+        logging.getLogger("posthog").setLevel(logging.NOTSET)
+        importlib.reload(tracking_mod)
+
+        assert logging.getLogger("posthog").level == logging.NOTSET

--- a/tests/comfy_cli/test_tracking_providers.py
+++ b/tests/comfy_cli/test_tracking_providers.py
@@ -420,7 +420,9 @@ class TestPostHogTokenResolution:
 
         warnings = _override_warnings(caplog)
         assert len(warnings) == 1
-        assert warnings[0].levelno == logging.WARNING
+        # ERROR, not WARNING: the default LOG_LEVEL is ERROR, so this must be
+        # visible to the user by default (see comfy_cli/tracking.py).
+        assert warnings[0].levelno == logging.ERROR
 
 
 class _FakePosthogClient:


### PR DESCRIPTION
## ELI-5

`comfy` sends anonymous usage telemetry to PostHog. The key it uses can be overridden with `$POSTHOG_API_KEY` — but PostHog's *own* command-line tool uses that exact same variable name for a completely different kind of key (a *personal* `phx_` key). So any developer who has `posthog-cli` set up got their personal key silently picked up by `comfy`, PostHog's ingestion endpoint rejected every upload with a 401, and the PostHog SDK printed a scary red error line on every single `comfy` command:

```
2026-07-28 14:14:26 - posthog - ERROR - [PostHog] error uploading: [PostHog] API key is not valid: personal_api_key (401)
```

Two fixes, shipped together because they live in the same file and each is independently useful:

1. **The CLI now checks the shape of the key** before using it. Only a `phc_*` project write key is accepted as an override; anything else is ignored in favour of the built-in key, with a single quiet warning. Telemetry keeps working instead of 401-ing.
2. **The `posthog` logger is silenced** unless you're explicitly debugging (`LOG_LEVEL=DEBUG`). Telemetry is best-effort by contract — a failed upload shouldn't look like a product failure on the user's stderr. This one matters beyond the 401: *every* transport failure (offline, DNS, proxy, 5xx) hits the same log line.

## What changed

**`comfy_cli/tracking.py`**

- Added a `posthog`-logger silencer next to the existing `urllib3` one. posthog-python does all of its logging on the single logger name `"posthog"` and never logs above ERROR (verified against locked 7.18.1: `grep getLogger` across the package returns exactly `getLogger("posthog")`, and its only above-`error` call is `log.exception`, which is itself ERROR-level), so `setLevel(CRITICAL)` covers every failure mode. The `urllib3` line is untouched. `LOG_LEVEL` is the same variable `comfy_cli/logging.py::setup_logging` reads, so the escape hatch is consistent with the rest of the CLI.
- Replaced the module-level `POSTHOG_TOKEN = os.environ.get(...)` read with a `_POSTHOG_DEFAULT_TOKEN` constant plus a lazy `_resolve_posthog_token()`, and call it from the `_get_providers()` factory tuple instead. Resolving inside the factory — which `_get_providers` builds once under `_PROVIDERS_LOCK` and caches — means the warning fires at most once per process and only when telemetry actually initialises; an import with consent off never warns.

Behavior table for `$POSTHOG_API_KEY`:

| Value | Result |
|---|---|
| unset | committed `phc_` default |
| `""` | provider disabled (preserves the existing `if not token: return` escape hatch) |
| `phc_…` | override honored (this is what the e2e live verifier uses to point at a test project) |
| `phx_…` or garbage | one-time warning + committed default → telemetry restored |

The warning goes through `comfy_cli.logging.warning` (root logger), so it is invisible at the default `LOG_LEVEL=ERROR` and visible under `WARNING`/`DEBUG` — deliberately quiet.

## Explicitly out of scope

No env-var rename (Comfy-Desktop shares the identical `POSTHOG_API_KEY` override and the same committed `phc_` default in `src/shared/posthogConfig.ts`, and the e2e live verifier relies on the current name), no change to `MIXPANEL_TOKEN`, `POSTHOG_HOST`, the committed default key, consent/opt-out logic, or event taxonomy. Mixpanel needed nothing here: mixpanel-python raises rather than logging, and `_dispatch` already catches and logs at WARNING (invisible at the default root level).

## Tests

Added to `tests/comfy_cli/test_tracking_providers.py`:

- `TestPostHogTokenResolution` — unset → default; `phc_custom` → honored with no warning; `""` → `""` and `PostHogProvider("")` stays disabled; `phx_test` / `not-a-key` / `phc-typo` → default plus exactly one WARNING record (asserted via `caplog`).
- `TestPostHogTokenResolutionThroughProviderBuild` — integration: with `POSTHOG_API_KEY=phx_test` and consent stubbed on, `_get_providers()` builds a `PostHogProvider` whose `client.api_key` is the committed default, and the warning fires exactly once across two `track_event` calls. Both SDKs are stubbed (a `_FakePosthogClient` that records the key it was handed, no consumer thread, no network).
- `TestPostHogLoggerIsQuiet` — after reloading `comfy_cli.tracking` without `LOG_LEVEL=DEBUG` the `posthog` logger is at `CRITICAL`; with `LOG_LEVEL=DEBUG` it is left untouched. An autouse fixture reloads the module back under a clean env and restores the logger level so test ordering can't leak either one.

Full suite green: `2967 passed, 37 skipped`. `ruff check` + `ruff format --diff` clean (0.15.15, matching CI).

Manual verification (the spike's repro, with a fake key):

```
$ POSTHOG_API_KEY=phx_$(head -c 40 /dev/zero | tr '\0' 'x') comfy which
{"schema": "envelope/1", ... }          # no `posthog - ERROR` line on stderr

$ python -c "import logging, comfy_cli.tracking; print(logging.getLogger('posthog').level)"
50                                       # CRITICAL
$ LOG_LEVEL=DEBUG python -c "import logging, comfy_cli.tracking; print(logging.getLogger('posthog').level)"
0                                        # NOTSET — untouched
$ LOG_LEVEL=WARNING POSTHOG_API_KEY=phx_xxxxxxxxxxxx python -c "..."
... - root - WARNING - Ignoring $POSTHOG_API_KEY: not a phc_* project write key ...
```

## Judgment calls / notes for review

- **The ticket's "nothing else in the repo references `POSTHOG_TOKEN`" was not quite right.** `tests/comfy_cli/test_tracking_lazy_import.py` set `t.POSTHOG_TOKEN = 'tok'` in two subprocess scripts. Those are `setattr`s, so deleting the constant would not have broken them — it would have left two dead lines silently doing nothing. I renamed them to `t._POSTHOG_DEFAULT_TOKEN` to preserve the original intent ("give both providers a token"). `tests/e2e/verify_tracking_live.py` mentions `POSTHOG_API_KEY` only in an error string and resolves through `_get_providers()`, so its `phc_`-keyed test-project workflow is unaffected.
- **This narrows an override, so I checked it doesn't remove a real capability.** The only key shape PostHog issues for cloud ingestion is `phc_`; a legacy un-prefixed key would only exist on a self-hosted instance, and `POSTHOG_HOST` is hardcoded to `https://t.comfy.org` with no env override, so pointing the CLI at a self-hosted PostHog was never possible in the first place. The one real override use case — the e2e verifier's `phc_` test project — is preserved verbatim. Non-`phc_` values are ignored rather than rejected, so no path that previously worked now fails; the previously-broken path now degrades to working telemetry plus a warning.
- **The logger silencer is process-global.** Importing `comfy_cli.tracking` sets the level on the `posthog` logger for the whole interpreter, so an application that embeds `comfy_cli` *and* uses posthog-python itself would inherit the silence. That is the same tradeoff the pre-existing `urllib3` line already makes (and broader in that case), and `LOG_LEVEL=DEBUG` restores it. Flagging it rather than hiding it.
