### PR TITLE
refactor: route the three inlined IPv6 bracketing copies through _bracket_host

### DIFF
--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -242,6 +242,7 @@ def _resolve_watch_target(state: jobs_state.JobState, host: str | None, port: in
     Shared by the liveness probe and the poll so the two can never disagree
     about which server they are talking about.
     """
+    from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port
 
     # Per-job recorded state (state.host/port, captured when the job was
@@ -249,10 +250,9 @@ def _resolve_watch_target(state: jobs_state.JobState, host: str | None, port: in
     # server it was launched against: flag > state > COMFY_LOCAL_URL > default.
     h, p = resolve_local_host_port(host or state.host, port or state.port)
     # Bracket IPv6 literals so ``_snapshot`` builds a well-formed URL (it takes
-    # an already-bracketed host, like the `jobs` resolver produces).
-    if ":" in h and not h.startswith("["):
-        h = f"[{h}]"
-    return h, p
+    # an already-bracketed host, like the `jobs` resolver produces). Delegates
+    # to the shared ``_bracket_host`` choke point.
+    return _bracket_host(h), p
 
 
 def _probe_local_server(host: str, port: int) -> str:

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -85,11 +85,13 @@ def resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
     env > ``config.background`` > defaults — then validate and bracket IPv6
     literals so callers building ``'http://{host}:{port}'`` get a well-formed
     URL (e.g. ``'::1'`` -> ``'[::1]'``)."""
+    from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port
 
     cfg = ConfigManager()
     host, port = resolve_local_host_port(host, port, background=cfg.background)
+    # Validate BEFORE bracketing: ``validate_host``'s unsafe-char set does not
+    # include ``[``/``]``, so it must see the unbracketed value.
     h = validate_host(host)
-    if ":" in h and not h.startswith("["):
-        h = f"[{h}]"
-    return (h, int(port))
+    # Bracketing is delegated to the shared ``_bracket_host`` choke point.
+    return (_bracket_host(h), int(port))

--- a/comfy_cli/target.py
+++ b/comfy_cli/target.py
@@ -110,11 +110,13 @@ def resolve_target(
     # env > 127.0.0.1:8188. host/port may be None here; callers that also honor
     # a persisted background server (run/jobs) resolve that upstream via
     # host_port.resolve_host_port before reaching us.
+    from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port
 
     resolved_host, resolved_port = resolve_local_host_port(host, port)
     # Bracket IPv6 literals so the URL is well-formed (RFC 3986 §3.2.2).
-    url_host = f"[{resolved_host}]" if ":" in resolved_host and not resolved_host.startswith("[") else resolved_host
+    # Delegates to the shared ``_bracket_host`` choke point.
+    url_host = _bracket_host(resolved_host)
     return Target(
         kind="local",
         base_url=f"http://{url_host}:{resolved_port}",

--- a/tests/comfy_cli/test_local_address.py
+++ b/tests/comfy_cli/test_local_address.py
@@ -173,6 +173,23 @@ def test_resolve_target_local_honors_env(monkeypatch):
     assert target.port == 8189
 
 
+def test_resolve_target_local_brackets_ipv6_in_url_only(monkeypatch):
+    """``base_url`` gets the bracketed literal; ``Target.host`` stays bare.
+
+    The two are deliberately different representations: the URL needs RFC 3986
+    §3.2.2 brackets, while ``host`` is the bracket-stripped value the address
+    resolver validated. Pins that distinction across the shared
+    ``_bracket_host`` choke point.
+    """
+    from comfy_cli.target import resolve_target
+
+    monkeypatch.setenv(ENV_LOCAL_URL, "http://[::1]:8189")
+    target = resolve_target(where="local")
+    assert target.base_url == "http://[::1]:8189"
+    assert target.host == "::1"
+    assert target.port == 8189
+
+
 def test_resolve_target_local_flag_beats_env(monkeypatch):
     from comfy_cli.target import resolve_target
 


### PR DESCRIPTION
## ELI-5

Turning a bare IPv6 address into a URL means wrapping it in square brackets — `::1` has to become `[::1]` or `http://::1:8188` is nonsense. Three different places in the codebase each wrote their own two-line copy of that wrapping, even though there is already one shared helper whose whole job is to do it. This swaps the three copies for calls to the helper. Nothing behaves differently; there is just one copy of the rule now instead of four.

## What changed

`comfy_cli/env_checker.py:71` `_bracket_host` is the documented, idempotent choke point for bracketing a bare IPv6 literal, and `command/launch.py` + `command/setup.py` already call it. Three sites still inlined the identical logic:

- `comfy_cli/target.py:117` (`resolve_target`, local branch → `base_url`)
- `comfy_cli/command/job_watcher.py:253-254` (`_resolve_watch_target`)
- `comfy_cli/host_port.py:93-94` (`resolve_host_port`)

Each is now a `_bracket_host(...)` call. The import is function-local at all three sites, matching the `from comfy_cli.local_address import resolve_local_host_port` import already sitting directly above each one — so no new module-import cost at CLI startup and no import cycle.

## Behaviour is unchanged

`_bracket_host`'s condition and result (`":" in host and not host.startswith("[")` → `f"[{host}]"`, else pass through) are byte-for-byte what each replaced copy did. None of the copies raised, so there is no error path to lose.

The one ordering constraint worth naming: `host_port.resolve_host_port` validates *before* bracketing, and it still does. `host_port.validate_host`'s unsafe-char set is `/@?#` and deliberately excludes `[`/`]`, so it must see the unbracketed value; that is now spelled out in a comment rather than being implicit in statement order.

## Test

Added `test_resolve_target_local_brackets_ipv6_in_url_only` — `resolve_target(where="local")` under `COMFY_LOCAL_URL=http://[::1]:8189` must yield `base_url == "http://[::1]:8189"` **and** `Target.host == "::1"` (bare). This was the one of the three sites with no direct IPv6 coverage; `resolve_host_port` and `_resolve_watch_target` were already pinned (`tests/comfy_cli/test_host_port.py:111,116`, `tests/comfy_cli/jobs/test_jobs.py:2136`).

Be honest about what that test is: it is a **characterization test**, not a regression test. It passes before and after this diff, because this diff changes no behaviour. Its value is forward-looking — it pins the deliberate bracketed-in-URL / bare-in-`host` asymmetry so a later, larger dedupe cannot quietly collapse the two representations.

## Verification

- `ruff check .` — clean
- `ruff format --diff .` — clean (run against the CI-pinned `ruff==0.15.15`; note a newer local ruff 0.16.x additionally reformats markdown code blocks and flags the pre-existing, untouched `docs/DESIGN-uv-compile.md`)
- `pytest` — 3743 passed, 37 skipped

## Judgment calls / deliberately out of scope

- **The two host/port parsers are NOT merged.** `host_port.parse_host_port_arg` and `local_address._split_host_port` are the same algorithm, and their `_to_port` helpers are the same range check — but they sit on either side of a validation boundary whose asymmetry is deliberate: `local_address._validate_host` only ever sees a bracket-*stripped* host (`_split_host_port` strips first, as `local_address.py:36-42` documents), which is why its unsafe-char set includes `[`/`]` and `host_port`'s does not. Unifying them is a bigger call that needs that distinction to survive explicitly, so it is left for a separate change. This PR dedupes bracketing only.
- **`_bracket_host` is left where it is, and left underscore-prefixed.** Importing a private name across modules is a smell, but it is the established pattern here (`launch.py:24`, `setup.py:610`) and promoting/relocating it would widen this diff beyond the dedupe. Worth doing, separately.
- **A fifth, related bracketing site exists and was left alone:** `comfy_cli/registry/config_parser.py:230` in `_strip_url_credentials`. It is *not* one of the four this change targets — it brackets `urlparse(...).hostname`, which is never bracketed to begin with, so its bare `":" in netloc` test is correct there and it belongs to the registry URL path rather than the local-address pipeline. Flagging it rather than silently folding it in.
