### PR TITLE
feat(generate): emit envelope/1 from `generate list` / `generate schema` under --json (BE-4933)

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -44,7 +44,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from comfy_cli import constants, tracking, ui
 from comfy_cli.command.generate import adapters, client, emit, output, poll, schema, spec, upload
 from comfy_cli.config_manager import ConfigManager
-from comfy_cli.output.renderer import get_renderer
+from comfy_cli.output.renderer import Renderer, get_renderer
 
 _HELP = "Generate images via ComfyUI partner nodes (Flux, Ideogram, DALL·E, Recraft, Stability, …)."
 
@@ -541,84 +541,138 @@ def _arg_value(args: list[str], *names: str) -> str | None:
     return None
 
 
+def _renderer_for(meta: dict[str, str | bool]) -> Renderer:
+    """Resolve the renderer for a `generate` sub-action.
+
+    ``generate`` runs with ``allow_extra_args``, so a trailing ``--json`` never
+    reaches the global Typer callback that resolves output mode — it lands in
+    ``meta`` instead. Honor both spellings: the global ``comfy --json generate
+    list`` (already reflected in the renderer's mode) and the tail
+    ``comfy generate list --json`` (upgrade a still-pretty renderer).
+    """
+    renderer = get_renderer()
+    if meta.get("json"):
+        renderer.force_json()
+    return renderer
+
+
+def _model_record(e: spec.Endpoint) -> dict[str, object]:
+    """One structured catalog row. ``category`` is what the human table renders
+    under its "Style" column; ``summary`` is the FULL text, not the ``…``-
+    truncated form the table has to cut to fit its width."""
+    return {
+        "alias": spec.preferred_alias(e.id) or e.id,
+        "id": e.id,
+        "partner": e.partner,
+        "category": e.category,
+        "mode": "async" if e.polling else "sync",
+        "summary": e.summary,
+    }
+
+
+def _param_record(f: schema.FlagDef) -> dict[str, object]:
+    """One structured parameter row for `generate schema`.
+
+    ``kind`` is retained alongside ``type`` because it is the vocabulary
+    ``comfy_cli.command.generate.schema`` uses internally and the name the
+    pre-envelope ``--json`` payload shipped; they always carry the same value.
+    """
+    return {
+        "name": f.name,
+        "type": f.kind,
+        "kind": f.kind,
+        "required": f.required,
+        "default": f.default,
+        "enum": list(f.enum),
+        "description": f.description,
+        "item_type": f.item_kind,
+        "upload_mode": f.upload_mode,
+    }
+
+
 def _list_models(extra_args: list[str]) -> None:
     """`comfy generate list` — show available models with their short aliases."""
     clean, meta = _separate_meta_flags(extra_args)
-    as_json = bool(meta.get("json", False))
+    renderer = _renderer_for(meta)
     partner = _arg_value(clean, "--partner", "-p")
     category = _arg_value(clean, "--category", "--style", "-c")
     query = _arg_value(clean, "--query", "-q")
     eps = spec.list_endpoints(partner=partner, category=category, query=query)
