### PR TITLE
feat(upload): add --host/--port to `comfy upload` for local target routing (BE-5662)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -50,6 +50,7 @@ from comfy_cli.cuda_detect import DEFAULT_CUDA_TAG, detect_cuda_driver_version, 
 from comfy_cli.discovery import build_discovery
 from comfy_cli.env_checker import EnvChecker
 from comfy_cli.help_json import build_help_json
+from comfy_cli.host_port import validate_host
 from comfy_cli.output import Renderer, get_renderer, rprint, set_renderer
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.skills import command as skill_command
@@ -1227,9 +1228,26 @@ def upload(
         bool,
         typer.Option("--overwrite/--no-overwrite", help="Overwrite existing files on the server."),
     ] = True,
+    host: Annotated[
+        str | None,
+        typer.Option(help="Server host (defaults to COMFY_LOCAL_URL or 127.0.0.1). Local targets only."),
+    ] = None,
+    port: Annotated[
+        int | None,
+        typer.Option(help="Server port (defaults to COMFY_LOCAL_URL or 8188). Local targets only."),
+    ] = None,
 ):
     config = ConfigManager()
     renderer = get_renderer()
+
+    # Validate the flags before resolving anything: the host lands verbatim in
+    # ``http://{host}:{port}/upload/image``, so a URL-special or control
+    # character is a usage error (BadParameter, exit 2) regardless of target.
+    if host is not None:
+        host = validate_host(host)
+    if port is not None and not (1 <= port <= 65535):
+        raise typer.BadParameter(f"invalid port: {port} is out of range (1-65535)")
+
     try:
         decision = where_module.resolve(flag=where, config_value=config.get(where_module.CONFIG_KEY_WHERE_DEFAULT))
     except ValueError as e:
