### PR TITLE
fix(output): escape server-controlled strings before rich markup sinks

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -38,6 +38,7 @@ from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.http import authed_urlopen, plain_urlopen
 from comfy_cli.output import get_renderer
+from comfy_cli.output.sanitize import sanitize_markup
 from comfy_cli.where import cloud_preflight_or_exit
 
 app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch ComfyUI prompts.")
@@ -556,11 +557,11 @@ def _watch_ls(*, host, port, limit, where, local_only, state_where=None, orphane
 
                 wf_display = Path(r.workflow_path).name
             tbl.add_row(
-                r.prompt_id[:8] + "…" if len(r.prompt_id) > 8 else r.prompt_id,
+                sanitize_markup(r.prompt_id[:8] + "…" if len(r.prompt_id) > 8 else r.prompt_id),
                 status_glyph(r.status),
                 r.where,
                 str(r.outputs) if r.outputs else "—",
-                wf_display,
+                sanitize_markup(wf_display),
             )
         if not rows:
             tbl.add_row("[dim]no jobs[/dim]", "", "", "", "")
@@ -628,7 +629,7 @@ def _render_jobs_pretty(rows: list[JobRow], *, host: str, port: int) -> None:
     tbl.add_column("outputs", no_wrap=True, justify="right")
     for r in rows:
         tbl.add_row(
-            r.prompt_id[:8] + "…" if len(r.prompt_id) > 8 else r.prompt_id,
+            sanitize_markup(r.prompt_id[:8] + "…" if len(r.prompt_id) > 8 else r.prompt_id),
             status_glyph(r.status),
             str(r.queue_position) if r.queue_position is not None else "—",
             str(r.workflow_size) if r.workflow_size is not None else "—",
@@ -842,12 +843,18 @@ def _render_status_pretty(snap: dict, *, host: str, port: int) -> None:
     tbl = Table.grid(padding=(0, 2), expand=False)
     tbl.add_column(justify="right", style="dim", no_wrap=True)
     tbl.add_column(overflow="fold")
-    tbl.add_row("prompt_id", snap["prompt_id"])
+    # `Table.add_row` parses markup in a `str` cell; every value below is
+    # chosen by the host answering `/queue` and `/history`. `badge` is a
+    # `Text`, which never parses markup — escaping it would print backslashes.
+    tbl.add_row("prompt_id", sanitize_markup(snap["prompt_id"]))
     tbl.add_row("status", badge)
     if snap.get("outputs"):
-        tbl.add_row("outputs", "\n".join(snap["outputs"]))
+        tbl.add_row("outputs", "\n".join(sanitize_markup(o) for o in snap["outputs"]))
     if snap.get("error"):
-        tbl.add_row("error", str(snap["error"])[:600])
+        # Truncate first, escape second: the 600-char budget stays a budget on
+        # the server's text rather than on the backslashes we add to it, and
+        # escaping last is what guarantees no half-written tag survives the cut.
+        tbl.add_row("error", sanitize_markup(str(snap["error"])[:600]))
 
     renderer.console().print(
         Panel(
@@ -963,7 +970,9 @@ def _render_wait_pretty(summary: dict) -> None:
     tbl.add_column("status")
     for r in summary["jobs"]:
         glyph, style = badge.get(r["status"], ("•", "white"))
-        tbl.add_row(r["prompt_id"], Text(f"{glyph} {r['status']}", style=style))
+        # The status cell is a `Text`, which never parses markup — only the
+        # bare-`str` prompt_id cell needs escaping here.
+        tbl.add_row(sanitize_markup(r["prompt_id"]), Text(f"{glyph} {r['status']}", style=style))
     get_renderer().console().print(tbl)
 
 
@@ -1708,17 +1717,20 @@ def _cloud_status(prompt_id: str) -> None:
         tbl = Table(title=f"Cloud prompt {prompt_id[:8]}…", border_style="cyan", show_header=False)
         tbl.add_column(style="bold cyan")
         tbl.add_column()
-        tbl.add_row("status", snap["status"])
+        # Every cell below comes straight off `/api/jobs/<id>` — including
+        # `status`, which falls through to the server's own vocabulary when it
+        # is not one of the aliases `_cloud_status_snapshot` knows.
+        tbl.add_row("status", sanitize_markup(snap["status"]))
         if snap.get("assigned_inference"):
-            tbl.add_row("inference", snap["assigned_inference"])
+            tbl.add_row("inference", sanitize_markup(snap["assigned_inference"]))
         if snap.get("created_at"):
-            tbl.add_row("created", snap["created_at"])
+            tbl.add_row("created", sanitize_markup(snap["created_at"]))
         if snap.get("updated_at"):
-            tbl.add_row("updated", snap["updated_at"])
+            tbl.add_row("updated", sanitize_markup(snap["updated_at"]))
         if snap.get("error_message"):
-            tbl.add_row("error", snap["error_message"])
+            tbl.add_row("error", sanitize_markup(snap["error_message"]))
         for u in snap.get("outputs") or []:
-            tbl.add_row("output", u)
+            tbl.add_row("output", sanitize_markup(u))
         renderer.console().print(tbl)
     renderer.emit(snap, command="jobs status", where="cloud")
 

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -38,7 +38,7 @@ from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.http import authed_urlopen, plain_urlopen
 from comfy_cli.output import get_renderer
-from comfy_cli.output.sanitize import sanitize_markup
+from comfy_cli.output.sanitize import sanitize, sanitize_markup
 from comfy_cli.where import cloud_preflight_or_exit
 
 app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch ComfyUI prompts.")
@@ -559,7 +559,7 @@ def _watch_ls(*, host, port, limit, where, local_only, state_where=None, orphane
             tbl.add_row(
                 sanitize_markup(r.prompt_id[:8] + "…" if len(r.prompt_id) > 8 else r.prompt_id),
                 status_glyph(r.status),
-                r.where,
+                sanitize_markup(r.where),
                 str(r.outputs) if r.outputs else "—",
                 sanitize_markup(wf_display),
             )
@@ -832,20 +832,26 @@ def _render_status_pretty(snap: dict, *, host: str, port: int) -> None:
 
     renderer = get_renderer()
     status = snap["status"]
+    # An unrecognized status falls through to the server's own string. `Text`
+    # declines to *parse* markup, but it still forwards `\x1b` — rich's
+    # `strip_control_codes` covers only BEL/BS/VT/FF/CR — so the escape bytes
+    # need the plain `sanitize`. Not `sanitize_markup`: a `Text` would print its
+    # backslashes verbatim, which is why the cell is control-stripped, not
+    # markup-escaped.
     badge = {
         "running": Text.assemble(("● ", "bold green"), ("running", "bold green")),
         "pending": Text.assemble(("◌ ", "bold yellow"), ("pending", "bold yellow")),
         "completed": Text.assemble(("✓ ", "bold green"), ("completed", "bold green")),
         "queued": Text.assemble(("◌ ", "dim"), ("queued", "dim")),
         "error": Text.assemble(("✗ ", "bold red"), ("error", "bold red")),
-    }.get(status, Text(status))
+    }.get(status, Text(sanitize(str(status))))
 
     tbl = Table.grid(padding=(0, 2), expand=False)
     tbl.add_column(justify="right", style="dim", no_wrap=True)
     tbl.add_column(overflow="fold")
     # `Table.add_row` parses markup in a `str` cell; every value below is
-    # chosen by the host answering `/queue` and `/history`. `badge` is a
-    # `Text`, which never parses markup — escaping it would print backslashes.
+    # chosen by the host answering `/queue` and `/history`. `badge` is the one
+    # exception — a `Text`, already control-stripped above.
     tbl.add_row("prompt_id", sanitize_markup(snap["prompt_id"]))
     tbl.add_row("status", badge)
     if snap.get("outputs"):
@@ -970,9 +976,13 @@ def _render_wait_pretty(summary: dict) -> None:
     tbl.add_column("status")
     for r in summary["jobs"]:
         glyph, style = badge.get(r["status"], ("•", "white"))
-        # The status cell is a `Text`, which never parses markup — only the
-        # bare-`str` prompt_id cell needs escaping here.
-        tbl.add_row(sanitize_markup(r["prompt_id"]), Text(f"{glyph} {r['status']}", style=style))
+        # The status cell is a `Text`, which never parses markup — so it takes
+        # the plain `sanitize` (escape bytes still pass through `Text`) rather
+        # than `sanitize_markup`, whose backslashes it would print verbatim.
+        tbl.add_row(
+            sanitize_markup(r["prompt_id"]),
+            Text(f"{glyph} {sanitize(str(r['status']))}", style=style),
+        )
     get_renderer().console().print(tbl)
 
 
@@ -1714,7 +1724,10 @@ def _cloud_status(prompt_id: str) -> None:
     if renderer.is_pretty():
         from rich.table import Table
 
-        tbl = Table(title=f"Cloud prompt {prompt_id[:8]}…", border_style="cyan", show_header=False)
+        # Rich parses a `str` table title as markup too, so the id belongs in
+        # the same escaping regime as the cells — an unbalanced `[/]` there
+        # raises `MarkupError` before a single row is added.
+        tbl = Table(title=f"Cloud prompt {sanitize_markup(prompt_id[:8])}…", border_style="cyan", show_header=False)
         tbl.add_column(style="bold cyan")
         tbl.add_column()
         # Every cell below comes straight off `/api/jobs/<id>` — including
@@ -1728,7 +1741,10 @@ def _cloud_status(prompt_id: str) -> None:
         if snap.get("updated_at"):
             tbl.add_row("updated", sanitize_markup(snap["updated_at"]))
         if snap.get("error_message"):
-            tbl.add_row("error", sanitize_markup(snap["error_message"]))
+            # Same 600-char budget the local `/history` error cell uses, and for
+            # the same reason: an unbounded API string becomes an unbounded Rich
+            # cell. Truncate first, escape second (see `_render_status_pretty`).
+            tbl.add_row("error", sanitize_markup(str(snap["error_message"])[:600]))
         for u in snap.get("outputs") or []:
             tbl.add_row("output", sanitize_markup(u))
         renderer.console().print(tbl)
@@ -1748,7 +1764,8 @@ def _cloud_watch(prompt_id: str, *, poll_interval: float, max_wait: float) -> No
 
     if renderer.is_pretty():
         renderer.console().print(
-            f"[bold]Watching cloud prompt[/bold] {prompt_id}   [dim]({base_url}, Ctrl-C to stop)[/dim]"
+            f"[bold]Watching cloud prompt[/bold] {sanitize_markup(prompt_id)}   "
+            f"[dim]({sanitize_markup(base_url)}, Ctrl-C to stop)[/dim]"
         )
 
     final_snap: dict | None = None
@@ -1769,14 +1786,19 @@ def _cloud_watch(prompt_id: str, *, poll_interval: float, max_wait: float) -> No
         if snap["status"] != last_state:
             last_state = snap["status"]
             if renderer.is_pretty():
-                renderer.console().print(f"[dim]→[/dim] state [bold]{last_state}[/bold]")
+                # `_cloud_status` hardens the one-shot view of this same
+                # snapshot; the streaming sibling prints the same server-chosen
+                # `status` into markup on every transition, and a `[/]` in it
+                # would raise `MarkupError` mid-poll. The `renderer.event` line
+                # below stays raw on purpose — JSON escapes it already.
+                renderer.console().print(f"[dim]→[/dim] state [bold]{sanitize_markup(last_state)}[/bold]")
             renderer.event("state", prompt_id=prompt_id, status=last_state)
 
         if snap["status"] in {"completed", "error", "cancelled"}:
             for u in snap.get("outputs") or []:
                 renderer.event("output", url=u, prompt_id=prompt_id)
                 if renderer.is_pretty():
-                    renderer.console().print(f"[bold green]✓[/bold green] output: [cyan]{u}[/cyan]")
+                    renderer.console().print(f"[bold green]✓[/bold green] output: [cyan]{sanitize_markup(u)}[/cyan]")
             final_snap = snap
             break
 

--- a/comfy_cli/command/system.py
+++ b/comfy_cli/command/system.py
@@ -14,6 +14,7 @@ from typing import Any
 import typer
 
 from comfy_cli.comfy_client import Client, HTTPError
+from comfy_cli.output.sanitize import sanitize_markup
 from comfy_cli.target import resolve_target
 
 
@@ -47,10 +48,14 @@ def _render_stats_pretty(renderer, stats: dict[str, Any]) -> None:
     for dev in devices:
         if not isinstance(dev, dict):
             continue
+        # Device name/type/index are whatever `/system_stats` reported, and
+        # `Table.add_row` parses markup in a `str` cell. The two byte columns
+        # are built by `_humanize_bytes`, which only ever emits digits and a
+        # unit, so they carry nothing to escape.
         tbl.add_row(
-            str(dev.get("name", "?")),
-            str(dev.get("type", "?")),
-            str(dev.get("index", "?")),
+            sanitize_markup(dev.get("name", "?")),
+            sanitize_markup(dev.get("type", "?")),
+            sanitize_markup(dev.get("index", "?")),
             _humanize_bytes(dev.get("vram_free")),
             _humanize_bytes(dev.get("vram_total")),
         )
@@ -59,7 +64,9 @@ def _render_stats_pretty(renderer, stats: dict[str, Any]) -> None:
     system = stats.get("system") or {}
     ram_free = _humanize_bytes(system.get("ram_free"))
     ram_total = _humanize_bytes(system.get("ram_total"))
-    version = system.get("comfyui_version", "?")
+    # Same payload, same hazard one line further on: this f-string IS markup,
+    # and `Renderer.print` hands it to `rich.print` without escaping anything.
+    version = sanitize_markup(system.get("comfyui_version", "?"))
     renderer.print(f"[dim]RAM: {ram_free} / {ram_total} free — ComfyUI {version}[/dim]")
 
 

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -35,6 +35,7 @@ from comfy_cli import tracking
 # ``urllib.request`` in at import time, so the precedent exists.
 from comfy_cli.http import ResponseTooLarge as _ResponseTooLarge
 from comfy_cli.output import get_renderer, rprint
+from comfy_cli.output.sanitize import sanitize_markup
 
 app = typer.Typer(no_args_is_help=True, help="Slot-based editing of frontend-format ComfyUI workflows.")
 
@@ -959,7 +960,12 @@ def _local_list(renderer, target, *, name: str | None, limit: int, sort: str, or
         tbl.add_column("id")
         tbl.add_column("size", justify="right", style="dim")
         for r in workflows[:50]:
-            tbl.add_row(r["id"], str(r["size"]) if r["size"] is not None else "")
+            # Both cells are fields of the `/userdata` listing the server
+            # returned, and `Table.add_row` parses markup in a `str` cell.
+            tbl.add_row(
+                sanitize_markup(r["id"]),
+                sanitize_markup(r["size"]) if r["size"] is not None else "",
+            )
         renderer.console().print(tbl)
         rprint(f"[dim]{len(workflows)} workflow(s) (local)[/dim]")
     renderer.emit(payload, command="workflow list", where="local")
@@ -1241,11 +1247,13 @@ def list_cmd(
         tbl.add_column("ver", justify="right", style="dim")
         tbl.add_column("updated", style="dim")
         for r in payload["workflows"][:50]:
+            # The cloud workflow catalog is server-supplied end to end, same as
+            # the local `/userdata` listing `_local_list` renders.
             tbl.add_row(
-                (r["id"] or "")[:8] + "…" if r["id"] else "",
-                r["name"] or "(untitled)",
-                str(r["latest_version"] or ""),
-                (r["updated_at"] or "")[:10],
+                sanitize_markup((r["id"] or "")[:8] + "…" if r["id"] else ""),
+                sanitize_markup(r["name"] or "(untitled)"),
+                sanitize_markup(r["latest_version"] or ""),
+                sanitize_markup((r["updated_at"] or "")[:10]),
             )
         renderer.console().print(tbl)
         rprint(f"[dim]{len(rows)} workflow(s)[/dim]")

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -1248,12 +1248,15 @@ def list_cmd(
         tbl.add_column("updated", style="dim")
         for r in payload["workflows"][:50]:
             # The cloud workflow catalog is server-supplied end to end, same as
-            # the local `/userdata` listing `_local_list` renders.
+            # the local `/userdata` listing `_local_list` renders. `str()` before
+            # the slices: `sanitize_markup` coerces, but the truncation runs
+            # first, and a numeric `id`/`updated_at` in the JSON would raise
+            # `TypeError: 'int' object is not subscriptable` before it got there.
             tbl.add_row(
-                sanitize_markup((r["id"] or "")[:8] + "…" if r["id"] else ""),
+                sanitize_markup(str(r["id"])[:8] + "…" if r["id"] else ""),
                 sanitize_markup(r["name"] or "(untitled)"),
                 sanitize_markup(r["latest_version"] or ""),
-                sanitize_markup((r["updated_at"] or "")[:10]),
+                sanitize_markup(str(r["updated_at"] or "")[:10]),
             )
         renderer.console().print(tbl)
         rprint(f"[dim]{len(rows)} workflow(s)[/dim]")

--- a/comfy_cli/output/glyphs.py
+++ b/comfy_cli/output/glyphs.py
@@ -54,4 +54,8 @@ def status_glyph(status: str | None) -> str:
     # bound for `Table.add_row` / `Text.from_markup`. Escaping the interpolated
     # half keeps the tags we author live while a server's `[red]` or `[/]` stays
     # inert text — a no-op for every status in `STATUS_STYLE`, all plain words.
-    return f"[{style}]{glyph} {sanitize_markup(canonical) if canonical else 'unknown'}[/{style}]"
+    # The `or "unknown"` tests the *sanitized* label, not the raw one: a status
+    # made only of control bytes is truthy but sanitizes to empty, and falling
+    # back there beats rendering a glyph with a dangling space and no word.
+    label = sanitize_markup(canonical) if canonical else ""
+    return f"[{style}]{glyph} {label or 'unknown'}[/{style}]"

--- a/comfy_cli/output/glyphs.py
+++ b/comfy_cli/output/glyphs.py
@@ -7,6 +7,8 @@ changes; easy to teach an agent ("✓ means completed everywhere").
 
 from __future__ import annotations
 
+from comfy_cli.output.sanitize import sanitize_markup
+
 # (glyph, rich-style) per terminal status. Mirrors the JobStatus enum from
 # the architecture doc; new statuses must be added here.
 STATUS_STYLE: dict[str, tuple[str, str]] = {
@@ -48,4 +50,8 @@ def status_glyph(status: str | None) -> str:
     """
     canonical = _canonical(status)
     glyph, style = STATUS_STYLE.get(canonical, DEFAULT_STYLE)
-    return f"[{style}]{glyph} {canonical or 'unknown'}[/{style}]"
+    # An unrecognized status is echoed verbatim, and the return value is markup
+    # bound for `Table.add_row` / `Text.from_markup`. Escaping the interpolated
+    # half keeps the tags we author live while a server's `[red]` or `[/]` stays
+    # inert text — a no-op for every status in `STATUS_STYLE`, all plain words.
+    return f"[{style}]{glyph} {sanitize_markup(canonical) if canonical else 'unknown'}[/{style}]"

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -531,6 +531,67 @@ def test_local_job_status_unknown_status_does_not_crash(pretty):
     assert "server said [/] oops" in out, f"Text cell was escaped or mangled: {out!r}"
 
 
+def test_local_job_status_unknown_status_strips_escape_bytes(pretty):
+    """The other half of that carve-out: `Text` declines to parse markup but
+    still forwards `\\x1b` (rich strips only BEL/BS/VT/FF/CR), so the fallback
+    cell needs the plain control-stripping sanitizer. `UNBALANCED` alone cannot
+    catch this — it carries markup and no escape bytes."""
+    from comfy_cli.command.jobs import _render_status_pretty
+
+    _render_status_pretty(
+        {"prompt_id": "p1", "status": EVIL, "outputs": [], "error": None},
+        host="127.0.0.1",
+        port=8188,
+    )
+    out = assert_inert(pretty)
+    # Still literal, still un-escaped: control bytes gone, brackets intact.
+    assert "[link=https://attacker.example]" in out, f"Text cell was markup-escaped: {out!r}"
+
+
+def test_wait_summary_status_strips_escape_bytes(pretty):
+    """`comfy jobs wait` renders the same server status through a second `Text`
+    cell, with the same escape-byte gap."""
+    from comfy_cli.command.jobs import _render_wait_pretty
+
+    _render_wait_pretty(
+        {
+            "total": 1,
+            "elapsed_seconds": 1.0,
+            "jobs": [{"prompt_id": UNBALANCED, "status": EVIL}],
+        }
+    )
+    out = assert_inert(pretty)
+    assert "[link=https://attacker.example]" in out, f"Text status cell was markup-escaped: {out!r}"
+
+
+def _cloud_watch_against(snap: dict, *, max_wait: float):
+    """Run `_cloud_watch` with the cloud snapshot replaced by `snap`."""
+    from comfy_cli.command import jobs
+
+    client = MagicMock()
+    client.target.base_url = "https://cloud.example"
+    with (
+        patch.object(jobs, "cloud_preflight_or_exit"),
+        patch.object(jobs, "_cloud_client", return_value=client),
+        patch.object(jobs, "_cloud_status_snapshot", return_value=snap),
+    ):
+        return jobs._cloud_watch("p" * 12, poll_interval=0.0, max_wait=max_wait)
+
+
+def test_cloud_watch_state_line_is_inert(pretty):
+    """`comfy jobs watch --where cloud` prints the same `/api/jobs/<id>` status
+    `_cloud_status` hardens — once per transition, straight into markup."""
+    with pytest.raises(typer.Exit):
+        _cloud_watch_against(_cloud_snap(status=EVIL), max_wait=0.0)
+    assert "boom" in assert_inert(pretty)
+
+
+def test_cloud_watch_output_urls_are_inert(pretty):
+    """The terminal-state branch echoes each output URL into a `[cyan]` wrapper."""
+    _cloud_watch_against(_cloud_snap(status="completed", outputs=[EVIL, UNBALANCED]), max_wait=30.0)
+    assert "boom" in assert_inert(pretty)
+
+
 def _cloud_status_against(snap: dict) -> None:
     """Run `_cloud_status` with the cloud snapshot replaced by `snap`."""
     from comfy_cli.command import jobs
@@ -618,6 +679,15 @@ def test_jobs_ls_table_is_inert(pretty):
     assert_inert(pretty)
 
 
+def test_status_glyph_control_only_status_falls_back_to_unknown():
+    """A status made entirely of control bytes is truthy but sanitizes to the
+    empty string; the `unknown` fallback must test the sanitized label, or the
+    glyph renders with a dangling space and no word at all."""
+    from comfy_cli.output.glyphs import status_glyph
+
+    assert status_glyph("\x1b[2J\x07") == "[dim]· unknown[/dim]"
+
+
 def test_status_glyph_keeps_its_own_tags_live(pretty):
     """The escaping must not neuter the tags `status_glyph` itself authors —
     a known status still renders styled, with no stray backslashes."""
@@ -647,6 +717,25 @@ def test_system_stats_table_is_inert(pretty):
         },
     )
     assert "boom" in assert_inert(pretty)
+
+
+def test_system_stats_non_string_fields_do_not_crash(pretty):
+    """`index` is normally an *integer* off `/system_stats`, and wrapping it
+    dropped an explicit `str()`. `sanitize_markup` coerces via `sanitize_value`,
+    but every other test here feeds strings — this is the case that would catch
+    a future sanitizer that stopped coercing."""
+    from comfy_cli.command.system import _render_stats_pretty
+
+    _render_stats_pretty(
+        get_renderer(),
+        {
+            "devices": [{"name": "cuda:0", "type": "cuda", "index": 0, "vram_free": 1, "vram_total": 2}],
+            "system": {"ram_free": 1, "ram_total": 2, "comfyui_version": 3},
+        },
+    )
+    out = assert_inert(pretty)
+    assert "cuda:0" in out
+    assert "ComfyUI 3" in out
 
 
 def test_local_workflow_list_table_is_inert(pretty):
@@ -685,3 +774,22 @@ def test_cloud_workflow_list_table_is_inert(pretty):
     ):
         workflow.list_cmd(name=None, limit=20, sort="create_time", order="desc", where=None)
     assert_inert(pretty)
+
+
+def test_cloud_workflow_list_numeric_fields_do_not_crash(pretty):
+    """`id` and `updated_at` are *sliced* before they are sanitized, so the
+    coercion `sanitize_markup` does internally comes too late: a numeric field
+    would raise `TypeError: 'int' object is not subscriptable` first."""
+    from comfy_cli.command import workflow
+
+    body = {"data": [{"id": 1234567890, "name": "wf", "latest_version": 2, "updated_at": 20260802}]}
+    target = MagicMock()
+    target.is_cloud = True
+    target.url.return_value = "https://cloud.example/api/workflows"
+    with (
+        patch.object(workflow, "_resolve_where_target", return_value=target),
+        patch.object(workflow, "_http_request", return_value=(200, body)),
+    ):
+        workflow.list_cmd(name=None, limit=20, sort="create_time", order="desc", where=None)
+    out = assert_inert(pretty)
+    assert "12345678…" in out, f"numeric id was not truncated as text: {out!r}"

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -29,6 +29,7 @@ import pytest
 import typer
 
 from comfy_cli.command.run.execution import WorkflowExecution
+from comfy_cli.output import get_renderer
 from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
 
 # A payload carrying every hazard at once: CSI 2J clears the screen, OSC 0
@@ -483,3 +484,204 @@ def test_download_status_row_error_with_unbalanced_markup_does_not_crash(pretty)
         ]
     )
     assert "oops" in assert_inert(pretty)
+
+
+# ---------------------------------------------------------------------------
+# jobs.py / system.py / workflow.py — `Table.add_row` cells (BE-6037)
+# ---------------------------------------------------------------------------
+#
+# `sanitize.py` names `Table.add_row` as a markup-interpreting sink, and the
+# `models`/`nodes` tables above already honor that. These four command modules
+# did not import `sanitize_markup` at all, so a hostile host's `prompt_id`,
+# `error_message`, device name or workflow id reached the sink raw — a live
+# OSC 8 hyperlink, a repaint of earlier output, or a `MarkupError` crash while
+# the CLI is merely rendering a status table.
+
+
+def test_local_job_status_table_is_inert(pretty):
+    """`comfy jobs status` against a hostile `--host/--port`: prompt_id, the
+    joined output list and the execution error all come off `/history`."""
+    from comfy_cli.command.jobs import _render_status_pretty
+
+    _render_status_pretty(
+        {
+            "prompt_id": EVIL,
+            "status": "completed",
+            "outputs": [EVIL, UNBALANCED],
+            "error": UNBALANCED,
+        },
+        host="127.0.0.1",
+        port=8188,
+    )
+    assert "boom" in assert_inert(pretty)
+
+
+def test_local_job_status_unknown_status_does_not_crash(pretty):
+    """An unrecognized `status` falls through to `Text(status)`, which never
+    parses markup — the docstring's carve-out, asserted so a later "sanitize
+    everything" pass cannot quietly start printing backslashes here."""
+    from comfy_cli.command.jobs import _render_status_pretty
+
+    _render_status_pretty(
+        {"prompt_id": "p1", "status": UNBALANCED, "outputs": [], "error": None},
+        host="127.0.0.1",
+        port=8188,
+    )
+    out = assert_inert(pretty)
+    assert "server said [/] oops" in out, f"Text cell was escaped or mangled: {out!r}"
+
+
+def _cloud_status_against(snap: dict) -> None:
+    """Run `_cloud_status` with the cloud snapshot replaced by `snap`."""
+    from comfy_cli.command import jobs
+
+    with (
+        patch.object(jobs, "cloud_preflight_or_exit"),
+        patch.object(jobs, "_cloud_status_snapshot", return_value=snap),
+    ):
+        jobs._cloud_status("p" * 12)
+
+
+def _cloud_snap(**overrides) -> dict:
+    snap = {
+        "prompt_id": "p" * 12,
+        "status": "completed",
+        "outputs": [],
+        "outputs_by_node": {},
+        "outputs_by_item": {},
+        "assigned_inference": None,
+        "error_message": None,
+        "created_at": None,
+        "updated_at": None,
+        "base_url": "https://cloud.example",
+    }
+    snap.update(overrides)
+    return snap
+
+
+def test_cloud_job_status_table_is_inert(pretty):
+    """`comfy jobs status --where cloud`: every cell is a field of the
+    `/api/jobs/<id>` response."""
+    _cloud_status_against(
+        _cloud_snap(
+            status=EVIL,
+            assigned_inference=EVIL,
+            created_at=EVIL,
+            updated_at=UNBALANCED,
+            error_message=EVIL,
+            outputs=[EVIL, UNBALANCED],
+        )
+    )
+    assert "boom" in assert_inert(pretty)
+
+
+def test_cloud_error_message_with_markup_renders_literally(pretty):
+    """The ticket's headline case: a markup-bearing `error_message` must render
+    as text and must not raise `MarkupError` mid-table."""
+    _cloud_status_against(_cloud_snap(status="error", error_message=UNBALANCED))
+    out = assert_inert(pretty)
+    assert "server said [/] oops" in out, f"error_message did not render literally: {out!r}"
+
+
+def test_cloud_output_url_with_markup_renders_literally(pretty):
+    """An output URL is the other realistic carrier — one row per URL."""
+    _cloud_status_against(_cloud_snap(outputs=["https://cdn.example/a.png[/]"]))
+    out = assert_inert(pretty)
+    assert "https://cdn.example/a.png[/]" in out, f"output URL did not render literally: {out!r}"
+
+
+def test_jobs_ls_table_is_inert(pretty):
+    """`comfy jobs ls` — prompt_id comes off `/queue` + `/history`, and the
+    workflow column is a filename, which can carry `[...]` just as easily.
+
+    The status cell goes through `status_glyph`, which *is* markup by design:
+    an unrecognized status is echoed into it, so only the echoed half is
+    escaped. Driving `EVIL` through it here is what proves that split holds.
+    """
+    from comfy_cli.command.jobs import JobRow, _render_jobs_pretty
+
+    _render_jobs_pretty(
+        [
+            JobRow(
+                prompt_id=EVIL,
+                status=EVIL,
+                queue_position=None,
+                elapsed_seconds=None,
+                workflow_size=3,
+                outputs=1,
+                workflow_path=f"/tmp/{UNBALANCED}.json",
+            )
+        ],
+        host="127.0.0.1",
+        port=8188,
+    )
+    assert_inert(pretty)
+
+
+def test_status_glyph_keeps_its_own_tags_live(pretty):
+    """The escaping must not neuter the tags `status_glyph` itself authors —
+    a known status still renders styled, with no stray backslashes."""
+    from rich.console import Console
+
+    from comfy_cli.output.glyphs import status_glyph
+
+    console = Console(file=pretty, force_terminal=True, width=80)
+    console.print(status_glyph("success"))
+    out = pretty.getvalue()
+
+    assert "✓ completed" in out, f"styled label was mangled: {out!r}"
+    assert "\\" not in out, f"escaping leaked backslashes into a benign status: {out!r}"
+    assert _RICH_SGR_RE.search(out), "the bold-green style we author was dropped"
+
+
+def test_system_stats_table_is_inert(pretty):
+    """`comfy system-stats` — device name/type/index and the ComfyUI version
+    line are all `/system_stats` fields."""
+    from comfy_cli.command.system import _render_stats_pretty
+
+    _render_stats_pretty(
+        get_renderer(),
+        {
+            "devices": [{"name": EVIL, "type": UNBALANCED, "index": EVIL, "vram_free": 1, "vram_total": 2}],
+            "system": {"ram_free": 1, "ram_total": 2, "comfyui_version": UNBALANCED},
+        },
+    )
+    assert "boom" in assert_inert(pretty)
+
+
+def test_local_workflow_list_table_is_inert(pretty):
+    """`comfy workflow list --where local` — the rows are the `/userdata`
+    listing verbatim, including a `size` the server chose."""
+    from comfy_cli.command import workflow
+
+    listing = json.dumps([{"path": EVIL, "size": UNBALANCED, "modified": 0, "created": 0}]).encode()
+    target = MagicMock()
+    target.url.return_value = "http://127.0.0.1:8188/userdata"
+    with patch.object(workflow, "_userdata_request", return_value=(200, listing)):
+        workflow._local_list(get_renderer(), target, name=None, limit=50, sort="created", order="desc")
+    assert "boom" in assert_inert(pretty)
+
+
+def test_cloud_workflow_list_table_is_inert(pretty):
+    """The cloud saved-workflow catalog reaches the same sink."""
+    from comfy_cli.command import workflow
+
+    body = {
+        "data": [
+            {
+                "id": EVIL,
+                "name": UNBALANCED,
+                "latest_version": EVIL,
+                "updated_at": UNBALANCED,
+            }
+        ]
+    }
+    target = MagicMock()
+    target.is_cloud = True
+    target.url.return_value = "https://cloud.example/api/workflows"
+    with (
+        patch.object(workflow, "_resolve_where_target", return_value=target),
+        patch.object(workflow, "_http_request", return_value=(200, body)),
+    ):
+        workflow.list_cmd(name=None, limit=20, sort="create_time", order="desc", where=None)
+    assert_inert(pretty)


### PR DESCRIPTION
## ELI-5

Some of the text `comfy` prints comes from whatever server it is talking to — a job's error message, an output URL, a GPU's name. Rich (the library that draws our tables) treats square brackets in a string as *formatting commands*: `[red]` repaints the line, `[link=…]` makes a real clickable hyperlink, and a stray `[/]` throws an exception that kills the command mid-print. So a hostile or just badly-behaved server could recolor our output to fake a success message, plant a clickable link, or crash the CLI. This PR runs that text through the escaper we already have (`sanitize_markup`) before it reaches Rich, so it prints as plain characters instead. Our own formatting still works.

## What

`comfy_cli/output/sanitize.py` already states the rule in-tree: use `sanitize_markup` for anything interpolated into a markup string or handed to `Table.add_row`. It is honored in 10 files and ~79 call sites — but four command modules did not import it at all while feeding server data straight to that sink. This is the groom finding in #632.

Fixed, per the enumerated scope:

| Site | Values |
|---|---|
| `jobs status` (local, `_render_status_pretty`) | `prompt_id`, the joined output list, the execution error |
| `jobs status --where cloud` (`_cloud_status`) | `status`, `assigned_inference`, `created_at`, `updated_at`, `error_message`, every output URL |
| `system-stats` (`_render_stats_pretty`) | `/system_stats` device `name`/`type`/`index` |
| `workflow list --where local` (`_local_list`) | the `/userdata` workflow ids |

The docstring's carve-out is followed exactly: values handed to `rich.text.Text` are **not** escaped (`Text` never parses markup, so escaping would print visible backslashes). That applies to the local status badge and the `jobs wait` status cell, both left untouched — and `test_local_job_status_unknown_status_does_not_crash` asserts a `Text` cell still renders unescaped, so a later "sanitize everything" pass can't quietly regress it.

## Beyond the enumerated four — and why

Three additions, each because leaving it out would have left a hole in a surface this PR claims to fix. Called out explicitly so they can be reviewed as deliberate rather than skimmed as scope creep.

1. **`output/glyphs.py` — `status_glyph`.** This one is not optional. `status_glyph` returns markup by design, and an *unrecognized* status is echoed verbatim into that template. It is the status cell of the `jobs ls` and `jobs watch` tables — so escaping only the `prompt_id` in those rows would have left the exact forge-a-hyperlink path open in a table this PR touches. Only the interpolated half is escaped; the tags we author stay live, and `test_status_glyph_keeps_its_own_tags_live` proves a known status still renders styled with no stray backslashes. It is a no-op for every status in `STATUS_STYLE` (all plain words) and for cloud's whole raw vocabulary.
2. **Sibling tables carrying the same values** — `jobs ls`, `jobs watch`, the `jobs wait` summary (`prompt_id`), and the cloud half of `workflow list` (`id`/`name`/`latest_version`/`updated_at`). The ticket's own title is about *inconsistency* between sibling call sites; fixing `jobs status` while `jobs ls` renders the same server-chosen `prompt_id` raw would have reproduced it one row over. Also escapes the `jobs watch` workflow-filename column, where a locally-saved `my[v2].json` is enough to break the render.
3. **`system.py`'s `comfyui_version` line**, eight lines below the enumerated table. Same `/system_stats` response, same hazard, different sink: the f-string *is* markup and `Renderer.print` forwards it to `rich.print` without escaping. Leaving it would have meant `comfy system-stats` was still crashable by a hostile host after a PR whose stated purpose was to close that.

## Not done — deliberately

- **The `output/` wrapper the ticket asks about.** A `safe_add_row` helper (or a `Table` subclass) that escapes `str` cells and passes `Text`/renderables through would make the default safe and retire this whole class of finding. It is the right end state, but it is a redesign touching every table in the CLI and needs its own review — proposing it separately, as the ticket directs.
- **`workflow.py:230`, the `workflow slots` table** (`address`/`type`/`current_value`). Its values come from a *local workflow file* plus `object_info`, not from a server response, so it sits on a different trust boundary than everything above. Worth noting that a downloaded/shared workflow with `[` in a slot value would still break that render — but deciding whether workflow files are trusted input is a separate call, not one to make silently inside a server-data fix.

## Risk

The riskiest line is `sanitize_markup(str(snap["error"])[:600])`: it truncates *before* escaping rather than after. That is deliberate and noted inline — the 600-char budget stays a budget on the server's text rather than on the backslashes we add, and escaping last is what guarantees no half-written tag survives the cut. Truncating a raw ANSI sequence mid-way is safe here because `sanitize`'s regex already matches partial CSI (optional final byte) and unterminated OSC (`\Z` alternative).

Two call sites drop an explicit `str(...)` in favor of `sanitize_markup`'s own coercion (`sanitize_value` stringifies non-`str` input), so non-string server values behave as before rather than raising.

Everything else is purely additive escaping — no existing check, default, or precedence is flipped, broadened, or removed.

## Verification

- `pytest` — 3752 passed, 37 skipped.
- `ruff check .` and `ruff format --diff .` clean under **0.15.15**, the version CI pins. Note for anyone reproducing locally: the lockfile resolves ruff 0.12.7, which reports 17 pre-existing `UP038` findings and reformats one unrelated test file. Both are artifacts of the older version; neither is in this diff.
- **Every one of the 9 new assertions was verified red first**, by stashing the source changes and re-running: 8 failed on `MarkupError` / a live OSC-8 escape reaching the terminal. Stashing only `glyphs.py` independently reproduces the `jobs ls` failure, which is the evidence that hole (point 1 above) was real and not theoretical.

The tests drive the real render functions in pretty mode with a forced-terminal stream — `force_terminal` matters, since Rich only emits OSC-8 hyperlinks to a terminal, so without it the markup half of the attack is invisible to the assertion. `test_cloud_error_message_with_markup_renders_literally` is the ticket's explicitly requested regression case.
