### PR TITLE
fix: collapse duplicate `server_died` error-code registry entry (BE-5024)

### DIFF
--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -363,11 +363,6 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "the job may still be running — check `comfy jobs status <id>`, or re-watch with a longer `--timeout`",
     ),
     ErrorCode(
-        "server_died",
-        "Server connection dropped while a foreground (`--wait`) job was in flight; recorded on the job state file.",
-        "check the server (it may have been OOM-killed); the prompt_id is in `comfy jobs status <id>`",
-    ),
-    ErrorCode(
         "watcher_poll_error",
         "Background watcher encountered a transient error polling the server.",
         "transient — the job is likely still running; re-run `comfy jobs watch <id>`",
@@ -375,8 +370,10 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "server_died",
         "The local ComfyUI server became unreachable (or restarted without the job) while it "
-        "was in flight — the server likely crashed or was killed (e.g. an out-of-memory allocation).",
-        "check the ComfyUI server log, then `comfy launch` and re-submit the workflow",
+        "was in flight — the server likely crashed or was killed (e.g. an out-of-memory allocation). "
+        "Raised by the background watcher and by a foreground (`--wait`) run; recorded on the job state file.",
+        "check the ComfyUI server log (it may have been OOM-killed), then `comfy launch` and re-submit; "
+        "the prompt_id is in `comfy jobs status <id>`",
     ),
     ErrorCode(
         "unknown_status_stall",


### PR DESCRIPTION
## ELI-5

Two different pull requests each taught the CLI the same new error name, `server_died`, and neither one noticed the other. Git merged both without complaining (they touched different lines), so the list of error names ended up with the same name written twice. A test whose whole job is "no name appears twice" started failing — on `main` itself, and therefore on every open PR, regardless of what that PR changed. This deletes one of the two and merges the useful wording from both into a single entry.

## What was wrong

`comfy_cli/error_codes.py` registered `ErrorCode("server_died", ...)` twice, so `tests/comfy_cli/output/test_error_code_registry.py::test_no_duplicate_codes` failed on `main` (`e6965d0`) with `AssertionError: Duplicate codes in registry: ['server_died']`. Every PR's `build` job inherited that failure — observed on #614, whose diff does not touch `error_codes.py` at all.

It was a semantic conflict between two cleanly-merged PRs: #605 (`comfy run --wait` writes job state at submit) and #604 (`jobs`: detect a dead local server). Neither touched the other's line, so nothing conflicted textually and the duplicate only surfaced at runtime.

The duplicate was also a live self-contradiction in the public contract, not just a red test: `error_codes.get("server_died")` returned the *first* entry while `comfy discover` emitted *both*, so the lookup and the published registry disagreed about what the code means.

## What this changes

Collapses the two entries into one. Both describe the same scenario — a local ComfyUI server dying while a job is in flight — so the union is straightforward:

- **Description:** keeps #604's fuller text (it names the crash / OOM / restart-without-the-job cases) and folds in #605's nuance, that the code is raised on the foreground `--wait` path too and is recorded on the job state file.
- **Hint:** merged so both actionable pointers survive — check the server log (it may have been OOM-killed), then `comfy launch` and re-submit; the `prompt_id` is in `comfy jobs status <id>`.

The error code string itself is unchanged, so nothing agents branch on moves. Only the human-facing `meaning` / `hint` prose changed.

`test_no_duplicate_codes` is deliberately **not** relaxed — the assertion is correct and is exactly what caught this contract collision.

## Verification

- `pytest tests/comfy_cli/output/test_error_code_registry.py` — 6 passed (was failing on `main`).
- Full suite: **3074 passed, 37 skipped**. On `main` the same suite is red on this one assertion.
- Both emitting call sites still resolve, checked explicitly: `tests/comfy_cli/command/test_run.py` (the `--wait` disconnect path in `command/run/__init__.py`, which sets `wait_state.error = {"code": "server_died", ...}`) and `tests/comfy_cli/jobs/test_jobs.py` (the `comfy jobs` watcher path from #604, via `_finalize_server_died` in `command/job_watcher.py`) — 308 passed together with the `output/` suite. The registry's own `test_every_registered_code_is_raised` / `test_every_raised_code_is_registered` pair independently confirms the code is still both registered and raised.
- Public surface checked empirically rather than assumed: `load_error_codes()` now yields exactly **one** `server_died` row carrying the merged text, and the registry holds 113 codes, 113 unique.
- `ruff check` + `ruff format --diff` clean at the version CI pins (`0.15.15`).

## Judgment calls

- **Kept the entry at #604's position**, after `watcher_poll_error`, rather than #605's slot. That groups the three `watcher_*` codes together and leaves `server_died` next to them. `REGISTRY` order is cosmetic (the module comments it as "ordered roughly by subsystem"; nothing indexes into it), so this is presentation only.
- **No `docs/json-output.md` change.** The ticket asked me to check for a stale second listing there — there is none. That table documents codes raised by `comfy run`, and `server_died` was never in it: on the run path the code is written to the *state file* while the emitted envelope code is `ws_disconnected`, which is already documented on line 348. The doc points at `comfy discover` for the full registry, and that output is now correct.
- **Local `ruff` (unpinned, newer than CI's) reports 16 lint findings plus one file needing reformat.** All of them reproduce identically on unmodified `main` with my change stashed, none are in a file I touched, and CI's pinned `0.15.15` is clean. Left alone as out of scope — flagging it because it will confuse anyone who runs a current `ruff` locally.
