### PR TITLE
fix(nodes): tokenized, order-independent `nodes search` with category haystack and close-match fallback

### DIFF
--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -397,10 +397,21 @@ def show_cmd(
 # ---------------------------------------------------------------------------
 
 
-@app.command("search", help="Fuzzy-search node classes by name, display name, or description.")
+@app.command(
+    "search",
+    help=(
+        "Search node classes by name, display name, category, or description "
+        "(case-insensitive, word-order-independent; falls back to close-name matches)."
+    ),
+)
 @tracking.track_command("nodes")
 def search_cmd(
-    query: Annotated[str, typer.Argument(help="Text to search for (case-insensitive substring).")],
+    query: Annotated[
+        str,
+        typer.Argument(
+            help=("Text to search for (case-insensitive, word-order-independent; falls back to close-name matches).")
+        ),
+    ],
     limit: Annotated[int, typer.Option(help="Cap output to N rows.")] = 20,
     input_path: Annotated[
         str | None,
@@ -429,30 +440,51 @@ def search_cmd(
         on_stale=lambda key, err: _stale.update(stale=True, source=key, reason=err),
     )
 
+    # Token-AND matching: every whitespace-separated token must be present, in
+    # any order. `q_joined` additionally lets a spaced query hit a CamelCase
+    # class name ('ksampler advanced' -> 'ksampleradvanced' == KSamplerAdvanced).
     q = query.lower()
+    tokens = q.split() or [q]
+    q_joined = "".join(tokens)
     scored: list[tuple[int, Any]] = []
     for m in graph.all_nodes():
         name_l = m.id.lower()
         display_l = m.display_name.lower()
         desc_l = m.description.lower()
-        # Simple scoring: exact name hit > prefix > substring in name > display > description.
-        if name_l == q:
+        cat_l = (m.category or "").lower()
+        blob = " ".join((name_l, display_l, desc_l, cat_l))
+        # Tiered: exact name > name prefix > all tokens in name > display > category > anywhere.
+        if name_l == q or name_l == q_joined:
             score = 0
-        elif name_l.startswith(q):
+        elif name_l.startswith(q) or name_l.startswith(q_joined):
             score = 1
-        elif q in name_l:
+        elif all(t in name_l for t in tokens):
             score = 2
-        elif q in display_l:
+        elif all(t in display_l for t in tokens):
             score = 3
-        elif q in desc_l:
+        elif all(t in cat_l for t in tokens):
             score = 4
+        elif all(t in blob for t in tokens):
+            score = 5
         else:
             continue
         scored.append((score, m))
 
     scored.sort(key=lambda x: (x[0], x[1].id))
-    total_matched = len(scored)
-    matched = [m for _, m in scored[: max(0, limit)]]
+    close_match = False
+    if scored:
+        total_matched = len(scored)
+        matched = [m for _, m in scored[: max(0, limit)]]
+    else:
+        # Zero hits: fall back to the closest node names, so a typo
+        # ('KSampeler') still points the caller at 'KSampler'.
+        by_lower: dict[str, Any] = {}
+        for m in graph.all_nodes():
+            by_lower.setdefault(m.id.lower(), m)
+        close = difflib.get_close_matches(q_joined, list(by_lower), n=max(1, limit), cutoff=0.6) if q_joined else []
+        matched = [by_lower[name_l] for name_l in close][: max(0, limit)]
+        total_matched = len(matched)
+        close_match = bool(matched)
 
     payload = {
         "query": query,
@@ -465,6 +497,7 @@ def search_cmd(
                 "display_name": m.display_name,
                 "description": m.description,
                 "output_types": m.output_types(),
+                **({"close_match": True} if close_match else {}),
             }
             for m in matched
         ],
@@ -480,9 +513,14 @@ def search_cmd(
         ]
 
     if renderer.is_pretty():
+        # The query is echoed back into a markup-interpreting sink, so escape it
+        # for the same reason the table cells below do.
+        query_safe = sanitize_markup(repr(query))
         if not matched:
-            rprint(f"[dim]No nodes match {query!r}.[/dim]")
+            rprint(f"[dim]No nodes match {query_safe}.[/dim]")
         else:
+            if close_match:
+                rprint(f"[dim]No nodes match {query_safe} — showing close name matches.[/dim]")
             from rich.table import Table
 
             tbl = Table(show_header=True, header_style="bold")

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -537,6 +537,13 @@ def search_cmd(
         # printing "no nodes match" there contradicts the JSON's `total`.
         if not total_matched:
             rprint(f"[dim]No nodes match {query_safe}.[/dim]")
+        elif not matched and close_match:
+            # Guesses, not matches — say so, or --limit 0 would report the
+            # fallback's finds as real hits and undo the distinction above.
+            rprint(
+                f"[dim]No nodes match {query_safe}; {total_matched} close name match(es) "
+                f"found but --limit {limit} returned none.[/dim]"
+            )
         elif not matched:
             rprint(f"[dim]{total_matched} node(s) match {query_safe}; --limit {limit} returned none.[/dim]")
         else:

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -443,11 +443,15 @@ def search_cmd(
     # Token-AND matching: every whitespace-separated token must be present, in
     # any order. `q_joined` additionally lets a spaced query hit a CamelCase
     # class name ('ksampler advanced' -> 'ksampleradvanced' == KSamplerAdvanced).
+    # A query with no tokens (empty or all-whitespace) has nothing to match on.
+    # Don't fall back to the raw string: `" "` would then be a substring of every
+    # blob and match the entire catalog, and `all(...)` over an empty token list
+    # is vacuously true, which does the same. Both mean "no match".
     q = query.lower()
-    tokens = q.split() or [q]
+    tokens = q.split()
     q_joined = "".join(tokens)
     scored: list[tuple[int, Any]] = []
-    for m in graph.all_nodes():
+    for m in graph.all_nodes() if tokens else ():
         name_l = m.id.lower()
         display_l = m.display_name.lower()
         desc_l = m.description.lower()
@@ -477,19 +481,31 @@ def search_cmd(
         matched = [m for _, m in scored[: max(0, limit)]]
     else:
         # Zero hits: fall back to the closest node names, so a typo
-        # ('KSampeler') still points the caller at 'KSampler'.
-        by_lower: dict[str, Any] = {}
+        # ('KSampeler') still points the caller at 'KSampler'. Ids are bucketed
+        # by their lowered form (difflib needs unique candidates) but every node
+        # in a colliding bucket is surfaced — a pack may register both
+        # 'LoadImage' and 'loadimage', and dropping one hides a real suggestion.
+        by_lower: dict[str, list[Any]] = {}
         for m in graph.all_nodes():
-            by_lower.setdefault(m.id.lower(), m)
+            by_lower.setdefault(m.id.lower(), []).append(m)
         close = difflib.get_close_matches(q_joined, list(by_lower), n=max(1, limit), cutoff=0.6) if q_joined else []
-        matched = [by_lower[name_l] for name_l in close][: max(0, limit)]
-        total_matched = len(matched)
-        close_match = bool(matched)
+        candidates = [m for name_l in close for m in by_lower[name_l]]
+        # Count before truncating, like every other path here (`ls`, `upstream`,
+        # and the scored branch above) — otherwise `--limit 0` reports total 0
+        # and silently erases the fact that a close match exists.
+        total_matched = len(candidates)
+        matched = candidates[: max(0, limit)]
+        close_match = bool(candidates)
 
     payload = {
         "query": query,
         "total": total_matched,
         "count": len(matched),
+        # Top-level too, not just per-row: a caller that gates on `count == 0` to
+        # mean "no such node" would otherwise have to inspect every row to notice
+        # the search actually found nothing and is guessing. Always present, so
+        # `data["close_match"]` is a stable check rather than a key-exists probe.
+        "close_match": close_match,
         "rows": [
             {
                 "name": m.id,
@@ -516,8 +532,13 @@ def search_cmd(
         # The query is echoed back into a markup-interpreting sink, so escape it
         # for the same reason the table cells below do.
         query_safe = sanitize_markup(repr(query))
-        if not matched:
+        # Key the empty-state on the pre-slice count, not on `matched`: with
+        # `--limit 0` the slice is empty even though the search found hits, and
+        # printing "no nodes match" there contradicts the JSON's `total`.
+        if not total_matched:
             rprint(f"[dim]No nodes match {query_safe}.[/dim]")
+        elif not matched:
+            rprint(f"[dim]{total_matched} node(s) match {query_safe}; --limit {limit} returned none.[/dim]")
         else:
             if close_match:
                 rprint(f"[dim]No nodes match {query_safe} — showing close name matches.[/dim]")

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -360,11 +360,16 @@ def _parse_morphism(node_id: str, raw: dict) -> Morphism:
         t = out if isinstance(out, str) else "COMBO"
         outputs.append(Port(name=name, type=t, required=True, is_link=True))
 
+    # These are declared `str` and every consumer treats them as one (`.lower()`,
+    # `.startswith()`, markup escaping). /object_info is server-supplied and a
+    # custom node can put any JSON type here, so coerce rather than trust the
+    # annotation — an int category used to crash `nodes search` with a raw
+    # AttributeError instead of the structured error the command otherwise emits.
     return Morphism(
         id=node_id,
-        display_name=raw.get("display_name") or node_id,
-        description=raw.get("description") or "",
-        category=raw.get("category") or "",
+        display_name=str(raw.get("display_name") or node_id),
+        description=str(raw.get("description") or ""),
+        category=str(raw.get("category") or ""),
         inputs=inputs,
         outputs=outputs,
         is_output_node=bool(raw.get("output_node", False)),
@@ -372,7 +377,7 @@ def _parse_morphism(node_id: str, raw: dict) -> Morphism:
         deprecated=bool(raw.get("deprecated", False)),
         experimental=bool(raw.get("experimental", False)),
         search_aliases=_unmarshal_string_list(raw.get("search_aliases")),
-        pack=_derive_pack(raw.get("python_module") or ""),
+        pack=_derive_pack(str(raw.get("python_module") or "")),
     )
 
 

--- a/comfy_cli/skills/comfy-debug/SKILL.md
+++ b/comfy_cli/skills/comfy-debug/SKILL.md
@@ -59,7 +59,7 @@ The server validated the workflow and rejected nodes. The full per-node error ma
   ```
   comfy --json nodes search MissingNodeName
   ```
-  If `data.count` is 0, the node is genuinely absent. Then either install via `comfy node install <pkg>` (local) or pick a different workflow (cloud).
+  If `data.count` is 0 — or every row carries `close_match: true`, meaning the search fell back to similarly-named classes — the node is genuinely absent. Then either install via `comfy node install <pkg>` (local) or pick a different workflow (cloud).
 
 - **Missing model file** (`ckpt_name`, `lora_name`, `vae_name` not found) → confirm the loader node exists and see its choices:
   ```

--- a/comfy_cli/skills/comfy-debug/SKILL.md
+++ b/comfy_cli/skills/comfy-debug/SKILL.md
@@ -59,7 +59,7 @@ The server validated the workflow and rejected nodes. The full per-node error ma
   ```
   comfy --json nodes search MissingNodeName
   ```
-  If `data.count` is 0 — or every row carries `close_match: true`, meaning the search fell back to similarly-named classes — the node is genuinely absent. Then either install via `comfy node install <pkg>` (local) or pick a different workflow (cloud).
+  If `data.count` is 0 — or `data.close_match` is true, meaning the search found nothing and fell back to similarly-named classes — the node is genuinely absent. Then either install via `comfy node install <pkg>` (local) or pick a different workflow (cloud).
 
 - **Missing model file** (`ckpt_name`, `lora_name`, `vae_name` not found) → confirm the loader node exists and see its choices:
   ```

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -326,7 +326,7 @@ comfy --json auth list       # all credentials (redacted)
 Use flag-based filters on `nodes ls` to find nodes by capability:
 
 ```bash
-comfy --json nodes search "checkpoint"           # fuzzy by name/desc
+comfy --json nodes search "checkpoint loader"    # name/display/category/desc, any word order
 comfy --json nodes show KSampler                 # full schema
 comfy --json nodes ls --produces MODEL --limit 5 # filter by output type
 comfy --json nodes ls --accepts CONDITIONING     # nodes that take this input
@@ -495,6 +495,9 @@ comfy --json templates ls --limit 1              # template count
 
 The `total` field in `nodes ls`, `nodes search`, and `models search`
 gives the full count even when `--limit` caps the returned rows.
+(One exception: when `nodes search` finds nothing it falls back to the
+closest node names and flags each row `close_match: true` — those rows are
+name-similarity guesses, not matches, and `total` is just how many it found.)
 
 ## Workflows — what can I tweak?
 

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -496,8 +496,10 @@ comfy --json templates ls --limit 1              # template count
 The `total` field in `nodes ls`, `nodes search`, and `models search`
 gives the full count even when `--limit` caps the returned rows.
 (One exception: when `nodes search` finds nothing it falls back to the
-closest node names and flags each row `close_match: true` — those rows are
-name-similarity guesses, not matches, and `total` is just how many it found.)
+closest node names and sets `data.close_match: true` — check that flag, not
+just `count`, because those rows are name-similarity guesses rather than
+matches, and `total` is only how many guesses it found. Each row carries
+`close_match: true` as well.)
 
 ## Workflows — what can I tweak?
 

--- a/tests/comfy_cli/command/test_nodes_introspect.py
+++ b/tests/comfy_cli/command/test_nodes_introspect.py
@@ -337,6 +337,91 @@ class TestSearch:
         assert env["ok"] is True
         assert env["data"]["rows"] == []
 
+    @pytest.mark.parametrize("query", [" ", "   ", "\t ", ""])
+    def test_blank_query_matches_nothing(self, query, patched_loader, capsys):
+        """A query with no tokens must not match the whole catalog.
+
+        `" "` is a substring of every blob (the fields are joined with spaces)
+        and an empty token list makes `all(...)` vacuously true, so both used to
+        return every node as a "match".
+        """
+        env = _run(["search", query], capsys)
+        assert env["ok"] is True
+        assert env["data"]["total"] == 0
+        assert env["data"]["rows"] == []
+        assert env["data"]["close_match"] is False
+
+    def test_close_match_flag_is_always_present_at_top_level(self, patched_loader, capsys):
+        """A caller gating on `count == 0` needs one stable place to learn the
+        search is guessing, without inspecting every row."""
+        hit = _run(["search", "KSampler"], capsys)
+        assert hit["data"]["close_match"] is False
+        guess = _run(["search", "KSampeler"], capsys)
+        assert guess["data"]["close_match"] is True
+
+    def test_zero_limit_still_reports_the_close_match_total(self, patched_loader, capsys):
+        """`total` counts before the `--limit` slice on the fallback path too,
+        so `--limit 0` doesn't erase the fact that a close match exists."""
+        env = _run(["search", "KSampeler", "--limit", "0"], capsys)
+        assert env["data"]["total"] >= 1
+        assert env["data"]["count"] == 0
+        assert env["data"]["close_match"] is True
+
+    def test_zero_limit_keeps_the_scored_total(self, patched_loader, capsys):
+        """Same invariant on the normal path: rows are capped, `total` isn't."""
+        env = _run(["search", "KSampler", "--limit", "0"], capsys)
+        assert env["data"]["total"] >= 1
+        assert env["data"]["rows"] == []
+
+    def test_case_colliding_ids_are_both_suggested(self, monkeypatch, capsys):
+        """A pack may register both `LoadImage` and `loadimage`; bucketing ids by
+        their lowered form for difflib must not drop one of them."""
+        from comfy_cli.cql.engine import Graph
+
+        info = _search_object_info()
+        for node_id in ("LoadImage", "loadimage"):
+            info[node_id] = {
+                "input": {"required": {}},
+                "output": ["IMAGE"],
+                "output_name": ["IMAGE"],
+                "category": "image",
+                "display_name": node_id,
+                "description": "Load an image.",
+                "python_module": "nodes",
+            }
+        graph = Graph.from_object_info(info)
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: graph)
+
+        env = _run(["search", "loadimgae"], capsys)
+        names = [r["name"] for r in env["data"]["rows"]]
+        assert env["data"]["close_match"] is True
+        assert "LoadImage" in names
+        assert "loadimage" in names
+
+    def test_non_string_category_does_not_crash(self, monkeypatch, capsys):
+        """/object_info is server-supplied; a custom node can declare a category
+        that isn't a string, and `.lower()` on it used to raise a raw
+        AttributeError that took down every search."""
+        from comfy_cli.cql.engine import Graph
+
+        info = _search_object_info()
+        info["HostileNode"] = {
+            "input": {"required": {}},
+            "output": [],
+            "output_name": [],
+            "category": 42,
+            "display_name": ["not", "a", "string"],
+            "description": {"nope": True},
+            "python_module": 7,
+            "output_node": False,
+        }
+        graph = Graph.from_object_info(info)
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: graph)
+
+        env = _run(["search", "sampling"], capsys)
+        assert env["ok"] is True
+        assert "KSampler" in [r["name"] for r in env["data"]["rows"]]
+
 
 class TestFlattenCategoryTree:
     """Pin the shape contract for the wasm CategoryTree, since the flattener

--- a/tests/comfy_cli/command/test_nodes_introspect.py
+++ b/tests/comfy_cli/command/test_nodes_introspect.py
@@ -398,6 +398,41 @@ class TestSearch:
         assert "LoadImage" in names
         assert "loadimage" in names
 
+    def test_pretty_empty_state_agrees_with_the_json_total(self, patched_loader):
+        """The two sinks must not contradict each other.
+
+        Keying the empty state on the post-slice list made `--limit 0` print
+        "No nodes match" while the envelope reported `total > 0`; and the
+        fallback's finds are guesses, so the limit-dropped-everything line must
+        not call them matches either.
+        """
+        import io
+
+        from comfy_cli.command.nodes import search_cmd
+
+        def pretty_run(**kwargs) -> str:
+            stream = io.StringIO()
+            r = Renderer.resolve(is_stdout_tty=True, env={}, caller=None)
+            r.mode = OutputMode.PRETTY
+            r.pretty_stream = stream
+            set_renderer(r)
+            search_cmd(input_path=None, host=None, port=None, where=None, **kwargs)
+            return stream.getvalue()
+
+        hit = pretty_run(query="KSampler", limit=0)
+        assert "No nodes match" not in hit
+        assert "--limit 0 returned none" in hit
+
+        guess = pretty_run(query="KSampeler", limit=0)
+        assert "No nodes match" in guess, "a fallback find is not a match"
+        assert "close name match" in guess
+
+        # The ordinary fallback still renders its rows rather than falling into
+        # the limit-dropped-everything branch.
+        shown = pretty_run(query="KSampeler", limit=20)
+        assert "showing close name matches" in shown
+        assert "KSampler" in shown
+
     def test_non_string_category_does_not_crash(self, monkeypatch, capsys):
         """/object_info is server-supplied; a custom node can declare a category
         that isn't a string, and `.lower()` on it used to raise a raw

--- a/tests/comfy_cli/command/test_nodes_introspect.py
+++ b/tests/comfy_cli/command/test_nodes_introspect.py
@@ -97,6 +97,35 @@ def _fake_object_info() -> dict[str, Any]:
     }
 
 
+def _search_object_info() -> dict[str, Any]:
+    """`_fake_object_info` plus the node names the search tiers discriminate on.
+
+    Kept separate so the `ls` tests keep their exact-count assertions.
+    """
+    info = _fake_object_info()
+    info["KSamplerAdvanced"] = {
+        "input": {"required": {"model": ["MODEL"]}},
+        "output": ["LATENT"],
+        "output_name": ["LATENT"],
+        "category": "sampling",
+        "display_name": "KSampler (Advanced)",
+        "description": "Denoise the latent with extra knobs.",
+        "output_node": False,
+        "python_module": "nodes",
+    }
+    info["VAEDecode"] = {
+        "input": {"required": {"samples": ["LATENT"], "vae": ["VAE"]}},
+        "output": ["IMAGE"],
+        "output_name": ["IMAGE"],
+        "category": "latent",
+        "display_name": "VAE Decode",
+        "description": "Turn a latent back into pixels.",
+        "output_node": False,
+        "python_module": "nodes",
+    }
+    return info
+
+
 def _fake_graph():
     """Build a Graph from the fake object_info."""
     from comfy_cli.cql.engine import Graph
@@ -218,6 +247,15 @@ class TestShow:
 
 
 class TestSearch:
+    @pytest.fixture
+    def patched_loader(self, monkeypatch: pytest.MonkeyPatch):
+        """Class-local override: search asserts on tiering, so it needs the
+        richer node set (`KSamplerAdvanced`, `VAEDecode`)."""
+        from comfy_cli.cql.engine import Graph
+
+        graph = Graph.from_object_info(_search_object_info())
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: graph)
+
     def test_exact_name_wins(self, patched_loader, capsys):
         env = _run(["search", "KSampler"], capsys)
         assert env["data"]["count"] >= 1
@@ -242,6 +280,62 @@ class TestSearch:
     def test_limit_caps_results(self, patched_loader, capsys):
         env = _run(["search", "e", "--limit", "2"], capsys)
         assert env["data"]["count"] <= 2
+
+    def test_multi_word_query_hits_camelcase_class(self, patched_loader, capsys):
+        """'ksampler advanced' must find KSamplerAdvanced — the display name's
+        parens used to defeat the contiguous-substring match."""
+        env = _run(["search", "ksampler advanced"], capsys)
+        assert env["data"]["total"] >= 1
+        assert env["data"]["rows"][0]["name"] == "KSamplerAdvanced"
+
+    def test_multi_word_query_is_word_order_independent(self, patched_loader, capsys):
+        env = _run(["search", "advanced ksampler"], capsys)
+        assert env["data"]["total"] >= 1
+        assert env["data"]["rows"][0]["name"] == "KSamplerAdvanced"
+
+    @pytest.mark.parametrize("query", ["vae decode", "decode vae"])
+    def test_spaced_query_matches_either_order(self, query, patched_loader, capsys):
+        env = _run(["search", query], capsys)
+        names = [r["name"] for r in env["data"]["rows"]]
+        assert "VAEDecode" in names
+
+    def test_category_is_searched(self, patched_loader, capsys):
+        """`sampling` is only in the category field of the KSampler nodes."""
+        env = _run(["search", "sampling"], capsys)
+        names = [r["name"] for r in env["data"]["rows"]]
+        assert "KSampler" in names
+        assert "KSamplerAdvanced" in names
+
+    def test_exact_name_outranks_prefix_sibling(self, patched_loader, capsys):
+        """Regression: tier 0 (exact) must beat KSamplerAdvanced's tier 1."""
+        env = _run(["search", "KSampler"], capsys)
+        assert env["data"]["rows"][0]["name"] == "KSampler"
+
+    def test_typo_falls_back_to_close_matches(self, patched_loader, capsys):
+        env = _run(["search", "KSampeler"], capsys)
+        rows = env["data"]["rows"]
+        assert rows, "close-match fallback should surface something for a typo"
+        assert rows[0]["name"] == "KSampler"
+        assert all(r["close_match"] is True for r in rows)
+        assert env["data"]["total"] == env["data"]["count"]
+
+    def test_exact_matches_carry_no_close_match_flag(self, patched_loader, capsys):
+        env = _run(["search", "KSampler"], capsys)
+        assert all("close_match" not in r for r in env["data"]["rows"])
+
+    def test_no_match_and_no_close_match_returns_empty(self, patched_loader, capsys):
+        """Nothing is within difflib's 0.6 cutoff of this, so the fallback is
+        empty too — an agent gets a clean zero, not noise."""
+        env = _run(["search", "xyzzy_nothing"], capsys)
+        assert env["data"]["total"] == 0
+        assert env["data"]["rows"] == []
+
+    def test_zero_limit_does_not_crash_the_fallback(self, patched_loader, capsys):
+        """`difflib.get_close_matches` rejects n <= 0; the fallback must not
+        pass the raw limit straight through."""
+        env = _run(["search", "KSampeler", "--limit", "0"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["rows"] == []
 
 
 class TestFlattenCategoryTree:

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -275,6 +275,19 @@ def test_nodes_search_is_inert(pretty, hostile_object_info):
     assert_inert(pretty)
 
 
+def test_nodes_search_echoed_query_is_inert(pretty, hostile_object_info):
+    """The no-match line echoes the query back into a markup-interpreting sink.
+
+    The query is caller-supplied rather than server-supplied, but an agent
+    frontend can relay attacker text into it, and `[/]` alone would raise
+    MarkupError while merely printing "no nodes match".
+    """
+    from comfy_cli.command.nodes import search_cmd
+
+    search_cmd(query=EVIL + UNBALANCED, limit=20, input_path=None, host=None, port=None, where=None)
+    assert_inert(pretty)
+
+
 def test_nodes_types_is_inert(pretty, hostile_object_info):
     from comfy_cli.command.nodes import types_cmd
 


### PR DESCRIPTION
## ELI-5

If you asked `comfy nodes search "ksampler advanced"`, you got nothing back — even though `KSamplerAdvanced` exists. The search treated your whole phrase as one blob of letters that had to appear, in that exact order, inside a node's name or description. `KSampler (Advanced)` has parentheses in the middle, so the phrase never matched. Same story for `image load`, `decode vae`, `checkpoint loader`, and for `sampling` (which is a *category*, a field search never even looked at). Typos returned nothing at all, despite the command's own help promising "fuzzy" search.

Now the search splits what you typed into words and requires all of them, in any order, and looks at the category too. If nothing matches at all, it suggests the closest node names instead of shrugging. Agents driving the CLI stop getting empty results for queries a human would consider obvious.

## What changed

**`comfy_cli/command/nodes.py::search_cmd`** — the scorer is now token-AND with a tiered rank: exact name (0) > name prefix (1) > all tokens in name (2) > all tokens in display name (3) > all tokens in category (4) > all tokens anywhere in name+display+description+category (5). Ties break on class name, as before. The query is also joined without spaces (`ksampler advanced` → `ksampleradvanced`) so a spaced query can hit a CamelCase class directly at tier 0/1.

**Zero-hit fallback** — when nothing scores, `difflib.get_close_matches` (cutoff 0.6) over lowercased class names returns the nearest names, each row flagged `close_match: true`. `KSampeler` → `KSampler`.

**Envelope shape is unchanged** — `query` / `total` / `count` / `rows` and every row field stay identical. `close_match` is additive and only present on fallback rows.

**Help text** is now honest about what it does (name, display name, category, description; word-order-independent; falls back to close names).

**Two doc/robustness gaps the self-review turned up**, both caused by this change and fixed here:
- `comfy_cli/skills/comfy-debug/SKILL.md` told agents "if `data.count` is 0, the node is genuinely absent" — with a close-match fallback a missing node now returns rows, so that check alone would have told an agent a missing node exists. It now also keys off `close_match`.
- `comfy_cli/skills/comfy/SKILL.md`'s "`total` gives the full count even when `--limit` caps rows" needed the fallback exception (there `total == count`).
- Unrelated-but-adjacent: the pretty no-match line echoed the raw query into a Rich markup sink, so a query containing `[/]` raised `MarkupError` and crashed the CLI while printing "no nodes match". Escaped via the same `sanitize_markup` the table cells already use, with a red→green test in the existing sanitize suite.

## Verification

`ruff check` + `ruff format --check` clean at the CI-pinned 0.15.15; full `pytest` green (**3753 passed, 37 skipped**).

Manually driven through the offline path, against a **real 3557-node ComfyUI catalog** (`--input <object_info.json>`), every case that previously returned 0 rows:

| query | before | after (top rows) |
|---|---|---|
| `ksampler advanced` | 0 | 5 — `KSamplerAdvanced` first |
| `advanced ksampler` | 0 | 5 — `KSamplerAdvanced` in set |
| `image load` | 0 | 25 — incl. `LoadImage`, `LoadImageMask` |
| `decode vae` | 0 | 18 — incl. `VAEDecode` |
| `checkpoint loader` | 0 | 9 — `CheckpointLoader` first |
| `sampling` | 44 | 113 (category tier) |
| `KSampeler` (typo) | 0 | 5 close matches, `KSampler` first |
| `KSampler` | 37 | 39 — exact still ranked first |
| `xyzzy_nothing` | 0 | 0 (nothing inside the 0.6 cutoff) |

**No-regression evidence for existing single-token callers:** ran the old and new scorers side by side over that same catalog for 20 single-token queries (`ksampler`, `vae`, `image`, `loader`, `sampling`, `mask`, `clip`, `latent`, `model`, `a`, `e`, …). Every old result set is a strict subset of the new one, and the top-ranked row is identical in all 20. Never fewer results, never a changed winner.

Cost on that 3557-node catalog: ~4.3 ms for the scorer, ~3.7 ms for the fallback (which only runs on the zero-hit path).

## Judgment calls

- **`n=max(1, limit)` rather than `n=limit`** in the difflib call: `get_close_matches` raises `ValueError` for `n <= 0`, so `--limit 0` would have crashed the fallback. The result is still sliced by `limit`, so `--limit 0` returns no rows as expected. Covered by a test.
- **`total == count` on the fallback path.** The fallback discovers at most `limit` names, so unlike the main path `total` can't report "there are more beyond your limit". It never overstates; documented in the agent-facing skill doc.
- **Word-order independence means the same match *set*, not always the same row 0.** On a real catalog `advanced ksampler` puts `KSamplerAdvanced` in the results but ranks `ClownsharKSamplerAutomation_Advanced` above it, because tier-2 ties break alphabetically on class name. Adding a length/specificity tiebreak would have re-ranked existing single-token queries too, which I deliberately left alone to keep the no-regression property above.
- **Left `models search` alone** — same failure class, separately tracked.
- The scorer builds the combined haystack per node per query rather than lazily; at ~4 ms on the largest catalog I've got, the readability is worth more than the micro-optimization.
