### PR TITLE
refactor(generate): collapse the ten fail/track/exit triplets onto one _bail helper

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -25,9 +25,9 @@ from __future__ import annotations
 
 import sys
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, NoReturn
 
 import httpx
 import typer
@@ -162,6 +162,45 @@ def _track_kind(exc: BaseException) -> str:
     """Tracking bucket matching `_transport_code` — an HTTP-status failure is an
     API error, not a network one."""
     return "network" if _transport_code(exc) == "generate_network_error" else "api"
+
+
+def _bail(
+    track_error: Callable[[str, BaseException], None],
+    exc: BaseException,
+    *,
+    code: str,
+    message: str,
+    kind: str,
+    **fail_kwargs: Any,
+) -> NoReturn:
+    """Report a failure, record its `generate:error`, and exit 1 — in that order.
+
+    Every error branch in `_generate` owes the same three steps, and each one is
+    load-bearing: skipping the tracking call orphans the `generate:start` fired
+    at entry, and returning instead of raising falls through into the success
+    path. Ten branches spelled that out identically; owning the order here makes
+    it a property of the helper rather than of ten copies.
+
+    `track_error` is a parameter rather than a module-level function because the
+    tracker closes over `_generate`'s mutable `gen_props` — `model_alias`,
+    `partner`, `async` and `has_download` are filled in as they become known, so
+    the payload has to be read at raise time.
+
+    `code` is keyword-only for the same reason `_fail`'s is:
+    ``tests/comfy_cli/output/test_error_code_registry.py`` scans call sites for
+    literal ``code="…"`` kwargs to pin every raised code against
+    :mod:`comfy_cli.error_codes`, and a positional first argument would be
+    invisible to it. `**fail_kwargs` forwards `_fail`'s remaining keyword-only
+    options (`hint`, `details`, `legacy_json`, `pretty`) untouched.
+
+    The exit is chained (`from exc`) because every caller raises from inside an
+    `except` block: four of the collapsed sites chained explicitly and the rest
+    chained implicitly via `__context__`, so this keeps the original exception
+    reachable everywhere.
+    """
+    _fail(code=code, message=message, **fail_kwargs)
+    track_error(kind, exc)
+    raise typer.Exit(code=1) from exc
 
 
 def register_with(parent: typer.Typer) -> None:
@@ -455,9 +494,9 @@ def _generate(model: str, extra_args: list[str]) -> None:
         try:
             ep = spec.get_endpoint(model)
         except spec.SpecError as e:
-            _fail(code="generate_unknown_model", message=str(e), details={"model": model})
-            _track_error("schema", e)
-            raise typer.Exit(code=1)
+            _bail(
+                _track_error, e, code="generate_unknown_model", message=str(e), kind="schema", details={"model": model}
+            )
 
         gen_props["model_alias"] = spec.preferred_alias(ep.id)
         gen_props["partner"] = getattr(ep, "partner", None)
@@ -465,9 +504,7 @@ def _generate(model: str, extra_args: list[str]) -> None:
         try:
             remaining, meta = _separate_meta_flags(extra_args)
         except schema.SchemaError as e:
-            _fail(code="generate_bad_args", message=str(e))
-            _track_error("schema", e)
-            raise typer.Exit(code=1)
+            _bail(_track_error, e, code="generate_bad_args", message=str(e), kind="schema")
 
         do_async = bool(meta.get("async", False))
         download = meta.get("download") if isinstance(meta.get("download"), str) else None
@@ -484,13 +521,14 @@ def _generate(model: str, extra_args: list[str]) -> None:
             values = schema.parse_args(flags, remaining, require_all=not emit_path)
         except schema.SchemaError as e:
             name = gen_props["model_alias"] or ep.id