@@ -1237,10 +1255,27 @@ def upload(
         raise typer.Exit(code=1)
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
+    # --host/--port address a local ComfyUI; the cloud target's address comes
+    # from the signed-in account's base URL and ignores them entirely
+    # (``Target.host``/``Target.port`` are documented local-only). Rejecting
+    # the combination beats silently uploading somewhere the user didn't name.
+    # Checked before the preflight so the flag error isn't masked by a
+    # "not signed in" error.
+    if effective_where == "cloud" and (host is not None or port is not None):
+        renderer.error(
+            code="host_flag_cloud",
+            message="--host/--port target a local ComfyUI server and cannot be combined with --where cloud",
+            hint=(
+                "pass --where local to aim at a local server; to reach a different cloud address "
+                "set COMFY_CLOUD_BASE_URL or run `comfy cloud set-base-url`"
+            ),
+            details={"host": host, "port": port, "where": effective_where},
+        )
+        raise typer.Exit(code=1)
     if effective_where == "cloud":
         where_module.cloud_preflight_or_exit()
 
-    transfer_inner.execute_upload(files, where=effective_where, overwrite=overwrite)
+    transfer_inner.execute_upload(files, where=effective_where, overwrite=overwrite, host=host, port=port)
 
 
 @app.command(help="Download outputs from a completed job. Reads prompt_id from argument or piped stdin.")

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1216,6 +1216,17 @@ def validate(
         raise typer.Exit(code=1)
 
 
+# How a `cloud` routing decision was reached, in words, for the --host/--port
+# rejection message. Keys are `where.WhereResolution.source` values.
+_WHERE_SOURCE_PHRASES = {
+    "flag": "targeting cloud via --where cloud",
+    "env": "targeting cloud via the COMFY_WHERE environment variable",
+    "project": "targeting cloud via this project's configured default",
+    "config": "targeting cloud via your saved `where_default` setting",
+    "auto": "targeting cloud because you're signed in (no explicit --where)",
+}
+
+
 @app.command(help="Upload files to the ComfyUI server's input directory.")
 @tracking.track_command()
 def upload(
@@ -1262,14 +1273,19 @@ def upload(
     # Checked before the preflight so the flag error isn't masked by a
     # "not signed in" error.
     if effective_where == "cloud" and (host is not None or port is not None):
+        # The cloud target can come from an explicit --where, but equally from
+        # COMFY_WHERE, a project/config default, or credential auto-detection —
+        # so name the source rather than accusing the user of passing a flag
+        # they may never have typed.
+        source = _WHERE_SOURCE_PHRASES.get(decision.source, f"resolved to cloud by {decision.source}")
         renderer.error(
             code="host_flag_cloud",
-            message="--host/--port target a local ComfyUI server and cannot be combined with --where cloud",
+            message=f"--host/--port target a local ComfyUI server, but this run is {source}",
             hint=(
                 "pass --where local to aim at a local server; to reach a different cloud address "
                 "set COMFY_CLOUD_BASE_URL or run `comfy cloud set-base-url`"
             ),
-            details={"host": host, "port": port, "where": effective_where},
+            details={"host": host, "port": port, "where": effective_where, "where_source": decision.source},
         )
         raise typer.Exit(code=1)
     if effective_where == "cloud":

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -394,14 +394,22 @@ def execute_upload(
     *,
     where: str | None = None,
     overwrite: bool = False,
+    host: str | None = None,
+    port: int | None = None,
 ) -> list[str]:
     """Upload one or more local files to the ComfyUI server's input directory.
+
+    ``host``/``port`` route a **local** upload at a specific ComfyUI (the
+    ``comfy upload --host/--port`` flags); they are ignored for a cloud target,
+    whose address comes from the signed-in account. ``resolve_target`` applies
+    the usual local precedence: explicit value > ``COMFY_LOCAL_URL`` >
+    ``127.0.0.1:8188``.
 
     Returns the list of server-side filenames (the ``name`` field from each
     upload response).
     """
     renderer = get_renderer()
-    target = resolve_target(where=where)
+    target = resolve_target(where=where, host=host, port=port)
 
     uploads: list[dict[str, Any]] = []
     cloud_names: list[str] = []

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -27,6 +27,7 @@ import typer
 
 from comfy_cli import jobs_state
 from comfy_cli.comfy_client import Client, Unauthenticated, extract_output_entries
+from comfy_cli.host_port import validate_host
 from comfy_cli.http import NoRedirectHandler, build_http_only_opener
 from comfy_cli.http import target_auth_headers as _auth_headers
 from comfy_cli.output import get_renderer
@@ -105,6 +106,14 @@ _MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024 * 1024  # 10 GB
 # transfer aborts instead of hanging forever, while a steadily-flowing body of
 # any size is unaffected.
 _DOWNLOAD_TIMEOUT_S = 30
+
+# Same per-socket-op timeout for uploads. Now that ``--host``/``--port`` can
+# aim the POST at an arbitrary address, a peer that completes the TCP handshake
+# and then stalls would otherwise wedge the CLI forever (urllib defaults to
+# ``socket._GLOBAL_DEFAULT_TIMEOUT``, i.e. no timeout) and hang any automation
+# driving it. This bounds each socket operation, not the whole transfer, so a
+# steadily-flowing multi-GB body is unaffected.
+_UPLOAD_TIMEOUT_S = 30
 
 # Stream/copy chunk size. 1 MiB keeps syscall volume low on multi-GB outputs
 # while still bounding memory and letting the size cap trip promptly.
@@ -385,7 +394,7 @@ def _upload_file(path: Path, target: Any, *, overwrite: bool) -> dict:
     for hdr, val in _auth_headers(target).items():
         req.add_header(hdr, val)
 
-    with _TRANSFER_OPENER.open(req) as resp:
+    with _TRANSFER_OPENER.open(req, timeout=_UPLOAD_TIMEOUT_S) as resp:
         return json.loads(resp.read().decode("utf-8", errors="replace"))
 
 
@@ -409,6 +418,16 @@ def execute_upload(
     upload response).
     """
     renderer = get_renderer()
+    # Defence in depth. ``cmdline.upload`` validates the flags, but this
+    # function is also called directly (comfy-mcp's ``_with_target`` is the
+    # motivating consumer) and ``resolve_target`` drops the host verbatim into
+    # ``http://{host}:{port}`` with no checks of its own. Validating here makes
+    # the no-URL-injection guarantee a property of ``execute_upload`` rather
+    # than of whoever happens to call it.
+    if host is not None:
+        host = validate_host(host)
+    if port is not None and not (1 <= port <= 65535):
+        raise typer.BadParameter(f"invalid port: {port} is out of range (1-65535)")
     target = resolve_target(where=where, host=host, port=port)
 
     uploads: list[dict[str, Any]] = []
@@ -447,14 +466,23 @@ def execute_upload(
                 details={"status": status, "filename": filename},
             )
             raise typer.Exit(code=1)
-        except (urllib.error.URLError, TimeoutError, ConnectionError, http.client.HTTPException) as e:
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            ConnectionError,
+            http.client.HTTPException,
+            UnicodeError,
+        ) as e:
             # A connection- or transfer-level failure — not HTTPError. A
             # refused/DNS/timeout/TLS failure at connect raises URLError; a read
             # timeout raises a bare TimeoutError; a reset raises ConnectionError;
             # a truncated (e.g. chunked) response body raises
-            # http.client.IncompleteRead (an HTTPException). Surface it as a
-            # structured envelope instead of an unhandled traceback that breaks
-            # machine/NDJSON consumers.
+            # http.client.IncompleteRead (an HTTPException). A non-ASCII host
+            # reaches http.client's ``host.encode("idna")`` fallback, which
+            # raises UnicodeError (a ValueError, so none of the above catch it)
+            # on a pathological label. Surface each as a structured envelope
+            # instead of an unhandled traceback that breaks machine/NDJSON
+            # consumers.
             reason = getattr(e, "reason", None) or e
             renderer.error(
                 code="upload_failed",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -242,7 +242,9 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "host_flag_cloud",
         "`--host`/`--port` were combined with an effective `cloud` target. They address a local "
         "ComfyUI only; the cloud address comes from the signed-in account. `details` carries the "
-        "offending host/port and the resolved `where`.",
+        "offending host/port, the resolved `where`, and the `where_source` that produced it "
+        "(`flag`, `env`, `project`, `config`, or `auto`) — the target may never have been "
+        "explicitly requested.",
         "pass `--where local` to aim at a local server; to reach a different cloud address set "
         "`COMFY_CLOUD_BASE_URL` or run `comfy cloud set-base-url`",
     ),

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -239,6 +239,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "use `--where local` or `--where cloud`",
     ),
     ErrorCode(
+        "host_flag_cloud",
+        "`--host`/`--port` were combined with an effective `cloud` target. They address a local "
+        "ComfyUI only; the cloud address comes from the signed-in account. `details` carries the "
+        "offending host/port and the resolved `where`.",
+        "pass `--where local` to aim at a local server; to reach a different cloud address set "
+        "`COMFY_CLOUD_BASE_URL` or run `comfy cloud set-base-url`",
+    ),
+    ErrorCode(
         "cloud_not_configured",
         "`--where cloud` requested without a stored session.",
         "run `comfy cloud login`",

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -16,6 +16,9 @@ module is the single home for that logic; callers should not re-implement it.
 
 from __future__ import annotations
 
+import ipaddress
+import urllib.parse
+
 import typer
 
 from comfy_cli.config_manager import ConfigManager
@@ -27,13 +30,45 @@ _UNSAFE_HOST_CHARS = frozenset("/@?#")
 
 def validate_host(host: str) -> str:
     """Reject host values that could cause URL injection."""
-    if any(c in host for c in _UNSAFE_HOST_CHARS):
-        raise typer.BadParameter(f"invalid host: {host!r} (contains URL-special characters)")
-    # Whitespace/control chars (notably CR/LF) never appear in a real host and
-    # are the canonical header/URL-injection vectors, so reject them too.
-    if any(c.isspace() or ord(c) < 0x20 or ord(c) == 0x7F for c in host):
-        raise typer.BadParameter(f"invalid host: {host!r} (contains whitespace or control characters)")
+    # An empty/blank host is not "no host": callers resolve it as absent
+    # (``host or env or DEFAULT_HOST``), so ``--host ""`` — a wrapper
+    # interpolating an unset variable — would silently retarget the request at
+    # a server the caller never named. ``_require_host`` rejects it on the
+    # parse path for the same reason; reject it here too so both agree.
+    if not host.strip():
+        raise typer.BadParameter(f"invalid host: {host!r} (empty host)")
+    # ``urllib.request.Request._parse`` percent-decodes the host it splits out
+    # of the URL, so a ``%0d%0a`` payload only becomes a real CRLF *after* this
+    # guard. Check the decoded form too rather than trusting the literal value.
+    for candidate in (host, urllib.parse.unquote(host)):
+        if any(c in candidate for c in _UNSAFE_HOST_CHARS):
+            raise typer.BadParameter(f"invalid host: {host!r} (contains URL-special characters)")
+        # Whitespace/control chars (notably CR/LF) never appear in a real host
+        # and are the canonical header/URL-injection vectors, so reject them.
+        if any(c.isspace() or ord(c) < 0x20 or ord(c) == 0x7F for c in candidate):
+            raise typer.BadParameter(f"invalid host: {host!r} (contains whitespace or control characters)")
+    _reject_embedded_port(host)
     return host
+
+
+def _reject_embedded_port(host: str) -> None:
+    """Reject a colon in a host unless it's a genuine IPv6 literal.
+
+    Callers bracket any colon-bearing host into ``http://[{host}]:{port}``, so
+    a combined ``'127.0.0.1:8188'`` would silently become
+    ``http://[127.0.0.1:8188]:8188`` — the embedded port dropped and the
+    request aimed at a bogus address. Only ``comfy run`` accepts the combined
+    form, and it splits it with :func:`parse_host_port_arg` before we see it.
+    """
+    if ":" not in host:
+        return
+    literal = host[1:-1] if host.startswith("[") and host.endswith("]") else host
+    try:
+        ipaddress.IPv6Address(literal)
+    except ValueError:
+        raise typer.BadParameter(
+            f"invalid host: {host!r} (contains ':'; pass the port separately with --port, or give a valid IPv6 literal)"
+        ) from None
 
 
 def parse_host_port_arg(value: str) -> tuple[str, int | None]:

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -1,11 +1,14 @@
 """Shared host/port parsing + resolution for local ComfyUI commands.
 
-Both ``comfy run`` and every ``comfy jobs`` subcommand accept a ``--host`` /
-``--port`` pair, fall back to the persisted ``config.background`` server, then
-to ``DEFAULT_HOST`` / ``DEFAULT_PORT``. In addition, ``comfy run`` accepts a
-combined ``host[:port]`` string (parsed via ``parse_host_port_arg``); the
-``comfy jobs`` subcommands only take the separate ``--host`` / ``--port``
-options. They all feed the resolved host straight into URLs like
+``comfy run``, every ``comfy jobs`` subcommand, and ``comfy upload`` accept a
+``--host`` / ``--port`` pair. ``run``/``jobs`` resolve it here — falling back
+to the persisted ``config.background`` server, then to ``DEFAULT_HOST`` /
+``DEFAULT_PORT``; ``comfy upload`` only borrows :func:`validate_host` and hands
+the pair to ``target.resolve_target``, which skips the background server (env
+override, then the defaults). In addition, ``comfy run`` accepts a combined
+``host[:port]`` string (parsed via ``parse_host_port_arg``); the ``comfy jobs``
+subcommands and ``comfy upload`` only take the separate ``--host`` / ``--port``
+options. All of them feed the resolved host straight into URLs like
 ``http://{host}:{port}/prompt`` / ``ws://{host}:{port}/ws``, so the value must
 be validated (no URL-injection characters) and IPv6 literals bracketed. This
 module is the single home for that logic; callers should not re-implement it.

--- a/tests/comfy_cli/command/test_transfer_upload.py
+++ b/tests/comfy_cli/command/test_transfer_upload.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 import typer
 
+from comfy_cli.cmdline import app
 from comfy_cli.command import transfer
 from comfy_cli.target import Target
 
@@ -134,7 +135,7 @@ class TestUploadMachineModeStdoutPurity:
 
         opener = _FakeOpener()
         monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
-        monkeypatch.setattr(transfer, "resolve_target", lambda where=None: _local_target())
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _local_target())
         set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
 
         transfer.execute_upload([str(asset)], where="local")
@@ -168,7 +169,7 @@ class TestUploadConnectionError:
 
         err = urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
         monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener(error=err))
-        monkeypatch.setattr(transfer, "resolve_target", lambda where=None: _local_target())
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _local_target())
         set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
 
         with pytest.raises(typer.Exit) as excinfo:
@@ -188,7 +189,7 @@ class TestUploadConnectionError:
         # A truncated response body raises http.client.IncompleteRead — an
         # HTTPException, not a URLError.
         monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener(error=http.client.IncompleteRead(b"x", 100)))