-    if as_json:
-        models = [
-            {
-                "alias": spec.preferred_alias(e.id) or e.id,
-                "id": e.id,
-                "partner": e.partner,
-                "category": e.category,
-                "mode": "async" if e.polling else "sync",
-                "summary": e.summary,
-            }
+    payload = {
+        "models": [_model_record(e) for e in eps],
+        "count": len(eps),
+        "filters": {"partner": partner, "category": category, "query": query},
+    }
+    if renderer.is_pretty():
+        if not eps:
+            rprint("[yellow]No models match those filters.[/yellow]")
+            raise typer.Exit(code=0)
+        rows = [
+            (
+                spec.preferred_alias(e.id) or e.id,
+                e.partner,
+                e.category,
+                "async" if e.polling else "sync",
+                (e.summary[:60] + "…") if len(e.summary) > 61 else e.summary,
+            )
             for e in eps
         ]
-        output.print_json({"models": models, "count": len(models)})
+        ui.display_table(rows, ["Model", "Partner", "Style", "Mode", "Summary"], title="Comfy Generate — Models")
+        rprint("\n[dim]Run `comfy generate schema <model>` to see parameters for a model.[/dim]")
         return
-    if not eps:
-        rprint("[yellow]No models match those filters.[/yellow]")
-        raise typer.Exit(code=0)
-    rows = [
-        (
-            spec.preferred_alias(e.id) or e.id,
-            e.partner,
-            e.category,
-            "async" if e.polling else "sync",
-            (e.summary[:60] + "…") if len(e.summary) > 61 else e.summary,
-        )
-        for e in eps
-    ]
-    ui.display_table(rows, ["Model", "Partner", "Style", "Mode", "Summary"], title="Comfy Generate — Models")
-    rprint("\n[dim]Run `comfy generate schema <model>` to see parameters for a model.[/dim]")
+    renderer.emit(payload, command="generate list")
 
 
 def _schema(extra_args: list[str]) -> None:
     """`comfy generate schema <model>` — show params for a model (fal-style)."""
     clean, meta = _separate_meta_flags(extra_args)
-    as_json = bool(meta.get("json", False))
+    renderer = _renderer_for(meta)
     if not clean or clean[0].startswith("-"):
-        if as_json:
-            output.print_json({"error": "Usage: comfy generate schema <model>"})
-            raise typer.Exit(code=1)
-        rprint("[bold red]Usage: comfy generate schema <model>[/bold red]")
+        if renderer.is_pretty():
+            rprint("[bold red]Usage: comfy generate schema <model>[/bold red]")
+        else:
+            renderer.error(
+                code="missing_argument",
+                message="Usage: comfy generate schema <model>",
+                hint="pass a model alias, e.g. `comfy generate schema flux-pro` "
+                "(run `comfy generate list` to see them)",
+                command="generate schema",
+            )
         raise typer.Exit(code=1)
     try:
         ep = spec.get_endpoint(clean[0])
     except spec.SpecError as e:
-        if as_json:
-            output.print_json({"error": str(e)})
-            raise typer.Exit(code=1)
-        rprint(f"[bold red]{e}[/bold red]")
+        if renderer.is_pretty():
+            rprint(f"[bold red]{e}[/bold red]")
+        else:
+            renderer.error(
+                code="generate_model_unknown",
+                message=str(e),
+                hint="run `comfy generate list` to see the available model aliases",
+                details={"requested": clean[0]},
+                command="generate schema",
+            )
         raise typer.Exit(code=1)
-    if as_json:
-        flags = schema.flags_for(ep)
-        output.print_json(
-            {
-                "model": spec.preferred_alias(ep.id) or ep.id,
-                "id": ep.id,
-                "params": [
-                    {
-                        "name": f.name,
-                        "kind": f.kind,
-                        "required": f.required,
-                        "default": f.default,
-                        "enum": f.enum,
-                        "description": f.description,
-                    }
-                    for f in flags
-                ],
-            }
-        )
+    if renderer.is_pretty():
+        _show_schema_help(ep)
         return
-    _show_schema_help(ep)
+    flags = schema.flags_for(ep)
+    name = spec.preferred_alias(ep.id) or ep.id
+    renderer.emit(
+        {
+            "model": name,
+            "id": ep.id,
+            "partner": ep.partner,
+            "category": ep.category,
+            "summary": ep.summary,
+            "mode": "async" if ep.polling else "sync",
+            "polling": ep.polling,
+            "content_type": ep.request_content_type,
+            "params": [_param_record(f) for f in flags],
+            "example": schema.example_invocation(ep, flags, display_name=name),
+        },
+        command="generate schema",
+    )
 
 
 def _fetch_spec(url: str) -> httpx.Response:

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -87,6 +87,11 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy model download-status": "download_status",
     "comfy model download-cancel": "download_status",
     "comfy model downloads": "downloads",
+    # partner-model discovery (`comfy generate`'s two read-only sub-actions —
+    # they are argv-tail actions, not Typer subcommands, so they have no node in
+    # the help tree; agents resolve them through `command_schemas`).
+    "comfy generate list": "generate_list",
+    "comfy generate schema": "generate_schema",
     # template gallery
     "comfy templates ls": "templates",
     "comfy templates show": "templates",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -626,6 +626,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     # --- generate / emit -----------------------------------------------------
     ErrorCode(
+        "generate_model_unknown",
+        "`comfy generate schema <model>` got a name that is neither a known alias nor a curated "
+        "endpoint id. `details.requested` carries the name as typed; the message lists close matches.",
+        "run `comfy generate list` to see the available model aliases",
+    ),
+    ErrorCode(
         "emit_workflow_failed",
         "`generate --emit-workflow` could not build the partner-node workflow.",
         "check the model name and that all required inputs are provided",

--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -170,6 +170,18 @@ class Renderer:
         """
         self.mode = OutputMode.NDJSON
 
+    def force_json(self) -> None:
+        """Upgrade a pretty renderer to single-envelope JSON mode.
+
+        Counterpart to ``force_stream`` for commands whose ``--json`` is
+        parsed out of an argv tail the global callback never sees — e.g.
+        ``comfy generate list --json``, where ``generate`` takes
+        ``allow_extra_args`` and hand-parses its own meta flags. Already-JSON
+        modes are left alone so this can never *downgrade* an NDJSON stream.
+        """
+        if self.mode is OutputMode.PRETTY:
+            self.mode = OutputMode.JSON
+
     # ----- printing -----
 
     def print(self, *args: Any, **kwargs: Any) -> None:

--- a/comfy_cli/schemas/generate_list.json
+++ b/comfy_cli/schemas/generate_list.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/generate_list.json",
+  "title": "comfy generate list",
+  "description": "The partner-model catalog `comfy generate list` exposes. This is the only source of the alias list — `comfy discover` does not carry it. Under --json the summary is the FULL text, not the '…'-truncated form the human table cuts to fit its column.",
+  "type": "object",
+  "required": ["models", "count"],
+  "properties": {
+    "models": {
+      "type": "array",
+      "description": "One record per model, ordered by (partner, id) — the same order the human table renders.",
+      "items": {
+        "type": "object",
+        "required": ["alias", "id", "partner", "category", "mode", "summary"],
+        "properties": {
+          "alias": {
+            "type": "string",
+            "description": "Short creative-facing name to pass to `comfy generate <alias>` / `comfy generate schema <alias>`. Falls back to `id` when the endpoint has no curated alias. Rendered as the table's 'Model' column."
+          },
+          "id": {
+            "type": "string",
+            "description": "Canonical endpoint id (the openapi path with /proxy/ stripped), e.g. 'bfl/flux-pro-1.1/generate'. Accepted anywhere an alias is."
+          },
+          "partner": {
+            "type": "string",
+            "description": "Partner namespace — the first path segment under /proxy/ (bfl, openai, ideogram, …)."
+          },
+          "category": {
+            "type": "string",
+            "description": "Model style: text-to-image, image-edit, controlnet, inpaint, outpaint, video, … Rendered as the table's 'Style' column and filterable via `--style` / `--category`."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["sync", "async"],
+            "description": "'async' when the partner returns a job to poll (resumable via `comfy generate resume`); 'sync' when the result comes back on the create call."
+          },
+          "summary": {
+            "type": "string",
+            "description": "Full one-line description from the openapi spec — never truncated."
+          }
+        }
+      }
+    },
+    "count": {
+      "type": "integer",
+      "description": "Number of records in `models` after filtering."
+    },
+    "filters": {
+      "type": "object",
+      "description": "The filters that produced this result, echoed back. Null where the flag was not passed.",
+      "properties": {
+        "partner": { "type": ["string", "null"] },
+        "category": { "type": ["string", "null"] },
+        "query": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/comfy_cli/schemas/generate_schema.json
+++ b/comfy_cli/schemas/generate_schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/generate_schema.json",
+  "title": "comfy generate schema <model>",
+  "description": "A single partner model's callable parameters, derived from the active openapi spec. Every entry in `params` is a `--<name> <value>` flag on `comfy generate <model>`.",
+  "type": "object",
+  "required": ["model", "id", "params"],
+  "properties": {
+    "model": {
+      "type": "string",
+      "description": "Preferred short alias for the model, or the endpoint id when it has none."
+    },
+    "id": {
+      "type": "string",
+      "description": "Canonical endpoint id (the openapi path with /proxy/ stripped)."
+    },
+    "partner": {
+      "type": "string",
+      "description": "Partner namespace (bfl, openai, ideogram, …)."
+    },
+    "category": {
+      "type": "string",
+      "description": "Model style: text-to-image, image-edit, inpaint, video, … Matches the `category` field in `generate list`."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Full one-line description from the openapi spec."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["sync", "async"],
+      "description": "'async' when the partner returns a job to poll; 'sync' otherwise."
+    },
+    "polling": {
+      "type": ["string", "null"],
+      "description": "Poller family driving the async result fetch (bfl, kling, luma, topaz), or null for sync models."
+    },
+    "content_type": {
+      "type": "string",
+      "description": "Request content type the proxy call uses: 'application/json' or 'multipart/form-data'."
+    },
+    "params": {
+      "type": "array",
+      "description": "Callable parameters, required ones first.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "required", "enum", "description"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Parameter name. The CLI flag is '--' + name."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["string", "integer", "number", "boolean", "enum", "object", "array", "binary"],
+            "description": "Value type. 'enum' means `enum` below lists the only accepted values; 'binary' means a local file path streamed as multipart."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Deprecated alias of `type`, always identical to it. Retained because it is the name the pre-envelope --json payload shipped; prefer `type`."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "True when `comfy generate <model>` rejects the call without this flag."
+          },
+          "default": {
+            "description": "Default applied when the flag is omitted; null when the spec declares none."
+          },
+          "enum": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Accepted values (e.g. output_format = ['jpeg', 'png']). Empty when the parameter is not enumerated."
+          },
+          "description": {
+            "type": "string",
+            "description": "Full parameter description from the openapi spec."
+          },
+          "item_type": {
+            "type": ["string", "null"],
+            "description": "For `type` == 'array', the type of each element; null otherwise."
+          },
+          "upload_mode": {
+            "type": ["string", "null"],
+            "enum": ["base64", "url", null],
+            "description": "Set when a local file path passed to this parameter is auto-transformed before the proxy call: 'base64' inlines the bytes, 'url' uploads and substitutes a signed URL. Null means the value is sent as typed."
+          }
+        }
+      }
+    },
+    "example": {
+      "type": "string",
+      "description": "Copy-pasteable invocation filling every required parameter."
+    }
+  }
+}

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -663,6 +663,15 @@ Mechanical contracts that bite agents — encode them, don't rediscover:
   `comfy generate consent always` (revert: `consent ask`; inspect:
   `consent show`). `list` / `schema` / `refresh` / `upload` / `resume` /
   `--emit-workflow` spend nothing and are not gated.
+- **Discovery is structured — never scrape the table.** `generate list --json`
+  and `generate schema <model> --json` both emit a full renderer envelope
+  (`command: "generate list"` / `"generate schema"`, schemas `generate_list` /
+  `generate_schema` in `comfy discover`). `data.models[]` carries
+  `{alias, id, partner, category, mode, summary}` with the **untruncated**
+  summary; `data.params[]` carries `{name, type, required, default, enum,
+  description}`. Unknown model → `generate_model_unknown`; missing model arg →
+  `missing_argument`. This catalog is **not** in `comfy discover` — `generate
+  list` is the only source of the alias list.
 - **Machine-readable output:** `generate <model> --json` prints the raw API
   response as JSON; `generate upload <file> --json` emits structured
   `{url, expires_at, …}`; `generate <model> --emit-workflow out.json` goes

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -83,11 +83,16 @@ def test_list_partner_filter(runner):
 
 
 def test_list_json_emits_parseable_models(runner):
+    """--json is an `envelope/1` on stdout, never a Rich table (BE-4933).
+    Full envelope/schema coverage lives in test_list_schema_envelope.py."""
     import json
 
     r = runner.invoke(cli_app, ["generate", "list", "--json"])
     assert r.exit_code == 0
-    payload = json.loads(r.stdout)  # must be pure JSON, no Rich table
+    envelope = json.loads(r.stdout)  # must be pure JSON, no Rich table
+    assert envelope["schema"] == "envelope/1"
+    assert envelope["command"] == "generate list"
+    payload = envelope["data"]
     assert payload["count"] == len(payload["models"]) >= 1
     fields = {"alias", "id", "partner", "category", "mode", "summary"}
     assert fields <= set(payload["models"][0])
@@ -99,10 +104,13 @@ def test_schema_json_emits_parseable_params(runner):
 
     r = runner.invoke(cli_app, ["generate", "schema", "flux-pro", "--json"])
     assert r.exit_code == 0
-    payload = json.loads(r.stdout)
+    envelope = json.loads(r.stdout)
+    assert envelope["schema"] == "envelope/1"
+    assert envelope["command"] == "generate schema"
+    payload = envelope["data"]
     assert payload["model"]
     assert isinstance(payload["params"], list) and payload["params"]
-    assert {"name", "kind", "required"} <= set(payload["params"][0])
+    assert {"name", "type", "kind", "required"} <= set(payload["params"][0])
 
 
 def test_list_partner_eq_form(runner):
@@ -124,7 +132,10 @@ def test_list_query_filter(runner):
 
 
 def test_list_no_matches(runner):
-    r = runner.invoke(cli_app, ["generate", "list", "--partner", "nonexistent"])
+    # --no-json pins pretty mode: CliRunner has no TTY, and since BE-4933 a
+    # non-TTY `generate list` resolves to the JSON envelope like every other
+    # renderer-backed command.
+    r = runner.invoke(cli_app, ["--no-json", "generate", "list", "--partner", "nonexistent"])
     assert r.exit_code == 0
     assert "No models" in r.stdout
 
@@ -133,7 +144,8 @@ def test_list_no_matches(runner):
 
 
 def test_schema_alias(runner):
-    r = runner.invoke(cli_app, ["generate", "schema", "flux-pro"])
+    # --no-json pins the human prose view (see test_list_no_matches).
+    r = runner.invoke(cli_app, ["--no-json", "generate", "schema", "flux-pro"])
     assert r.exit_code == 0
     assert "prompt" in r.stdout
     assert "Example" in r.stdout

--- a/tests/comfy_cli/command/generate/test_list_schema_envelope.py
+++ b/tests/comfy_cli/command/generate/test_list_schema_envelope.py
@@ -1,0 +1,322 @@
+"""``comfy generate list`` / ``comfy generate schema`` emit ``envelope/1`` (BE-4933).
+
+These are the two discovery verbs an agent needs before it can run a partner
+model: one enumerates the aliases, the other gives a model's parameters. Both
+used to ignore the *global* ``--json`` outright (Rich table / plain prose on
+stdout, exit 0) and, when the tail ``--json`` was picked up by
+``_separate_meta_flags``, emitted a bare JSON blob rather than the versioned
+envelope every other machine-readable command in the family returns. Agents had
+to scrape box-drawing characters to get the model list — the catalog is not
+reachable any other way (``comfy discover`` does not carry it).
+
+What is pinned here:
+  - both verbs, under both ``--json`` spellings, emit one ``envelope/1`` whose
+    ``data`` validates against the command's registered schema;
+  - the summary/description text is the FULL value, not the ``…``-truncated
+    form the human table cuts to fit its column;
+  - error paths carry a registered ``error.code`` instead of an ad-hoc blob;
+  - pretty (human) output is untouched — this is an additive change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[4] / "comfy_cli" / "schemas"
+
+
+def _validator_for(schema_name: str) -> jsonschema.Validator:
+    schema = json.loads((SCHEMAS_DIR / schema_name).read_text())
+    store: dict[str, dict] = {}
+    for path in SCHEMAS_DIR.glob("*.json"):
+        s = json.loads(path.read_text())
+        if s.get("$id"):
+            store[s["$id"]] = s
+        store[path.name] = s
+    base = SCHEMAS_DIR.absolute().as_uri() + "/"
+    resolver = jsonschema.RefResolver(base_uri=base, referrer=schema, store=store)
+    return jsonschema.Draft202012Validator(schema, resolver=resolver)
+
+
+def _run(args: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
+    proc_env = os.environ.copy()
+    proc_env.setdefault("NO_COLOR", "1")
+    # Keep the CLI out of the user's real config/telemetry during the test run.
+    proc_env.setdefault("COMFY_CLI_DISABLE_TELEMETRY", "1")
+    if env:
+        proc_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "comfy_cli", *args],
+        capture_output=True,
+        text=True,
+        env=proc_env,
+        check=False,
+    )
+
+
+def _envelope(args: list[str], env: dict | None = None) -> dict:
+    result = _run(args, env=env)
+    assert result.stdout.strip(), f"empty stdout. stderr={result.stderr!r}"
+    last = [line for line in result.stdout.splitlines() if line.strip()][-1]
+    return json.loads(last)
+
+
+# Both spellings must work: the global flag the Typer callback resolves, and the
+# tail flag `generate`'s own `_separate_meta_flags` picks out of ctx.args.
+LIST_INVOCATIONS = [
+    ["--json", "generate", "list"],
+    ["generate", "list", "--json"],
+]
+SCHEMA_INVOCATIONS = [
+    ["--json", "generate", "schema", "flux-pro"],
+    ["generate", "schema", "flux-pro", "--json"],
+]
+
+
+# --------------------------------------------------------------------------- #
+# generate list
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("args", LIST_INVOCATIONS)
+def test_list_emits_valid_envelope(args):
+    envelope = _envelope(args)
+    _validator_for("envelope.json").validate(envelope)
+    assert envelope["schema"] == "envelope/1"
+    assert envelope["type"] == "envelope"
+    assert envelope["ok"] is True
+    assert envelope["command"] == "generate list"
+    assert envelope["error"] is None
+
+
+@pytest.mark.parametrize("args", LIST_INVOCATIONS)
+def test_list_payload_validates(args):
+    envelope = _envelope(args)
+    _validator_for("generate_list.json").validate(envelope["data"])
+
+
+def test_list_carries_one_record_per_model_with_the_table_columns():
+    from comfy_cli.command.generate import spec
+
+    data = _envelope(["--json", "generate", "list"])["data"]
+    assert data["count"] == len(data["models"]) == len(spec.list_endpoints())
+    assert data["count"] > 1, "catalog should not be a one-row table"
+    for row in data["models"]:
+        # alias/name, partner, style, mode, summary — the columns the table renders.
+        assert row["alias"] and row["id"] and row["partner"] and row["category"]
+        assert row["mode"] in {"sync", "async"}
+        assert isinstance(row["summary"], str)
+
+
+def test_list_summaries_are_full_not_table_truncated():
+    """The table cuts summaries at 60 chars + '…'; the JSON must not."""
+    from comfy_cli.command.generate import spec
+
+    data = _envelope(["--json", "generate", "list"])["data"]
+    by_id = {e.id: e.summary for e in spec.list_endpoints()}
+    for row in data["models"]:
+        assert row["summary"] == by_id[row["id"]]
+        assert not row["summary"].endswith("…")
+    # Guard the assertion above is meaningful: at least one summary is long
+    # enough that the table would have truncated it.
+    assert any(len(row["summary"]) > 61 for row in data["models"])
+
+
+def test_list_honors_filters_and_echoes_them():
+    envelope = _envelope(["--json", "generate", "list", "--partner", "bfl"])
+    data = envelope["data"]
+    assert data["filters"] == {"partner": "bfl", "category": None, "query": None}
+    assert data["models"], "expected at least one bfl model"
+    assert {row["partner"] for row in data["models"]} == {"bfl"}
+
+
+def test_list_with_no_matches_is_an_empty_success_not_an_error():
+    result = _run(["--json", "generate", "list", "--partner", "no-such-partner"])
+    envelope = json.loads(result.stdout.splitlines()[-1])
+    assert result.returncode == 0
+    assert envelope["ok"] is True
+    assert envelope["data"]["models"] == []
+    assert envelope["data"]["count"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# generate schema <model>
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("args", SCHEMA_INVOCATIONS)
+def test_schema_emits_valid_envelope(args):
+    envelope = _envelope(args)
+    _validator_for("envelope.json").validate(envelope)
+    assert envelope["schema"] == "envelope/1"
+    assert envelope["ok"] is True
+    assert envelope["command"] == "generate schema"
+    assert envelope["error"] is None
+
+
+@pytest.mark.parametrize("args", SCHEMA_INVOCATIONS)
+def test_schema_payload_validates(args):
+    envelope = _envelope(args)
+    _validator_for("generate_schema.json").validate(envelope["data"])
+
+
+def test_schema_params_carry_name_type_required_description():
+    data = _envelope(["--json", "generate", "schema", "flux-pro"])["data"]
+    assert data["model"] == "flux-pro"
+    assert data["id"] == "bfl/flux-pro-1.1/generate"
+    by_name = {p["name"]: p for p in data["params"]}
+
+    prompt = by_name["prompt"]
+    assert prompt["type"] == "string"
+    assert prompt["kind"] == prompt["type"], "`kind` is a retained alias of `type`"
+    assert prompt["required"] is True
+    assert prompt["description"], "descriptions must survive into JSON"
+
+
+def test_schema_surfaces_enum_values():
+    data = _envelope(["--json", "generate", "schema", "flux-pro"])["data"]
+    by_name = {p["name"]: p for p in data["params"]}
+    output_format = by_name["output_format"]
+    assert output_format["type"] == "enum"
+    assert output_format["enum"] == ["jpeg", "png"]
+    assert output_format["required"] is False
+
+
+def test_schema_descriptions_match_the_spec_verbatim():
+    from comfy_cli.command.generate import schema as gen_schema
+    from comfy_cli.command.generate import spec
+
+    endpoint = spec.get_endpoint("flux-pro")
+    expected = {f.name: f.description for f in gen_schema.flags_for(endpoint)}
+    data = _envelope(["--json", "generate", "schema", "flux-pro"])["data"]
+    assert {p["name"]: p["description"] for p in data["params"]} == expected
+
+
+def test_schema_unknown_model_emits_registered_error_code():
+    from comfy_cli import error_codes
+
+    result = _run(["--json", "generate", "schema", "definitely-not-a-model"])
+    envelope = json.loads(result.stdout.splitlines()[-1])
+    assert result.returncode == 1
+    assert envelope["ok"] is False
+    assert envelope["data"] is None
+    assert envelope["error"]["code"] == "generate_model_unknown"
+    assert error_codes.is_registered(envelope["error"]["code"])
+    assert envelope["error"]["hint"]
+    assert envelope["error"]["details"]["requested"] == "definitely-not-a-model"
+
+
+def test_schema_without_a_model_emits_registered_error_code():
+    from comfy_cli import error_codes
+
+    result = _run(["--json", "generate", "schema"])
+    envelope = json.loads(result.stdout.splitlines()[-1])
+    assert result.returncode == 1
+    assert envelope["ok"] is False
+    assert envelope["error"]["code"] == "missing_argument"
+    assert error_codes.is_registered(envelope["error"]["code"])
+
+
+# --------------------------------------------------------------------------- #
+# mode resolution
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["generate", "list", "--json"],
+        ["generate", "schema", "flux-pro", "--json"],
+        # An explicit tail --json also outranks a global --no-json: it is the
+        # more specific flag.
+        ["--no-json", "generate", "list", "--json"],
+    ],
+)
+def test_tail_json_upgrades_an_otherwise_pretty_renderer(args):
+    """`Renderer.force_json` — the tail `--json` is parsed by `generate`'s own
+    `_separate_meta_flags`, so it never reaches the global callback that
+    resolves output mode. Without the upgrade, `renderer.emit` would no-op in
+    pretty mode and the command would print nothing at all."""
+    envelope = _envelope(args, env={"COMFY_OUTPUT": "pretty"})
+    _validator_for("envelope.json").validate(envelope)
+    assert envelope["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "args", [["--json-stream", "generate", "list"], ["--json-stream", "generate", "schema", "flux-pro"]]
+)
+def test_stream_mode_emits_the_envelope_as_its_final_line(args):
+    """These verbs have no intermediate events, so NDJSON degenerates to the
+    single terminating envelope — and must not silently downgrade to JSON."""
+    result = _run(args)
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    envelope = json.loads(lines[-1])
+    assert envelope["type"] == "envelope"
+    assert envelope["ok"] is True
+
+
+def test_json_mode_leaves_stderr_clean():
+    """No Rich table leaks to stderr alongside the envelope."""
+    result = _run(["--json", "generate", "list"])
+    assert result.stderr == ""
+
+
+# --------------------------------------------------------------------------- #
+# additive: pretty output is untouched
+# --------------------------------------------------------------------------- #
+
+
+def test_pretty_list_still_renders_the_table():
+    result = _run(["generate", "list"], env={"COMFY_OUTPUT": "pretty", "COLUMNS": "100"})
+    assert result.returncode == 0
+    assert "Comfy Generate — Models" in result.stdout
+    assert "Run `comfy generate schema <model>` to see parameters" in result.stdout
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+
+
+def test_pretty_schema_still_renders_prose():
+    result = _run(["generate", "schema", "flux-pro"], env={"COMFY_OUTPUT": "pretty", "COLUMNS": "100"})
+    assert result.returncode == 0
+    assert result.stdout.startswith("Model: flux-pro")
+    assert "Parameters (use as `--name value`):" in result.stdout
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)
+
+
+def test_pretty_schema_errors_stay_plain_red_lines():
+    """Error paths keep their one-line human form — no envelope, no error panel."""
+    env = {"COMFY_OUTPUT": "pretty", "COLUMNS": "100"}
+    usage = _run(["generate", "schema"], env=env)
+    assert usage.returncode == 1
+    assert usage.stdout.strip() == "Usage: comfy generate schema <model>"
+
+    unknown = _run(["generate", "schema", "definitely-not-a-model"], env=env)
+    assert unknown.returncode == 1
+    assert unknown.stdout.startswith("Unknown model: 'definitely-not-a-model'.")
+
+
+# --------------------------------------------------------------------------- #
+# discovery registration
+# --------------------------------------------------------------------------- #
+
+
+def test_both_verbs_register_a_schema_for_discover():
+    from comfy_cli.discovery import COMMAND_SCHEMAS
+
+    assert COMMAND_SCHEMAS["comfy generate list"] == "generate_list"
+    assert COMMAND_SCHEMAS["comfy generate schema"] == "generate_schema"
+
+
+def test_discover_ships_the_new_schemas():
+    data = _envelope(["--json", "discover", "--schemas-only"])["data"]
+    assert "generate_list" in data["schemas"]
+    assert "generate_schema" in data["schemas"]


