### PR TITLE
fix(generate): drop wrong flux-pro emit mapping, add flux-ultra (BE-4937)

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -804,7 +804,7 @@ def _print_top_help() -> None:
     )
     rprint('  comfy generate dalle --prompt "a watercolor whale" --download whale.png')
     rprint(
-        '  comfy generate flux-pro --prompt "a fox" --emit-workflow flux.json   '
+        '  comfy generate flux-2 --prompt "a fox" --emit-workflow flux.json   '
         "[dim]# write a runnable workflow instead of calling the proxy[/dim]"
     )
     rprint("")

--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -222,8 +222,19 @@ def build_workflow(model: str, values: dict[str, Any], *, output_prefix: str = "
 
     # Nodes that take an aspect ratio instead of width/height: fold the two
     # proxy flags into the node's single "W:H" input when both are present.
-    if ns.aspect_from_wh and values.get("width") and values.get("height"):
-        node_inputs[ns.aspect_from_wh] = f"{values['width']}:{values['height']}"
+    # A lone --width/--height has no fixed default to fall back on here (unlike
+    # flux-2's independent param_map entries), so silently keeping the default
+    # aspect ratio would drop the user's flag with no error - fail loudly instead.
+    if ns.aspect_from_wh:
+        width_given = values.get("width") is not None
+        height_given = values.get("height") is not None
+        if width_given != height_given:
+            raise EmitError(
+                f"--emit-workflow for {model!r} needs --width and --height together "
+                "to set the aspect ratio; only one was provided."
+            )
+        if width_given and height_given:
+            node_inputs[ns.aspect_from_wh] = f"{values['width']}:{values['height']}"
 
     partner = {
         "class_type": ns.node_class,

--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -32,6 +32,11 @@ class EmitError(RuntimeError):
 class NodeSpec:
     """How to render one partner model as a ComfyUI node.
 
+    ``endpoint`` is the canonical ``/proxy/`` endpoint id the node's ``execute()``
+    posts to (read off the ComfyUI source). It must equal the endpoint the alias
+    itself proxies to — otherwise ``--emit-workflow`` would silently swap the
+    model out from under the user; ``test_emit.py`` asserts that invariant.
+
     ``param_map`` maps a ``comfy generate`` flag name → the partner node's input
     key. ``image_params`` lists flag names whose value is a local image path
     that must be materialized with a ``LoadImage`` node and wired into the
@@ -42,11 +47,15 @@ class NodeSpec:
     """
 
     node_class: str
+    endpoint: str  # canonical /proxy/ endpoint id the node's execute() posts to
     param_map: dict[str, str]
     output: str  # "IMAGE" | "VIDEO"
     fixed: dict[str, Any] = field(default_factory=dict)
     image_params: dict[str, str] = field(default_factory=dict)  # flag -> node input key
     media_port: int = 0
+    # Node input to set to "{width}:{height}" when the user passes both flags —
+    # for nodes that take an aspect ratio where the proxy schema takes w/h.
+    aspect_from_wh: str | None = None
 
 
 # proxy model alias → partner node spec. Param keys are the *generate* flag
@@ -56,6 +65,7 @@ MODEL_NODE_MAP: dict[str, NodeSpec] = {
     # Google Gemini Flash Image (nano-banana). Node: GeminiImageNode.
     "nano-banana": NodeSpec(
         node_class="GeminiImageNode",
+        endpoint="vertexai/gemini/{model}",
         param_map={
             "prompt": "prompt",
             "model": "model",
@@ -69,6 +79,7 @@ MODEL_NODE_MAP: dict[str, NodeSpec] = {
     # ByteDance Seedance image-to-video. Node: ByteDanceImageToVideoNode.
     "seedance": NodeSpec(
         node_class="ByteDanceImageToVideoNode",
+        endpoint="byteplus/api/v3/contents/generations/tasks",
         param_map={
             "prompt": "prompt",
             "model": "model",
@@ -86,9 +97,16 @@ MODEL_NODE_MAP: dict[str, NodeSpec] = {
         },
         output="VIDEO",
     ),
-    # BFL Flux (text-to-image). Node: Flux2ProImageNode.
-    "flux-pro": NodeSpec(
+    # BFL Flux 2 [pro] (text-to-image). Node: Flux2ProImageNode.
+    #
+    # There is deliberately NO "flux-pro" entry: that alias means BFL Flux Pro
+    # 1.1 (`bfl/flux-pro-1.1/generate`), and ComfyUI has no node for it — the
+    # only `flux-pro-1.1` node is the Ultra variant below. Mapping it to
+    # Flux2ProImageNode would emit a workflow for a *different* model, so
+    # `flux-pro` falls through to the EmitError instead.
+    "flux-2": NodeSpec(
         node_class="Flux2ProImageNode",
+        endpoint="bfl/flux-2-pro/generate",
         param_map={
             "prompt": "prompt",
             "width": "width",
@@ -99,21 +117,24 @@ MODEL_NODE_MAP: dict[str, NodeSpec] = {
         fixed={"width": 1024, "height": 768, "seed": 0, "prompt_upsampling": True},
         output="IMAGE",
     ),
-    "flux-2": NodeSpec(
-        node_class="Flux2ProImageNode",
+    # BFL Flux 1.1 [pro] Ultra (text-to-image). Node: FluxProUltraImageNode.
+    # The node takes an `aspect_ratio` string where the proxy schema takes
+    # width/height, so w/h are folded into it via `aspect_from_wh`.
+    "flux-ultra": NodeSpec(
+        node_class="FluxProUltraImageNode",
+        endpoint="bfl/flux-pro-1.1-ultra/generate",
         param_map={
             "prompt": "prompt",
-            "width": "width",
-            "height": "height",
             "seed": "seed",
-            "prompt_upsampling": "prompt_upsampling",
         },
-        fixed={"width": 1024, "height": 768, "seed": 0, "prompt_upsampling": True},
+        fixed={"aspect_ratio": "16:9", "raw": False, "prompt_upsampling": False, "seed": 0},
+        aspect_from_wh="aspect_ratio",
         output="IMAGE",
     ),
     # Kling image-to-video. Node: KlingImage2VideoNode.
     "kling-i2v": NodeSpec(
         node_class="KlingImage2VideoNode",
+        endpoint="kling/v1/videos/image2video",
         param_map={
             "prompt": "prompt",
             "negative_prompt": "negative_prompt",
@@ -198,6 +219,11 @@ def build_workflow(model: str, values: dict[str, Any], *, output_prefix: str = "
     for flag, node_key in ns.param_map.items():
         if flag in values and values[flag] is not None:
             node_inputs[node_key] = values[flag]
+
+    # Nodes that take an aspect ratio instead of width/height: fold the two
+    # proxy flags into the node's single "W:H" input when both are present.
+    if ns.aspect_from_wh and values.get("width") and values.get("height"):
+        node_inputs[ns.aspect_from_wh] = f"{values['width']}:{values['height']}"
 
     partner = {
         "class_type": ns.node_class,

--- a/tests/comfy_cli/command/generate/test_emit.py
+++ b/tests/comfy_cli/command/generate/test_emit.py
@@ -112,6 +112,20 @@ def test_build_flux_ultra_without_width_height_keeps_default_aspect_ratio():
     assert wf["1"]["inputs"]["aspect_ratio"] == "16:9"
 
 
+def test_build_flux_ultra_only_width_errors_instead_of_dropping_it():
+    # flux-ultra has no fixed width/height fallback (unlike flux-2), so a lone
+    # --width would otherwise be silently dropped in favor of the "16:9" default.
+    with pytest.raises(emit.EmitError) as ei:
+        emit.build_workflow("flux-ultra", {"prompt": "a fox", "width": 1024})
+    assert "--width" in str(ei.value) and "--height" in str(ei.value)
+
+
+def test_build_flux_ultra_only_height_errors_instead_of_dropping_it():
+    with pytest.raises(emit.EmitError) as ei:
+        emit.build_workflow("flux-ultra", {"prompt": "a fox", "height": 768})
+    assert "--width" in str(ei.value) and "--height" in str(ei.value)
+
+
 def test_emitted_workflow_is_api_format_node_ids_are_strings():
     wf = emit.build_workflow("flux-2", {"prompt": "p"})
     for k, node in wf.items():

--- a/tests/comfy_cli/command/generate/test_emit.py
+++ b/tests/comfy_cli/command/generate/test_emit.py
@@ -9,7 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from comfy_cli.cmdline import app as cli_app
-from comfy_cli.command.generate import emit
+from comfy_cli.command.generate import emit, spec
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +27,7 @@ def runner():
 
 
 def test_build_flux_text_to_image_class_type_and_params():
-    wf = emit.build_workflow("flux-pro", {"prompt": "a fox", "width": 512})
+    wf = emit.build_workflow("flux-2", {"prompt": "a fox", "width": 512})
     # partner node is "1"
     assert wf["1"]["class_type"] == "Flux2ProImageNode"
     assert wf["1"]["inputs"]["prompt"] == "a fox"
@@ -71,11 +71,49 @@ def test_unknown_model_lists_supported():
     with pytest.raises(emit.EmitError) as ei:
         emit.build_workflow("dalle", {"prompt": "x"})
     msg = str(ei.value)
-    assert "flux-pro" in msg and "nano-banana" in msg
+    assert "flux-2" in msg and "flux-ultra" in msg and "nano-banana" in msg
+
+
+def test_every_mapped_node_endpoint_matches_its_alias():
+    # A NodeSpec's endpoint records what the ComfyUI node actually calls;
+    # the alias must proxy to the same endpoint, or emit silently swaps models.
+    assert emit.MODEL_NODE_MAP, "an empty map would make this invariant vacuous"
+    known = spec.aliases()
+    for alias, ns in emit.MODEL_NODE_MAP.items():
+        # `resolve_alias` echoes an unrecognized name back unchanged, so a
+        # typo'd key would otherwise satisfy the equality below against itself.
+        assert alias in known, alias
+        assert spec.resolve_alias(alias) == ns.endpoint, alias
+
+
+def test_flux_pro_is_rejected_no_node_for_flux_pro_1_1():
+    # `flux-pro` means BFL Flux Pro 1.1, which has no ComfyUI node — emit must
+    # fail loudly rather than quietly emit a graph for a different Flux model.
+    with pytest.raises(emit.EmitError) as ei:
+        emit.build_workflow("flux-pro", {"prompt": "x"})
+    assert "flux-ultra" in str(ei.value)
+
+
+def test_build_flux_ultra_folds_width_height_into_aspect_ratio():
+    wf = emit.build_workflow("flux-ultra", {"prompt": "a fox", "width": 1024, "height": 768})
+    assert wf["1"]["class_type"] == "FluxProUltraImageNode"
+    # the node takes an aspect ratio, not w/h — the two flags fold into it
+    assert wf["1"]["inputs"]["aspect_ratio"] == "1024:768"
+    assert wf["1"]["inputs"]["prompt"] == "a fox"
+    # the Ultra node's own default, unlike Flux2Pro's True
+    assert wf["1"]["inputs"]["prompt_upsampling"] is False
+    save = [n for n in wf.values() if n["class_type"] == "SaveImage"]
+    assert len(save) == 1
+    assert save[0]["inputs"]["images"] == ["1", 0]
+
+
+def test_build_flux_ultra_without_width_height_keeps_default_aspect_ratio():
+    wf = emit.build_workflow("flux-ultra", {"prompt": "a fox"})
+    assert wf["1"]["inputs"]["aspect_ratio"] == "16:9"
 
 
 def test_emitted_workflow_is_api_format_node_ids_are_strings():
-    wf = emit.build_workflow("flux-pro", {"prompt": "p"})
+    wf = emit.build_workflow("flux-2", {"prompt": "p"})
     for k, node in wf.items():
         assert isinstance(k, str)
         assert "class_type" in node
@@ -91,7 +129,7 @@ def test_cli_emit_writes_file_no_api_key(runner, tmp_path, monkeypatch):
     out = tmp_path / "wf.json"
     r = runner.invoke(
         cli_app,
-        ["generate", "flux-pro", "--prompt", "a cat", "--emit-workflow", str(out)],
+        ["generate", "flux-2", "--prompt", "a cat", "--emit-workflow", str(out)],
     )
     assert r.exit_code == 0, r.stdout
     assert out.is_file()
@@ -128,7 +166,7 @@ def test_emit_workflow_uses_envelope(runner, monkeypatch, tmp_path):
     out = tmp_path / "wf.json"
     r = runner.invoke(
         cli_app,
-        ["generate", "flux-pro", "--prompt", "x", "--width", "1024", "--height", "768", "--emit-workflow", str(out)],
+        ["generate", "flux-2", "--prompt", "x", "--width", "1024", "--height", "768", "--emit-workflow", str(out)],
     )
     assert r.exit_code == 0, r.stdout
     lines = [ln for ln in r.stdout.splitlines() if ln.strip().startswith("{")]
@@ -157,7 +195,7 @@ def test_cli_emit_output_prefix(runner, tmp_path, monkeypatch):
         cli_app,
         [
             "generate",
-            "flux-pro",
+            "flux-2",
             "--prompt",
             "p",
             "--emit-workflow",

--- a/tests/comfy_cli/command/generate/test_spend_gate.py
+++ b/tests/comfy_cli/command/generate/test_spend_gate.py
@@ -167,7 +167,7 @@ def test_interactive_prompt_default_is_no(runner, api_key, post_spy, interactive
 def test_emit_workflow_is_not_gated(runner, post_spy, tmp_path):
     # --emit-workflow writes a local artifact, calls no proxy, spends nothing.
     out = tmp_path / "wf.json"
-    r = runner.invoke(cli_app, ["generate", "flux-pro", "--prompt", "x", "--emit-workflow", str(out)])
+    r = runner.invoke(cli_app, ["generate", "flux-2", "--prompt", "x", "--emit-workflow", str(out)])
     assert r.exit_code == 0, r.stdout
     assert out.exists()
     assert post_spy == []


### PR DESCRIPTION
## ELI-5

If you typed `comfy generate flux-pro --emit-workflow x.json`, you got a workflow file that ran a **different model** than the one you asked for. `flux-pro` means BFL *Flux Pro 1.1*, but the emitted graph ran `Flux2ProImageNode` — BFL *Flux 2 Pro*. Same brand, different model, silently. This PR stops that: `flux-pro` now fails with a clear message instead of lying, `flux-ultra` is added (it has a real node), and a new test makes this class of mix-up impossible to reintroduce.

## What changed

- **Removed the `flux-pro` → `Flux2ProImageNode` mapping.** No alias/redirect — it falls through to the existing `EmitError` that lists supported models, which is the module's stated fail-loudly design. The canonical-id form (`bfl/flux-pro-1.1/generate`) fails identically, since `preferred_alias` resolves it back to `flux-pro`.
- **Added `flux-ultra` → `FluxProUltraImageNode`** (`bfl/flux-pro-1.1-ultra/generate`) — this one genuinely exists and is registered.
- **`NodeSpec` gains a required `endpoint` field**, recording the canonical `/proxy/` endpoint id the node's `execute()` actually posts to (read off ComfyUI source, not copied from `spec.py` — see the verification table below).
- **New invariant test** asserting `spec.resolve_alias(alias) == ns.endpoint` for every mapping. This is the regression guard the original bug slipped past.
- **New `aspect_from_wh` hook.** `FluxProUltraImageNode` takes an `aspect_ratio` string where the proxy schema takes `width`/`height`, so when both flags are present they fold into `"{width}:{height}"`. Without them, the node's own `"16:9"` default stands.
- **Help example** at `app.py` now uses `flux-2` for `--emit-workflow`. The plain proxy `flux-pro` example is untouched and still valid.

## Negative-claim falsification

This diff **denies a capability**, so per the falsification discipline I went and empirically looked for a Flux Pro 1.1 node rather than just asserting my own premise in a test. Evidence, against `Comfy-Org/ComfyUI@origin/master`:

- `git grep -n "flux-pro-1.1" origin/master` over the **entire repo** returns exactly **one** hit: `comfy_api_nodes/nodes_bfl.py:121` → `/proxy/bfl/flux-pro-1.1-ultra/generate`. There is no node anywhere that posts to the non-Ultra `/proxy/bfl/flux-pro-1.1/generate`.
- `BFLExtension.get_node_list()` registers ten BFL nodes; none is a Flux Pro 1.1 node. The former candidate `FluxProImageNode` is absent from master — `git log -S FluxProImageNode` shows it removed in `5c7b08ca` ("[API Nodes] add Flux.2 Pro node", #10880).
- The one combined node with a model dropdown, `Flux2ImageNode`, offers only `Flux.2 [pro]` and `Flux.2 [max]` (`nodes_bfl.py:842-843`) — not Flux Pro 1.1. So there is no alternate route to the capability either.

Conclusion: the denial is real, and there is no working path to redirect users to. Users who want a Flux Pro 1.1 *image* still have the proxy path (`comfy generate flux-pro --prompt …`), which is unaffected by this PR.

## Endpoint verification

Every `endpoint=` value was read from ComfyUI node source, not from `comfy-cli`'s own `spec.py` — otherwise the invariant test would be tautological.

| alias | node | ComfyUI source |
|---|---|---|
| `nano-banana` | `GeminiImageNode` | `nodes_gemini.py:1001` |
| `seedance` | `ByteDanceImageToVideoNode` | `nodes_bytedance.py:99` (`BYTEPLUS_TASK_ENDPOINT`) |
| `flux-2` | `Flux2ProImageNode` | `nodes_bfl.py:689` (`API_ENDPOINT`) |
| `flux-ultra` | `FluxProUltraImageNode` | `nodes_bfl.py:121` |
| `kling-i2v` | `KlingImage2VideoNode` | `nodes_kling.py:119` + `KLING_API_VERSION = "v1"` |

`FluxProUltraImageNode`'s schema was read directly (`nodes_bfl.py:33-130`) to source the fixed defaults: `prompt_upsampling` defaults to **False** here, unlike Flux2Pro's True.

## Testing

Verified live against the built CLI, not just in unit tests:

- `comfy --json generate flux-pro --prompt x --emit-workflow …` → exit **1**, `emit_workflow_failed`, `Supported models: flux-2, flux-ultra, kling-i2v, nano-banana, seedance`.
- `comfy generate flux-ultra --prompt x --emit-workflow …` → node `"1"` is `FluxProUltraImageNode`, `aspect_ratio` `"16:9"`, `prompt_upsampling` false, `SaveImage` wired to `["1", 0]`.
- With `--width 1024 --height 768` → `aspect_ratio` `"1024:768"`.
- `comfy generate flux-2 --prompt x --emit-workflow …` → unchanged (`Flux2ProImageNode`, 1024/768 defaults).
- Canonical-id forms behave the same: `bfl/flux-pro-1.1/generate` fails, `bfl/flux-pro-1.1-ultra/generate` emits the Ultra node.
- **Mutation check on the new invariant test:** re-inserting the pre-fix `flux-pro` entry makes it fail with `AssertionError: flux-pro`. It genuinely catches the bug it is there to catch.
- Full suite: **2860 passed, 13 skipped**. `ruff check` + `ruff format --diff` clean under the CI-pinned `ruff==0.15.15`.

## Judgment calls

- **Hardened the invariant test beyond the spec.** `spec.resolve_alias` echoes an unrecognized name back unchanged, so a typo'd map key (`"flux-ultrra"` with a matching typo'd endpoint) would have satisfied the equality against itself. Added `assert alias in spec.aliases()` plus a non-empty-map guard so the assertion can't be vacuous.
- **Also updated `test_spend_gate.py:170`** (`test_emit_workflow_is_not_gated`), which the ticket's file list did not mention but which used `flux-pro` as a valid emit model and would otherwise have failed.
- **`aspect_from_wh` uses truthiness** (`values.get("width")`), so `--width 0` is ignored rather than producing an invalid `"0:768"`. Deliberate.
- **No clamping of out-of-range ratios.** `FluxProUltraImageNode` validates `aspect_ratio` to 1:4–4:1, so e.g. `--width 100 --height 1000` emits `"100:1000"` and is rejected at run time by the node. I chose a clear node-side error over silently altering the dimensions the user asked for.
- **Left `flux-2` on the deprecated-but-registered `Flux2ProImageNode`** and did not add mappings for other aliases with existing nodes — both explicitly out of scope.

## Known limitation

The invariant test catches **alias↔endpoint** drift. It cannot catch **endpoint↔node-class** drift, because `endpoint` is hand-recorded from ComfyUI source — nothing in this repo can verify that `FluxProUltraImageNode` still posts where we say it does. Closing that would need the ComfyUI node schemas available at test time; out of scope here.
