### PR TITLE
fix(http): bound three unbounded HTTP body reads behind a shared read cap

### DIFF
--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -269,7 +269,12 @@ class Client:
         except urllib.error.HTTPError as e:
             body_text = ""
             try:
-                body_text = e.read().decode("utf-8", errors="replace")
+                # An error body arrives from the same server as the success
+                # body, so it needs the same ceiling. Over-cap it raises, and
+                # the swallow below leaves body_text empty — the status and
+                # reason still reach the caller, which is the part that matters
+                # for a body too large to be a real error message.
+                body_text = read_capped(e, url).decode("utf-8", errors="replace")
             except Exception:  # noqa: BLE001
                 pass
             # Auto-refresh on 401 for OAuth cloud targets, retry once.

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -23,7 +23,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from comfy_cli.http import NoRedirectHandler, build_http_only_opener, target_auth_headers
+from comfy_cli.http import (
+    NoRedirectHandler,
+    ResponseTooLarge,
+    build_http_only_opener,
+    read_capped,
+    target_auth_headers,
+)
 from comfy_cli.http import assert_safe_url as _assert_safe_url
 from comfy_cli.target import Target
 
@@ -248,7 +254,15 @@ class Client:
             req.add_header(header, value)
         try:
             with _OPENER.open(req, timeout=timeout or self.timeout) as resp:
-                text = resp.read().decode("utf-8", errors="replace")
+                # Bounded read: without a ceiling the server on the other end
+                # decides how much of our memory to consume. An over-cap body
+                # is reported as a response error rather than truncated —
+                # truncated JSON would surface as a misleading parse failure.
+                try:
+                    raw = read_capped(resp, url)
+                except ResponseTooLarge as e:
+                    raise HTTPError(resp.status, "response too large", str(e)) from e
+                text = raw.decode("utf-8", errors="replace")
                 if not text:
                     return None
                 return json.loads(text)

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -36,7 +36,7 @@ from websocket import WebSocket, WebSocketException, WebSocketTimeoutException
 from comfy_cli import cancellation, execution_errors, tracking
 from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.host_port import resolve_host_port as _resolve_host_port
-from comfy_cli.http import authed_urlopen, plain_urlopen
+from comfy_cli.http import ResponseTooLarge, authed_urlopen, plain_urlopen, read_capped
 from comfy_cli.output import get_renderer
 from comfy_cli.where import cloud_preflight_or_exit
 
@@ -82,12 +82,21 @@ def _server_or_error(host: str, port: int, *, raise_on_missing: bool = True) -> 
 
 
 def _http_get_json(url: str, *, timeout: float = 10.0) -> Any:
+    """GET a JSON body from the local ComfyUI server.
+
+    The read is capped (``read_capped``) so a server streaming an endless
+    ``/history`` can't OOM the CLI. Every failure — unreachable, oversize,
+    non-JSON — leaves as a ``RuntimeError``, which is the single family every
+    call site below already catches.
+    """
     req = urllib.request.Request(url)
     try:
         with plain_urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read())
+            return json.loads(read_capped(resp, url))
     except urllib.error.URLError as e:
         raise RuntimeError(f"failed to GET {url}: {e}") from e
+    except ResponseTooLarge as e:
+        raise RuntimeError(str(e)) from e
     except ValueError as e:
         # json.JSONDecodeError is a ValueError — a non-JSON 200 (captive
         # portal, proxy error page) must look like any other GET failure to

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -30,7 +30,7 @@ from typing import Annotated, Any
 import typer
 
 from comfy_cli import tracking
-from comfy_cli.http import plain_urlopen
+from comfy_cli.http import ResponseTooLarge, plain_urlopen, read_capped
 from comfy_cli.output import get_renderer, rprint
 
 app = typer.Typer(no_args_is_help=True, help="Browse the Comfy workflow-template gallery.")
@@ -46,11 +46,17 @@ GALLERY_TTL_SECONDS = 24 * 60 * 60
 
 # Everything a gallery load can throw. ``_fetch_gallery`` raises ``RuntimeError``
 # on a non-200 status (which ``urlopen`` doesn't already turn into an