### PR DESCRIPTION
## ELI-5

`comfy generate list` tells an agent which partner models exist; `comfy generate schema flux-pro` tells it what knobs that model takes. Both used to answer with a pretty terminal table / paragraph of prose even when you asked for JSON, so the only way to read the model list from a script was to `grep` box-drawing characters. Now both answer with the same structured JSON envelope every other machine-readable comfy command returns.

## What changed

Both verbs now resolve the process renderer instead of a local `as_json` bool, and emit `envelope/1` through `renderer.emit`. Pretty (TTY) output is untouched.

- **`comfy_cli/command/generate/app.py`** — `_list_models` (was `main:544`, now `593`) and `_schema` (was `main:583`, now `626`) rewritten; new helpers `_renderer_for` (`544`), `_model_record` (`559`), `_param_record` (`573`). The mechanism the ticket suspected is confirmed: `_separate_meta_flags` (`107`, unchanged) only ever scans `ctx.args`, so a **global** `--json` — the spelling in the ticket's repro — never reached these two functions at all; the **tail** spelling was picked up but emitted a bare blob via `output.print_json` rather than an envelope.
- **`comfy_cli/output/renderer.py`** — new `Renderer.force_json` (`173`), the counterpart to the existing `force_stream` (`162`). `generate` runs with `allow_extra_args`, so its tail `--json` never reaches the global Typer callback that resolves output mode; without the upgrade `renderer.emit` would no-op in pretty mode and the command would print nothing. It only ever upgrades `PRETTY`, so it can never downgrade an NDJSON stream.
- **`comfy_cli/schemas/generate_list.json`, `generate_schema.json`** — new payload schemas, registered in `COMMAND_SCHEMAS` (`comfy_cli/discovery.py:90-94`) so `comfy discover` advertises them. The registration ratchet in `test_discovery.py` requires this for any new `emit(command=...)` site.
- **`comfy_cli/error_codes.py`** — new `generate_model_unknown` (`628`). The missing-model-argument path reuses the existing `missing_argument`. Both replace the old ad-hoc `{"error": "..."}` blob.
- **`comfy_cli/skills/comfy/SKILL.md`** — the bundled agent skill's "Partner-API one-call generation" section previously documented the machine-readable surface of `generate <model>` / `upload` / `--emit-workflow` but said nothing about `list` / `schema`. Added the contract so agents stop reaching for the table.

