### PR TITLE
fix(run): detach the job watcher on Windows, not just POSIX

### DIFF
--- a/comfy_cli/command/run/watcher.py
+++ b/comfy_cli/command/run/watcher.py
@@ -116,7 +116,11 @@ def _spawn_watcher(
             **kwargs,
         )
         return True
-    except OSError:
+    except (OSError, ValueError):
         # Watcher spawn failed — the job still ran; the user just won't get
-        # a state-file update without manual polling. Don't bail the submit.
+        # a state-file update without manual polling. Don't bail the submit:
+        # we're past the point of no return, the workflow is already queued.
+        # ValueError covers Popen's argument-level rejections (an embedded NUL
+        # in host/prompt_id, creationflags on a non-Windows platform), which
+        # aren't OSError.
         return False

--- a/comfy_cli/command/run/watcher.py
+++ b/comfy_cli/command/run/watcher.py
@@ -79,8 +79,11 @@ def _spawn_watcher(
 ) -> bool:
     """Detach a watcher subprocess that polls + updates the state file.
 
-    Fully decoupled from the parent: stdio redirected to /dev/null, a new
-    session so a controlling terminal closing doesn't kill it. We don't
+    Fully decoupled from the parent: stdio redirected to /dev/null, and a
+    detached process group so a controlling terminal closing doesn't kill it.
+    POSIX gets its own session; Windows gets
+    DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP for the equivalent, because
+    ``start_new_session`` is POSIX-only and CPython ignores it there. We don't
     track the PID — the watcher writes its own PID into the state file so
     callers can find it there if needed.
 
@@ -93,14 +96,24 @@ def _spawn_watcher(
     if port:
         argv += ["--port", str(port)]
     argv += ["--notify"] if notify else ["--no-notify"]
+
+    kwargs: dict = {}
+    if sys.platform == "win32":
+        # Not module-level attributes on POSIX, hence the getattr lookups.
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0)
+        new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        kwargs["creationflags"] = detached | new_group
+    else:
+        kwargs["start_new_session"] = True
+
     try:
         subprocess.Popen(
             argv,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
-            start_new_session=True,
             close_fds=True,
+            **kwargs,
         )
         return True
     except OSError:

--- a/tests/comfy_cli/command/test_run_watcher_spawn.py
+++ b/tests/comfy_cli/command/test_run_watcher_spawn.py
@@ -1,0 +1,63 @@
+"""The job watcher must be detached on every platform CI runs.
+
+``start_new_session`` is POSIX-only — CPython silently ignores it on Windows,
+which left the watcher in the parent's console and process group despite the
+docstring promising otherwise. Windows needs
+``DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`` instead, the same way
+``models._spawn_download_worker`` does it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+from comfy_cli.command.run import watcher
+
+
+class TestWatcherSpawnFlags:
+    def _capture_popen(self, monkeypatch):
+        popen = MagicMock()
+        monkeypatch.setattr(subprocess, "Popen", popen)
+        return popen
+
+    def test_posix_uses_a_new_session(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        popen = self._capture_popen(monkeypatch)
+
+        assert watcher._spawn_watcher("abc123", where="cloud") is True
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["start_new_session"] is True
+        assert "creationflags" not in kwargs
+
+    def test_windows_uses_detached_process_flags(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        # These constants only exist on Windows builds of the stdlib.
+        monkeypatch.setattr(subprocess, "DETACHED_PROCESS", 0x8, raising=False)
+        monkeypatch.setattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200, raising=False)
+        popen = self._capture_popen(monkeypatch)
+
+        assert watcher._spawn_watcher("abc123", where="local", host="127.0.0.1", port=8188) is True
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["creationflags"] == 0x8 | 0x200
+        assert "start_new_session" not in kwargs
+
+    def test_stdio_stays_detached_from_the_parent(self, monkeypatch):
+        popen = self._capture_popen(monkeypatch)
+
+        watcher._spawn_watcher("abc123", where="cloud")
+
+        kwargs = popen.call_args.kwargs
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["stdout"] is subprocess.DEVNULL
+        assert kwargs["stderr"] is subprocess.DEVNULL
+        assert kwargs["close_fds"] is True
+
+    def test_spawn_failure_is_reported_not_raised(self, monkeypatch):
+        popen = self._capture_popen(monkeypatch)
+        popen.side_effect = OSError("no fork for you")
+
+        assert watcher._spawn_watcher("abc123", where="cloud") is False

--- a/tests/comfy_cli/command/test_run_watcher_spawn.py
+++ b/tests/comfy_cli/command/test_run_watcher_spawn.py
@@ -61,3 +61,13 @@ class TestWatcherSpawnFlags:
         popen.side_effect = OSError("no fork for you")
 
         assert watcher._spawn_watcher("abc123", where="cloud") is False
+
+    def test_argument_rejection_is_reported_not_raised(self, monkeypatch):
+        # Popen rejects bad *arguments* with ValueError, not OSError — an
+        # embedded NUL in host/prompt_id, or creationflags off Windows. The
+        # workflow is already submitted by the time we spawn, so neither may
+        # escape and abort `comfy run`.
+        popen = self._capture_popen(monkeypatch)
+        popen.side_effect = ValueError("embedded null byte")
+
+        assert watcher._spawn_watcher("abc123", where="local", host="127.0.0.1\x00") is False


### PR DESCRIPTION
## ELI-5

When you submit a job, comfy-cli quietly starts a little background "watcher" process that keeps checking on the job and writing its status to a file — so the job keeps being tracked even after you close your terminal. On Mac and Linux that works. On Windows it never actually did: the code asked for detachment using a switch that only exists on Unix, and Python silently ignores it on Windows, so the watcher stayed attached to the terminal that started it. This PR gives Windows the flags that actually detach a process there, so the watcher survives the terminal closing on every platform.

## What was wrong

`_spawn_watcher` (`comfy_cli/command/run/watcher.py`) promised in its docstring "a new session so a controlling terminal closing doesn't kill it", but passed only `start_new_session=True`. That argument is POSIX-only and CPython ignores it on Windows, so the watcher stayed in the parent's console and process group and the documented liveness property did not hold. The repo does support and test Windows (`.github/workflows/test-windows.yml`).

## The fix

Add the platform branch that `models._spawn_download_worker` (`comfy_cli/command/models/models.py`) already uses, mirrored exactly — same `getattr` lookups (neither constant exists on POSIX builds of the stdlib), same flags:

- `sys.platform == "win32"` → `creationflags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`
- everything else → `start_new_session=True`

The docstring is updated to describe both platforms instead of just POSIX.

Deliberately **not** part of this PR: unifying the two spawners behind a shared helper. That is a separate judgment call, and mixing a refactor into a correctness fix makes both harder to review.

## Tests

New `tests/comfy_cli/command/test_run_watcher_spawn.py`, modelled on the existing `TestSpawnFlags` in `tests/comfy_cli/command/test_model_download_background.py`: POSIX gets a new session and no `creationflags`; win32 gets `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` and no `start_new_session`; stdio stays on `DEVNULL` with `close_fds`; a failed spawn still returns `False` rather than raising.

Verified as a red→green pair — with the fix reverted, `test_windows_uses_detached_process_flags` fails with `KeyError: 'creationflags'`.

Local run: `pytest` → 3746 passed, 37 skipped. `ruff check` / `ruff format --diff` at the CI-pinned 0.15.15 → clean.

## Review notes / things I checked

- **No other spawner has the same gap.** `start_new_session` appears only in `models.py` (already correct) and here; `launch.py`'s `creationflags=subprocess.CREATE_NEW_PROCESS_GROUP` uses are all inside `win32` branches.
- **No kill-side gap is introduced.** Nothing signals the watcher's PID via `killpg` (only the download worker has a cancel path), so giving the watcher its own Windows process group has no counterpart to update.
- **Windows notifications are unaffected.** `job_watcher._notify` has no Windows backend and falls through to a stderr write — and the watcher's stderr is already `DEVNULL` on every platform, so that fallback was inert for the detached watcher before this change too. `DETACHED_PROCESS` removing the inherited console does not regress it.
