### PR TITLE
fix(workflow): emit a JSON failure envelope for bad routing instead of a traceback

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -104,7 +104,10 @@ def _get_graph(input_path: str | None, host: str | None, port: int | None, on_st
         # Live fetch: resolve mode from global routing chain, then use resilient loader.
         from comfy_cli import where as where_module
 
-        decision = where_module.resolve_default()
+        # ``_or_exit``: this command has no per-command --where flag to fall
+        # back to, so a bad COMFY_WHERE / project / persisted where_default
+        # becomes a clean `where_invalid` envelope rather than a traceback.
+        decision = where_module.resolve_default_or_exit()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
         from comfy_cli.cql.loader import resilient_load_object_info
 

--- a/comfy_cli/command/workflow_fragments.py
+++ b/comfy_cli/command/workflow_fragments.py
@@ -324,6 +324,13 @@ def _slug_name(text: str) -> str:
 
 def _load_object_info(renderer, *, input_path: str | None, host: str | None, port: int | None) -> dict:
     """Fetch raw object_info for frontend→API conversion (offline dump or live server)."""
+    # ``LoadError`` is how ``resilient_load_object_info`` reports an unreachable
+    # server / bad dump — the handler below predates that loader (it was written
+    # when the fetch raised a bare OSError), so an unreachable local server used
+    # to escape as a traceback even though the hint here is written for exactly
+    # that case. ``workflow.py``'s sibling ``_get_graph`` already catches it.
+    from comfy_cli.cql.engine import LoadError
+
     try:
         if input_path is not None:
             p = Path(input_path).expanduser()
@@ -331,10 +338,14 @@ def _load_object_info(renderer, *, input_path: str | None, host: str | None, por
         from comfy_cli import where as where_module
         from comfy_cli.cql.loader import resilient_load_object_info
 
-        decision = where_module.resolve_default()
+        # ``_or_exit``: no per-command --where flag here either, so a bad
+        # COMFY_WHERE / project / persisted where_default emits a clean
+        # `where_invalid` envelope instead of escaping as a traceback (the
+        # handler below is for object_info failures, not routing ones).
+        decision = where_module.resolve_default_or_exit()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
         return resilient_load_object_info(mode=mode, host=host, port=port)
-    except (OSError, json.JSONDecodeError) as e:
+    except (OSError, json.JSONDecodeError, LoadError) as e:
         renderer.error(
             code="object_info_unavailable",
             message=f"Could not load object_info: {e}",

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -101,6 +101,40 @@ def resolve_default(
     return resolve(flag=flag, env=env, config_value=config_value, project_value=project_value)
 
 
+def resolve_default_or_exit(
+    flag: str | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    project_value: str | None = _UNSET,
+) -> WhereResolution:
+    """:func:`resolve_default` that emits a ``where_invalid`` envelope and exits.
+
+    The shared "emit-and-exit" wrapper for command call sites that have no
+    sensible fallback for a bad routing value — a typo'd ``COMFY_WHERE``, a
+    stale ``defaults.where`` in the project ``comfy.yaml``, or a corrupt
+    persisted ``where_default`` would otherwise escape as a raw ``ValueError``
+    traceback, which is the worst possible shape for a machine consumer of a
+    JSON-envelope command.
+
+    Commands that *can* recover (``nodes``, ``jobs``) keep their own
+    ``except ValueError`` fallback instead of calling this.
+    """
+    import typer
+
+    from comfy_cli.output import get_renderer
+
+    try:
+        return resolve_default(flag=flag, env=env, project_value=project_value)
+    except ValueError as e:
+        get_renderer().error(
+            code="where_invalid",
+            message=str(e),
+            hint="use --where local or --where cloud, and check COMFY_WHERE, "
+            "`defaults.where` in comfy.yaml, and `comfy set-default --where`",
+        )
+        raise typer.Exit(code=1) from e
+
+
 def _project_where_default() -> str | None:
     """``defaults.where`` from the project/1 ``comfy.yaml`` governing cwd, if
     any. Discovery itself never raises (see :mod:`comfy_cli.project`); a

--- a/tests/comfy_cli/auth/test_where.py
+++ b/tests/comfy_cli/auth/test_where.py
@@ -100,6 +100,65 @@ def test_resolve_default_forwards_project_value(fake_config, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# resolve_default_or_exit: the emit-and-exit wrapper for call sites with no
+# per-command --where flag to fall back to
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_renderer(monkeypatch):
+    """Replace the process renderer so ``error()`` calls are inspectable."""
+    captured: dict = {}
+
+    class _Renderer:
+        def error(self, **kw):
+            captured.update(kw)
+
+    monkeypatch.setattr("comfy_cli.output.get_renderer", lambda: _Renderer())
+    return captured
+
+
+def test_resolve_default_or_exit_returns_resolution(fake_config, captured_renderer, monkeypatch):
+    monkeypatch.setattr(fake_config, "_value", "cloud")
+    r = where_module.resolve_default_or_exit(env={}, project_value=None)
+    assert r.target is where_module.WhereTarget.CLOUD
+    assert captured_renderer == {}, "valid routing must not emit an error"
+
+
+def test_resolve_default_or_exit_emits_envelope_for_typoed_env(fake_config, captured_renderer):
+    """A typo'd COMFY_WHERE is a `where_invalid` envelope, never a traceback."""
+    import typer
+
+    with pytest.raises(typer.Exit) as excinfo:
+        where_module.resolve_default_or_exit(env={"COMFY_WHERE": "clod"}, project_value=None)
+    assert excinfo.value.exit_code == 1
+    assert captured_renderer["code"] == "where_invalid"
+    assert "clod" in captured_renderer["message"]
+    assert captured_renderer["hint"]
+
+
+def test_resolve_default_or_exit_emits_envelope_for_bad_persisted_config(fake_config, captured_renderer, monkeypatch):
+    """Same for a bad persisted ``where_default`` — the value parses, not the read."""
+    import typer
+
+    monkeypatch.setattr(fake_config, "_value", "clould")
+    with pytest.raises(typer.Exit) as excinfo:
+        where_module.resolve_default_or_exit(env={}, project_value=None)
+    assert excinfo.value.exit_code == 1
+    assert captured_renderer["code"] == "where_invalid"
+    assert "clould" in captured_renderer["message"]
+
+
+def test_resolve_default_or_exit_forwards_flag(fake_config, captured_renderer, monkeypatch):
+    """The wrapper mirrors ``resolve_default``'s signature — a valid flag wins."""
+    monkeypatch.setattr(fake_config, "_value", "clould")
+    r = where_module.resolve_default_or_exit(flag="local", env={}, project_value=None)
+    assert r.target is where_module.WhereTarget.LOCAL
+    assert r.source == "flag"
+    assert captured_renderer == {}
+
+
+# ---------------------------------------------------------------------------
 # project/1 precedence: flag → env → project → config → auto
 # ---------------------------------------------------------------------------
 

--- a/tests/comfy_cli/command/test_workflow_fragments.py
+++ b/tests/comfy_cli/command/test_workflow_fragments.py
@@ -1242,3 +1242,55 @@ class TestComposeJournal:
         envelope = _run(["compose", str(blueprint), "-o", str(out), "--lib", str(lib_dir)], capsys)
         assert envelope["ok"] is True
         assert out.exists()
+
+
+class TestDecomposeFailureEnvelopes:
+    """Every `workflow decompose` failure must be a JSON envelope, not a traceback.
+
+    A frontend-format workflow needs object_info, so decompose resolves routing
+    and hits the network — with no per-command ``--where`` flag to fall back to.
+    Two failures used to escape ``_load_object_info`` uncaught: a typo'd
+    ``COMFY_WHERE`` (a ``ValueError`` out of ``resolve_default``) and an
+    unreachable server (a ``LoadError`` out of the resilient loader).
+    """
+
+    _UI_WF = {
+        "nodes": [{"id": 6, "type": "CLIPTextEncode", "widgets_values": ["a cat"]}],
+        "links": [],
+    }
+
+    def test_typoed_comfy_where_emits_envelope(self, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setenv("COMFY_WHERE", "clod")
+        wf = tmp_path / "ui.json"
+        wf.write_text(json.dumps(self._UI_WF))
+        envelope = _run(["decompose", str(wf), "--lib", str(tmp_path / "fragments")], capsys)
+        assert envelope["ok"] is False
+        assert envelope["error"]["code"] == "where_invalid"
+        assert "clod" in envelope["error"]["message"]
+
+    def test_api_format_workflow_never_resolves_routing(self, tmp_path: Path, monkeypatch, capsys):
+        """API format needs no object_info, so bad routing stays harmless."""
+        monkeypatch.setenv("COMFY_WHERE", "clod")
+        wf = tmp_path / "restyle.json"
+        wf.write_text(json.dumps(TestFragmentizeCmd._RESTYLE_WF))
+        envelope = _run(["decompose", str(wf), "--name", "restyle", "--lib", str(tmp_path / "fragments")], capsys)
+        assert envelope["ok"] is True, envelope
+
+    def test_unreachable_server_emits_envelope(self, tmp_path: Path, monkeypatch, capsys):
+        """An unreachable server is a `LoadError` from the resilient loader —
+        that is the handler's own documented case ("start the server with
+        `comfy launch`"), but it predates the loader and used to escape as a
+        traceback."""
+        from comfy_cli.cql.engine import LoadError
+
+        def _boom(**kwargs):
+            raise LoadError("cannot reach http://127.0.0.1:8188/object_info: connection refused")
+
+        monkeypatch.setenv("COMFY_WHERE", "local")
+        monkeypatch.setattr("comfy_cli.cql.loader.resilient_load_object_info", _boom)
+        wf = tmp_path / "ui.json"
+        wf.write_text(json.dumps(self._UI_WF))
+        envelope = _run(["decompose", str(wf), "--lib", str(tmp_path / "fragments")], capsys)
+        assert envelope["ok"] is False
+        assert envelope["error"]["code"] == "object_info_unavailable"
+        assert "comfy launch" in envelope["error"]["hint"]

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -799,3 +799,40 @@ class TestStaleEnvelope:
         assert any(w.get("code") == "object_info_stale" for w in warnings), (
             f"expected a warning with code='object_info_stale', got {warnings}"
         )
+
+
+class TestRoutingErrorEnvelope:
+    """A bad routing value must degrade to the JSON failure envelope.
+
+    ``_get_graph`` here has no per-command ``--where`` flag to fall back to, so
+    a typo'd ``COMFY_WHERE`` (or a stale project/persisted ``where_default``)
+    used to escape ``resolve_default`` as a raw ``ValueError`` — the try block
+    around it only handles ``LoadError``. Regression: it is a ``where_invalid``
+    envelope now, and nothing reaches the network.
+    """
+
+    def test_slots_typoed_comfy_where_emits_envelope(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("COMFY_WHERE", "clod")
+        path = _write_workflow(tmp_path, _direct_workflow())
+        captured, _err, result = _invoke(["slots", str(path)], capsys)
+        assert result.exception is None, f"routing error escaped as a traceback: {result.exception!r}"
+        env = json.loads([ln for ln in captured.strip().splitlines() if ln.strip()][-1])
+        assert env["ok"] is False
+        assert env["error"]["code"] == "where_invalid"
+        assert "clod" in env["error"]["message"]
+
+    def test_set_slot_typoed_comfy_where_emits_envelope(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("COMFY_WHERE", "clod")
+        path = _write_workflow(tmp_path, _direct_workflow())
+        env = _run(["set-slot", str(path), '6.text="a dog"'], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "where_invalid"
+
+    def test_input_path_short_circuits_routing(self, tmp_path, monkeypatch, capsys):
+        """``--input`` never resolves routing, so a bad value stays harmless."""
+        monkeypatch.setenv("COMFY_WHERE", "clod")
+        oi = tmp_path / "object_info.json"
+        oi.write_text(json.dumps(_object_info()), encoding="utf-8")
+        path = _write_workflow(tmp_path, _direct_workflow())
+        env = _run(["slots", str(path), "--input", str(oi)], capsys)
+        assert env["ok"] is True, env


### PR DESCRIPTION
## ELI-5

If you typo the routing setting — `COMFY_WHERE=clod` instead of `cloud` — some `comfy workflow` commands used to crash with a raw Python traceback instead of the clean JSON error they promise. A script or agent reading that output gets garbage where it expected an envelope. Now it gets a normal `where_invalid` error with a hint about what to fix.

## What was wrong

`where.resolve_default()` raises `ValueError` on an invalid routing value, and its docstring is explicit that **callers keep their own error handling**. Five call sites; two did not have any:

| Call site | Before |
|---|---|
| `command/nodes.py` `_resolved_where` | catches `ValueError`, retries with the bad config dropped |
| `command/jobs.py` `_is_cloud` | catches `ValueError`, falls back to local |
| `command/launch.py` `logs` | catches `ValueError`, emits a `where_invalid` envelope |
| `command/workflow.py` `_get_graph` | **bare call** inside a `try` whose only handler is `except LoadError` |
| `command/workflow_fragments.py` `_load_object_info` | **bare call** inside a `try` catching only `OSError` / `json.JSONDecodeError` |

A bad persisted `where_default`, a stale `defaults.where` in the project `comfy.yaml`, or a typo'd `COMFY_WHERE` therefore escaped as an uncaught `ValueError` from `comfy workflow slots` / `set-slot` / `vary` / `decompose` — a raw traceback on a JSON-envelope command.

Reproduced before the fix (both paths), with `COMFY_WHERE=clod`:

```
$ COMFY_WHERE=clod comfy --json workflow slots wf.json
ValueError: invalid --where value 'clod': expected one of ['local', 'cloud']
```

## What changed

Added `where.resolve_default_or_exit()` — the same emit-and-exit shape as the existing `cloud_preflight_or_exit()` in that module (lazy `typer` / renderer imports, `renderer.error(...)` then `typer.Exit(1)`), so the envelope stays identical across call sites instead of the block being re-inlined. Both leaking sites now use it. After:

```
$ COMFY_WHERE=clod comfy --json workflow slots wf.json ; echo $?
{"schema": "envelope/1", ..., "ok": false, "error": {"code": "where_invalid", "message": "invalid --where value 'clod': expected one of ['local', 'cloud']", "hint": "use --where local or --where cloud, and check COMFY_WHERE, `defaults.where` in comfy.yaml, and `comfy set-default --where`"}}
1
```

**Why an envelope rather than the silent fallback `nodes`/`jobs` use.** The ticket's scope line asks for both "handle it the way the others do" and "emit the normal JSON failure envelope". Those point different directions, so: `nodes` and `jobs` can silently fall back because each has a per-command `--where` flag to fall back *to*. `workflow._get_graph` takes no `where` parameter at all, so there is nothing to recover to — and silently routing to `local` when the user explicitly (if mistakenly) asked for something else is worse for a machine consumer than a clean, actionable error. `launch.py logs` already sets that precedent with the same `where_invalid` code. Flagging it as a judgment call.

## Adjacent fix found during self-review

`_load_object_info`'s handler catches only `OSError` / `json.JSONDecodeError`, but `resilient_load_object_info` reports failures as `LoadError`. `git log -L` shows the handler predates that loader migration (it was written when the fetch raised a bare `OSError`), so an **unreachable local server** — the far more common case than a typo'd env var — also escaped as a traceback, even though the handler's own hint ("start the server with `comfy launch`") is written for exactly that case. `workflow.py`'s sibling `_get_graph` already catches `LoadError`. Added it to the tuple, so the already-written `object_info_unavailable` envelope now actually fires:

```
$ COMFY_WHERE=local comfy workflow decompose ui.json ; echo $?     # no server running
# before: LoadError: cannot reach http://127.0.0.1:8188/object_info: [Errno 61] Connection refused
{"ok": false, "error": {"code": "object_info_unavailable", "message": "Could not load object_info: cannot reach ...", "hint": "pass --input <object_info.json>, sign into cloud, or start the server with `comfy launch`"}}
1
```

## Tests

Nine tests added, **each verified red against this branch with the source fix stashed**:

- `tests/comfy_cli/auth/test_where.py` — four unit tests on the wrapper: valid routing returns quietly and emits nothing; a typo'd `COMFY_WHERE` and a bad persisted `where_default` each emit `where_invalid` and raise `Exit(1)`; a valid `flag` still beats a bad config.
- `tests/comfy_cli/command/test_workflow_slots.py` — `slots` and `set-slot` with a typo'd `COMFY_WHERE` produce the envelope (the `slots` one asserts `result.exception is None`, i.e. nothing escaped as a traceback), plus a positive guard that `--input` short-circuits routing entirely so a bad value stays harmless.
- `tests/comfy_cli/command/test_workflow_fragments.py` — `decompose` with a typo'd `COMFY_WHERE`; `decompose` against an unreachable server (the `LoadError` case); plus a positive guard that an API-format workflow never resolves routing at all.

Full suite green: **3752 passed, 37 skipped**. `ruff check` and `ruff format --diff` clean using the CI-pinned **0.15.15** (note: with a newer local ruff, `origin/main` already reports 17 pre-existing lint errors and one format diff — unrelated to this change, and clean at the pinned version).

## Out of scope — but worth a separate issue

**`target.py resolve_target` has the same half-defense and leaks the same way.** It wraps the config *read* in `except Exception` but not the value *parse*, so `where_module.resolve(...)` at `target.py:77` still raises. Verified live on `main`:

```
$ COMFY_WHERE=clod comfy --json system-stats
ValueError: invalid --where value 'clod': expected one of ['local', 'cloud']
```

That is a different function with ~19 call sites needing per-command judgment (several pass `where="cloud"` literally and can never fail), so fixing it here would blow up a scoped correctness fix into a sweep. Recommend a follow-up issue. The broader "unify object_info/Graph loading across commands" proposal is likewise untouched.

Closes #637