## Behavior

```
$ comfy --json generate list
{"schema":"envelope/1","type":"envelope","ok":true,"command":"generate list","data":{"models":[{"alias":"flux-2","id":"bfl/flux-2-pro/generate","partner":"bfl","category":"text-to-image","mode":"async","summary":"Proxy request to BFL Flux 2 Pro for image generation"}, ...],"count":52,"filters":{"partner":null,"category":null,"query":null}},"error":null}

$ comfy --json generate schema flux-pro | jq '.data.params[] | select(.name=="output_format")'
{"name":"output_format","type":"enum","kind":"enum","required":false,"default":null,"enum":["jpeg","png"],"description":"Output image format","item_type":null,"upload_mode":null}

$ comfy --json generate schema nope-9000; echo $?
{"schema":"envelope/1",...,"ok":false,"error":{"code":"generate_model_unknown","message":"Unknown model: 'nope-9000'. ...","hint":"run `comfy generate list` to see the available model aliases","details":{"requested":"nope-9000"}}}
1
```

## Acceptance criteria

| Criterion | Status |
|---|---|
| `generate list --json` → valid `envelope/1`, one structured record per model (alias, partner, style, mode, summary) | met |
| `generate schema <model> --json` → valid `envelope/1`, params as structured records with name / type / required / description / enum | met — `output_format` = `jpeg\|png`, exactly the ticket's example |
| Without `--json`, human output unchanged byte-for-byte | met in pretty/TTY mode; **one documented exception below** |
| Summary/description text is the FULL value, not `…`-truncated | met — pinned by `test_list_summaries_are_full_not_table_truncated`, which compares against `spec.list_endpoints()` and asserts at least one summary is long enough that the table *would* have cut it |
| Tests assert parseable `envelope/1` validating against the same schema `discover` / `emit-workflow` use | met — both verbs validate against `comfy_cli/schemas/envelope.json` and their own payload schema |
| Confirmed file paths + line numbers recorded here | met, above |

