### PR TITLE
feat(node): add `comfy node deps --registry <node-id>` pre-install dependency report (BE-4774)

### DIFF
--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -1002,12 +1002,40 @@ def deps(
             autocompletion=installed_pack_completer,
         ),
     ] = None,
+    registry: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--registry",
+            show_default=False,
+            help=(
+                "Registry node id of a NOT-yet-installed pack to include, so its declared dependencies can be "
+                "checked for conflicts before installing. Repeatable, and additive with the pack names above. "
+                "Always reports the pack's LATEST published version: the registry exposes no read-only endpoint "
+                "for a pinned version's dependencies. Installs nothing."
+            ),
+            autocompletion=node_completer,
+        ),
+    ] = None,
+    refresh: Annotated[
+        bool,
+        typer.Option(
+            "--refresh",
+            help="Bypass the 1h cache of registry lookups (only affects --registry).",
+        ),
+    ] = False,
 ):
-    # Native + read-only on purpose: no cm-cli, no pip install, no network, so
-    # it works on a workspace that never installed ComfyUI-Manager.
+    # Native + read-only on purpose: no cm-cli, no pip install, and no network
+    # at all unless --registry is passed (a side-effect-free GET /nodes/{id}) —
+    # so it works on a workspace that never installed ComfyUI-Manager.
     from comfy_cli.command import node_deps
 
-    node_deps.execute(get_renderer(), workspace_manager.workspace_path, pack_names)
+    node_deps.execute(
+        get_renderer(),
+        workspace_manager.workspace_path,
+        pack_names,
+        registry_ids=registry,
+        refresh=refresh,
+    )
 
 
 def validate_node_for_publishing():

--- a/comfy_cli/command/node_deps.py
+++ b/comfy_cli/command/node_deps.py
@@ -78,6 +78,21 @@ REGISTRY_CACHE_PREFIX = "deps-registry:"
 
 NO_REGISTRY_DEPENDENCY_METADATA = "registry did not return dependency metadata for this pack"
 
+# A registry node id is an opaque server-side slug that ``RegistryAPI.get_node``
+# interpolates unescaped into ``GET {base_url}/nodes/{id}``. Every id in the
+# public registry matches this charset, so nothing legitimate is rejected — but
+# ``/``, ``?`` and ``#`` are URL-significant: ``--registry <pack>/install``
+# would build the exact URL of ``install_node`` (itself a GET on
+# ``/nodes/{id}/install``, which records an installation server-side), and
+# ``?``/``#`` inject a query string or truncate the path. A read-only report
+# must not be steerable into those, so ids are validated before any request.
+_REGISTRY_NODE_ID_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+# A registry failure message is server-controlled text — on a captive-portal or
+# misbehaving-proxy network it is a whole HTML page — and gets copied into the
+# single-line JSON envelope consumers parse. Clamp it first.
+MAX_REGISTRY_ERROR_CHARS = 300
+
 
 # ---------------------------------------------------------------------------
 # Installed versions
