### PR TITLE
feat: add system-stats and free commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ Comfy provides commands that allow you to easily run the installed ComfyUI.
   - Maximum of 10 PR builds are kept (oldest are removed automatically)
   - Cache limits help manage disk space while keeping recent builds available
 
+- To check VRAM/RAM usage: `comfy system-stats` (add `--where cloud` to target Comfy Cloud instead of local)
+- To unload models / free the executor cache: `comfy free` (pass `--free-memory` to also reset the executor cache)
+
 ### Managing Custom Nodes
 
 comfy provides a convenient way to manage custom nodes for extending ComfyUI's functionality. Here are some examples:

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1207,6 +1207,49 @@ def validate_comfyui(_env_checker):
         raise typer.Exit(code=1)
 
 
+@app.command(
+    "system-stats",
+    help="Show ComfyUI system stats: per-device VRAM + system RAM/version (GET /system_stats).",
+)
+@tracking.track_command()
+def system_stats(
+    where: Annotated[
+        str | None,
+        typer.Option("--where", show_default=False, help="Routing target: 'local' (default) or 'cloud'."),
+    ] = None,
+):
+    from comfy_cli.command import system as system_command
+
+    system_command.system_stats_execute(get_renderer(), where=where)
+
+
+@app.command(
+    help="Ask ComfyUI to unload models / free the executor cache (POST /free). "
+    "Applies on the worker's next iteration — never interrupts a running job."
+)
+@tracking.track_command()
+def free(
+    unload_models: Annotated[
+        bool,
+        typer.Option("--unload-models/--no-unload-models", help="Unload all models from VRAM."),
+    ] = True,
+    free_memory: Annotated[
+        bool,
+        typer.Option(
+            "--free-memory",
+            help="Also reset the executor cache; implies --unload-models on the server side.",
+        ),
+    ] = False,
+    where: Annotated[
+        str | None,
+        typer.Option("--where", show_default=False, help="Routing target: 'local' (default) or 'cloud'."),
+    ] = None,
+):
+    from comfy_cli.command import system as system_command
+
+    system_command.free_execute(get_renderer(), where=where, unload_models=unload_models, free_memory=free_memory)
+
+
 @app.command(help="Stop background ComfyUI")
 @tracking.track_command()
 def stop():

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -432,6 +432,33 @@ class Client:
                 return None
             raise
 