## Judgment calls

**1. Non-TTY without `--json` now returns the envelope, not the table.** This is the one place the change is not strictly additive, and it deserves an explicit look. The CLI's global contract (`Renderer.resolve` precedence rule 6, pinned by `test_non_tty_auto_selects_json`) is *"stdout is not a TTY → JSON"*; every renderer-backed command already behaves this way. Once these two verbs emit envelopes, they inherit it — so `comfy generate list | grep` now yields JSON rather than a table. That is the intended outcome (an agent that forgets `--json` still gets machine-readable output instead of the scraping problem this ticket is about), and it satisfies the precondition the existing module comment in `app.py` set for exactly this migration: *"Migrate only once `generate` emits envelopes via the renderer."* Interactive TTY output is byte-for-byte identical — verified by diffing all six reachable pretty paths (list, list+filter, list-with-no-matches, schema, unknown model, missing argument) against `origin/main`. `--no-json` and `COMFY_OUTPUT=pretty` force the table back in a pipe. Three existing tests in `test_app.py` were adjusted for this (two `--json` shape assertions moved to the envelope; two pretty-output assertions now pass `--no-json`, since `CliRunner` has no TTY).

**2. `data.params[]` carries both `type` and `kind`, always identical.** The ticket names `type`; `kind` is the vocabulary `generate/schema.py` uses internally and the key the pre-envelope `--json` payload shipped. Keeping both costs one field and is documented in `generate_schema.json` as a retained alias — prefer `type`.

