### PR TITLE
ci(groom): add the shared groom caller, daily tick with a tunable cadence variable

### DIFF
--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -1,0 +1,89 @@
+name: Groom
+
+# Thin caller for the shared reusable code-cleanup sweep. All of the logic (the
+# two-phase finder then independent verifier audit, the durable dedup ledger, the
+# GitHub-issue sink) lives in Comfy-Org/github-workflows. This repo carries only
+# the pin and its cadence, exactly like the other shared-workflow callers here.
+#
+# FINDS ONLY. The opt-in auto-builder (`builder: true`, which turns findings into
+# review-gated PRs) is deliberately left OFF. Groom files issues a human triages;
+# it opens no PRs, writes no commits, and never merges.
+#
+# CADENCE lives in the repo Actions variable GROOM_INTERVAL_DAYS, not in this
+# file. Retuning is a variable edit with no workflow change:
+#
+#   gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-cli --body 14
+#
+# PREREQUISITE (operator): `secrets.ANTHROPIC_API_KEY` must reach this repo, at
+# org or repo level. The finder and verifier agents bill through it and the
+# reusable declares it required, so an absent key fails the run LOUD at the agent
+# step by design rather than leaving the sweep silently inert. `vars.APP_ID` plus
+# `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are optional: with them, issues are filed
+# as cloud-code-bot, and without them the reusable degrades to
+# github-actions[bot] rather than failing.
+
+on:
+  schedule:
+    # DAILY base tick, deliberately NOT the effective cadence. GitHub Actions cron
+    # is static in the file, so "every N days" is a frequent tick plus the
+    # reusable's runtime interval gate: a tick inside GROOM_INTERVAL_DAYS of the
+    # last real run no-ops cheaply, before the finder ever spins up. Never fires
+    # on a PR. Off-peak and on a non-round minute to dodge scheduler congestion,
+    # staggered from the other groom callers so the org's runs do not all land in
+    # the same minute.
+    - cron: '53 9 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >-
+          Run the full audit and dedup but do NOT open issues. Prints what WOULD
+          be filed to the job summary. Use this for the first run to confirm the
+          agent credentials resolve and to eyeball finding quality before
+          trusting live filing.
+        type: boolean
+        default: false
+
+# NOTE: intentionally NO caller-level `concurrency:`. The reusable already
+# declares `concurrency: groom-${{ github.repository }}` (cancel-in-progress:
+# false), which is the real TOCTOU guard for the read-then-file dedup ledger.
+# Repeating that group here would DEADLOCK the run: the caller would hold the
+# group while its `uses:` job waits on the identical group.
+
+jobs:
+  groom:
+    permissions:
+      # REQUIRED UNION. A reusable's nested jobs cannot request more GITHUB_TOKEN
+      # scope than the caller grants, and GitHub validates this at STARTUP, so a
+      # short grant fails the run before any job with an opaque "workflow file
+      # issue".
+      contents: read
+      issues: write
+      pull-requests: read
+      # REQUIRED by the reusable's `gate` job, which lists THIS caller's Actions
+      # run history to find the last real groom run for the interval gate.
+      # Omitting it rejects the run outright ("requesting 'actions: read', but is
+      # only allowed 'actions: none'").
+      actions: read
+    uses: Comfy-Org/github-workflows/.github/workflows/groom.yml@ece4c3eaa71812a5a665f48d5d1f4bb0ff5f655e # main @ ece4c3e
+    with:
+      # File as cloud-code-bot (App token) rather than github-actions[bot]. Absent
+      # APP_ID degrades to github-actions[bot] instead of failing.
+      bot_app_id: ${{ vars.APP_ID }}
+      # Keep the assets ref (finder and verifier briefs plus dedup ledger) in
+      # lock-step with the `uses:` ref above, so a run always loads the briefs
+      # that match the workflow filing the issues.
+      workflows_ref: ece4c3eaa71812a5a665f48d5d1f4bb0ff5f655e
+      # Manual dispatch can dry-run; the scheduled run always files live.
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+      # Effective cadence. A tick inside this window no-ops before the
+      # finder spins up, so retuning is a repo-variable edit with no workflow
+      # change. Fallback 7 matches this repo's recent merge activity.
+      interval_days: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
+      # Volume-gate window, kept in lock-step with the cadence above: skip the
+      # expensive audit when nothing merged in that window. A dry-run bypasses it
+      # so the spot-check always exercises the full audit.
+      cadence: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
+      volume_gate: ${{ github.event.inputs.dry_run != 'true' }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLOUD_CODE_BOT_PRIVATE_KEY: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -14,13 +14,27 @@ name: Groom
 #
 #   gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-cli --body 14
 #
+# Expected value: a whole number of days, sensibly 1..30 (7 is the fallback when
+# the variable is unset or empty). The reusable owns normalization — its parser
+# degrades blank/garbage/negative to 7 — so a typo cannot fail the run closed.
+# Two values are meaningful but sharp, so set them deliberately: `0` DISABLES the
+# interval throttle (the sweep then runs on every daily tick), and a very large
+# value parks the sweep indefinitely. Both are silent, so prefer a value in range
+# over using this variable as an off switch — to stop grooming, disable the
+# workflow.
+#
 # PREREQUISITE (operator): `secrets.ANTHROPIC_API_KEY` must reach this repo, at
 # org or repo level. The finder and verifier agents bill through it and the
 # reusable declares it required, so an absent key fails the run LOUD at the agent
-# step by design rather than leaving the sweep silently inert. `vars.APP_ID` plus
-# `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are optional: with them, issues are filed
-# as cloud-code-bot, and without them the reusable degrades to
-# github-actions[bot] rather than failing.
+# step by design rather than leaving the sweep silently inert.
+#
+# `vars.APP_ID` and `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are optional, but they
+# are ALL-OR-NOTHING and must be set/rotated together. The reusable gates App
+# token minting on `bot_app_id != ''` — the ID alone, NOT the key — so it
+# degrades to github-actions[bot] only when APP_ID is absent. With APP_ID present
+# (including inherited from the org) and the private key missing or rotated out,
+# the token step fails in the `file` job, i.e. AFTER the finder and verifier have
+# already billed, discarding that run's findings. If you unset one, unset both.
 
 on:
   schedule:
@@ -40,6 +54,15 @@ on:
           be filed to the job summary. Use this for the first run to confirm the
           agent credentials resolve and to eyeball finding quality before
           trusting live filing.
+        type: boolean
+        default: false
+      force:
+        description: >-
+          Run the audit even if nothing merged recently (turns the reusable's
+          volume gate OFF for this dispatch). `workflow_dispatch` already
+          bypasses the interval gate, but NOT the volume gate, so without this a
+          live manual run on a quiet repo silently no-ops with no failure signal.
+          Ignored on the schedule, which always keeps the gate on.
         type: boolean
         default: false
 
@@ -74,7 +97,20 @@ jobs:
       # that match the workflow filing the issues.
       workflows_ref: ece4c3eaa71812a5a665f48d5d1f4bb0ff5f655e
       # Manual dispatch can dry-run; the scheduled run always files live.
-      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+      #
+      # BOTH comparisons are load-bearing, and the `inputs` context is NOT usable
+      # here. A `type: boolean` dispatch input arrives as the STRING 'true' from
+      # the Actions UI but as a JSON BOOLEAN from a REST/`gh api -F` dispatch, and
+      # GitHub compares mismatched types by coercing to number — boolean true
+      # becomes 1 while 'true' becomes NaN, so `true == 'true'` is FALSE. Testing
+      # only the string form would silently downgrade an API-requested dry run to
+      # a live, issue-filing run: failing open toward the destructive side. The
+      # typed `inputs` context would collapse both cases, but it is empty on the
+      # `schedule` event (workflow_dispatch defaults are not applied there), so it
+      # would feed '' to these boolean reusable inputs on every scheduled tick.
+      # Reading the raw payload and accepting either shape is correct on both
+      # triggers: on `schedule` the key is absent, so both sides are false.
+      dry_run: ${{ github.event.inputs.dry_run == 'true' || github.event.inputs.dry_run == true }}
       # Effective cadence. A tick inside this window no-ops before the
       # finder spins up, so retuning is a repo-variable edit with no workflow
       # change. Fallback 7 matches this repo's recent merge activity.
@@ -83,7 +119,15 @@ jobs:
       # expensive audit when nothing merged in that window. A dry-run bypasses it
       # so the spot-check always exercises the full audit.
       cadence: ${{ vars.GROOM_INTERVAL_DAYS || '7' }}
-      volume_gate: ${{ github.event.inputs.dry_run != 'true' }}
+      # An explicit `force` also bypasses it — the only way to make a LIVE manual
+      # run reach the finder on a quiet repo. Same dual string/boolean comparison
+      # as dry_run above, for the same reason.
+      volume_gate: ${{ !(github.event.inputs.dry_run == 'true' || github.event.inputs.dry_run == true) && !(github.event.inputs.force == 'true' || github.event.inputs.force == true) }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      CLOUD_CODE_BOT_PRIVATE_KEY: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}
+      # NAME ON THE LEFT IS THE REUSABLE'S, not this repo's. The reusable declares
+      # `BOT_APP_PRIVATE_KEY` under `on.workflow_call.secrets`; GitHub validates
+      # reusable secret names at STARTUP, so passing our local secret's name as the
+      # key fails every tick and dispatch before any job runs ("Invalid secret,
+      # CLOUD_CODE_BOT_PRIVATE_KEY is not defined in the referenced workflow").
+      BOT_APP_PRIVATE_KEY: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds the shared groom caller from Comfy-Org/github-workflows. Groom runs a two-phase audit (a finder, then an independent verifier on a fresh session) over a clean default-branch checkout, and files the surviving refactor candidates as `groom`-labeled issues. Finds only: no commits, no PRs, no merges.

Follows the pattern from https://github.com/Comfy-Org/cloud/pull/5674, where the cadence lives in a repo Actions variable instead of the cron line.

## ELI5

A robot reads this repo once every few days, writes down cleanup ideas it is confident about, and files them as issues. A second robot checks the first one's homework before anything gets filed. Neither robot can change any code. How often it runs is a setting you can change in the repo settings, without editing this file.

## Cadence

The daily cron is only a tick. The real cadence is the reusable's runtime interval gate, which reads `vars.GROOM_INTERVAL_DAYS` on every run and no-ops cheaply if the last real run was inside that window. The fallback is 7 days, chosen from this repo's recent activity (81 commits in the last 13 weeks). Retune with no workflow change:

    gh variable set GROOM_INTERVAL_DAYS --repo Comfy-Org/comfy-cli --body 14

## Precondition to verify before the first scheduled run

`secrets.ANTHROPIC_API_KEY` must reach this repo. It is not set at repo level here, and it does not need to be: the `ANTHROPIC_API_KEY` secret is set org-wide on Comfy-Org, which is how Comfy-Org/cloud grooms green with no repo-level key of its own. No secret work is needed before merging.

A `workflow_dispatch` run with `dry_run: true` is the cheapest way to confirm credentials resolve and to eyeball finding quality before trusting live filing. Dispatch bypasses the interval gate.

## Follow-up (required, and not in this PR)

Once this merges, this repo must be added to the `GROOM_CALLERS` Actions variable on Comfy-Org/github-workflows. Without that, the SHA pinned above is never bumped and this caller silently drifts from the reusable it calls.