-        monkeypatch.setattr(transfer, "resolve_target", lambda where=None: _local_target())
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _local_target())
         set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
 
         with pytest.raises(typer.Exit) as excinfo:
@@ -197,3 +198,207 @@ class TestUploadConnectionError:
         assert excinfo.value.exit_code == 1
         env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
         assert env["error"]["code"] == "upload_failed"
+
+
+class TestUploadHostPortRouting:
+    """``comfy upload --host/--port`` aims a LOCAL upload at a specific ComfyUI
+    (BE-5662).
+
+    Before this the only lever was the process-wide ``COMFY_LOCAL_URL`` env
+    var, so a caller wrapping the CLI (comfy-mcp's ``_with_target``) could not
+    route a single invocation. ``execute_upload`` now forwards the pair to
+    ``resolve_target``, which applies the documented local precedence:
+    explicit value > ``COMFY_LOCAL_URL`` > ``127.0.0.1:8188``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_ambient_local_url(self, monkeypatch):
+        # The resolver honors COMFY_LOCAL_URL, so drop any ambient value and
+        # let each test state its own precedence inputs.
+        monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+
+    def test_host_and_port_reach_resolve_target(self, asset, monkeypatch):
+        seen: dict = {}
+
+        def fake_resolve_target(**kwargs):
+            seen.update(kwargs)
+            return _local_target()
+
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener())
+        monkeypatch.setattr(transfer, "resolve_target", fake_resolve_target)
+
+        transfer.execute_upload([str(asset)], where="local", host="10.0.0.5", port=9999)
+
+        assert seen == {"where": "local", "host": "10.0.0.5", "port": 9999}
+
+    def test_post_url_targets_the_given_host_and_port(self, asset, monkeypatch):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local", host="10.0.0.5", port=9999)
+
+        assert opener.requests[0].full_url == "http://10.0.0.5:9999/upload/image"
+
+    def test_no_flags_keeps_the_loopback_default(self, asset, monkeypatch):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local")
+
+        assert opener.requests[0].full_url == "http://127.0.0.1:8188/upload/image"
+
+    def test_no_flags_still_honors_comfy_local_url(self, asset, monkeypatch):
+        monkeypatch.setenv("COMFY_LOCAL_URL", "http://192.168.1.9:8189")
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local")
+
+        assert opener.requests[0].full_url == "http://192.168.1.9:8189/upload/image"
+
+    def test_flags_beat_comfy_local_url(self, asset, monkeypatch):
+        monkeypatch.setenv("COMFY_LOCAL_URL", "http://192.168.1.9:8189")
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local", host="10.0.0.5", port=9999)
+
+        assert opener.requests[0].full_url == "http://10.0.0.5:9999/upload/image"
+
+    def test_host_only_flag_keeps_the_env_port(self, asset, monkeypatch):
+        # host and port resolve independently, so --host alone must not drop
+        # the env var's port back to the 8188 default.
+        monkeypatch.setenv("COMFY_LOCAL_URL", "http://192.168.1.9:8189")
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local", host="10.0.0.5")
+
+        assert opener.requests[0].full_url == "http://10.0.0.5:8189/upload/image"
+
+    def test_ipv6_host_is_bracketed_in_the_url(self, asset, monkeypatch):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        transfer.execute_upload([str(asset)], where="local", host="::1", port=8189)
+
+        assert opener.requests[0].full_url == "http://[::1]:8189/upload/image"
+
+    def test_cloud_target_ignores_host_and_port(self, asset, monkeypatch):
+        # Belt-and-braces behind the CLI guard below: even if the pair reached a
+        # cloud resolve, the cloud address comes from the account, not the flags.
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _cloud_target())
+
+        transfer.execute_upload([str(asset)], where="cloud", host="10.0.0.5", port=9999)
+
+        assert opener.requests[0].full_url == "https://cloud.example.com/api/upload/image"
+
+
+class TestUploadCliHostPortFlags:
+    """CLI surface of the same feature: `comfy upload --host/--port` mirrors the
+    separate options `comfy jobs` takes (not `comfy run`'s combined
+    ``host[:port]`` positional), validates the host, and refuses to pair with a
+    cloud target."""
+
+    @pytest.fixture
+    def runner(self):
+        from typer.testing import CliRunner
+
+        return CliRunner()
+
+    @staticmethod
+    def _envelope(result) -> dict:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_flags_are_forwarded_to_execute_upload(self, asset, runner, monkeypatch):
+        from comfy_cli import cmdline
+
+        seen: dict = {}
+
+        def fake_execute_upload(files, **kwargs):
+            seen["files"] = files
+            seen.update(kwargs)
+            return ["ab12.png"]
+
+        monkeypatch.setattr(cmdline.transfer_inner, "execute_upload", fake_execute_upload)
+
+        result = runner.invoke(
+            app,
+            ["upload", str(asset), "--host", "10.0.0.5", "--port", "9999"],
+            env={"COMFY_WHERE": "local"},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert seen["files"] == [str(asset)]
+        assert seen["host"] == "10.0.0.5"
+        assert seen["port"] == 9999
+        assert seen["where"] == "local"
+
+    def test_no_flags_forwards_none(self, asset, runner, monkeypatch):
+        from comfy_cli import cmdline
+
+        seen: dict = {}
+        monkeypatch.setattr(
+            cmdline.transfer_inner,
+            "execute_upload",
+            lambda files, **kwargs: seen.update(kwargs) or ["ab12.png"],
+        )
+
+        result = runner.invoke(app, ["upload", str(asset)], env={"COMFY_WHERE": "local"})
+
+        assert result.exit_code == 0, result.output
+        assert seen["host"] is None
+        assert seen["port"] is None
+
+    @pytest.mark.parametrize("flags", [["--host", "10.0.0.5"], ["--port", "9999"], ["--host", "h", "--port", "1"]])
+    def test_host_or_port_with_cloud_where_flag_is_rejected(self, asset, runner, flags):
+        result = runner.invoke(app, ["--json", "upload", str(asset), "--where", "cloud", *flags])
+
+        assert result.exit_code == 1, result.output
+        env = self._envelope(result)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "host_flag_cloud"
+
+    def test_host_with_cloud_where_env_is_rejected(self, asset, runner):
+        # COMFY_WHERE is how the top-level `comfy --where cloud` arrives, so the
+        # guard has to key off the RESOLVED target, not the flag.
+        result = runner.invoke(
+            app,
+            ["--json", "upload", str(asset), "--host", "10.0.0.5"],
+            env={"COMFY_WHERE": "cloud"},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert self._envelope(result)["error"]["code"] == "host_flag_cloud"
+
+    def test_cloud_without_the_flags_is_untouched(self, asset, runner, monkeypatch):
+        from comfy_cli import cmdline
+
+        seen: dict = {}
+        monkeypatch.setattr(cmdline.where_module, "cloud_preflight_or_exit", lambda: None)
+        monkeypatch.setattr(
+            cmdline.transfer_inner,
+            "execute_upload",
+            lambda files, **kwargs: seen.update(kwargs) or ["ab12.png"],
+        )
+
+        result = runner.invoke(app, ["upload", str(asset), "--where", "cloud"])
+
+        assert result.exit_code == 0, result.output
+        assert seen["where"] == "cloud"
+        assert seen["host"] is None and seen["port"] is None
+
+    @pytest.mark.parametrize("bad", ["evil/host", "user@evil", "host?x", "host#x", "host\rname", "host\nname"])
+    def test_invalid_host_is_a_usage_error(self, asset, runner, bad):
+        result = runner.invoke(app, ["upload", str(asset), "--host", bad], env={"COMFY_WHERE": "local"})
+
+        # typer.BadParameter -> click UsageError -> exit code 2.
+        assert result.exit_code == 2, result.output
+
+    @pytest.mark.parametrize("bad", ["0", "65536", "-1"])
+    def test_out_of_range_port_is_a_usage_error(self, asset, runner, bad):
+        result = runner.invoke(app, ["upload", str(asset), "--port", bad], env={"COMFY_WHERE": "local"})
+
+        assert result.exit_code == 2, result.output

--- a/tests/comfy_cli/command/test_transfer_upload.py
+++ b/tests/comfy_cli/command/test_transfer_upload.py
@@ -37,9 +37,11 @@ class _FakeOpener:
         self.payload = payload or {"name": "ab12.png", "subfolder": "", "type": "input"}
         self.error = error
         self.requests: list = []
+        self.timeouts: list = []
 
-    def open(self, req):
+    def open(self, req, timeout=None):
         self.requests.append(req)
+        self.timeouts.append(timeout)
         if self.error is not None:
             raise self.error
         return _FakeResponse(json.dumps(self.payload).encode())
@@ -198,6 +200,46 @@ class TestUploadConnectionError:
         assert excinfo.value.exit_code == 1
         env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
         assert env["error"]["code"] == "upload_failed"
+
+    def test_unicode_error_emits_upload_failed_envelope(self, asset, monkeypatch, capsys):
+        from comfy_cli.output import Renderer, set_renderer
+        from comfy_cli.output.renderer import OutputMode
+
+        # A non-ASCII host reaches http.client's ``host.encode("idna")``
+        # fallback, which raises UnicodeError on a pathological label.
+        # UnicodeError is a ValueError, so it is caught by none of the
+        # connection-error classes above and used to escape as a traceback.
+        err = UnicodeError("encoding with 'idna' codec failed: label too long")
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", _FakeOpener(error=err))
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _local_target())
+        set_renderer(Renderer(mode=OutputMode.JSON, command="upload"))
+
+        with pytest.raises(typer.Exit) as excinfo:
+            transfer.execute_upload([str(asset)], where="local")
+
+        assert excinfo.value.exit_code == 1
+        env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+        assert env["ok"] is False
+        assert env["error"]["code"] == "upload_failed"
+
+
+class TestUploadTimeout:
+    """The upload POST must carry an explicit socket timeout.
+
+    ``--host``/``--port`` can now aim the POST at an arbitrary address, so a
+    peer that completes the handshake and then stalls would hang the CLI
+    forever on urllib's no-timeout default (BE-5662).
+    """
+
+    def test_upload_passes_an_explicit_timeout(self, asset, monkeypatch):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+        monkeypatch.setattr(transfer, "resolve_target", lambda **kw: _local_target())
+
+        transfer.execute_upload([str(asset)], where="local")
+
+        assert opener.timeouts == [transfer._UPLOAD_TIMEOUT_S]
+        assert transfer._UPLOAD_TIMEOUT_S is not None
 
 
 class TestUploadHostPortRouting:
@@ -390,15 +432,84 @@ class TestUploadCliHostPortFlags:
         assert seen["where"] == "cloud"
         assert seen["host"] is None and seen["port"] is None
 
-    @pytest.mark.parametrize("bad", ["evil/host", "user@evil", "host?x", "host#x", "host\rname", "host\nname"])
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "evil/host",
+            "user@evil",
+            "host?x",
+            "host#x",
+            "host\rname",
+            "host\nname",
+            # Empty/blank: resolved as *absent* downstream, so without this
+            # guard `--host "$UNSET_VAR"` silently retargets the upload at
+            # COMFY_LOCAL_URL or the 127.0.0.1:8188 default.
+            "",
+            "   ",
+            # Percent-encoded URL-special/control chars: urllib unquotes the
+            # host it parses out of the URL, so these decode downstream.
+            "a%0d%0aX-Injected:%201",
+            "host%2fpath",
+            # A combined host:port would be bracketed as an IPv6 literal
+            # (`http://[127.0.0.1:8188]:8188`), silently dropping the port.
+            "127.0.0.1:8188",
+            "localhost:8188",
+        ],
+    )
     def test_invalid_host_is_a_usage_error(self, asset, runner, bad):
         result = runner.invoke(app, ["upload", str(asset), "--host", bad], env={"COMFY_WHERE": "local"})
 
         # typer.BadParameter -> click UsageError -> exit code 2.
         assert result.exit_code == 2, result.output
 
+    @pytest.mark.parametrize("good", ["::1", "[::1]", "fe80::1"])
+    def test_ipv6_literal_host_is_accepted(self, asset, runner, good, monkeypatch):
+        from comfy_cli import cmdline
+
+        seen: dict = {}
+        monkeypatch.setattr(
+            cmdline.transfer_inner,
+            "execute_upload",
+            lambda files, **kwargs: seen.update(kwargs) or ["ab12.png"],
+        )
+
+        result = runner.invoke(app, ["upload", str(asset), "--host", good], env={"COMFY_WHERE": "local"})
+
+        assert result.exit_code == 0, result.output
+        assert seen["host"] == good
+
     @pytest.mark.parametrize("bad", ["0", "65536", "-1"])
     def test_out_of_range_port_is_a_usage_error(self, asset, runner, bad):
         result = runner.invoke(app, ["upload", str(asset), "--port", bad], env={"COMFY_WHERE": "local"})
 
         assert result.exit_code == 2, result.output
+
+
+class TestExecuteUploadValidatesItsOwnArgs:
+    """``execute_upload`` must not rely on its caller for host/port validation.
+
+    The CLI validates the flags, but comfy-mcp's ``_with_target`` calls
+    ``execute_upload`` directly and ``resolve_target`` drops the host verbatim
+    into ``http://{host}:{port}`` — so without this the guarantee would belong
+    to the caller, not the function (BE-5662).
+    """
+
+    @pytest.mark.parametrize("bad", ["attacker.tld/x?", "", "   ", "a%0d%0aX:%201", "127.0.0.1:8188"])
+    def test_bad_host_raises_before_any_request(self, asset, monkeypatch, bad):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        with pytest.raises(typer.BadParameter):
+            transfer.execute_upload([str(asset)], where="local", host=bad)
+
+        assert opener.requests == []
+
+    @pytest.mark.parametrize("bad", [0, 65536, -1])
+    def test_bad_port_raises_before_any_request(self, asset, monkeypatch, bad):
+        opener = _FakeOpener()
+        monkeypatch.setattr(transfer, "_TRANSFER_OPENER", opener)
+
+        with pytest.raises(typer.BadParameter):
+            transfer.execute_upload([str(asset)], where="local", port=bad)
+
+        assert opener.requests == []

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -94,6 +94,38 @@ def test_validate_host_rejects_whitespace_and_control_chars(host):
         validate_host(host)
 
 
+@pytest.mark.parametrize("host", ["", "   ", "\t"])
+def test_validate_host_rejects_empty(host):
+    # An empty host is resolved as *absent* downstream (`host or env or
+    # DEFAULT_HOST`), so accepting it silently retargets the request at a
+    # server the caller never named — e.g. `--host "$UNSET_VAR"`.
+    with pytest.raises(typer.BadParameter):
+        validate_host(host)
+
+
+@pytest.mark.parametrize("host", ["a%0d%0aX-Injected:%201", "host%2fpath", "h%40ost", "host%23x"])
+def test_validate_host_rejects_percent_encoded_specials(host):
+    # urllib.request.Request._parse unquotes the host it splits out of the
+    # URL, so a percent-encoded payload decodes downstream of this guard.
+    with pytest.raises(typer.BadParameter):
+        validate_host(host)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1:8188", "localhost:8188", "example.com:80"])
+def test_validate_host_rejects_embedded_port(host):
+    # Colon-bearing hosts get bracketed as IPv6 literals by callers, so a
+    # combined host:port would become `http://[127.0.0.1:8188]:8188` with the
+    # embedded port silently dropped. Only `comfy run` takes the combined
+    # form, and it splits it via parse_host_port_arg first.
+    with pytest.raises(typer.BadParameter):
+        validate_host(host)
+
+
+@pytest.mark.parametrize("host", ["::1", "[::1]", "fe80::1", "2001:db8::8a2e:370:7334"])
+def test_validate_host_allows_ipv6_literals(host):
+    assert validate_host(host) == host
+
+
 # ---------------------------------------------------------------------------
 # resolve_host_port
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

`comfy upload` could only ever upload to one ComfyUI: whatever `COMFY_LOCAL_URL` said, or `127.0.0.1:8188`. If you had a second ComfyUI on another port or another machine on your LAN, the only way to reach it was to change that environment variable for the whole process. `comfy run` and every `comfy jobs` subcommand already let you say `--host X --port Y` for one invocation; `upload` now does too, so a program driving the CLI (comfy-mcp's `_with_target`) can point each call at whichever server it means.

## What changed

- **`comfy upload --host / --port`** (`comfy_cli/cmdline.py`): two separate options, mirroring the `comfy jobs` subcommands — deliberately NOT `comfy run`'s combined `host[:port]` positional. The host goes through `comfy_cli.host_port.validate_host` (rejects URL-special and whitespace/control characters, the URL-injection vectors) and the port is range-checked; both surface as a `typer.BadParameter` usage error (exit 2).
- **Cloud target + either flag → structured `host_flag_cloud` error, exit 1.** `Target.host`/`Target.port` are documented local-only and the cloud branch of `resolve_target` ignores them entirely, so the alternative to erroring is uploading somewhere the caller didn't name. The guard keys off the *resolved* target, so `--where cloud`, `COMFY_WHERE=cloud`, and a persisted `where_default` all trip it, and it runs *before* the cloud preflight so the flag error isn't masked by a "not signed in" error.
- **`transfer.execute_upload(..., host=None, port=None)`** forwards the pair to `resolve_target(where=..., host=..., port=...)`, which applies the documented precedence: explicit value > `COMFY_LOCAL_URL` > `127.0.0.1:8188`.
- Registered the new `host_flag_cloud` code in `comfy_cli/error_codes.py` (the registry test enforces both directions) and refreshed the `comfy_cli/host_port.py` module docstring, which claimed only `run`/`jobs` take the pair.
- Envelope output (`renderer.emit({"uploads": ...}, command="upload")`) is unchanged.

## Tests

`tests/comfy_cli/command/test_transfer_upload.py` gains two classes (32 tests in the file, all green): flags reach `resolve_target` and the POST lands on `http://X:Y/upload/image`; no flags → today's behavior (loopback default, `COMFY_LOCAL_URL` still honored); flags beat `COMFY_LOCAL_URL`; `--host` alone keeps the env var's port (host and port resolve independently); IPv6 hosts get bracketed; CLI-level forwarding, the `host_flag_cloud` rejection via both `--where cloud` and `COMFY_WHERE`, cloud-without-flags still untouched, and invalid hosts (`evil/host`, `user@evil`, `host?x`, `host#x`, CR, LF) / out-of-range ports as usage errors.

Full suite: **3766 passed, 37 skipped**. `ruff check` + `ruff format --diff` clean under the CI-pinned ruff 0.15.15. (Note for anyone running locally: `uv.lock` resolves ruff 0.12.7, which reports 17 pre-existing `UP038` hits and one format diff in files this PR doesn't touch — CI's pinned 0.15.15 is clean. Unrelated to this change, but it will bite the next person who runs `uv run ruff`.)

## Judgment calls

1. **The spec said "check how `comfy jobs` handles the cloud + host combination and mirror it exactly" — there is nothing to mirror.** Neither `comfy jobs` nor `comfy run` rejects it: `run` comments "Cloud path uses HTTPS + Bearer auth; host/port aren't applicable" and returns early, and `jobs ls` resolves host/port and then ignores them on the cloud branch. Both silently accept-and-drop. I implemented the explicit rejection the spec asks for twice (implementation step 2 and the acceptance test), because a silently-ignored routing flag is the failure mode this PR exists to remove. **This does make `upload` stricter than `jobs`/`run` on the same combination** — if the preference is consistency-by-silence instead, the guard is one contiguous block to delete. A follow-up to bring `jobs`/`run` up to the same rejection would be the other direction.
2. **Port range validation deviates from `jobs`.** `jobs` doesn't range-check `--port` at all (`resolve_local_host_port` only validates ports it parses out of `COMFY_LOCAL_URL`), so `--port 0` there silently falls through to 8188 via `port or default`. The spec said to validate the range, so `upload` does. It only rejects values that could never produce a working URL.
3. **`resolve_target` does not consult the persisted background server.** The spec described the precedence as "explicit flag > `COMFY_LOCAL_URL` > persisted background server > `127.0.0.1:8188`", but `resolve_target`'s local branch calls `resolve_local_host_port(host, port)` with no `background=` argument — that fallback is `host_port.resolve_host_port`, which `run`/`jobs` use upstream. I left this alone rather than widening `upload`'s resolution as a side effect: it is exactly today's `upload` behavior, and the no-flags acceptance criterion ("identical to today") holds.

## Falsification of the deny path

The new error denies a capability, so per our own rule I went looking for a path where it actually works before shipping the dead-end:

- `comfy upload` on `origin/main` has **no** `--host`/`--port` at all (`git show origin/main:comfy_cli/cmdline.py`), so no invocation that works today is being refused — the flags and their contract arrive together.
- Live check that host/port genuinely cannot aim a cloud upload: `resolve_target(where="cloud", host="10.0.0.5", port=9999)` returns `base_url=https://cloud.comfy.org`, `host=None`, `port=None`, and `target.url("upload/image")` → `https://cloud.comfy.org/api/upload/image`. The arguments are discarded; the address comes from `cloud.get_base_url()`.
- There **is** a working path to a different cloud address — `COMFY_CLOUD_BASE_URL`, or `comfy cloud set-base-url` — so the error hint redirects users there instead of dead-ending them. (I verified the command's real name against `comfy cloud --help`; my first draft of the hint said `comfy auth set-base-url`, which does not exist.)