@@ -275,33 +290,99 @@ def _pack_report(pack_dir: Path, workspace: Path, installed_versions: dict[str, 
 # ---------------------------------------------------------------------------
 
 
+def _truncate(message: str, limit: int = MAX_REGISTRY_ERROR_CHARS) -> str:
+    """Clamp server-controlled error text before it enters the JSON envelope.
+
+    Whitespace is collapsed first so a multi-line HTML error page cannot break
+    the single-line JSON output consumers read.
+    """
+    text = " ".join(message.split())
+    return text if len(text) <= limit else text[:limit] + "… (truncated)"
+
+
+def _registry_cache_key(registry_api: Any, node_id: str) -> str:
+    """Cache key for one registry lookup.
+
+    Includes the registry base URL because ``RegistryAPI`` selects localhost,
+    staging or production from ``ENVIRONMENT``: metadata fetched from a dev or
+    staging registry must not be served to a later production run, where it
+    could hide a real dependency conflict. The id is lower-cased because the
+    registry resolves ids case-insensitively (``GET /nodes/comfyui-lcm`` 302s to
+    ``/nodes/ComfyUI-LCM``), so two spellings share one entry rather than
+    duplicating both the request and the stored value.
+    """
+    base = getattr(registry_api, "base_url", "") or ""
+    return f"{REGISTRY_CACHE_PREFIX}{base}:{node_id.lower()}"
+
+
+def _normalize_dependencies(dependencies: Any) -> tuple[list[str] | None, bool]:
+    """Return ``(declared, dropped_any)`` for a raw registry dependency list.
+
+    ``map_node_version`` defaults a missing ``dependencies`` to ``[]``, so an
+    empty list is indistinguishable from "the field was absent" — we must not
+    claim the pack declares zero dependencies. Both collapse to ``None``, as
+    does anything that isn't a list of strings (iterating a stray bare string
+    would yield one row per character). ``dropped_any`` reports whether a
+    non-string entry was filtered out, so a caller holding an otherwise usable
+    list can warn that the row is partial rather than silently under-reporting.
+
+    Applied to the cached value as well as the network one: a cache entry
+    written by another comfy-cli version (or hand-edited) can hold ``[null]``,
+    which would reach ``_classify`` and raise ``AttributeError`` on
+    ``raw.startswith`` — aborting the whole report, the opposite of this
+    module's degrade-to-a-warning design.
+    """
+    if not isinstance(dependencies, list):
+        return None, False
+    kept = [d.strip() for d in dependencies if isinstance(d, str) and d.strip()]
+    dropped = any(not (isinstance(d, str) and d.strip()) for d in dependencies)
+    return (kept or None), dropped
+
+
+def _registry_error(node_id: str, exc: Exception) -> dict[str, str]:
+    """Map a ``get_node`` failure to a ``{"code", "message"}`` warning.
+
+    A 404 is permanent — the id is misspelled or was never published — and must
+    not be reported as ``registry_unavailable``, whose hint tells the caller to
+    check network access and retry with ``--refresh``. An agent following that
+    hint against a 404 retries forever against an id that will never resolve.
+    """
+    if getattr(exc, "status_code", None) == 404:
+        return {
+            "code": "registry_node_not_found",
+            "message": f"registry has no node '{node_id}' (HTTP 404) — check the id, or the pack may be unpublished",
+        }
+    return {
+        "code": "registry_unavailable",
+        "message": f"could not fetch registry metadata for '{node_id}': {_truncate(str(exc))}",
+    }
+
+
 def _registry_declared(
     node_id: str,
     cache: dict[str, Any],
     refresh: bool,
     registry_api: Any,
-) -> tuple[list[str] | None, str | None, str | None]:
-    """Return ``(declared, version, error)`` for a registry node id.
+) -> tuple[list[str] | None, str | None, dict[str, str] | None, bool]:
+    """Return ``(declared, version, error, partial)`` for a registry node id.
 
     ``declared`` is the latest version's published dependency list, or ``None``
-    when the registry gave us nothing usable. Results (including "the registry
-    published no dependencies") are cached for an hour under the same file
-    ``comfy outdated`` uses, so repeated agent calls stay cheap; ``refresh``
-    bypasses the read.
+    when the registry gave us nothing usable. ``error`` is a ``{"code",
+    "message"}`` warning. ``partial`` marks an otherwise usable list that lost malformed
+    entries. Results (including "the registry published no dependencies") are
+    cached for an hour under the same file ``comfy outdated`` uses, so repeated
+    agent calls stay cheap; ``refresh`` bypasses the read.
     """
     from comfy_cli.command.outdated import _cache_get, _cache_set
 
-    key = f"{REGISTRY_CACHE_PREFIX}{node_id}"
+    key = _registry_cache_key(registry_api, node_id)
     if not refresh:
         cached = _cache_get(cache, key)
         if isinstance(cached, dict):
-            declared = cached.get("dependencies")
+            # Normalized on the way out too — see ``_normalize_dependencies``.
+            declared, _ = _normalize_dependencies(cached.get("dependencies"))
             version = cached.get("version")
-            return (
-                declared if isinstance(declared, list) else None,
-                version if isinstance(version, str) else None,
-                None,
-            )
+            return declared, (version if isinstance(version, str) else None), None, False
 
     try:
         # get_node, NOT install_node: the install endpoint records an
@@ -309,22 +390,14 @@ def _registry_declared(
         # a pre-install *report* must never touch it.
         node = registry_api.get_node(node_id)
     except Exception as e:  # noqa: BLE001 - registry unreachable → a per-entry warning, not a failed command
-        return None, None, f"could not fetch registry metadata for '{node_id}': {e}"
+        return None, None, _registry_error(node_id, e), False
 
     latest = getattr(node, "latest_version", None)
     version = getattr(latest, "version", None)
-    dependencies = getattr(latest, "dependencies", None)
-    # ``map_node_version`` defaults a missing ``dependencies`` to ``[]``, so an
-    # empty list is indistinguishable from "the field was absent" — we must not
-    # claim the pack declares zero dependencies. Both collapse to `declared:
-    # null` + the honest warning below, as does anything that isn't a list of
-    # strings (iterating a stray bare string would yield one row per character).
-    declared = None
-    if isinstance(dependencies, list):
-        declared = [d.strip() for d in dependencies if isinstance(d, str) and d.strip()] or None
+    declared, partial = _normalize_dependencies(getattr(latest, "dependencies", None))
 
     _cache_set(cache, key, {"version": version if isinstance(version, str) else None, "dependencies": declared})
-    return declared, (version if isinstance(version, str) else None), None
+    return declared, (version if isinstance(version, str) else None), None, partial
 
 
 def _registry_report(
@@ -335,7 +408,7 @@ def _registry_report(
     registry_api: Any,
 ) -> tuple[dict[str, Any], list[dict[str, str]]]:
     """Build one registry-candidate row. Returns ``(row, warnings)``."""
-    declared, version, error = _registry_declared(node_id, cache, refresh, registry_api)
+    declared, version, error, partial = _registry_declared(node_id, cache, refresh, registry_api)
 
     warnings: list[dict[str, str]] = []
     row: dict[str, Any] = {
@@ -351,8 +424,8 @@ def _registry_report(
     }
 
     if error is not None:
-        row["warning"] = error
-        warnings.append({"code": "registry_unavailable", "message": error})
+        row["warning"] = error["message"]
+        warnings.append(error)
         return row, warnings
 
     if declared is None:
@@ -364,6 +437,13 @@ def _registry_report(
             }
         )
         return row, warnings
+
+    if partial:
+        # The list is usable but lossy: a dropped entry that would have
+        # conflicted is invisible, so the row must not read as complete metadata.
+        message = f"registry returned malformed dependency entries for '{node_id}'; this row is incomplete"
+        row["warning"] = message
+        warnings.append({"code": "registry_partial_dependency_metadata", "message": message})
 
     # Same per-requirement diff, against the same single ``pip list`` map.
     rows: dict[str, dict[str, Any]] = {}
@@ -435,9 +515,32 @@ def build_report(
             }
         )
 
-    # Dedupe (order-preserving) and drop blanks — an empty id would otherwise
-    # become a request for the registry's whole node collection.
-    wanted_registry = list(dict.fromkeys(i.strip() for i in (registry_ids or []) if i and i.strip()))
+    # Validate, then dedupe (order-preserving). Dedupe is case-insensitive
+    # because the registry resolves ids that way, so `--registry Some-Pack
+    # --registry some-pack` is one pack, not two rows and two network calls;
+    # the first spelling seen is the one reported. Every rejected id is
+    # surfaced as a warning rather than dropped silently — a caller whose only
+    # `--registry` value was rejected must not read an empty report as "no
+    # conflicts".
+    wanted_registry: list[str] = []
+    seen_registry: set[str] = set()
+    for raw_id in registry_ids or []:
+        candidate = (raw_id or "").strip()
+        if not _REGISTRY_NODE_ID_RE.fullmatch(candidate):
+            warnings.append(
+                {
+                    "code": "registry_invalid_node_id",
+                    "message": (
+                        f"ignored --registry value {candidate!r}: a registry node id must be non-empty and "
+                        "match [A-Za-z0-9._-]"
+                    ),
+                }
+            )
+            continue
+        if candidate.lower() in seen_registry:
+            continue
+        seen_registry.add(candidate.lower())
+        wanted_registry.append(candidate)
 
     pack_dirs = iter_pack_dirs(workspace / "custom_nodes")
     packs: list[dict[str, Any]] = []
@@ -451,17 +554,20 @@ def build_report(
             row, pack_warnings = _pack_report(match, workspace, installed_versions)
             packs.append(row)
             warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
-    elif not wanted_registry:
+    elif not registry_ids:
         # Bare `comfy node deps` reports the whole workspace. A `--registry`-only
         # invocation is a targeted pre-install question, so it does NOT also dump
-        # every installed pack; name packs positionally to get both.
+        # every installed pack; name packs positionally to get both. Keyed on the
+        # *requested* ids, not the surviving ones: if every `--registry` value
+        # was rejected above, the answer is that targeted question's warning, not
+        # a surprise dump of every installed pack.
         for pack_dir in pack_dirs:
             row, pack_warnings = _pack_report(pack_dir, workspace, installed_versions)
             packs.append(row)
             warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
 
     if wanted_registry:
-        from comfy_cli.command.outdated import _load_cache, _save_cache
+        from comfy_cli.command.outdated import _cache_get, _load_cache, _save_cache
 
         # Shares ``comfy outdated``'s 1h cache file under a distinct key prefix.
         cache = _load_cache()
@@ -470,11 +576,39 @@ def build_report(
             from comfy_cli.registry import RegistryAPI
 
             api = RegistryAPI()
+        touched: set[str] = set()
         for node_id in wanted_registry:
+            key = _registry_cache_key(api, node_id)
+            before = cache.get(key)
             row, registry_warnings = _registry_report(node_id, installed_versions, cache, refresh, api)
             packs.append(row)
             warnings.extend(registry_warnings)
-        _save_cache(cache)
+            # Identity, not membership: a lookup that failed (or was served from
+            # cache) leaves any pre-existing entry untouched, and an *expired*
+            # one of those must stay prunable below rather than being carried
+            # forward as though we had just written it.
+            if cache.get(key) is not before:
+                touched.add(key)
+
+        # `node deps` is a second writer of a file `comfy outdated` already
+        # owns, so it must not blind-write the dict it read minutes ago: re-read
+        # and merge only our own keys, or a concurrent `outdated` run's writes
+        # are silently discarded. (`_save_cache` renames into place, so a reader
+        # never sees a half-written file — but this is still last-writer-wins on
+        # a genuinely simultaneous write, which for a rebuildable 1h cache costs
+        # only a re-fetch.)
+        fresh = _load_cache()
+        for key in touched:
+            fresh[key] = cache[key]
+        # Prune expired registry entries while we hold the file. `_cache_get`
+        # only checks the TTL at read time and `_save_cache` rewrites every key,
+        # so without this these never leave: unlike `outdated`'s keys, this
+        # prefix's key space is arbitrary caller-supplied ids holding whole
+        # dependency lists, which a loop over many ids would grow without bound.
+        for key in [k for k in fresh if k.startswith(REGISTRY_CACHE_PREFIX) and k not in touched]:
+            if _cache_get(fresh, key) is None:
+                del fresh[key]
+        _save_cache(fresh)
 
     compiled = workspace / "requirements.compiled"
     compiled_present = compiled.is_file()

--- a/comfy_cli/command/node_deps.py
+++ b/comfy_cli/command/node_deps.py
@@ -6,10 +6,17 @@ line), reports the pack's *declared* Python requirements — from its
 — alongside the version actually installed in the workspace venv and a
 computed status per requirement.
 
-Read-only by construction: it never installs anything, never shells out to
-``cm-cli``, and never touches the network. The only subprocess it runs is a
-single ``<workspace python> -m pip list --format=json`` for the whole report
-(not once per pack).
+``--registry <node-id>`` extends the same diff to a pack that is **not yet
+installed**: the registry's published dependency list for that pack's latest
+version, diffed against the very same ``pip list`` map, so conflict risk can be
+assessed *before* installing anything.
+
+Read-only by construction: it never installs anything and never shells out to
+``cm-cli``. The only subprocess it runs is a single ``<workspace python> -m pip
+list --format=json`` for the whole report (not once per pack). The only network
+call is the registry's side-effect-free ``GET /nodes/{id}``, made solely for
+``--registry`` ids — never ``install_node``, whose endpoint records an
+installation and fires an analytics event server-side on every call.
 
 Statuses:
 
@@ -30,6 +37,11 @@ parser (:func:`comfy_cli.command.pack_scan.read_pyproject`), which drops the
 ``comfyui-frontend-package`` pin from ``[project] dependencies``. Such a pin is
 a core-ComfyUI concern rather than a pack dependency, so it will not appear in
 this report even though it is declared.
+
+Known caveat (``--registry``): the registry exposes dependency metadata only on
+a node's *latest* published version — there is no read-only endpoint for a
+pinned version's dependencies — so a ``--registry`` row always describes the
+latest version, whatever version an eventual install would pick.
 """
 
 from __future__ import annotations
@@ -57,6 +69,14 @@ STATUSES = ("satisfied", "mismatch", "missing", "unparseable", "unknown")
 
 SOURCE_REQUIREMENTS_TXT = "requirements.txt"
 SOURCE_PYPROJECT = "pyproject.toml"
+# Not a file: the registry's published metadata for a not-yet-installed pack.
+SOURCE_REGISTRY = "registry"
+
+# Namespaced away from ``outdated``'s own ``pack:<id>`` entries, which share the
+# cache file but hold a bare version string rather than this dict.
+REGISTRY_CACHE_PREFIX = "deps-registry:"
+
+NO_REGISTRY_DEPENDENCY_METADATA = "registry did not return dependency metadata for this pack"
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +270,113 @@ def _pack_report(pack_dir: Path, workspace: Path, installed_versions: dict[str, 
     )
 
 
+# ---------------------------------------------------------------------------
+# Registry candidates (not-yet-installed packs)
+# ---------------------------------------------------------------------------
+
+
+def _registry_declared(
+    node_id: str,
+    cache: dict[str, Any],
+    refresh: bool,
+    registry_api: Any,
+) -> tuple[list[str] | None, str | None, str | None]:
+    """Return ``(declared, version, error)`` for a registry node id.
+
+    ``declared`` is the latest version's published dependency list, or ``None``
+    when the registry gave us nothing usable. Results (including "the registry
+    published no dependencies") are cached for an hour under the same file
+    ``comfy outdated`` uses, so repeated agent calls stay cheap; ``refresh``
+    bypasses the read.
+    """
+    from comfy_cli.command.outdated import _cache_get, _cache_set
+
+    key = f"{REGISTRY_CACHE_PREFIX}{node_id}"
+    if not refresh:
+        cached = _cache_get(cache, key)
+        if isinstance(cached, dict):
+            declared = cached.get("dependencies")
+            version = cached.get("version")
+            return (
+                declared if isinstance(declared, list) else None,
+                version if isinstance(version, str) else None,
+                None,
+            )
+
+    try:
+        # get_node, NOT install_node: the install endpoint records an
+        # installation + fires an analytics event server-side on every call, so
+        # a pre-install *report* must never touch it.
+        node = registry_api.get_node(node_id)
+    except Exception as e:  # noqa: BLE001 - registry unreachable → a per-entry warning, not a failed command
+        return None, None, f"could not fetch registry metadata for '{node_id}': {e}"
+
+    latest = getattr(node, "latest_version", None)
+    version = getattr(latest, "version", None)
+    dependencies = getattr(latest, "dependencies", None)
+    # ``map_node_version`` defaults a missing ``dependencies`` to ``[]``, so an
+    # empty list is indistinguishable from "the field was absent" — we must not
+    # claim the pack declares zero dependencies. Both collapse to `declared:
+    # null` + the honest warning below, as does anything that isn't a list of
+    # strings (iterating a stray bare string would yield one row per character).
+    declared = None
+    if isinstance(dependencies, list):
+        declared = [d.strip() for d in dependencies if isinstance(d, str) and d.strip()] or None
+
+    _cache_set(cache, key, {"version": version if isinstance(version, str) else None, "dependencies": declared})
+    return declared, (version if isinstance(version, str) else None), None
+
+
+def _registry_report(
+    node_id: str,
+    installed_versions: dict[str, str] | None,
+    cache: dict[str, Any],
+    refresh: bool,
+    registry_api: Any,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    """Build one registry-candidate row. Returns ``(row, warnings)``."""
+    declared, version, error = _registry_declared(node_id, cache, refresh, registry_api)
+
+    warnings: list[dict[str, str]] = []
+    row: dict[str, Any] = {
+        "pack": node_id,
+        "path": None,
+        "status": "registry",
+        "registry": True,
+        "version": version,
+        "declared": declared,
+        "requirement_files": [],
+        "requirements": [],
+        "summary": dict.fromkeys(STATUSES, 0),
+    }
+
+    if error is not None:
+        row["warning"] = error
+        warnings.append({"code": "registry_unavailable", "message": error})
+        return row, warnings
+
+    if declared is None:
+        row["warning"] = NO_REGISTRY_DEPENDENCY_METADATA
+        warnings.append(
+            {
+                "code": "registry_no_dependency_metadata",
+                "message": f"{NO_REGISTRY_DEPENDENCY_METADATA}: '{node_id}'",
+            }
+        )
+        return row, warnings
+
+    # Same per-requirement diff, against the same single ``pip list`` map.
+    rows: dict[str, dict[str, Any]] = {}
+    for line in declared:
+        if line not in rows:
+            rows[line] = {**_classify(line, installed_versions), "source": SOURCE_REGISTRY}
+    row["requirements"] = list(rows.values())
+    row["requirement_files"] = [SOURCE_REGISTRY]
+    for req in row["requirements"]:
+        row["summary"][req["status"]] += 1
+    return row, warnings
+
+
 def _not_installed_row(name: str) -> dict[str, Any]:
     return {
         "pack": name,
@@ -271,6 +398,9 @@ def build_report(
     pack_names: list[str] | None = None,
     *,
     python: str | None = None,
+    registry_ids: list[str] | None = None,
+    refresh: bool = False,
+    registry_api: Any | None = None,
 ) -> tuple[dict[str, Any] | None, list[dict[str, str]]]:
     """Build the per-pack dependency report.
 
@@ -278,6 +408,10 @@ def build_report(
     resolves to no usable workspace — the caller turns that into a
     ``not_in_workspace`` error envelope. Each warning is
     ``{"code": ..., "message": ...}``.
+
+    *registry_ids* names not-yet-installed registry packs to include as extra
+    rows (``status: "registry"``). Inject *registry_api* (anything with
+    ``get_node``) to unit-test without the network.
     """
     from comfy_cli.resolve_python import resolve_workspace_python
 
@@ -301,6 +435,10 @@ def build_report(
             }
         )
 
+    # Dedupe (order-preserving) and drop blanks — an empty id would otherwise
+    # become a request for the registry's whole node collection.
+    wanted_registry = list(dict.fromkeys(i.strip() for i in (registry_ids or []) if i and i.strip()))
+
     pack_dirs = iter_pack_dirs(workspace / "custom_nodes")
     packs: list[dict[str, Any]] = []
     if pack_names:
@@ -313,11 +451,30 @@ def build_report(
             row, pack_warnings = _pack_report(match, workspace, installed_versions)
             packs.append(row)
             warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
-    else:
+    elif not wanted_registry:
+        # Bare `comfy node deps` reports the whole workspace. A `--registry`-only
+        # invocation is a targeted pre-install question, so it does NOT also dump
+        # every installed pack; name packs positionally to get both.
         for pack_dir in pack_dirs:
             row, pack_warnings = _pack_report(pack_dir, workspace, installed_versions)
             packs.append(row)
             warnings.extend({"code": "pack_read_error", "message": w} for w in pack_warnings)
+
+    if wanted_registry:
+        from comfy_cli.command.outdated import _load_cache, _save_cache
+
+        # Shares ``comfy outdated``'s 1h cache file under a distinct key prefix.
+        cache = _load_cache()
+        api = registry_api
+        if api is None:
+            from comfy_cli.registry import RegistryAPI
+
+            api = RegistryAPI()
+        for node_id in wanted_registry:
+            row, registry_warnings = _registry_report(node_id, installed_versions, cache, refresh, api)
+            packs.append(row)
+            warnings.extend(registry_warnings)
+        _save_cache(cache)
 
     compiled = workspace / "requirements.compiled"
     compiled_present = compiled.is_file()
@@ -354,11 +511,15 @@ def _render_pretty(renderer, report: dict[str, Any]) -> None:
     console = renderer.console()
     for pack in report["packs"]:
         title = escape(pack["pack"])
+        if pack.get("registry"):
+            version = pack.get("version")
+            title += " [dim](registry, latest " + (escape(version) if version else "unknown") + ")[/dim]"
         if pack["status"] == "not_installed":
             renderer.print(f"[bold]{title}[/bold] — [yellow]not installed[/yellow]")
             continue
         if not pack["requirements"]:
-            renderer.print(f"[bold]{title}[/bold] — [dim]no declared requirements[/dim]")
+            reason = pack.get("warning") or "no declared requirements"
+            renderer.print(f"[bold]{title}[/bold] — [dim]{escape(reason)}[/dim]")
             continue
 
         tbl = Table(show_header=True, header_style="bold", title=title, title_justify="left")
@@ -391,11 +552,18 @@ def _render_pretty(renderer, report: dict[str, Any]) -> None:
         renderer.print(f"[dim]compiled lock: {escape(report['compiled_lock']['path'])}[/dim]")
 
 
-def execute(renderer, comfy_path: str | None, pack_names: list[str] | None = None) -> None:
+def execute(
+    renderer,
+    comfy_path: str | None,
+    pack_names: list[str] | None = None,
+    *,
+    registry_ids: list[str] | None = None,
+    refresh: bool = False,
+) -> None:
     """Entry point wired from ``comfy node deps``."""
     from rich.markup import escape
 
-    report, warnings = build_report(comfy_path, pack_names)
+    report, warnings = build_report(comfy_path, pack_names, registry_ids=registry_ids, refresh=refresh)
     if report is None:
         import typer
 

--- a/comfy_cli/command/outdated.py
+++ b/comfy_cli/command/outdated.py
@@ -85,7 +85,13 @@ def _save_cache(cache: dict[str, Any]) -> None:
         # must not share (and truncate) one temp path.
         tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
         try:
-            tmp.write_text(json.dumps(cache))
+            # `encoding` pinned rather than left to the platform locale:
+            # `_load_cache` decodes bytes as JSON, which only accepts
+            # UTF-8/16/32. Today `json.dumps` defaults to `ensure_ascii=True`,
+            # so the payload is pure ASCII and any locale would round-trip —
+            # this keeps that a property of the writer, not a lucky default, if
+            # a non-ASCII pack id ever reaches the file verbatim.
+            tmp.write_text(json.dumps(cache), encoding="utf-8")
             os.replace(tmp, path)
         finally:
             tmp.unlink(missing_ok=True)

--- a/comfy_cli/command/outdated.py
+++ b/comfy_cli/command/outdated.py
@@ -78,7 +78,17 @@ def _save_cache(cache: dict[str, Any]) -> None:
     path = _cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(cache))
+        # Write-then-rename: an interrupt mid-write must not leave a truncated
+        # file that the next `_load_cache` silently resets to `{}`. `os.replace`
+        # is atomic within a filesystem, and the temp file is a sibling so the
+        # rename never crosses one. Unique per process — two concurrent writers
+        # must not share (and truncate) one temp path.
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        try:
+            tmp.write_text(json.dumps(cache))
+            os.replace(tmp, path)
+        finally:
+            tmp.unlink(missing_ok=True)
     except OSError:
         # A read-only cache dir must never break a read-only report.
         pass

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -670,6 +670,20 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "rest of the report still succeeds.",
         "check the file's permissions under `custom_nodes/<pack>/`",
     ),
+    ErrorCode(
+        "registry_unavailable",
+        "`comfy node deps --registry <node-id>` could not reach the Comfy registry (network failure, timeout, "
+        "or a non-200 response), so that candidate's row carries `declared: null` plus a per-entry `warning`. "
+        "Surfaced in `data.warnings[]` (not as an error envelope): every other pack still reports normally.",
+        "check network access to api.comfy.org, then re-run (add `--refresh` to bypass the 1h cache)",
+    ),
+    ErrorCode(
+        "registry_no_dependency_metadata",
+        "`comfy node deps --registry <node-id>` reached the registry, but it published no dependency metadata "
+        "for that pack's latest version, so the row carries `declared: null` rather than an empty list — the "
+        'API cannot distinguish "declares nothing" from "field absent". Surfaced in `data.warnings[]`.',
+        "the pack publisher must publish a version declaring its dependencies; nothing to fix locally",
+    ),
 )
 
 

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -364,19 +364,16 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "server_died",
-        "Server connection dropped while a foreground (`--wait`) job was in flight; recorded on the job state file.",
-        "check the server (it may have been OOM-killed); the prompt_id is in `comfy jobs status <id>`",
+        "The local ComfyUI server became unreachable (or restarted without the job) while a job was in "
+        "flight — the server likely crashed or was killed (e.g. an out-of-memory allocation). Recorded on "
+        "the job state file, both for a foreground (`--wait`) run and for the background watcher.",
+        "check the ComfyUI server log (it may have been OOM-killed), then `comfy launch` and re-submit; "
+        "the prompt_id is in `comfy jobs status <id>`",
     ),
     ErrorCode(
         "watcher_poll_error",
         "Background watcher encountered a transient error polling the server.",
         "transient — the job is likely still running; re-run `comfy jobs watch <id>`",
-    ),
-    ErrorCode(
-        "server_died",
-        "The local ComfyUI server became unreachable (or restarted without the job) while it "
-        "was in flight — the server likely crashed or was killed (e.g. an out-of-memory allocation).",
-        "check the ComfyUI server log, then `comfy launch` and re-submit the workflow",
     ),
     ErrorCode(
         "unknown_status_stall",
@@ -676,6 +673,31 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "or a non-200 response), so that candidate's row carries `declared: null` plus a per-entry `warning`. "
         "Surfaced in `data.warnings[]` (not as an error envelope): every other pack still reports normally.",
         "check network access to api.comfy.org, then re-run (add `--refresh` to bypass the 1h cache)",
+    ),
+    ErrorCode(
+        "registry_invalid_node_id",
+        "A `comfy node deps --registry <node-id>` value was blank or contained characters outside "
+        "`[A-Za-z0-9._-]`, so it was rejected without a network call. Registry ids never contain `/`, `?` "
+        "or `#`; interpolated into the lookup URL those would retarget the request at a different path "
+        "(including the side-effecting install endpoint) or inject a query string. "
+        "Surfaced in `data.warnings[]`: the other `--registry` ids still report normally.",
+        "pass the pack's registry id as shown by `comfy node registry-list` (e.g. `comfyui-example`), "
+        "not a URL, an `owner/repo` path, or a local directory name",
+    ),
+    ErrorCode(
+        "registry_node_not_found",
+        "`comfy node deps --registry <node-id>` reached the Comfy registry, which reported no such node "
+        "(HTTP 404) — a misspelled id, or a pack that was never published to the registry. Distinct from "
+        "`registry_unavailable`: retrying or `--refresh` will never resolve it. Surfaced in `data.warnings[]`.",
+        "check the id with `comfy node registry-list`; an unpublished pack has no registry metadata, so "
+        "install it and re-run `comfy node deps` to read its requirements from disk instead",
+    ),
+    ErrorCode(
+        "registry_partial_dependency_metadata",
+        "`comfy node deps --registry <node-id>` got a dependency list from the registry containing "
+        "non-string entries (e.g. `null`), which were dropped. The row's `declared` list is therefore "
+        "incomplete — a dropped entry that would have conflicted is not reported. Surfaced in `data.warnings[]`.",
+        "treat that row as partial; read the pack's own `requirements.txt` upstream to confirm the full set",
     ),
     ErrorCode(
         "registry_no_dependency_metadata",

--- a/comfy_cli/registry/__init__.py
+++ b/comfy_cli/registry/__init__.py
@@ -1,9 +1,10 @@
-from .api import RegistryAPI
+from .api import NodeFetchError, RegistryAPI
 from .config_parser import extract_node_configuration, initialize_project_config
 from .types import Node, NodeVersion, PublishNodeVersionResponse, PyProjectConfig
 
 __all__ = [
     "RegistryAPI",
+    "NodeFetchError",
     "extract_node_configuration",
     "PyProjectConfig",
     "PublishNodeVersionResponse",

--- a/comfy_cli/registry/api.py
+++ b/comfy_cli/registry/api.py
@@ -14,6 +14,20 @@ from comfy_cli.registry.types import (
 )
 
 
+class NodeFetchError(Exception):
+    """``get_node`` got a non-200 from the registry.
+
+    Carries ``status_code`` so callers can tell a permanent 404 ("no such node")
+    apart from a transient 5xx/proxy failure — the two need different remediation
+    and only one is worth retrying. Subclasses ``Exception`` and keeps the
+    original message, so pre-existing ``except Exception`` callers are unaffected.
+    """
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
 class RegistryAPI:
     def __init__(self):
         self.base_url = self.determine_base_url()
@@ -152,7 +166,10 @@ class RegistryAPI:
             logging.debug(f"RegistryAPI get_node response: {response.json()}")
             return map_node_to_node_class(response.json())
         else:
-            raise Exception(f"Failed to retrieve node: {response.status_code} - {response.text}")
+            raise NodeFetchError(
+                f"Failed to retrieve node: {response.status_code} - {response.text}",
+                status_code=response.status_code,
+            )
 
 
 def map_node_version(api_node_version):

--- a/comfy_cli/schemas/node_deps.json
+++ b/comfy_cli/schemas/node_deps.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "comfy node deps",
-  "description": "Per-pack Python dependency report: each installed custom node pack's declared requirements (requirements.txt and/or pyproject.toml [project] dependencies) against the versions installed in the workspace venv. Read-only: no installs, no cm-cli, no network. Exit code is 0 even when requirements are missing or mismatched — this is a report, not a check.",
+  "description": "Per-pack Python dependency report: each installed custom node pack's declared requirements (requirements.txt and/or pyproject.toml [project] dependencies) against the versions installed in the workspace venv. `--registry <node-id>` adds a row for a NOT-yet-installed registry pack, diffing its published latest-version dependencies against the same venv so conflict risk can be assessed before installing. Read-only: no installs, no cm-cli, and no network except the registry's side-effect-free GET /nodes/{id} for --registry ids. Exit code is 0 even when requirements are missing or mismatched — this is a report, not a check.",
   "type": "object",
   "properties": {
     "workspace": { "type": "string", "description": "Resolved ComfyUI workspace path." },
@@ -20,24 +20,44 @@
     },
     "packs": {
       "type": "array",
-      "description": "One row per reported pack, in directory-name order (or in the order requested on the command line).",
+      "description": "One row per reported pack, in directory-name order (or in the order requested on the command line); `--registry` candidates follow, in the order given. `pack` is NOT a unique key: naming the same id both positionally and via `--registry` deliberately yields two rows for it — an installed one and a `registry` one. Key on (`pack`, `registry`) if you need uniqueness.",
       "items": {
         "type": "object",
         "properties": {
-          "pack": { "type": "string", "description": "Pack directory name." },
+          "pack": {
+            "type": "string",
+            "description": "Pack directory name, or the registry node id on a `registry` row."
+          },
           "path": {
             "type": ["string", "null"],
-            "description": "Pack path relative to the workspace, or null when the named pack is not installed."
+            "description": "Pack path relative to the workspace; null when the named pack is not installed, and always null on a `registry` row."
           },
           "status": {
             "type": "string",
-            "enum": ["installed", "not_installed"],
-            "description": "`not_installed` when a name given on the command line matched no pack directory."
+            "enum": ["installed", "not_installed", "registry"],
+            "description": "`not_installed` when a name given on the command line matched no pack directory. `registry` marks a `--registry <node-id>` candidate: a pack that is NOT installed, whose requirements come from the registry's published metadata."
+          },
+          "registry": {
+            "type": "boolean",
+            "description": "Present and true only on a `--registry` candidate row. Absent on rows sourced from the local workspace."
+          },
+          "version": {
+            "type": ["string", "null"],
+            "description": "Registry rows only: the LATEST published version whose dependencies this row describes (null when the registry returned none). The registry exposes no read-only endpoint for a pinned version's dependencies, so this is always the latest — not necessarily what an install would resolve to."
+          },
+          "declared": {
+            "type": ["array", "null"],
+            "description": "Registry rows only: the dependency strings the registry published for `version`, verbatim. Null (with `warning` set) when the registry returned no usable dependency metadata — distinct from an empty list, which is never emitted because the API cannot distinguish 'declares nothing' from 'field absent'.",
+            "items": { "type": "string" }
+          },
+          "warning": {
+            "type": "string",
+            "description": "Registry rows only: why this row carries no requirements (registry unreachable, or no dependency metadata published). Never fails the command — other rows still render."
           },
           "requirement_files": {
             "type": "array",
-            "description": "Which declaration files contributed requirements.",
-            "items": { "type": "string", "enum": ["requirements.txt", "pyproject.toml"] }
+            "description": "Which declaration sources contributed requirements. `registry` is not a file — it is the registry's published metadata for a `--registry` candidate.",
+            "items": { "type": "string", "enum": ["requirements.txt", "pyproject.toml", "registry"] }
           },
           "requirements": {
             "type": "array",
@@ -57,7 +77,7 @@
                   "type": "string",
                   "description": "PEP 508 environment marker, when declared. NOT evaluated — the relevant environment is the workspace venv's, not the CLI's."
                 },
-                "source": { "type": "string", "enum": ["requirements.txt", "pyproject.toml"] },
+                "source": { "type": "string", "enum": ["requirements.txt", "pyproject.toml", "registry"] },
                 "installed": {
                   "type": ["string", "null"],
                   "description": "Version found in the workspace venv, or null when missing/unparseable/unknown."
@@ -89,7 +109,7 @@
     },
     "warnings": {
       "type": "array",
-      "description": "Non-fatal problems. `installed_versions_unavailable` means the pip probe failed, so every requirement is `unknown`.",
+      "description": "Non-fatal problems. `installed_versions_unavailable` means the pip probe failed, so every requirement is `unknown`. `registry_unavailable` / `registry_no_dependency_metadata` mean a `--registry` candidate could not be diffed; every other row is unaffected.",
       "items": {
         "type": "object",
         "properties": {

--- a/comfy_cli/schemas/node_deps.json
+++ b/comfy_cli/schemas/node_deps.json
@@ -52,7 +52,7 @@
           },
           "warning": {
             "type": "string",
-            "description": "Registry rows only: why this row carries no requirements (registry unreachable, or no dependency metadata published). Never fails the command — other rows still render."
+            "description": "Registry rows only: why this row carries no requirements (registry unreachable, no such node, or no dependency metadata published) — or, when requirements ARE present, that they are incomplete because the registry returned malformed entries. Never fails the command — other rows still render."
           },
           "requirement_files": {
             "type": "array",
@@ -109,7 +109,7 @@
     },
     "warnings": {
       "type": "array",
-      "description": "Non-fatal problems. `installed_versions_unavailable` means the pip probe failed, so every requirement is `unknown`. `registry_unavailable` / `registry_no_dependency_metadata` mean a `--registry` candidate could not be diffed; every other row is unaffected.",
+      "description": "Non-fatal problems. `installed_versions_unavailable` means the pip probe failed, so every requirement is `unknown`. `registry_unavailable` (transient — retry) / `registry_node_not_found` (permanent 404 — do NOT retry) / `registry_no_dependency_metadata` mean a `--registry` candidate could not be diffed; `registry_partial_dependency_metadata` means its `declared` list lost malformed entries and is incomplete; `registry_invalid_node_id` means a `--registry` value was blank or outside `[A-Za-z0-9._-]` and was rejected without a request. Every other row is unaffected.",
       "items": {
         "type": "object",
         "properties": {

--- a/tests/comfy_cli/command/test_node_deps.py
+++ b/tests/comfy_cli/command/test_node_deps.py
@@ -781,6 +781,28 @@ def test_expired_registry_cache_entries_are_pruned_on_save(workspace, fake_pip):
     assert "pack:someone-elses-expired" in saved, "pruning is scoped to this command's own key space"
 
 
+def test_cache_round_trips_a_non_ascii_registry_id(workspace, fake_pip):
+    """`--registry` takes arbitrary caller-supplied ids, so a non-ASCII one can
+    reach a cache key. `_load_cache` decodes bytes as JSON (UTF-8/16/32 only),
+    so the writer must not emit anything a non-UTF-8 locale would mangle — the
+    whole cache silently resets to `{}` on the next read if it does. Two
+    independent guards hold that today (`json.dumps` escapes to pure ASCII,
+    `_save_cache` pins `encoding="utf-8"`); this pins the round-trip itself so
+    dropping either one fails here rather than in a Windows user's cache.
+    """
+    from comfy_cli.command import outdated as outdated_cmd
+
+    key = f"{node_deps_cmd.REGISTRY_CACHE_PREFIX}https://api.comfy.org:café-pack"
+    cache = outdated_cmd._load_cache()
+    outdated_cmd._cache_set(cache, key, {"version": "1.0.0", "dependencies": ["numpé>=1.20"]})
+    outdated_cmd._save_cache(cache)
+
+    assert outdated_cmd._cache_get(outdated_cmd._load_cache(), key) == {
+        "version": "1.0.0",
+        "dependencies": ["numpé>=1.20"],
+    }
+
+
 def test_registry_rows_validate_against_the_shipped_schema(workspace, fake_pip):
     import jsonschema
 
@@ -847,8 +869,7 @@ def test_registry_flags_are_registered_on_the_deps_command():
 
     from comfy_cli.command.custom_nodes.command import app
 
-    command = next(c for c in app.registered_commands if c.name == "deps")
-    click_command = typer.main.get_command_from_info(command, pretty_exceptions_short=False, rich_markup_mode="rich")
+    click_command = typer.main.get_command(app).commands["deps"]
     opts = {opt for p in click_command.params if isinstance(p, click.Option) for opt in p.opts}
     assert {"--registry", "--refresh"} <= opts
 

--- a/tests/comfy_cli/command/test_node_deps.py
+++ b/tests/comfy_cli/command/test_node_deps.py
@@ -38,6 +38,17 @@ def _renderer_isolation():
     reset_renderer_for_testing()
 
 
+@pytest.fixture(autouse=True)
+def _isolated_registry_cache(tmp_path, monkeypatch):
+    """Point the shared ``outdated.json`` registry cache at a throwaway dir.
+
+    ``--registry`` reuses ``comfy outdated``'s cache file, which is resolved
+    from ``XDG_CACHE_HOME`` at call time — without this, a test run would read
+    and rewrite the developer's real cache.
+    """
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+
+
 class _FakePipList:
     """Stand-in for ``subprocess.run``; records every invocation."""
 
@@ -312,6 +323,326 @@ def test_no_names_reports_every_pack(workspace, fake_pip):
     report, _ = node_deps_cmd.build_report(str(workspace), python="/fake/python")
 
     assert sorted(p["pack"] for p in report["packs"]) == ["Registry-Pack", "comfyui-impact-pack"]
+
+
+# ---------------------------------------------------------------------------
+# --registry (not-yet-installed candidates)
+# ---------------------------------------------------------------------------
+
+
+def _node(node_id: str, version: str | None = "1.2.3", dependencies=None):
+    """A registry ``Node`` as ``RegistryAPI.get_node`` would return one."""
+    from comfy_cli.registry.types import Node, NodeVersion
+
+    latest = None
+    if version is not None:
+        latest = NodeVersion(
+            changelog="",
+            # ``map_node_version`` defaults a missing key to [], so [] is what
+            # "the registry published no dependency metadata" looks like here.
+            dependencies=[] if dependencies is None else dependencies,
+            deprecated=False,
+            id=f"{node_id}@{version}",
+            version=version,
+            download_url="https://example.invalid/pack.zip",
+        )
+    return Node(id=node_id, name=node_id, description="", latest_version=latest)
+
+
+class _FakeRegistry:
+    """Records every ``get_node`` call; ``install_node`` must never be reached."""
+
+    def __init__(self, node=None, error: Exception | None = None):
+        self.calls: list[str] = []
+        self._node = node
+        self._error = error
+
+    def get_node(self, node_id):
+        self.calls.append(node_id)
+        if self._error is not None:
+            raise self._error
+        return self._node
+
+    def install_node(self, node_id, version=None):  # pragma: no cover - a failure, not a path
+        raise AssertionError("install_node must never be called: it records an install + analytics event")
+
+
+def _registry_row(report: dict) -> dict:
+    rows = [p for p in report["packs"] if p.get("registry")]
+    assert len(rows) == 1, f"expected exactly one registry row, got {[p['pack'] for p in report['packs']]}"
+    return rows[0]
+
+
+def test_registry_candidate_is_diffed_against_the_same_pip_list(workspace, fake_pip):
+    api = _FakeRegistry(
+        _node(
+            "comfyui-impact-pack",
+            "8.28.3",
+            # satisfied / mismatch / missing / unparseable, in that order.
+            ["numpy>=1.20", "opencv-python<4.0", "segment-anything", "-r extra.txt"],
+        )
+    )
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["comfyui-impact-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    assert api.calls == ["comfyui-impact-pack"]
+    assert row["pack"] == "comfyui-impact-pack"
+    assert row["status"] == "registry"
+    assert row["path"] is None
+    assert row["version"] == "8.28.3"
+    assert row["declared"] == ["numpy>=1.20", "opencv-python<4.0", "segment-anything", "-r extra.txt"]
+    assert row["requirement_files"] == ["registry"]
+    assert "warning" not in row
+    assert warnings == []
+
+    reqs = _reqs_by_raw(row)
+    assert reqs["numpy>=1.20"]["status"] == "satisfied"
+    assert reqs["numpy>=1.20"]["installed"] == "1.26.4"
+    assert reqs["opencv-python<4.0"]["status"] == "mismatch"
+    assert reqs["opencv-python<4.0"]["installed"] == "4.9.0.80"
+    assert reqs["segment-anything"]["status"] == "missing"
+    assert reqs["-r extra.txt"]["status"] == "unparseable"
+    assert all(r["source"] == "registry" for r in row["requirements"])
+    assert row["summary"] == {"satisfied": 1, "mismatch": 1, "missing": 1, "unparseable": 1, "unknown": 0}
+
+    # A single `pip list`, shared with the installed packs — not one per entry.
+    assert len(fake_pip.calls) == 1
+
+
+def test_registry_without_dependency_metadata_warns_honestly(workspace, fake_pip):
+    api = _FakeRegistry(_node("bare-pack", "1.0.0", []))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["bare-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    # `declared: null`, NOT `[]`: the API cannot distinguish "declares nothing"
+    # from "field absent", so we must not claim the former.
+    assert row["declared"] is None
+    assert row["registry"] is True
+    assert row["requirements"] == []
+    assert row["requirement_files"] == []
+    assert row["warning"] == "registry did not return dependency metadata for this pack"
+    assert [w["code"] for w in warnings] == ["registry_no_dependency_metadata"]
+
+
+def test_registry_node_without_latest_version_warns_honestly(workspace, fake_pip):
+    api = _FakeRegistry(_node("unpublished-pack", version=None))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["unpublished-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    assert row["version"] is None
+    assert row["declared"] is None
+    assert row["warning"] == "registry did not return dependency metadata for this pack"
+    assert [w["code"] for w in warnings] == ["registry_no_dependency_metadata"]
+
+
+def test_registry_non_list_dependencies_do_not_become_one_row_per_character(workspace, fake_pip):
+    """A malformed payload must degrade to the honest warning, not to garbage."""
+    api = _FakeRegistry(_node("odd-pack", "1.0.0", "numpy"))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["odd-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    assert row["declared"] is None
+    assert row["requirements"] == []
+    assert row["warning"] == "registry did not return dependency metadata for this pack"
+    assert [w["code"] for w in warnings] == ["registry_no_dependency_metadata"]
+
+
+def test_registry_blank_only_dependencies_degrade_to_the_warning(workspace, fake_pip):
+    api = _FakeRegistry(_node("blank-pack", "1.0.0", ["", "   "]))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["blank-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    assert row["declared"] is None
+    assert [w["code"] for w in warnings] == ["registry_no_dependency_metadata"]
+
+
+def test_registry_network_failure_is_a_per_entry_warning_not_a_failed_command(workspace, fake_pip):
+    import requests
+
+    api = _FakeRegistry(error=requests.exceptions.RequestException("connection timed out"))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace),
+        ["comfyui-impact-pack"],
+        registry_ids=["some-pack"],
+        python="/fake/python",
+        registry_api=api,
+    )
+
+    row = _registry_row(report)
+    assert row["declared"] is None
+    assert row["version"] is None
+    assert "connection timed out" in row["warning"]
+    assert [w["code"] for w in warnings] == ["registry_unavailable"]
+
+    # The installed pack's section is untouched by the registry failure.
+    installed = _packs_by_name(report)["comfyui-impact-pack"]
+    assert installed["status"] == "installed"
+    assert _reqs_by_raw(installed)["numpy<1.20"]["status"] == "mismatch"
+
+
+def test_registry_never_calls_install_node(workspace, fake_pip, monkeypatch):
+    """The install endpoint records an install + analytics event server-side."""
+    from unittest import mock
+
+    from comfy_cli.registry import RegistryAPI
+
+    with (
+        mock.patch.object(RegistryAPI, "install_node", autospec=True) as install,
+        mock.patch.object(RegistryAPI, "get_node", autospec=True) as get_node,
+    ):
+        get_node.return_value = _node("some-pack", "2.0.0", ["numpy"])
+        # No injected api: build_report must construct the real RegistryAPI and
+        # still only reach for the read-only endpoint.
+        report, warnings = node_deps_cmd.build_report(str(workspace), registry_ids=["some-pack"], python="/fake/python")
+
+    install.assert_not_called()
+    assert get_node.call_count == 1
+    assert _registry_row(report)["declared"] == ["numpy"]
+    assert warnings == []
+
+
+def test_registry_lookup_is_cached_and_refresh_bypasses_it(workspace, fake_pip):
+    api = _FakeRegistry(_node("cached-pack", "3.0.0", ["numpy"]))
+
+    for _ in range(2):
+        report, _ = node_deps_cmd.build_report(
+            str(workspace), registry_ids=["cached-pack"], python="/fake/python", registry_api=api
+        )
+        assert _registry_row(report)["version"] == "3.0.0"
+    assert api.calls == ["cached-pack"], "second lookup must be served from the 1h cache"
+
+    node_deps_cmd.build_report(
+        str(workspace), registry_ids=["cached-pack"], python="/fake/python", registry_api=api, refresh=True
+    )
+    assert api.calls == ["cached-pack", "cached-pack"], "--refresh must bypass the cache"
+
+
+def test_registry_failure_is_not_cached(workspace, fake_pip):
+    """A transient outage must not poison the next hour of lookups."""
+    import requests
+
+    api = _FakeRegistry(error=requests.exceptions.RequestException("boom"))
+    for _ in range(2):
+        node_deps_cmd.build_report(str(workspace), registry_ids=["flaky-pack"], python="/fake/python", registry_api=api)
+    assert api.calls == ["flaky-pack", "flaky-pack"]
+
+
+def test_registry_only_invocation_does_not_dump_every_installed_pack(workspace, fake_pip):
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    report, _ = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api
+    )
+
+    assert [p["pack"] for p in report["packs"]] == ["some-pack"]
+
+
+def test_registry_is_additive_with_positional_pack_names(workspace, fake_pip):
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    report, _ = node_deps_cmd.build_report(
+        str(workspace),
+        ["Registry-Pack"],
+        registry_ids=["some-pack"],
+        python="/fake/python",
+        registry_api=api,
+    )
+
+    assert [p["pack"] for p in report["packs"]] == ["Registry-Pack", "some-pack"]
+    assert report["packs"][0]["status"] == "installed"
+
+
+def test_registry_ids_are_deduped_and_blanks_dropped(workspace, fake_pip):
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    report, _ = node_deps_cmd.build_report(
+        str(workspace),
+        registry_ids=["some-pack", "  some-pack ", "", "   "],
+        python="/fake/python",
+        registry_api=api,
+    )
+
+    assert [p["pack"] for p in report["packs"]] == ["some-pack"]
+    assert api.calls == ["some-pack"]
+
+
+def test_registry_rows_validate_against_the_shipped_schema(workspace, fake_pip):
+    import jsonschema
+
+    from comfy_cli import discovery
+
+    schema = discovery._read_schema("node_deps")
+
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy>=1.20", "-r extra.txt"]))
+    report, _ = node_deps_cmd.build_report(
+        str(workspace), ["Registry-Pack"], registry_ids=["some-pack"], python="/fake/python", registry_api=api
+    )
+    report["warnings"] = []
+    jsonschema.validate(report, schema)
+
+    # the no-metadata / unreachable shapes must validate too
+    bare, _ = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["bare"], python="/fake/python", registry_api=_FakeRegistry(_node("bare", "1.0"))
+    )
+    bare["warnings"] = []
+    jsonschema.validate(bare, schema)
+
+
+def test_registry_pretty_mode_renders_version_and_status(workspace, fake_pip, capsys):
+    from unittest import mock
+
+    from comfy_cli.registry import RegistryAPI
+
+    reset_renderer_for_testing()
+    r = Renderer(mode=OutputMode.PRETTY)
+    set_renderer(r)
+
+    with mock.patch.object(RegistryAPI, "get_node", autospec=True) as get_node:
+        get_node.return_value = _node("some-pack", "9.9.9", ["numpy>=1.20"])
+        node_deps_cmd.execute(r, str(workspace), registry_ids=["some-pack"])
+
+    out = capsys.readouterr().out
+    assert "some-pack" in out
+    assert "9.9.9" in out
+    assert "satisfied" in out
+
+
+def test_registry_pretty_mode_renders_the_warning_row(workspace, fake_pip, capsys):
+    from unittest import mock
+
+    from comfy_cli.registry import RegistryAPI
+
+    reset_renderer_for_testing()
+    r = Renderer(mode=OutputMode.PRETTY)
+    set_renderer(r)
+
+    with mock.patch.object(RegistryAPI, "get_node", autospec=True) as get_node:
+        get_node.return_value = _node("bare-pack", "1.0.0", [])
+        node_deps_cmd.execute(r, str(workspace), registry_ids=["bare-pack"])
+
+    out = capsys.readouterr().out
+    assert "bare-pack" in out
+    assert "did not return dependency metadata" in out
+    assert r.exit_code == 0  # a report, not a check
+
+
+def test_registry_flags_are_registered_on_the_deps_command():
+    import click
+    import typer
+
+    from comfy_cli.command.custom_nodes.command import app
+
+    command = next(c for c in app.registered_commands if c.name == "deps")
+    click_command = typer.main.get_command_from_info(command, pretty_exceptions_short=False, rich_markup_mode="rich")
+    opts = {opt for p in click_command.params if isinstance(p, click.Option) for opt in p.opts}
+    assert {"--registry", "--refresh"} <= opts
 
 
 def test_unreadable_requirements_file_warns_instead_of_crashing(tmp_path, fake_pip, monkeypatch):

--- a/tests/comfy_cli/command/test_node_deps.py
+++ b/tests/comfy_cli/command/test_node_deps.py
@@ -562,7 +562,7 @@ def test_registry_is_additive_with_positional_pack_names(workspace, fake_pip):
 
 def test_registry_ids_are_deduped_and_blanks_dropped(workspace, fake_pip):
     api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
-    report, _ = node_deps_cmd.build_report(
+    report, warnings = node_deps_cmd.build_report(
         str(workspace),
         registry_ids=["some-pack", "  some-pack ", "", "   "],
         python="/fake/python",
@@ -571,6 +571,214 @@ def test_registry_ids_are_deduped_and_blanks_dropped(workspace, fake_pip):
 
     assert [p["pack"] for p in report["packs"]] == ["some-pack"]
     assert api.calls == ["some-pack"]
+    # The blanks are reported, not silently swallowed.
+    assert [w["code"] for w in warnings] == ["registry_invalid_node_id"] * 2
+
+
+def test_registry_ids_dedupe_case_insensitively(workspace, fake_pip):
+    """The registry resolves ids case-insensitively (`GET /nodes/comfyui-lcm`
+    302s to `/nodes/ComfyUI-LCM`), so two spellings are one pack — not two
+    network calls, two cache entries and two rows.
+    """
+    api = _FakeRegistry(_node("Some-Pack", "1.0.0", ["numpy"]))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace),
+        registry_ids=["Some-Pack", "some-pack", "SOME-PACK"],
+        python="/fake/python",
+        registry_api=api,
+    )
+
+    assert [p["pack"] for p in report["packs"]] == ["Some-Pack"], "first spelling seen wins"
+    assert api.calls == ["Some-Pack"]
+    assert warnings == []
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "some-pack/install",  # the side-effecting install endpoint's own URL
+        "../nodes/other",
+        "some-pack?version=1",
+        "some-pack#frag",
+        "some pack",
+        "https://api.comfy.org/nodes/some-pack",
+    ],
+)
+def test_registry_id_outside_the_safe_charset_is_rejected_without_a_request(workspace, fake_pip, bad_id):
+    """`get_node` interpolates the id straight into `GET {base}/nodes/{id}`, so a
+    `/` retargets the request — `<pack>/install` builds exactly `install_node`'s
+    URL, the endpoint this feature promises never to touch. Reject before the call.
+    """
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=[bad_id], python="/fake/python", registry_api=api
+    )
+
+    assert api.calls == [], "an invalid id must never reach the network"
+    assert report["packs"] == []
+    assert [w["code"] for w in warnings] == ["registry_invalid_node_id"]
+
+
+def test_all_registry_ids_rejected_does_not_dump_every_installed_pack(workspace, fake_pip):
+    """A targeted pre-install question whose ids were all rejected must answer
+    with the warning, not silently fall back to the whole-workspace report.
+    """
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["", "bad/id"], python="/fake/python", registry_api=api
+    )
+
+    assert report["packs"] == []
+    assert [w["code"] for w in warnings] == ["registry_invalid_node_id"] * 2
+
+
+def test_registry_404_is_distinct_from_a_transient_outage(workspace, fake_pip):
+    """`registry_unavailable`'s hint says "check the network, retry with
+    --refresh" — an agent following that against a 404 retries forever.
+    """
+    from comfy_cli.registry import NodeFetchError
+
+    api = _FakeRegistry(error=NodeFetchError("Failed to retrieve node: 404 - Node not found", status_code=404))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["no-such-pack"], python="/fake/python", registry_api=api
+    )
+
+    assert [w["code"] for w in warnings] == ["registry_node_not_found"]
+    assert "404" in _registry_row(report)["warning"]
+
+
+def test_registry_5xx_stays_registry_unavailable(workspace, fake_pip):
+    from comfy_cli.registry import NodeFetchError
+
+    api = _FakeRegistry(error=NodeFetchError("Failed to retrieve node: 503 - upstream down", status_code=503))
+    _, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api
+    )
+
+    assert [w["code"] for w in warnings] == ["registry_unavailable"]
+
+
+def test_registry_error_text_is_truncated_before_entering_the_envelope(workspace, fake_pip):
+    """A captive portal answers with a whole HTML page; it must not be copied
+    verbatim into the single-line JSON envelope consumers parse.
+    """
+    api = _FakeRegistry(error=Exception("Failed to retrieve node: 502 - " + ("<html>padding</html>" * 500)))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api
+    )
+
+    message = _registry_row(report)["warning"]
+    assert len(message) < node_deps_cmd.MAX_REGISTRY_ERROR_CHARS + 120
+    assert message.endswith("… (truncated)")
+    assert warnings[0]["message"] == message
+
+
+def test_registry_partial_dependency_list_is_flagged_not_silently_shortened(workspace, fake_pip):
+    """`["numpy", null]` must not render as complete metadata containing only
+    numpy — the dropped entry could have been the conflicting one.
+    """
+    api = _FakeRegistry(_node("mixed-pack", "1.0.0", ["numpy>=1.20", None, 123]))
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["mixed-pack"], python="/fake/python", registry_api=api
+    )
+
+    row = _registry_row(report)
+    assert row["declared"] == ["numpy>=1.20"]
+    assert [w["code"] for w in warnings] == ["registry_partial_dependency_metadata"]
+    assert "incomplete" in row["warning"]
+
+
+def test_malformed_cache_entry_does_not_abort_the_report(workspace, fake_pip):
+    """A cache entry written by another comfy-cli version (or hand-edited) can
+    hold `[null]`; reaching `_classify` it would raise AttributeError and kill
+    the whole report — the opposite of this module's degrade-to-a-warning design.
+    """
+    from comfy_cli.command import outdated as outdated_cmd
+
+    api = _FakeRegistry(_node("cached-pack", "1.0.0", ["numpy"]))
+    cache = outdated_cmd._load_cache()
+    key = node_deps_cmd._registry_cache_key(api, "cached-pack")
+    outdated_cmd._cache_set(cache, key, {"version": "1.0.0", "dependencies": [None, 123, "numpy>=1.20"]})
+    outdated_cmd._save_cache(cache)
+
+    report, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["cached-pack"], python="/fake/python", registry_api=api
+    )
+
+    assert api.calls == [], "served from cache"
+    assert _registry_row(report)["declared"] == ["numpy>=1.20"]
+    assert warnings == []
+
+
+def test_registry_cache_key_is_scoped_to_the_registry_base_url(workspace, fake_pip):
+    """Staging metadata must not be served to a later production run, where it
+    could hide a real dependency conflict.
+    """
+
+    class _Scoped(_FakeRegistry):
+        def __init__(self, base_url, node):
+            super().__init__(node)
+            self.base_url = base_url
+
+    staging = _Scoped("https://stagingapi.comfy.org", _node("some-pack", "9.9.9-staging", ["numpy"]))
+    production = _Scoped("https://api.comfy.org", _node("some-pack", "1.0.0", ["numpy"]))
+
+    node_deps_cmd.build_report(str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=staging)
+    report, _ = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=production
+    )
+
+    assert production.calls == ["some-pack"], "the staging entry must not satisfy a production lookup"
+    assert _registry_row(report)["version"] == "1.0.0"
+
+
+def test_saving_the_cache_preserves_a_concurrent_writers_keys(workspace, fake_pip):
+    """`node deps` is a second writer of the file `comfy outdated` owns: it must
+    merge into a freshly re-read dict, not blind-write the one it loaded.
+    """
+    from comfy_cli.command import outdated as outdated_cmd
+
+    class _RacingRegistry(_FakeRegistry):
+        """Writes a rival key *after* build_report has loaded the cache."""
+
+        def get_node(self, node_id):
+            rival = outdated_cmd._load_cache()
+            outdated_cmd._cache_set(rival, "pack:written-by-outdated", "2.0.0")
+            outdated_cmd._save_cache(rival)
+            return super().get_node(node_id)
+
+    api = _RacingRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    node_deps_cmd.build_report(str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api)
+
+    saved = outdated_cmd._load_cache()
+    assert outdated_cmd._cache_get(saved, "pack:written-by-outdated") == "2.0.0"
+    assert node_deps_cmd._registry_cache_key(api, "some-pack") in saved
+
+
+def test_expired_registry_cache_entries_are_pruned_on_save(workspace, fake_pip):
+    """The key space is arbitrary caller-supplied ids holding whole dependency
+    lists, and `_save_cache` rewrites every key — without pruning it grows without bound.
+    """
+    import time
+
+    from comfy_cli.command import outdated as outdated_cmd
+
+    api = _FakeRegistry(_node("some-pack", "1.0.0", ["numpy"]))
+    cache = outdated_cmd._load_cache()
+    stale_key = f"{node_deps_cmd.REGISTRY_CACHE_PREFIX}https://api.comfy.org:long-gone-pack"
+    cache[stale_key] = {"value": {"version": "1", "dependencies": ["numpy"]}, "ts": time.time() - 999_999}
+    # A *fresh* registry entry and `outdated`'s own expired keys are both left alone.
+    fresh_key = f"{node_deps_cmd.REGISTRY_CACHE_PREFIX}https://api.comfy.org:still-fresh"
+    outdated_cmd._cache_set(cache, fresh_key, {"version": "1", "dependencies": ["numpy"]})
+    cache["pack:someone-elses-expired"] = {"value": "1.0.0", "ts": time.time() - 999_999}
+    outdated_cmd._save_cache(cache)
+
+    node_deps_cmd.build_report(str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api)
+
+    saved = outdated_cmd._load_cache()
+    assert stale_key not in saved
+    assert fresh_key in saved
+    assert "pack:someone-elses-expired" in saved, "pruning is scoped to this command's own key space"
 
 
 def test_registry_rows_validate_against_the_shipped_schema(workspace, fake_pip):
@@ -805,3 +1013,27 @@ def test_deps_command_is_registered_on_the_node_app():
     names = {c.name for c in app.registered_commands}
     assert "deps" in names
     assert {"deps-in-workflow", "install-deps"} <= names, "must not shadow the existing deps-* commands"
+
+
+def test_a_failed_refresh_does_not_resurrect_an_expired_cache_entry(workspace, fake_pip):
+    """The failed lookup writes nothing, so the stale entry it could not replace
+    must still be pruned rather than carried forward as a fresh write.
+    """
+    import time
+
+    import requests
+
+    from comfy_cli.command import outdated as outdated_cmd
+
+    api = _FakeRegistry(error=requests.exceptions.RequestException("boom"))
+    key = node_deps_cmd._registry_cache_key(api, "some-pack")
+    cache = outdated_cmd._load_cache()
+    cache[key] = {"value": {"version": "1", "dependencies": ["numpy"]}, "ts": time.time() - 999_999}
+    outdated_cmd._save_cache(cache)
+
+    _, warnings = node_deps_cmd.build_report(
+        str(workspace), registry_ids=["some-pack"], python="/fake/python", registry_api=api
+    )
+
+    assert [w["code"] for w in warnings] == ["registry_unavailable"]
+    assert key not in outdated_cmd._load_cache()

--- a/tests/comfy_cli/command/test_node_deps.py
+++ b/tests/comfy_cli/command/test_node_deps.py
@@ -785,10 +785,10 @@ def test_cache_round_trips_a_non_ascii_registry_id(workspace, fake_pip):
     """`--registry` takes arbitrary caller-supplied ids, so a non-ASCII one can
     reach a cache key. `_load_cache` decodes bytes as JSON (UTF-8/16/32 only),
     so the writer must not emit anything a non-UTF-8 locale would mangle — the
-    whole cache silently resets to `{}` on the next read if it does. Two
-    independent guards hold that today (`json.dumps` escapes to pure ASCII,
-    `_save_cache` pins `encoding="utf-8"`); this pins the round-trip itself so
-    dropping either one fails here rather than in a Windows user's cache.
+    whole cache silently resets to `{}` on the next read if it does. This is the
+    end-to-end guard; it passes on any host today because `json.dumps` escapes
+    the payload to pure ASCII. The `encoding="utf-8"` pin that holds once that
+    is no longer true is asserted separately, below.
     """
     from comfy_cli.command import outdated as outdated_cmd
 
@@ -801,6 +801,34 @@ def test_cache_round_trips_a_non_ascii_registry_id(workspace, fake_pip):
         "version": "1.0.0",
         "dependencies": ["numpé>=1.20"],
     }
+
+
+def test_save_cache_pins_the_write_encoding(monkeypatch):
+    """The round-trip above cannot catch a dropped `encoding="utf-8"`: the bytes
+    it writes are pure ASCII, which every locale encodes identically, so the
+    pin only matters the day `json.dumps` stops escaping. Nor can the ambient
+    encoding be faked — CPython resolves `write_text`'s default below the Python
+    `locale` module. So assert the writer's contract directly: `_save_cache`
+    names its encoding rather than inheriting the host's, and what lands on disk
+    is the UTF-8 that `_load_cache`'s `json.loads(bytes)` can decode.
+    """
+    import time
+
+    from comfy_cli.command import outdated as outdated_cmd
+
+    seen: dict[str, object] = {}
+    real_write_text = Path.write_text
+
+    def spy(self, data, encoding=None, **kwargs):
+        seen["encoding"] = encoding
+        return real_write_text(self, data, encoding=encoding, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", spy)
+    key = f"{node_deps_cmd.REGISTRY_CACHE_PREFIX}https://api.comfy.org:café-pack"
+    outdated_cmd._save_cache({key: {"value": "1.0.0", "ts": time.time()}})
+
+    assert seen["encoding"] == "utf-8", "the host locale must not pick the cache encoding"
+    assert json.loads(outdated_cmd._cache_path().read_bytes())[key]["value"] == "1.0.0"
 
 
 def test_registry_rows_validate_against_the_shipped_schema(workspace, fake_pip):

--- a/tests/comfy_cli/command/test_outdated.py
+++ b/tests/comfy_cli/command/test_outdated.py
@@ -437,3 +437,34 @@ def test_cli_json_envelope_shape(workspace, monkeypatch, capsys):
     assert envelope["command"] == "outdated"
     assert envelope["data"]["core"]["outdated"] is True
     assert isinstance(envelope["data"]["packs"], list)
+
+
+# ---------------------------------------------------------------------------
+# cache durability
+# ---------------------------------------------------------------------------
+
+
+def test_save_cache_is_atomic_and_leaves_no_temp_residue():
+    """The cache is written by more than one command (`outdated` and `node
+    deps`). A write interrupted midway must not leave a truncated file that
+    `_load_cache` silently resets to `{}` — so it renames into place rather
+    than truncating the live file.
+    """
+    payload = {"pack:one": {"value": "1.0.0", "ts": 1}, "core": {"value": "v0.3.40", "ts": 1}}
+    outdated_cmd._save_cache(payload)
+
+    path = outdated_cmd._cache_path()
+    assert outdated_cmd._load_cache() == payload
+    assert list(path.parent.iterdir()) == [path], "temp file must not survive the write"
+
+
+def test_save_cache_survives_an_unwritable_cache_dir(monkeypatch, tmp_path):
+    """A read-only cache dir must never break a read-only report."""
+    unwritable = tmp_path / "nope"
+    unwritable.mkdir()
+    unwritable.chmod(0o500)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(unwritable))
+    try:
+        outdated_cmd._save_cache({"pack:one": {"value": "1.0.0", "ts": 1}})
+    finally:
+        unwritable.chmod(0o700)


### PR DESCRIPTION
## ELI-5

`comfy node deps` already tells you which Python packages each *installed* custom node pack wants, and whether your workspace venv actually has them. This adds `--registry <node-id>`, which asks the same question about a pack you have **not installed yet** — so an agent can see "installing this would want numpy 2.x, but you're pinned to 1.26" *before* pulling anything down. It installs nothing and reads only.

## What changed

- New `--registry <node-id>` option on `comfy node deps` (repeatable, and additive with the positional pack names — a single report can mix installed packs and registry candidates).
- New `--refresh` option to bypass the registry lookup cache.
- Registry candidates come back as `packs[]` rows with `"status": "registry"`, `"registry": true`, `"version": "<latest>"`, `"declared": [...]`, and the **same** per-requirement `installed` / `status` fields, computed against the **same single `pip list`** map as the installed packs (still one subprocess for the whole report).
- Two new warning codes registered in `comfy_cli/error_codes.py`: `registry_unavailable`, `registry_no_dependency_metadata`.
- `comfy_cli/schemas/node_deps.json` updated for the new row/field shapes.

## Live verification of the ticket's step-1 premise

The ticket asked me to confirm against the live registry — **before** implementing — that `/nodes/{id}`'s `latest_version` actually carries `dependencies`, and to ship an honest `declared: null` warning if it does not. It does:

```
$ curl -s https://api.comfy.org/nodes/comfyui-impact-pack
latest_version keys: [..., 'dependencies', ..., 'version']
version: 8.28.3
dependencies: ["segment-anything", "scikit-image", "piexif", "transformers",
               "opencv-python-headless", "scipy", "numpy", "dill", "matplotlib",
               "sam2 @ git+https://github.com/facebookresearch/sam2"]
```

I then ran the real CLI end-to-end against the live API (not a mock): `comfy node deps --registry comfyui-impact-pack` returned `"version": "8.28.3"` with all 10 dependencies classified, and a second run was served from the cache. So the **working path is the shipped path** — the `declared: null` + warning branch is a genuine fallback for packs whose publisher shipped no dependency metadata, not a dead end standing in for a capability that actually exists. No `install_node` fallback and no requirements.txt web-fetch, per the ticket.

## Read-only / no-side-effects guarantee

Dependencies come from `RegistryAPI.get_node` — **never** `install_node`, whose `/nodes/{id}/install` endpoint records an installation and fires an analytics event on every call. This is the same read `comfy outdated` uses for the same reason. A test locks it in: it patches `install_node` and `get_node` with `autospec` mocks on the real `RegistryAPI` class, runs the report with no injected fake, and asserts `install_node.assert_not_called()`.

## Failure behavior

- **Registry unreachable / timeout / non-200** → that row gets `declared: null` + a per-entry `warning`, plus a `registry_unavailable` entry in `data.warnings[]`. The command still exits 0 and every installed-pack section still renders (covered by a test that mixes a failing registry id with a real installed pack).
- **No dependency metadata published** → `declared: null` + the `registry_no_dependency_metadata` warning. Deliberately `null`, never `[]`: `map_node_version` defaults a missing `dependencies` key to `[]`, so the API genuinely cannot distinguish "declares nothing" from "field absent", and claiming the former would be dishonest.
- Failures are **not** cached, so a transient outage can't poison the next hour (tested).

## Caching

Reuses `outdated.py`'s `_cache_*` helpers and its 1h TTL, keyed on node id under a distinct `deps-registry:` prefix so it coexists with `outdated`'s own `pack:<id>` entries in the same file (verified on disk). `--refresh` bypasses the read. Tests point `XDG_CACHE_HOME` at a tmpdir so a test run can never touch a developer's real cache.

## Judgment calls

1. **`--registry`-only invocations do not also dump every installed pack.** Bare `comfy node deps` still reports the whole workspace (byte-identical behavior — the new branch is unreachable unless `--registry` is passed). But `comfy node deps --registry foo` is a targeted pre-install question, so it reports just `foo`; pass pack names positionally to get both. Documented in the help text and schema.
2. **`--registry` is repeatable**, though the ticket allowed single-only for v1 — it was free via `list[str]` and strictly more useful. Ids are deduped order-preservingly and blanks dropped (an empty id would otherwise request the registry's whole node collection).
3. **`pack` is not a unique key.** Naming the same id both positionally and via `--registry` deliberately yields two rows (one `installed`, one `registry`) — that's a legitimate "what do I have vs what would I get" query. Called out in the schema so JSON consumers key on (`pack`, `registry`).
4. **Latest-version-only granularity**, as the ticket specifies — there is no read-only endpoint for a pinned version's dependencies. Stated in the `--registry` help text, the module docstring, and the schema's `version` description.
5. **`--refresh` is a no-op without `--registry`** (there is nothing else cached); the help text says so rather than erroring on a harmless combination.

## Self-review notes

Reviewing my own diff adversarially caught one real defect, now fixed with a regression test: if the API ever returned a non-list truthy `dependencies` (a bare string `"numpy"`), the comprehension would have iterated it *per character*, producing five bogus requirement rows. It now requires `isinstance(dependencies, list)` and degrades to the honest warning otherwise. A blank-strings-only payload degrades the same way.

Both touched pre-existing branches are safe against regression: the `else:` → `elif not wanted_registry:` split is unreachable without `--registry` (which did not exist before this PR), and the pretty renderer's `no declared requirements` line falls back to the exact prior string for any row without a `warning` key — it now `escape()`s that text, which is required because a registry error message can contain server-supplied markup.

## Testing

`uv run --locked --extra dev pytest .` → **3089 passed, 37 skipped, 1 failed**. 20 new tests in `tests/comfy_cli/command/test_node_deps.py`.

⚠️ The single failure, `test_error_code_registry.py::test_no_duplicate_codes`, is **pre-existing on `main` and unrelated to this PR** — I verified it fails identically on a clean `origin/main` checkout. `comfy_cli/error_codes.py` has two `ErrorCode("server_died", ...)` entries (lines ~365 and ~375) with different descriptions. I left it alone rather than drive-by-fixing, since picking which description is canonical is a call for whoever owns the jobs/watcher surface — but it means `main` is currently red and worth a follow-up.

`ruff check` / `ruff format --check` add no new findings: the 16 lint errors and one unformatted file (`tests/comfy_cli/command/github/test_pr.py`) present on this branch are byte-identical to the `origin/main` baseline, which I measured explicitly.