+    # ----- resource management -----
+
+    def get_system_stats(self, *, timeout: float | None = None) -> dict | None:
+        """GET {prefix}/system_stats.
+
+        Per-device VRAM (``vram_total``/``vram_free``/``torch_vram_total``/
+        ``torch_vram_free``) plus system RAM and version info. Same shape on
+        local and cloud — passed through unmodified so the schema tracks
+        whatever ComfyUI itself reports.
+        """
+        return self._request("GET", ("system_stats",), timeout=timeout)
+
+    def post_free(self, *, unload_models: bool = True, free_memory: bool = False, timeout: float | None = None) -> None:
+        """POST {prefix}/free — ask the queue worker to unload models / free the cache.
+
+        ``free_memory=True`` implies unloading models on the server side even
+        when ``unload_models`` is False. The flags apply the next time the
+        worker iterates: immediately if it's idle, after the current job if
+        one is running — this never interrupts an in-flight job.
+        """
+        self._request(
+            "POST",
+            ("free",),
+            body={"unload_models": unload_models, "free_memory": free_memory},
+            timeout=timeout,
+        )
+
     # ----- polling helpers -----
 
     def wait_for_completion(

--- a/comfy_cli/command/system.py
+++ b/comfy_cli/command/system.py
@@ -1,0 +1,138 @@
+"""``comfy system-stats`` and ``comfy free`` — ComfyUI resource-management passthrough.
+
+Thin wrappers over ComfyUI's own ``GET /system_stats`` and ``POST /free``
+endpoints (routed through :class:`comfy_cli.comfy_client.Client`, cloud or
+local via ``resolve_target``), so agents can read VRAM state and free it
+without any direct HTTP.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from typing import Any
+
+import typer
+
+from comfy_cli.comfy_client import Client, HTTPError
+from comfy_cli.target import resolve_target
+
+
+def _humanize_bytes(n: Any) -> str:
+    """Render a byte count as a compact human-readable string (e.g. ``3.5 GiB``).
+
+    Non-numeric input (a device that omitted the field) renders as ``?``
+    rather than raising, since pretty-mode rendering must never crash on a
+    server payload we don't fully control.
+    """
+    if not isinstance(n, (int, float)):
+        return "?"
+    value = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0:
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PiB"
+
+
+def _render_stats_pretty(renderer, stats: dict[str, Any]) -> None:
+    from rich.table import Table
+
+    devices = stats.get("devices") or []
+    tbl = Table(show_header=True, header_style="bold")
+    tbl.add_column("name")
+    tbl.add_column("type")
+    tbl.add_column("index")
+    tbl.add_column("vram_free")
+    tbl.add_column("vram_total")
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        tbl.add_row(
+            str(dev.get("name", "?")),
+            str(dev.get("type", "?")),
+            str(dev.get("index", "?")),
+            _humanize_bytes(dev.get("vram_free")),
+            _humanize_bytes(dev.get("vram_total")),
+        )
+    renderer.console().print(tbl)
+
+    system = stats.get("system") or {}
+    ram_free = _humanize_bytes(system.get("ram_free"))
+    ram_total = _humanize_bytes(system.get("ram_total"))
+    version = system.get("comfyui_version", "?")
+    renderer.print(f"[dim]RAM: {ram_free} / {ram_total} free — ComfyUI {version}[/dim]")
+
+
+def _handle_unreachable(renderer, e: Exception, *, target, operation: str) -> None:
+    if isinstance(e, HTTPError):
+        code = "cloud_http_error" if target.is_cloud else "server_not_running"
+        renderer.error(
+            code=code,
+            message=f"HTTP {e.status} from ComfyUI during {operation}: {e.message}",
+            hint="run `comfy cloud whoami` to verify auth"
+            if target.is_cloud
+            else "run `comfy launch` to start a local server",
+            details={"status": e.status},
+        )
+        return
+    code = "cloud_http_error" if target.is_cloud else "server_not_running"
+    renderer.error(
+        code=code,
+        message=f"could not reach ComfyUI during {operation}: {e}",
+        hint="check `--where` and network connectivity"
+        if target.is_cloud
+        else "run `comfy launch` to start a local server",
+    )
+
+
+def system_stats_execute(renderer, *, where: str | None = None) -> None:
+    """Entry point wired from ``comfy system-stats`` in cmdline.py."""
+    target = resolve_target(where=where)
+    client = Client(target)
+    try:
+        stats = client.get_system_stats()
+    except (HTTPError, urllib.error.URLError, OSError) as e:
+        _handle_unreachable(renderer, e, target=target, operation="system-stats")
+        raise typer.Exit(code=1) from e
+
+    if not isinstance(stats, dict):
+        renderer.error(
+            code="cloud_http_error" if target.is_cloud else "server_not_running",
+            message="ComfyUI returned an unparseable /system_stats response",
+            hint="check that the host really is a ComfyUI server",
+        )
+        raise typer.Exit(code=1)
+
+    if renderer.is_pretty():
+        _render_stats_pretty(renderer, stats)
+    renderer.emit(stats, command="system-stats")
+
+
+def free_execute(
+    renderer,
+    *,
+    where: str | None = None,
+    unload_models: bool = True,
+    free_memory: bool = False,
+) -> None:
+    """Entry point wired from ``comfy free`` in cmdline.py."""
+    target = resolve_target(where=where)
+    client = Client(target)
+    try:
+        client.post_free(unload_models=unload_models, free_memory=free_memory)
+    except (HTTPError, urllib.error.URLError, OSError) as e:
+        _handle_unreachable(renderer, e, target=target, operation="free")
+        raise typer.Exit(code=1) from e
+
+    note = (
+        "applies when the queue worker next iterates — immediate if idle, after the current job if busy; "
+        "does not interrupt a running job"
+    )
+    payload = {
+        "requested": {"unload_models": unload_models, "free_memory": free_memory},
+        "note": note,
+    }
+    if renderer.is_pretty():
+        renderer.success(f"Requested: unload_models={unload_models}, free_memory={free_memory}")
+        renderer.print(f"[dim]{note}[/dim]")
+    renderer.emit(payload, command="free")

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -114,6 +114,9 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy node deps": "node_deps",
     # background server logs
     "comfy logs": "logs",
+    # resource management (ComfyUI /system_stats + /free passthrough)
+    "comfy system-stats": "system_stats",
+    "comfy free": "free",
 }
 
 

--- a/comfy_cli/schemas/free.json
+++ b/comfy_cli/schemas/free.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/free.json",
+  "title": "comfy free",
+  "description": "Result of POST /free — echoes back what was requested. The flags apply the next time the queue worker iterates (immediate if idle, after the current job if busy); they never interrupt a running job.",
+  "type": "object",
+  "required": ["requested", "note"],
+  "additionalProperties": true,
+  "properties": {
+    "requested": {
+      "type": "object",
+      "required": ["unload_models", "free_memory"],
+      "additionalProperties": false,
+      "properties": {
+        "unload_models": { "type": "boolean" },
+        "free_memory": { "type": "boolean" }
+      }
+    },
+    "note": { "type": "string" }
+  }
+}

--- a/comfy_cli/schemas/system_stats.json
+++ b/comfy_cli/schemas/system_stats.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/system_stats.json",
+  "title": "comfy system-stats",
+  "description": "Passthrough of ComfyUI's GET /system_stats response — per-device VRAM plus system RAM/version info. Shape tracks whatever ComfyUI itself reports, so this schema only pins the fields agents rely on.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "system": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "ram_total": { "type": "number" },
+        "ram_free": { "type": "number" },
+        "comfyui_version": { "type": "string" }
+      }
+    },
+    "devices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "index": { "type": "integer" },
+          "vram_total": { "type": "number" },
+          "vram_free": { "type": "number" },
+          "torch_vram_total": { "type": "number" },
+          "torch_vram_free": { "type": "number" }
+        }
+      }
+    }
+  }
+}

--- a/tests/comfy_cli/command/test_system.py
+++ b/tests/comfy_cli/command/test_system.py
@@ -1,0 +1,231 @@
+"""Tests for `comfy system-stats` and `comfy free` — the ComfyUI
+`/system_stats` and `/free` passthrough.
+
+All HTTP is mocked at the `comfy_client._OPENER` seam (the opener the
+`Client` class actually calls through), matching the mocking style used for
+`Client`-based commands elsewhere (e.g. `comfy download`).
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from comfy_cli import comfy_client
+from comfy_cli.caller import Caller
+from comfy_cli.command import system as system_cmd
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+from comfy_cli.target import Target
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+LOCAL_TARGET = Target(kind="local", base_url="http://127.0.0.1:8188", path_prefix="", host="127.0.0.1", port=8188)
+CLOUD_TARGET = Target(
+    kind="cloud",
+    base_url="https://cloud.example.com",
+    path_prefix="/api",
+    history_path="history_v2",
+    jobs_path="jobs",
+    api_key="test-api-key",
+)
+
+
+class _FakeResp:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _force_renderer() -> Renderer:
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _envelope(capsys: pytest.CaptureFixture[str]) -> dict:
+    captured = capsys.readouterr().out
+    assert captured.strip(), "no envelope on stdout"
+    return json.loads(captured.strip().splitlines()[-1])
+
+
+# ---------------------------------------------------------------------------
+# system-stats
+# ---------------------------------------------------------------------------
+
+
+_RAW_STATS = {
+    "system": {"os": "posix", "ram_total": 34359738368, "ram_free": 12884901888, "comfyui_version": "0.3.45"},
+    "devices": [
+        {
+            "name": "cuda:0 NVIDIA GeForce RTX 4090",
+            "type": "cuda",
+            "index": 0,
+            "vram_total": 25769803776,
+            "vram_free": 21474836480,
+            "torch_vram_total": 4294967296,
+            "torch_vram_free": 2147483648,
+        }
+    ],
+}
+
+
+class TestSystemStats:
+    def test_emits_passthrough_envelope(self, capsys):
+        renderer = _force_renderer()
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=LOCAL_TARGET),
+            patch.object(
+                comfy_client._OPENER,
+                "open",
+                side_effect=lambda req, timeout=None: _FakeResp(json.dumps(_RAW_STATS).encode()),
+            ),
+        ):
+            system_cmd.system_stats_execute(renderer, where="local")
+        env = _envelope(capsys)
+        assert env["ok"] is True
+        assert env["command"] == "system-stats"
+        # Passed through unmodified — same dict, not a re-shaped one.
+        assert env["data"] == _RAW_STATS
+        assert isinstance(env["data"]["devices"][0]["vram_free"], int)
+
+    def test_local_unreachable_server_not_running(self, capsys):
+        renderer = _force_renderer()
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=LOCAL_TARGET),
+            patch.object(comfy_client._OPENER, "open", side_effect=urllib.error.URLError("Connection refused")),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                system_cmd.system_stats_execute(renderer, where="local")
+        assert exc_info.value.exit_code == 1
+        env = _envelope(capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_not_running"
+
+    def test_cloud_unreachable_is_cloud_http_error(self, capsys):
+        renderer = _force_renderer()
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=CLOUD_TARGET),
+            patch.object(comfy_client._OPENER, "open", side_effect=urllib.error.URLError("Connection refused")),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                system_cmd.system_stats_execute(renderer, where="cloud")
+        assert exc_info.value.exit_code == 1
+        env = _envelope(capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+
+    def test_http_error_status_surfaced(self, capsys):
+        renderer = _force_renderer()
+
+        def _raise(req, timeout=None):
+            raise urllib.error.HTTPError(req.full_url, 500, "Internal Server Error", {}, None)
+
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=LOCAL_TARGET),
+            patch.object(comfy_client._OPENER, "open", side_effect=_raise),
+        ):
+            with pytest.raises(typer.Exit):
+                system_cmd.system_stats_execute(renderer, where="local")
+        env = _envelope(capsys)
+        assert env["ok"] is False
+        assert env["error"]["details"]["status"] == 500
+
+
+# ---------------------------------------------------------------------------
+# free
+# ---------------------------------------------------------------------------
+
+
+class TestFree:
+    def _run_free(self, capsys, *, unload_models=True, free_memory=False, target=LOCAL_TARGET):
+        renderer = _force_renderer()
+        calls: list[dict] = []
+
+        def _fake(req, timeout=None):
+            calls.append({"url": req.full_url, "method": req.get_method(), "body": req.data})
+            return _FakeResp(b"")
+
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=target),
+            patch.object(comfy_client._OPENER, "open", side_effect=_fake),
+        ):
+            system_cmd.free_execute(
+                renderer,
+                where="local" if not target.is_cloud else "cloud",
+                unload_models=unload_models,
+                free_memory=free_memory,
+            )
+        return calls, _envelope(capsys)
+
+    def test_default_body(self, capsys):
+        calls, env = self._run_free(capsys)
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["url"].endswith("/free")
+        assert json.loads(calls[0]["body"]) == {"unload_models": True, "free_memory": False}
+        assert env["ok"] is True
+        assert env["command"] == "free"
+        assert env["data"]["requested"] == {"unload_models": True, "free_memory": False}
+        assert "does not interrupt" in env["data"]["note"]
+
+    @pytest.mark.parametrize(
+        "unload_models,free_memory",
+        [
+            (False, False),
+            (True, True),
+            (False, True),
+        ],
+    )
+    def test_flag_combinations(self, capsys, unload_models, free_memory):
+        calls, env = self._run_free(capsys, unload_models=unload_models, free_memory=free_memory)
+        assert json.loads(calls[0]["body"]) == {"unload_models": unload_models, "free_memory": free_memory}
+        assert env["data"]["requested"] == {"unload_models": unload_models, "free_memory": free_memory}
+
+    def test_local_unreachable_server_not_running(self, capsys):
+        renderer = _force_renderer()
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=LOCAL_TARGET),
+            patch.object(comfy_client._OPENER, "open", side_effect=urllib.error.URLError("Connection refused")),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                system_cmd.free_execute(renderer, where="local")
+        assert exc_info.value.exit_code == 1
+        env = _envelope(capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "server_not_running"
+
+    def test_cloud_unreachable_is_cloud_http_error(self, capsys):
+        renderer = _force_renderer()
+        with (
+            patch("comfy_cli.command.system.resolve_target", return_value=CLOUD_TARGET),
+            patch.object(comfy_client._OPENER, "open", side_effect=urllib.error.URLError("Connection refused")),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                system_cmd.free_execute(renderer, where="cloud")
+        assert exc_info.value.exit_code == 1
+        env = _envelope(capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"


### PR DESCRIPTION
## ELI-5
Comfy CLI can now ask a ComfyUI server (local or cloud) how much VRAM/RAM is free, and can tell it to unload models / clear its cache — the same two things the ComfyUI web UI's memory panel does, but scriptable: `comfy system-stats` and `comfy free`.

## What changed
- `comfy_cli/comfy_client.py`: added `get_system_stats()` (GET `system_stats`) and `post_free(unload_models=True, free_memory=False)` (POST `free`) to the shared `Client` class, following the existing `get_history`/`get_job_status` style — both just delegate to `_request`, so retries/auth/redaction are unchanged.
- `comfy_cli/command/system.py` (new): `system_stats_execute` and `free_execute`, wired as top-level `@app.command`s in `cmdline.py` (same shape as `stop`/`launch`/`outdated`). Both resolve the target via `resolve_target` (respects the global `--where`, defaults to local) and reuse the existing `server_not_running` / `cloud_http_error` error-code convention for an unreachable server.
  - `system-stats`: JSON mode passes the server's `/system_stats` payload through unmodified (`renderer.emit(stats, ...)`) so the schema tracks ComfyUI's own shape; pretty mode renders a Rich table of devices (name/type/index/vram_free/vram_total, human-readable) plus a system RAM/version line.
  - `free`: `--unload-models/--no-unload-models` (default on) and `--free-memory` (default off, implies unload server-side per ComfyUI's own semantics — the CLI does not synthesize that on the client side, it just forwards the flags). Emits `{"requested": {...}, "note": "..."}` describing that the flags apply on the worker's next iteration and never interrupt a running job.
- `comfy_cli/discovery.py` + two new `comfy_cli/schemas/*.json`: registered both commands' output schemas (required by `test_every_emitted_command_registers_a_schema`). `system_stats.json` only pins the fields agents rely on (`additionalProperties: true`) since the payload is a ComfyUI passthrough; `free.json` pins the fixed `requested`/`note` shape.
- `README.md`: one-line mentions of both commands next to the existing launch/stop docs.
- `tests/comfy_cli/command/test_system.py` (new): mocks HTTP at the `Client`'s own opener seam. Covers the JSON passthrough shape, the pretty/local/cloud unreachable-server error codes (`server_not_running` vs `cloud_http_error`), an HTTP-level error status surfacing in `error.details`, and the `free` request body for the default flags plus three explicit on/off combinations.

## Verification
- `ruff check .` / `ruff format --check .` clean on the touched files (repo-wide `ruff format --check` only flags one pre-existing unrelated doc file).
- Full `pytest` suite green on Python 3.14 (3079 passed) and re-ran the new/discovery/error-registry tests on a fresh Python 3.10 venv (both clean). Three pre-existing failures are unrelated to this change and reproduce identically on `origin/main` before this branch: `test_node_deps.py::test_non_pep440_installed_version_is_unknown_not_a_crash`, `test_broken_pipe.py::TestBrokenPipeExitCode::test_closed_stdout_exits_zero`, `test_broken_pipe.py::TestBrokenPipeExitCode::test_head_pipeline_exits_zero`, and `test_error_code_registry.py::test_no_duplicate_codes` (a genuine pre-existing duplicate `server_died` entry in `error_codes.py`, also reproduces on `origin/main`, out of scope here).
- Manually smoke-tested both commands end-to-end against a throwaway local HTTP server implementing `/system_stats` + `/free`, in both `--json` and pretty mode, and against an unreachable port (connection-refused path) — all matched the automated-test expectations. No live ComfyUI instance was available in this environment, so the acceptance criterion's literal "against a live local ComfyUI" step is unverified beyond the throwaway server standing in for the documented `/system_stats` response shape from the ticket's spike evidence.

## Judgment calls
- The ticket's snippet names the class `ComfyClient`; the actual class in `comfy_client.py` is `Client` (used elsewhere as `from comfy_cli.comfy_client import Client`). Added the two methods to the existing `Client` class rather than introducing a new name.
- Added `--where` as the only routing option on both commands (no `--host`/`--port`), matching the simplest existing precedent (`comfy models list-folders`) — `resolve_target` already handles `COMFY_LOCAL_URL` / persisted defaults for local without them.