-# ``HTTPError``), the fetch itself raises ``URLError``/``OSError``, and decoding a
-# 200-with-garbage body raises ``JSONDecodeError`` — all of which must route
-# through the same stale-cache fallback / command-level error, never an uncaught
-# traceback.
-_GALLERY_LOAD_ERRORS = (urllib.error.URLError, OSError, RuntimeError, json.JSONDecodeError)
+# ``HTTPError``), the fetch itself raises ``URLError``/``OSError``, decoding a
+# 200-with-garbage body raises ``JSONDecodeError``, and an over-cap body raises
+# ``ResponseTooLarge`` — all of which must route through the same stale-cache
+# fallback / command-level error, never an uncaught traceback.
+_GALLERY_LOAD_ERRORS = (
+    urllib.error.URLError,
+    OSError,
+    RuntimeError,
+    json.JSONDecodeError,
+    ResponseTooLarge,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -65,11 +71,14 @@ def _cache_path() -> Path:
 
 
 def _fetch_gallery(url: str = GALLERY_URL, timeout: float = 15.0) -> bytes:
+    """Pull the gallery index from GitHub raw. Bounded read — this is a body
+    from a host we don't control, so it goes through the shared cap rather than
+    letting the remote decide how much memory we buffer."""
     req = urllib.request.Request(url, headers={"User-Agent": "comfy-cli"})
     with plain_urlopen(req, timeout=timeout) as resp:
         if resp.status != 200:
             raise RuntimeError(f"gallery fetch failed: HTTP {resp.status}")
-        return resp.read()
+        return read_capped(resp, url)
 
 
 def _load_gallery(
@@ -495,7 +504,10 @@ def refresh_cmd():
     renderer = get_renderer()
     try:
         data = _fetch_gallery()
-    except (urllib.error.URLError, OSError) as e:
+    except _GALLERY_LOAD_ERRORS as e:
+        # Same family `_load_gallery` routes: a non-200 (`RuntimeError`) and an
+        # over-cap body (`ResponseTooLarge`) must surface as this envelope too,
+        # not as an uncaught traceback.
         renderer.error(code="gallery_fetch_failed", message=str(e))
         raise typer.Exit(code=1) from e
     cache = _cache_path()
@@ -520,7 +532,7 @@ def _fetch_template_workflow(name: str, *, timeout: float = 15.0) -> bytes:
     with plain_urlopen(req, timeout=timeout) as resp:
         if resp.status != 200:
             raise RuntimeError(f"template workflow fetch failed: HTTP {resp.status}")
-        return resp.read()
+        return read_capped(resp, url)
 
 
 @app.command(
@@ -574,7 +586,10 @@ def fetch_cmd(
 
     try:
         body = _fetch_template_workflow(name)
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+    # ``RuntimeError`` (a 2xx-but-not-200 status) and ``ResponseTooLarge`` (an
+    # over-cap body) are the same class of upstream misbehaviour as a URLError
+    # and belong in the same envelope, not in an uncaught traceback.
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, RuntimeError, ResponseTooLarge) as e:
         status = getattr(e, "code", None)
         renderer.error(
             code="template_fetch_failed",
@@ -934,7 +949,9 @@ def run_template_cmd(
     # -- Resolve the template against the gallery index (close-matches on miss).
     try:
         cats = _load_gallery(gallery_path, refresh=refresh)
-    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+    # The full `_GALLERY_LOAD_ERRORS` family, matching every other `_load_gallery`
+    # call site — a non-200 or an over-cap body escapes here just as a URLError does.
+    except _GALLERY_LOAD_ERRORS as e:
         renderer.error(code="gallery_load_failed", message=str(e))
         raise typer.Exit(code=1) from e
 
@@ -954,7 +971,10 @@ def run_template_cmd(
     # -- Fetch + parse the template's workflow JSON.
     try:
         body = _fetch_template_workflow(name)
-    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+    # ``RuntimeError`` (a 2xx-but-not-200 status) and ``ResponseTooLarge`` (an
+    # over-cap body) are the same class of upstream misbehaviour as a URLError
+    # and belong in the same envelope, not in an uncaught traceback.
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, RuntimeError, ResponseTooLarge) as e:
         status = getattr(e, "code", None)
         renderer.error(
             code="template_fetch_failed",

--- a/comfy_cli/http.py
+++ b/comfy_cli/http.py
@@ -209,6 +209,52 @@ class ResponseTooLarge(Exception):
     """A response exceeded the caller's byte cap — refuse to truncate."""
 
 
+# Default ceiling for a single response body buffered whole into memory.
+#
+# 64 MiB, picked for this primitive rather than inherited from whichever call
+# site happened to be nearest. Two numbers bracket it. The largest legitimate
+# body any of these readers sees is ``/api/object_info`` at roughly 9 MB on
+# cloud (the template gallery index and the ComfyUI ``/queue`` + ``/history``
+# payloads are orders of magnitude smaller), so 64 MiB is ~7x headroom over the
+# real ceiling and cannot plausibly reject a well-behaved server. At the other
+# end it is a body a laptop can hold twice over without swapping, which is what
+# a cap is for: the failure mode being bounded here is a server that streams
+# without end, not one that is merely chatty.
+#
+# It also matches the cap the already-bounded call sites converged on
+# independently (``models/search``, both ``workflow`` readers), so the CLI has
+# one number rather than five. ``cql.loader`` keeps its own, larger
+# ``MAX_INPUT_BYTES`` — that one bounds a user-supplied object_info dump, a
+# different thing being measured.
+MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+
+
+def read_capped(resp, url: str, *, max_bytes: int = MAX_RESPONSE_BYTES) -> bytes:
+    """Read a whole response body, refusing to buffer more than ``max_bytes``.
+
+    The shared bounded-read primitive: an unbounded ``resp.read()`` lets a
+    misbehaving or hostile server decide how much of the CLI's memory to
+    consume, so every reader that buffers a body whole goes through here.
+
+    Reads one byte past the cap so a body that exactly fills it is still
+    recognizable as complete, and raises :class:`ResponseTooLarge` rather than
+    returning a silently truncated body — a truncated JSON body would surface
+    as a confusing parse error, and a truncated file body would be written to
+    disk as if it were whole.
+
+    ``url`` is interpolated into the error message; call sites pass the URL
+    they requested, since ``resp`` alone may not name the host after a
+    redirect. Callers that need a different ceiling pass ``max_bytes``; see
+    ``MAX_RESPONSE_BYTES`` above for why the default is what it is.
+    """
+    if max_bytes < 1:
+        raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+    raw = resp.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise ResponseTooLarge(f"response from {url} exceeds {max_bytes} byte cap")
+    return raw
+
+
 def request_json(
     url: str,
     target,
@@ -233,6 +279,8 @@ def request_json(
     30x can't replay the credential at another host), and the URL itself
     must be HTTPS or loopback before a credential is attached.
     """
+    # ``read_capped`` re-checks this, but only after the request has gone out;
+    # validating up front means a bad cap costs no network round-trip.
     if max_bytes < 1:
         raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
     headers = target_auth_headers(target)
@@ -246,11 +294,9 @@ def request_json(
         req.add_header("Content-Type", "application/json")
     with _AUTHED_OPENER.open(req, timeout=timeout) as resp:
         status = resp.status
-        # Read one byte past the cap so a full body is distinguishable from a truncated one.
-        raw = resp.read(max_bytes + 1)
-    if len(raw) > max_bytes:
-        # Keep the message descriptive: search interpolates it into its envelope.
-        raise ResponseTooLarge(f"response from {url} exceeds {max_bytes} byte cap")
+        # ``read_capped``'s message names the URL and the cap — search
+        # interpolates it into its envelope, so it must stay descriptive.
+        raw = read_capped(resp, url, max_bytes=max_bytes)
     if not raw:
         return status, None
     try:

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -967,3 +967,30 @@ class TestBoundedResponseReads:
             with pytest.raises(comfy_client.HTTPError) as exc_info:
                 comfy_client.Client(target).submit_prompt({"1": {}}, "cid")
         assert "too large" in str(exc_info.value)
+
+    def test_error_body_is_read_with_a_cap_too(self):
+        # The 4xx/5xx body comes from the same server as the success body, so
+        # it needs the same ceiling — the fake refuses an unbounded read().
+        err = _http_error(400, b"bad workflow")
+        with patch.object(comfy_client._OPENER, "open", side_effect=err):
+            with pytest.raises(comfy_client.HTTPError) as exc_info:
+                comfy_client.Client(LOCAL).submit_prompt({"1": {}}, "cid")
+        # Still capped-but-generous, so a real error body reaches the caller.
+        assert exc_info.value.body == "bad workflow"
+
+    def test_oversize_error_body_degrades_to_an_empty_body_not_a_crash(self, monkeypatch):
+        # Over the cap the read raises; the status and reason must still make it
+        # out, with the body simply dropped rather than the request blowing up.
+        import comfy_cli.http as http_mod
+
+        monkeypatch.setattr(
+            comfy_client,
+            "read_capped",
+            lambda r, url, max_bytes=4: http_mod.read_capped(r, url, max_bytes=max_bytes),
+        )
+        err = _http_error(500, b"x" * 4096)
+        with patch.object(comfy_client._OPENER, "open", side_effect=err):
+            with pytest.raises(comfy_client.HTTPError) as exc_info:
+                comfy_client.Client(LOCAL).submit_prompt({"1": {}}, "cid")
+        assert exc_info.value.status == 500
+        assert exc_info.value.body == ""

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -22,8 +22,10 @@ def _mock_response(payload):
         def __init__(self, body):
             self.body = body if isinstance(body, bytes) else json.dumps(body).encode()
 
-        def read(self):
-            return self.body
+        def read(self, n=None):
+            # Mirror http.client.HTTPResponse.read(amt) — the client reads with
+            # a byte cap, so a no-arg-only fake would not match the real API.
+            return self.body if n is None else self.body[:n]
 
         def __enter__(self):
             return self
@@ -905,3 +907,63 @@ class TestTokenRedaction:
     def test_target_repr_omits_token(self):
         # Bearer should never show in logger.debug("%r", target).
         assert "tok-abc" not in repr(CLOUD)
+
+
+# ---------------------------------------------------------------------------
+# Bounded response reads
+# ---------------------------------------------------------------------------
+
+
+class _CapRecordingResp:
+    """A urlopen response that records the byte cap it was read with.
+
+    ``read(None)`` fails outright — an unbounded read is the bug being guarded
+    against, and a lenient fake would let it back in.
+    """
+
+    def __init__(self, body: bytes, status: int = 200):
+        self._body = body
+        self.status = status
+        self.requested: list[int] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, n=None):
+        if n is None:
+            raise AssertionError("unbounded read() — the body must be read with a cap")
+        self.requested.append(n)
+        return self._body[:n]
+
+
+class TestBoundedResponseReads:
+    def test_response_is_read_with_a_cap_not_unbounded(self):
+        import comfy_cli.http as http_mod
+
+        resp = _CapRecordingResp(json.dumps({"prompt_id": "pid", "number": 1, "node_errors": {}}).encode())
+        target = Target(kind="local", base_url="http://127.0.0.1:8188", path_prefix="")
+        with patch.object(comfy_client._OPENER, "open", return_value=resp):
+            comfy_client.Client(target).submit_prompt({"1": {}}, "cid")
+        # One byte past the cap, so a body that exactly fills it is still complete.
+        assert resp.requested == [http_mod.MAX_RESPONSE_BYTES + 1]
+
+    def test_oversize_response_raises_http_error_not_a_truncated_parse(self, monkeypatch):
+        # A truncated body would surface as a misleading JSON decode error (or,
+        # worse, parse into something plausible). Surface it as the same
+        # HTTPError family every caller already handles instead.
+        import comfy_cli.http as http_mod
+
+        resp = _CapRecordingResp(b"x" * 4096)
+        monkeypatch.setattr(
+            comfy_client,
+            "read_capped",
+            lambda r, url, max_bytes=8: http_mod.read_capped(r, url, max_bytes=max_bytes),
+        )
+        target = Target(kind="local", base_url="http://127.0.0.1:8188", path_prefix="")
+        with patch.object(comfy_client._OPENER, "open", return_value=resp):
+            with pytest.raises(comfy_client.HTTPError) as exc_info:
+                comfy_client.Client(target).submit_prompt({"1": {}}, "cid")
+        assert "too large" in str(exc_info.value)

--- a/tests/comfy_cli/command/test_system.py
+++ b/tests/comfy_cli/command/test_system.py
@@ -44,8 +44,10 @@ class _FakeResp:
     def __init__(self, body: bytes):
         self._body = body
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, n: int | None = None) -> bytes:
+        # Mirror http.client.HTTPResponse.read(amt) — bodies are read with a
+        # byte cap, so a no-arg-only fake would not match the real API.
+        return self._body if n is None else self._body[:n]
 
     def __enter__(self):
         return self

--- a/tests/comfy_cli/command/test_templates.py
+++ b/tests/comfy_cli/command/test_templates.py
@@ -673,7 +673,7 @@ def test_oversize_gallery_under_templates_refresh_is_a_clean_envelope(cache_file
     assert json.loads(cache_file.read_bytes()) == FIXTURE
 
 
-def test_oversize_template_workflow_is_a_clean_envelope(gallery_file, monkeypatch, capsys):
+def test_oversize_template_workflow_is_a_clean_envelope(gallery_file, monkeypatch):
     # The workflow fetch happens after the gallery lookup, so point the opener
     # at an oversize body and resolve the name from the local fixture index.
     monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))

--- a/tests/comfy_cli/command/test_templates.py
+++ b/tests/comfy_cli/command/test_templates.py
@@ -15,8 +15,10 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+import comfy_cli.http as http_mod
 from comfy_cli.caller import Caller
 from comfy_cli.command import templates as templates_cmd
+from comfy_cli.http import ResponseTooLarge
 from comfy_cli.output.renderer import (
     OutputMode,
     Renderer,
@@ -551,3 +553,135 @@ def test_readonly_cache_dir_still_serves_fetched_data(cache_file, monkeypatch):
     env = _envelope(result.output)
     names = [r["name"] for r in env["data"]["rows"]]
     assert names == ["brand_new_template"]
+
+
+# ---------------------------------------------------------------------------
+# Bounded gallery reads — a remote host must not decide how much memory we use
+# ---------------------------------------------------------------------------
+
+
+class _RecordingResponse:
+    """Stands in for a urlopen response, recording how the body was read.
+
+    ``read(None)`` — the unbounded form — is an outright failure here: that is
+    the bug being guarded against, and a fake that quietly tolerated it would
+    let the regression back in.
+    """
+
+    def __init__(self, body: bytes = b"[]", status: int = 200):
+        self._body = body
+        self.status = status
+        self.requested: list[int] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, n=None):
+        if n is None:
+            raise AssertionError("unbounded read() — the body must be read with a cap")
+        self.requested.append(n)
+        return self._body[:n]
+
+
+def _small_cap(monkeypatch, cap: int = 8) -> None:
+    """Run the real ``read_capped`` at a tiny cap so a few bytes trip it.
+
+    Patches the name the module under test resolves, not the primitive itself,
+    so the production call path (including which exception it raises and where
+    that lands) is exercised end to end without allocating 64 MiB.
+    """
+    monkeypatch.setattr(
+        templates_cmd,
+        "read_capped",
+        lambda resp, url, max_bytes=cap: http_mod.read_capped(resp, url, max_bytes=max_bytes),
+    )
+
+
+def test_fetch_gallery_reads_with_a_cap_not_unbounded(monkeypatch):
+    resp = _RecordingResponse(json.dumps(FIXTURE).encode())
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: resp)
+
+    assert json.loads(templates_cmd._fetch_gallery()) == FIXTURE
+    # One byte past the cap, so a body that exactly fills it is still complete.
+    assert resp.requested == [http_mod.MAX_RESPONSE_BYTES + 1]
+
+
+def test_fetch_template_workflow_reads_with_a_cap_not_unbounded(monkeypatch):
+    resp = _RecordingResponse(b'{"nodes": []}')
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: resp)
+
+    assert templates_cmd._fetch_template_workflow("image_flux2") == b'{"nodes": []}'
+    assert resp.requested == [http_mod.MAX_RESPONSE_BYTES + 1]
+
+
+def test_oversize_gallery_raises_rather_than_truncating(monkeypatch):
+    # Refuse, don't truncate: a short body would be cached and parsed as if it
+    # were the whole index.
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))
+    _small_cap(monkeypatch)
+
+    with pytest.raises(ResponseTooLarge):
+        templates_cmd._fetch_gallery()
+
+
+def test_oversize_gallery_under_refresh_is_a_clean_envelope(cache_file, monkeypatch):
+    # An over-cap body is upstream misbehaviour like any other — it must land in
+    # gallery_load_failed, not as an uncaught traceback.
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))
+    _small_cap(monkeypatch)
+    _force_json_renderer()
+
+    runner = CliRunner()
+    result = runner.invoke(templates_cmd.app, ["ls", "--refresh"])
+    assert result.exit_code != 0
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "gallery_load_failed"
+    # The good cache is left intact — an oversize response must not clobber it.
+    assert json.loads(cache_file.read_bytes()) == FIXTURE
+
+
+def test_oversize_gallery_during_ttl_refresh_falls_back_to_stale(cache_file, monkeypatch):
+    # Same failure on an automatic (TTL-expired) refresh degrades to the stale
+    # cache, matching every other fetch failure.
+    _set_mtime(cache_file, templates_cmd.GALLERY_TTL_SECONDS + 3600)
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))
+    _small_cap(monkeypatch)
+    _force_json_renderer()
+
+    runner = CliRunner()
+    result = runner.invoke(templates_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert _envelope(result.output)["data"]["total_in_gallery"] == 3
+
+
+def test_oversize_gallery_under_templates_refresh_is_a_clean_envelope(cache_file, monkeypatch):
+    # `templates refresh` calls `_fetch_gallery` directly, so it needs the same
+    # error family as `_load_gallery` — this is the call site that used to catch
+    # only URLError/OSError.
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))
+    _small_cap(monkeypatch)
+    _force_json_renderer()
+
+    runner = CliRunner()
+    result = runner.invoke(templates_cmd.app, ["refresh"])
+    assert result.exit_code != 0
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "gallery_fetch_failed"
+    assert json.loads(cache_file.read_bytes()) == FIXTURE
+
+
+def test_oversize_template_workflow_is_a_clean_envelope(gallery_file, monkeypatch, capsys):
+    # The workflow fetch happens after the gallery lookup, so point the opener
+    # at an oversize body and resolve the name from the local fixture index.
+    monkeypatch.setattr(templates_cmd, "plain_urlopen", lambda req, timeout=None: _RecordingResponse(b"x" * 4096))
+    _small_cap(monkeypatch)
+    _force_json_renderer()
+
+    runner = CliRunner()
+    result = runner.invoke(templates_cmd.app, ["fetch", "image_flux2", "--gallery", gallery_file])
+    assert result.exit_code != 0
+    env = _envelope(result.output)
+    assert env["error"]["code"] == "template_fetch_failed"

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -691,8 +691,11 @@ def _capture_urlopen(monkeypatch: pytest.MonkeyPatch, routes: dict):
         def __exit__(self, *a):
             return False
 
-        def read(self):
-            return self.body
+        def read(self, n=None):
+            # Mirror http.client.HTTPResponse.read(amt) — `_http_get_json`
+            # reads with a byte cap, so a no-arg-only fake would not match the
+            # real API.
+            return self.body if n is None else self.body[:n]
 
     def _fake(req, timeout=None):
         url = req.full_url
@@ -2318,3 +2321,86 @@ def test_watcher_does_not_clobber_a_concurrent_cancel_with_server_died(monkeypat
     assert on_disk.error["code"] == "cancelled"
     # The notification reports the verdict that actually stands.
     assert notified[0].status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Bounded reads — a ComfyUI server must not be able to OOM the CLI
+# ---------------------------------------------------------------------------
+
+
+class _CapRecordingResp:
+    """A urlopen response that records the byte cap it was read with.
+
+    ``read(None)`` fails outright: an unbounded read is the bug being guarded
+    against, and a lenient fake would let it back in.
+    """
+
+    def __init__(self, body: bytes):
+        self._body = body
+        self.status = 200
+        self.requested: list[int] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n=None):
+        if n is None:
+            raise AssertionError("unbounded read() — the body must be read with a cap")
+        self.requested.append(n)
+        return self._body[:n]
+
+
+def test_http_get_json_reads_with_a_cap_not_unbounded(monkeypatch: pytest.MonkeyPatch):
+    import comfy_cli.http as http_mod
+
+    resp = _CapRecordingResp(b'{"queue_running": []}')
+    monkeypatch.setattr(http_mod._PLAIN_OPENER, "open", lambda req, timeout=None: resp)
+
+    assert jobs_mod._http_get_json("http://127.0.0.1:8188/queue") == {"queue_running": []}
+    # One byte past the cap, so a body that exactly fills it is still complete.
+    assert resp.requested == [http_mod.MAX_RESPONSE_BYTES + 1]
+
+
+def test_http_get_json_oversize_body_is_a_runtime_error_not_a_truncated_parse(monkeypatch: pytest.MonkeyPatch):
+    # RuntimeError is the single failure family every `_http_get_json` call site
+    # already catches; an oversize body must join it rather than escaping as a
+    # new exception type or degrading into a confusing JSON parse error.
+    import comfy_cli.http as http_mod
+
+    resp = _CapRecordingResp(b"x" * 4096)
+    monkeypatch.setattr(http_mod._PLAIN_OPENER, "open", lambda req, timeout=None: resp)
+    monkeypatch.setattr(
+        jobs_mod,
+        "read_capped",
+        lambda r, url, max_bytes=8: http_mod.read_capped(r, url, max_bytes=max_bytes),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        jobs_mod._http_get_json("http://127.0.0.1:8188/history")
+    assert "http://127.0.0.1:8188/history" in str(exc_info.value)
+
+
+def test_jobs_ls_survives_an_oversize_queue_response(monkeypatch: pytest.MonkeyPatch):
+    # End to end: `jobs ls` catches RuntimeError from `_http_get_json`, so an
+    # oversize /queue degrades to the on-disk fallback instead of a traceback.
+    import comfy_cli.http as http_mod
+
+    monkeypatch.setattr(jobs_mod, "_server_or_error", lambda h, p, **kw: True)
+    monkeypatch.setattr(http_mod._PLAIN_OPENER, "open", lambda req, timeout=None: _CapRecordingResp(b"x" * 4096))
+    monkeypatch.setattr(
+        jobs_mod,
+        "read_capped",
+        lambda r, url, max_bytes=8: http_mod.read_capped(r, url, max_bytes=max_bytes),
+    )
+
+    from typer.testing import CliRunner
+
+    result = CliRunner().invoke(jobs_mod.app, ["ls", "--where", "local"])
+    # `_gather_jobs` treats an unreadable /queue and /history as empty, so the
+    # command still succeeds — what matters is that ResponseTooLarge never
+    # escapes as an uncaught exception.
+    assert result.exit_code == 0, result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2401,6 +2401,5 @@ def test_jobs_ls_survives_an_oversize_queue_response(monkeypatch: pytest.MonkeyP
     result = CliRunner().invoke(jobs_mod.app, ["ls", "--where", "local"])
     # `_gather_jobs` treats an unreadable /queue and /history as empty, so the
     # command still succeeds — what matters is that ResponseTooLarge never
-    # escapes as an uncaught exception.
+    # escapes as an uncaught exception. A non-zero exit here would mean it did.
     assert result.exit_code == 0, result.output
-    assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/tests/comfy_cli/test_http.py
+++ b/tests/comfy_cli/test_http.py
@@ -488,14 +488,6 @@ def test_read_capped_message_names_the_url_and_the_cap():
     assert "4" in msg
 
 
-def test_read_capped_never_returns_a_truncated_body():
-    # The whole point: refuse, don't truncate. A silently short body would be
-    # written to disk or parsed as if it were whole.
-    resp = _fake_resp(b"x" * 100)
-    with pytest.raises(ResponseTooLarge):
-        read_capped(resp, "https://example.com/x", max_bytes=10)
-
-
 @pytest.mark.parametrize("max_bytes", [0, -1])
 def test_read_capped_rejects_non_positive_max_bytes(max_bytes):
     with pytest.raises(ValueError):

--- a/tests/comfy_cli/test_http.py
+++ b/tests/comfy_cli/test_http.py
@@ -9,11 +9,13 @@ import pytest
 
 import comfy_cli.http as http_mod
 from comfy_cli.http import (
+    MAX_RESPONSE_BYTES,
     NoRedirectHandler,
     ResponseTooLarge,
     authed_urlopen,
     build_authed_request,
     no_redirect_urlopen,
+    read_capped,
     request_json,
     target_auth_headers,
 )
@@ -453,3 +455,75 @@ def test_request_json_recursion_error_returns_none(monkeypatch, cloud_target):
     _patch_urlopen(monkeypatch, b'{"a": 1}')
     monkeypatch.setattr(http_mod.json, "loads", lambda *a, **kw: (_ for _ in ()).throw(RecursionError()))
     assert request_json("https://cloud.example/api/thing", cloud_target, max_bytes=1024) == (200, None)
+
+
+# ---------------------------------------------------------------------------
+# read_capped — the shared bounded-read primitive
+# ---------------------------------------------------------------------------
+
+
+def test_read_capped_returns_a_body_under_the_cap():
+    assert read_capped(_fake_resp(b"hello"), "https://example.com/x", max_bytes=1024) == b"hello"
+
+
+def test_read_capped_body_exactly_at_cap_is_complete_not_truncated():
+    # Boundary: len(raw) == cap is a *complete* body. The primitive reads cap+1
+    # precisely so this case is distinguishable from a truncated one.
+    body = b"0123456789"
+    assert read_capped(_fake_resp(body), "https://example.com/x", max_bytes=len(body)) == body
+
+
+def test_read_capped_one_byte_over_the_cap_raises():
+    with pytest.raises(ResponseTooLarge):
+        read_capped(_fake_resp(b"0123456789"), "https://example.com/x", max_bytes=9)
+
+
+def test_read_capped_message_names_the_url_and_the_cap():
+    # Callers interpolate this into user-facing envelopes, so it must stay
+    # descriptive enough to tell a user *which* endpoint misbehaved.
+    with pytest.raises(ResponseTooLarge) as exc_info:
+        read_capped(_fake_resp(b"x" * 100), "https://example.com/gallery.json", max_bytes=4)
+    msg = str(exc_info.value)
+    assert "https://example.com/gallery.json" in msg
+    assert "4" in msg
+
+
+def test_read_capped_never_returns_a_truncated_body():
+    # The whole point: refuse, don't truncate. A silently short body would be
+    # written to disk or parsed as if it were whole.
+    resp = _fake_resp(b"x" * 100)
+    with pytest.raises(ResponseTooLarge):
+        read_capped(resp, "https://example.com/x", max_bytes=10)
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1])
+def test_read_capped_rejects_non_positive_max_bytes(max_bytes):
+    with pytest.raises(ValueError):
+        read_capped(_fake_resp(b"x"), "https://example.com/x", max_bytes=max_bytes)
+
+
+def test_read_capped_default_cap_is_the_shared_constant():
+    # An unbounded read is the bug this primitive exists to remove, so the
+    # default must be a real ceiling, not None/0.
+    assert MAX_RESPONSE_BYTES == 64 * 1024 * 1024
+    reads: list[int] = []
+
+    class _Recording:
+        def read(self, n):
+            reads.append(n)
+            return b"body"
+
+    assert read_capped(_Recording(), "https://example.com/x") == b"body"
+    assert reads == [MAX_RESPONSE_BYTES + 1]
+
+
+def test_read_capped_asks_for_exactly_one_byte_past_the_cap():
+    reads: list[int] = []
+
+    class _Recording:
+        def read(self, n):
+            reads.append(n)
+            return b"ab"
+
+    read_capped(_Recording(), "https://example.com/x", max_bytes=8)
+    assert reads == [9]


### PR DESCRIPTION
## ELI-5

When comfy-cli asks a server for something, it has to read the reply into memory. Three places read the whole reply with no size limit — whatever the server sends, we hold. The sharp one fetches the workflow-template gallery from a host on the internet. A server that just keeps sending would grow the CLI's memory until it dies. This adds one shared "read at most N bytes, then refuse" helper and puts those three reads behind it.

## What changed

**New primitive** — `comfy_cli/http.py`:

- `MAX_RESPONSE_BYTES = 64 MiB`, with the rationale written at the constant rather than inherited from whichever call site happened to be nearest.
- `read_capped(resp, url, *, max_bytes=MAX_RESPONSE_BYTES) -> bytes` — reads `cap + 1` so a body that exactly fills the cap is still recognizable as complete, and raises the existing `ResponseTooLarge` rather than returning a silently truncated body. Truncation is the worse failure: truncated JSON surfaces as a confusing parse error, and a truncated file body gets written to disk as if it were whole.
- `request_json` now delegates its own capped read to the primitive. Externally unchanged — same exception, same message, same early `max_bytes` validation before the network call.

**Three unbounded readers converted**, each keeping its established failure contract so no user-visible error changes shape:

| Reader | Was | Over-cap now surfaces as |
|---|---|---|
| `templates._fetch_gallery` | `resp.read()` on a remote gallery URL | `ResponseTooLarge` → `_GALLERY_LOAD_ERRORS` → stale-cache fallback on a TTL refresh, `gallery_load_failed` / `gallery_fetch_failed` envelope otherwise |
| `jobs._http_get_json` | `json.loads(resp.read())` | `RuntimeError` — the single family all seven call sites already catch |
| `comfy_client.Client._request` | `resp.read().decode(...)` | the module's own `HTTPError`, the same shape `submit_prompt` already uses for a bad 200 |

**Two additions beyond the three, both judgment calls flagged here:**

1. `templates._fetch_template_workflow` — same function family, same file, the same unbounded read of the same remote host. Converting the gallery index but not the per-template workflow next to it would have been an odd place to stop.
2. `Client._request`'s **error**-body read (`e.read()`), three lines below the success read this PR caps. Same server, same vector. Over the cap the read raises and the pre-existing `except Exception: pass` leaves `body_text` empty — status and reason still reach the caller, which is the part that matters for a body too large to be a real error message.

**Three `except` tuples widened in `templates.py`.** These were narrower than the error families their callees actually raise, so a non-200 (`RuntimeError`) already escaped as an uncaught traceback before this change; `ResponseTooLarge` would have joined it. The narrow tuples all date to the file's original commit (#470); `_GALLERY_LOAD_ERRORS` was introduced later (#559) specifically to route this class of failure into an envelope, and that PR's own tests (`test_non_200_status_..._not_uncaught`) pin the intent. Widening to the same family completes that intent rather than reversing a decision — it is not a behavior flip on a deliberate guard.

## Why 64 MiB

Measured rather than guessed, so the refusal path cannot plausibly fire on legitimate traffic:

- The real gallery index (`Comfy-Org/workflow_templates/templates/index.json`) is **623 KB** — 0.9% of the cap.
- The largest of all **599** template workflow JSONs upstream is **1.09 MB**; *every* template JSON in that repo concatenated is 32.2 MB, still under the cap as a single body.
- The largest documented API body is `/api/object_info` at ~9 MB on cloud (per the existing note in `models/search.py`).

So ~60x headroom over the largest real gallery body and ~7x over the largest documented API body, while still bounding a server that streams without end. It also matches the cap the already-bounded readers (`models/search`, both `workflow` readers) converged on independently, so the CLI has one number rather than five. `cql.loader` keeps its own larger `MAX_INPUT_BYTES` — that bounds a user-supplied object_info dump, a different thing being measured.

## Scope line I did not cross

The task also mentioned "one JSON-parse failure type" for the primitive. **I did not add one**, deliberately: `http.py` already centralizes JSON parsing in `request_json` (empty or unparseable → `None`), and each of the three converted readers has a distinct parse-failure contract its callers depend on — `jobs` wraps it into `RuntimeError`, `templates` lets `JSONDecodeError` route through `_GALLERY_LOAD_ERRORS`, `comfy_client` propagates it. Preserving those was the explicit constraint, so a shared parse-failure type would have had no caller and shipped as dead code.

Converting the four already-capped readers (called out as optional and secondary) was also skipped — they are not broken, and three of the four already share `http.ResponseTooLarge` on `main`.

**Unbounded reads that remain, deliberately out of scope** (worth a follow-up; all are same-shape, none are the remote-gallery case this PR was filed for):

- `cloud/oauth.py:899` (token response) and `:902` (error body)
- `command/transfer.py:389` (JSON body)
- `command/run/execution.py:182` / `:184` (success + error body)
- `command/jobs.py:1194` / `:1226` (response drains), `:1283` (body), `:1285` (error body, sliced *after* an unbounded read)
- `command/models/search.py:173` and `cql/engine.py:1493` (error bodies, sliced after an unbounded read)
- `file_utils.py:332` (error body)

## Testing

`ruff check .`, `ruff format --check` on every changed file, and the full `pytest` suite: **3764 passed, 37 skipped**.

New coverage (23 tests): `read_capped` boundary behaviour (under / exactly-at / one-past the cap, message content, non-positive cap rejection, that the default is a real ceiling and the read asks for exactly `cap + 1`); and per call site, one test proving the read is issued *with* a cap and one proving an over-cap body lands in that reader's own error envelope rather than a traceback. The per-call-site tests run the real `read_capped` at a tiny cap through the real production path, so they exercise the actual routing without allocating 64 MiB.

Three pre-existing test fakes had `read(self)` with no size parameter, which does not match `http.client.HTTPResponse.read(amt)`; they now accept and honour one. The new fakes go further and **fail outright on `read(None)`**, so a future revert to an unbounded read breaks the test rather than passing quietly.

## Risk

The riskiest line is `raise HTTPError(resp.status, "response too large", str(e))` in `comfy_client._request` — it raises a 200-status error. It is safe because: (a) it is the module's own `HTTPError`, not `urllib.error.HTTPError`, so the surrounding handler does not swallow it; (b) status 200 is not retryable in `wait_for_completion` (`if e.status != 429 and not (500 <= e.status < 600): raise`) and is not 404, so `get_history` / `get_job_status` cannot silently convert it to `None`; (c) `submit_prompt` already establishes this exact idiom for a malformed 200.

On the capability-denial question: this diff adds a refusal path, but the capability being refused is "buffer an unbounded response body", and the numbers above are the empirical check that no real endpoint the CLI talks to produces one. It denies no product feature and adds no user-facing "not supported" path.