**3. `category`, not a duplicate `style` key.** The human table's column header is "Style" but the shipped field name (and the `--style`/`--category` filter target) is `category`. Rather than fork the contract with a synonym, the schema documents the mapping.

**4. Additions beyond the strict minimum**, all optional and schema-documented: `filters` echoed back on `list`; `partner`/`category`/`summary`/`mode`/`polling`/`content_type`/`example` on `schema`; `item_type`/`upload_mode` per param (`upload_mode` tells an agent that a local file path passed to that field is auto-base64'd or auto-uploaded — non-obvious and otherwise undiscoverable).

**5. Left alone deliberately.** The other reserved sub-actions (`refresh`, `upload`, `resume`, `consent`) are out of scope per the ticket. Also pre-existing and untouched: `_separate_meta_flags` raises an uncaught `SchemaError` on a valueless meta flag (`comfy generate list --timeout`), which surfaces as a traceback rather than a structured error — same on `main`, unrelated to `--json`, and fixing it would widen this diff into the shared parser every `generate` path uses.

## Negative-claim falsification

The diff adds an "Unknown model" denial string, which trips the falsification trigger, so: this is not a new dead-end. `main` already prints `Unknown model: '<x>'` and exits 1 for the same input — the change only re-codes that existing denial as a structured `generate_model_unknown` error, and no test was flipped to assert a dead-end. The denial is also not terminal: its `hint` and `details.requested` point at `comfy generate list`, which was exercised live and returns all 52 models. The diff's net user-facing effect is to *add* a capability (structured discovery), not remove one.

## Testing

- `tests/comfy_cli/command/generate/test_list_schema_envelope.py` — 28 new tests: envelope + payload-schema validation for both verbs under both `--json` spellings; full-summary/full-description parity against the spec; filter echo; empty result as `ok:true` exit 0; both error codes with registry membership; `force_json` upgrading a pretty renderer (including over a global `--no-json`); NDJSON mode terminating in the envelope; stderr clean in JSON mode; pretty output preserved on all paths; discover registration.
- Full suite: **2986 passed, 37 skipped**.
- `ruff check` + `ruff format --diff` clean at the CI-pinned `0.15.15`.