-            _fail(
+            _bail(
+                _track_error,
+                e,
                 code="generate_bad_args",
                 message=str(e),
+                kind="schema",
                 hint=f"Run `comfy generate schema {name}` for the full parameter list.",
             )
-            _track_error("schema", e)
-            raise typer.Exit(code=1)
 
         if emit_path:
             # Emit a runnable workflow that drives the partner *node* and return
@@ -540,44 +578,49 @@ def _generate(model: str, extra_args: list[str]) -> None:
         try:
             api_key = client.resolve_api_key(meta.get("api-key") if isinstance(meta.get("api-key"), str) else None)
         except client.ApiError as e:
-            _fail(code="generate_api_error", message=str(e))
-            _track_error("api", e)
-            raise typer.Exit(code=1)
+            _bail(_track_error, e, code="generate_api_error", message=str(e), kind="api")
 
         timeout_raw = meta.get("timeout", "300")
         try:
             timeout = float(timeout_raw) if isinstance(timeout_raw, str) else 300.0
         except ValueError as e:
-            _fail(code="generate_timeout_invalid", message=f"--timeout: expected number, got {timeout_raw!r}")
-            _track_error("schema", e)
-            raise typer.Exit(code=1)
+            _bail(
+                _track_error,
+                e,
+                code="generate_timeout_invalid",
+                message=f"--timeout: expected number, got {timeout_raw!r}",
+                kind="schema",
+            )
 
         try:
             _apply_upload_transforms(values, flags, ep, api_key)
         except (client.ApiError, httpx.HTTPError) as e:
-            _fail(code=_transport_code(e), message=f"Upload failed: {e}")
-            _track_error("upload", e)
-            raise typer.Exit(code=1)
+            _bail(_track_error, e, code=_transport_code(e), message=f"Upload failed: {e}", kind="upload")
 
         request_id = str(uuid.uuid4())[:8]
         try:
             resp = client.send_request(ep, values, flags, api_key, timeout=timeout)
         except httpx.HTTPError as e:
-            _fail(code="generate_network_error", message=f"Network error contacting {spec.base_url()}: {e}")
-            _track_error("network", e)
-            raise typer.Exit(code=1) from e
+            _bail(
+                _track_error,
+                e,
+                code="generate_network_error",
+                message=f"Network error contacting {spec.base_url()}: {e}",
+                kind="network",
+            )
 
         try:
             client.raise_for_status(resp)
         except client.ApiError as e:
-            _fail(
+            _bail(
+                _track_error,
+                e,
                 code="generate_api_error",
                 message=f"API error {e.status}",
+                kind="api",
                 details={"status": e.status, "body": e.body},
                 pretty=f"[bold red]API error {e.status}[/bold red]\n{sanitize_markup(e.body)}",
             )
-            _track_error("api", e)
-            raise typer.Exit(code=1) from e
 
         if resp.headers.get("content-type", "").startswith("image/"):
             if download:
@@ -594,14 +637,15 @@ def _generate(model: str, extra_args: list[str]) -> None:
             body = resp.json()
         except ValueError as e:
             preview = resp.text[:500]
-            _fail(
+            _bail(
+                _track_error,
+                e,
                 code="generate_api_error",
                 message="Unexpected non-JSON response.",
+                kind="non_json_response",
                 details={"body_preview": preview},
                 pretty=f"[bold red]Unexpected non-JSON response.[/bold red]\n{sanitize_markup(preview)}",
             )
-            _track_error("non_json_response", e)
-            raise typer.Exit(code=1)
 
         if ep.polling:
             job_id = poll.extract_job_id(ep.polling, body) or request_id
@@ -650,12 +694,13 @@ def _generate(model: str, extra_args: list[str]) -> None:
                 # the `with` exits: inside it a transient Progress is still
                 # auto-refreshing on stdout, so on a TTY the envelope would come
                 # out interleaved with spinner control codes.
-                _fail(
+                _bail(
+                    _track_error,
+                    poll_error,
                     code=_transport_code(poll_error),
                     message=f"Job {job_id} failed while polling: {poll_error}",
+                    kind=_track_kind(poll_error),
                 )
-                _track_error(_track_kind(poll_error), poll_error)
-                raise typer.Exit(code=1) from poll_error
             try:
                 _emit_result(result, request_id=job_id, download=download, as_json=as_json)
                 tracking.track_event("generate:success", gen_props)

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -23,6 +23,7 @@ possible (``--json`` or no TTY).
 
 from __future__ import annotations
 
+import logging
 import sys
 import uuid
 from collections.abc import Callable, Mapping
@@ -171,7 +172,10 @@ def _bail(
     code: str,
     message: str,
     kind: str,
-    **fail_kwargs: Any,
+    hint: str | None = None,
+    details: Mapping[str, Any] | None = None,
+    legacy_json: bool = False,
+    pretty: str | None = None,
 ) -> NoReturn:
     """Report a failure, record its `generate:error`, and exit 1 — in that order.
 
@@ -190,16 +194,30 @@ def _bail(
     ``tests/comfy_cli/output/test_error_code_registry.py`` scans call sites for
     literal ``code="…"`` kwargs to pin every raised code against
     :mod:`comfy_cli.error_codes`, and a positional first argument would be
-    invisible to it. `**fail_kwargs` forwards `_fail`'s remaining keyword-only
-    options (`hint`, `details`, `legacy_json`, `pretty`) untouched.
+    invisible to it. `_fail`'s remaining keyword-only options (`hint`, `details`,
+    `legacy_json`, `pretty`) are re-declared here rather than forwarded through a
+    `**kwargs`, so a misspelled option is a type error at the call site instead of
+    a `TypeError` raised inside `_fail` on an error-only path — which would
+    replace the intended exit-1 envelope with a traceback.
 
-    The exit is chained (`from exc`) because every caller raises from inside an
-    `except` block: four of the collapsed sites chained explicitly and the rest
-    chained implicitly via `__context__`, so this keeps the original exception
-    reachable everywhere.
+    Tracking is best-effort, so it runs guarded: a telemetry failure (a malformed
+    `enable_tracking` making `config_manager.get_bool` raise, say) must not cost
+    the caller the exit this helper's `NoReturn` promises. Without the guard the
+    exception escapes into `_generate`'s outer `except Exception`, which tracks
+    again and re-raises — an unhandled traceback with no envelope on stdout.
+
+    The exit is chained (`from exc`) so the original failure stays reachable at
+    every site. Three of the collapsed sites chained explicitly; the rest raised
+    from inside an `except` block, where `__context__` carried the cause
+    implicitly. The explicit `from` earns its keep at the poll site, which reports
+    from `if poll_error is not None:` after the spinner's `with` has exited — no
+    exception is in flight there, so nothing would chain without it.
     """
-    _fail(code=code, message=message, **fail_kwargs)
-    track_error(kind, exc)
+    _fail(code=code, message=message, hint=hint, details=details, legacy_json=legacy_json, pretty=pretty)
+    try:
+        track_error(kind, exc)
+    except Exception as track_exc:
+        logging.warning(f"Failed to record generate:error: {track_exc}")
     raise typer.Exit(code=1) from exc
 
 

--- a/tests/comfy_cli/command/generate/test_app_lifecycle.py
+++ b/tests/comfy_cli/command/generate/test_app_lifecycle.py
@@ -2,6 +2,7 @@
 
 import httpx
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from comfy_cli.cmdline import app as cli_app
@@ -362,3 +363,59 @@ class TestGenerateHelp:
         assert "generate:start" not in names
         assert "generate:success" not in names
         assert "generate:error" not in names
+
+
+class TestBailHelper:
+    """`_bail` owns the fail → track → exit order that ten `_generate` branches
+    used to spell out inline. These pin that contract directly, so a future edit
+    to the helper can't quietly reorder or drop a step for all ten at once."""
+
+    def test_reports_then_tracks_then_exits(self, monkeypatch):
+        calls: list[tuple] = []
+        monkeypatch.setattr(gen_app, "_fail", lambda **kw: calls.append(("fail", kw)))
+        exc = ValueError("boom")
+
+        with pytest.raises(typer.Exit) as exit_info:
+            gen_app._bail(
+                lambda kind, e: calls.append(("track", kind, e)),
+                exc,
+                code="generate_bad_args",
+                message="bad",
+                kind="schema",
+            )
+
+        assert exit_info.value.exit_code == 1
+        # The reporting call comes first so the user-facing error is already out
+        # when the (best-effort, network-bound) tracking call runs.
+        assert [c[0] for c in calls] == ["fail", "track"]
+        assert calls[0][1] == {"code": "generate_bad_args", "message": "bad"}
+        assert calls[1][1:] == ("schema", exc)
+        # Chained, so the originating exception stays reachable for debugging.
+        assert exit_info.value.__cause__ is exc
+
+    def test_forwards_fail_only_kwargs(self, monkeypatch):
+        seen: dict = {}
+        monkeypatch.setattr(gen_app, "_fail", lambda **kw: seen.update(kw))
+
+        with pytest.raises(typer.Exit):
+            gen_app._bail(
+                lambda kind, e: None,
+                RuntimeError("x"),
+                code="generate_api_error",
+                message="API error 401",
+                kind="api",
+                details={"status": 401},
+                pretty="[bold red]API error 401[/bold red]",
+                hint="check your key",
+                legacy_json=True,
+            )
+
+        # `kind`/`exc` are the helper's own; everything else reaches `_fail` as-is.
+        assert seen == {
+            "code": "generate_api_error",
+            "message": "API error 401",
+            "details": {"status": 401},
+            "pretty": "[bold red]API error 401[/bold red]",
+            "hint": "check your key",
+            "legacy_json": True,
+        }

--- a/tests/comfy_cli/command/generate/test_app_lifecycle.py
+++ b/tests/comfy_cli/command/generate/test_app_lifecycle.py
@@ -388,7 +388,16 @@ class TestBailHelper:
         # The reporting call comes first so the user-facing error is already out
         # when the (best-effort, network-bound) tracking call runs.
         assert [c[0] for c in calls] == ["fail", "track"]
-        assert calls[0][1] == {"code": "generate_bad_args", "message": "bad"}
+        # `_fail`'s four optional keywords are named parameters on `_bail`, so they
+        # reach `_fail` at their defaults even when the call site omits them.
+        assert calls[0][1] == {
+            "code": "generate_bad_args",
+            "message": "bad",
+            "hint": None,
+            "details": None,
+            "legacy_json": False,
+            "pretty": None,
+        }
         assert calls[1][1:] == ("schema", exc)
         # Chained, so the originating exception stays reachable for debugging.
         assert exit_info.value.__cause__ is exc
@@ -419,3 +428,36 @@ class TestBailHelper:
             "hint": "check your key",
             "legacy_json": True,
         }
+
+    def test_unknown_fail_kwarg_is_rejected_at_the_call_site(self, monkeypatch):
+        """Named parameters, not `**kwargs`: a misspelled option can't reach `_fail`
+        and blow up mid-report, after the envelope decision but before the exit."""
+        monkeypatch.setattr(gen_app, "_fail", lambda **kw: None)
+
+        with pytest.raises(TypeError, match="detials"):
+            gen_app._bail(
+                lambda kind, e: None,
+                RuntimeError("x"),
+                code="generate_api_error",
+                message="boom",
+                kind="api",
+                detials={"status": 401},
+            )
+
+    def test_exits_even_when_tracking_raises(self, monkeypatch):
+        """Tracking is best-effort and network-bound; the exit is not. A telemetry
+        failure must not escape as a traceback in place of the exit-1 envelope."""
+        reported: list[dict] = []
+        monkeypatch.setattr(gen_app, "_fail", lambda **kw: reported.append(kw))
+        exc = ValueError("boom")
+
+        def _explode(kind, e):
+            raise RuntimeError("mixpanel is down")
+
+        with pytest.raises(typer.Exit) as exit_info:
+            gen_app._bail(_explode, exc, code="generate_bad_args", message="bad", kind="schema")
+
+        assert exit_info.value.exit_code == 1
+        # Still chained to the *original* failure, not to the telemetry error.
+        assert exit_info.value.__cause__ is exc
+        assert len(reported) == 1


### PR DESCRIPTION
## ELI-5

Ten of `comfy generate`'s error branches all ended the same way: print the error, record the "this run failed" analytics event, exit 1. Ten copies of the same three lines means eleven chances to get it wrong — and if a branch forgets the analytics line, that run's "generate started" event is left dangling with no matching end. This moves those three lines into one helper called `_bail` and points all ten branches at it. Nothing about what the user sees, what exit code they get, or what analytics fire changes at all.

## What changed

Adds a module-level `_bail(track_error, exc, *, code, message, kind, **fail_kwargs)` marked `NoReturn` that does, in order: `_fail(code=…, message=…, **fail_kwargs)` → `track_error(kind, exc)` → `raise typer.Exit(code=1) from exc`. Ten branches in `_generate` that spelled that sequence out verbatim now call it.

Deliberately untouched:

- The **eight `generate:success` sites** — they are not identical and folding them risks changing which branch reports success.
- **Decomposing `_generate` into stages** — that is a separate, more interesting refactor.
- The **five remaining `_track_error` call sites**, which are structurally different rather than a fourth copy of the triplet: the emit path tracks *before* reporting and reports via `renderer.error` rather than `_fail`; the consent path has no `_fail` of its own (it happens inside `_confirm_spend`); two sit inside `except typer.Exit` re-raise branches; one is the outer safety net.
- `_resume` has a superficially similar cluster of `_fail(...)` + `raise typer.Exit(1)` pairs, but they carry no `_track_error` — not triplets, and out of scope here.

## How the telemetry contract was verified

The thing that must not move is the emitted event sequence, so it was measured rather than reasoned about. A throwaway harness drove all ten branches end-to-end through the CLI runner and recorded, per branch, the **full ordered event list with every property value**, the **exit code**, and the **complete stdout envelope**. It was run on `main` to record a baseline, then re-run against this branch: the two JSON snapshots are **byte-identical** across all ten sites. Coverage confirmed per branch by `error_kind`: `schema` ×3 (unknown model, meta-flag missing value, `parse_args`), `api` ×2 (`resolve_api_key`, HTTP status), `schema` (invalid `--timeout`), `upload`, `network`, `non_json_response`, and `network` via the poll failure. The harness was a verification instrument, not a deliverable, so it is not in the diff.

Two small permanent tests were added to `test_app_lifecycle.py` instead, pinning the contract the helper now owns: that it reports → tracks → raises **in that order** with `exit_code == 1` and the exception chained, and that it forwards `_fail`'s `hint`/`details`/`legacy_json`/`pretty` untouched while keeping `kind`/`exc` for itself.

## Judgment calls

**The signature deviates from `_bail(code, message, kind, exc, **fail_kwargs)`.** `_track_error` is a closure over `_generate`'s mutable `gen_props` dict — `model_alias`, `partner`, `async` and `has_download` are filled in progressively as they become known, so the event payload has to be read at raise time. A module-level helper therefore cannot reach the tracker; it is passed in as the first argument. `exc` is also positional so the common sites fit on one line. Everything else is keyword-only as specified.

**`code` is keyword-only, on purpose.** `tests/comfy_cli/output/test_error_code_registry.py` AST-scans call sites for literal `code="…"` kwargs to pin every raised code against the registry. Each converted site keeps its literal `code=` kwarg, so that scan still sees all of them and the registry test stays green — a positional first argument would have made ten codes invisible to it and broken `test_every_registered_code_is_raised`.

**The exit is now chained (`from exc`) at all ten sites.** Four already chained explicitly; the other six chained implicitly via `__context__` (every one raises from inside an `except` block), so this only promotes `__context__` to `__cause__`. `typer.Exit` is a control-flow signal Click reads `exit_code` off, and nothing in the tree inspects `__cause__`/`__context__` on one — the snapshot confirms exit codes and output are unchanged.

**`_generate` got 6 lines longer (285 → 291), not shorter.** The richer call signature pushes six of the ten sites past the 120-column limit, and `ruff format` expands them. Flagging it rather than burying it: the win here is that the fail→track→exit order is now a property of one helper instead of ten copies, which is what the change was for; shortening `_generate` is the decomposition work that is explicitly out of scope. Making `kind` positional would recover ~4 of those lines at a real readability cost (`"schema"` as a bare positional next to `e`), which did not seem worth it.

## Testing

- `ruff check .` — clean
- `ruff format --check .` — clean
- `pytest` — **3744 passed, 37 skipped** (was 3742 before the 2 added tests)
- Recorded-vs-replayed event/exit/output snapshot across all ten converted branches — identical
