### PR TITLE
ci: add AGENTS.md integrity check (thin caller of shared workflow)

### DIFF
--- a/.github/workflows/agents-md-integrity.yml
+++ b/.github/workflows/agents-md-integrity.yml
@@ -1,0 +1,21 @@
+name: AGENTS.md Integrity
+
+# Thin caller for the shared reusable AGENTS.md integrity check. The checker
+# lives in Comfy-Org/github-workflows (single source of truth), loaded from
+# the pinned workflows_ref — never from this repo's checkout. Bump the SHA to
+# pick up upstream changes and keep `workflows_ref` matching so the check
+# script loads from the same commit; the upstream bump dispatcher
+# (AGENTS_MD_CALLERS) opens SHA-bump PRs automatically once registered.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  agents-md:
+    permissions:
+      contents: read
+    uses: Comfy-Org/github-workflows/.github/workflows/agents-md-integrity.yml@bcde90f4c5b0267d32583dc1d339ac8731c0da9a # github-workflows main (bcde90f)
+    with:
+      workflows_ref: bcde90f4c5b0267d32583dc1d339ac8731c0da9a


### PR DESCRIPTION
## ELI-5

Every Comfy repo is supposed to keep its agent instructions in one thin top-level `AGENTS.md`, with `CLAUDE.md` as a one-line shim that just imports it. This PR wires up a CI check that enforces that, so nobody can accidentally let those files drift (grow past the line ceiling, lose the shim, sprout a stray `.cursorrules`, or add a nested `AGENTS.md` with no sibling shim). The check itself is not written here — it lives once in `Comfy-Org/github-workflows`, and this file is just a 21-line caller that says "run that shared check, pinned at this exact commit."

## What changed

Adds `.github/workflows/agents-md-integrity.yml`: a thin caller for the reusable `Comfy-Org/github-workflows/.github/workflows/agents-md-integrity.yml`, SHA-pinned to `bcde90f4c5b0267d32583dc1d339ac8731c0da9a` with a matching `workflows_ref` so the workflow definition and the check script always load from the same commit. Runs on `pull_request` and on `push` to `main`. All reusable inputs stay at their defaults; no secrets are needed. Same shape as this repo's existing shared-workflow callers (`ci-cursor-review.yml`, `groom.yml`), which are pinned to the same SHA.

I also registered this repo in the upstream auto-bump variable so the SHA gets bumped by PR automatically from now on: `AGENTS_MD_CALLERS` on `Comfy-Org/github-workflows` now contains `{"repo":"Comfy-Org/comfy-cli","file":".github/workflows/agents-md-integrity.yml","label":""}` (applied idempotently and read back to confirm — no permission problem, so no manual command is needed).

## Verification

Preflight against a clean `origin/main` export, running the upstream checker directly before adding any caller — this repo is already compliant, so the check was expected to pass on the first run and did:

```
Checking AGENTS.md integrity in '<clean origin/main export>'...

WARN: no CODEOWNERS file found, so 'AGENTS.md' has no DRI. Add a CODEOWNERS rule assigning an owner.

Result: passed with 1 warning(s).
```

The CODEOWNERS line is a warning, not a failure — `require_codeowners` defaults to `false` — and deliberately not addressed here: adding a CODEOWNERS file is a separate, human-owned decision, not part of wiring up the check. Concretely, root `AGENTS.md` is 65 lines (ceiling 200, aspirational target 150), root `CLAUDE.md` is a proper `@AGENTS.md` shim, there is no `.cursorrules`, and there are no nested `AGENTS.md` files.

Repo checks on the branch: `ruff check .` clean, `ruff format --check .` clean under the CI-pinned `ruff==0.15.15`, and `pytest` green at 3742 passed / 37 skipped. (A local ruff 0.16.0 flags `docs/DESIGN-uv-compile.md` — that is upstream formatter drift on a file this PR does not touch, and it is clean under the version CI actually installs.) The workflow file itself parses as valid YAML, which is what the repo's `check-yaml` pre-commit hook enforces.

## Notes / judgment calls

The pin was re-verified at implementation time rather than trusted: `bcde90f4c5b0267d32583dc1d339ac8731c0da9a` is still the tip of `github-workflows@main` and is the commit that last touched the reusable, so it is used as-is. The `v1` tag is deliberately not used — it points at `4d9cb6b8`, which predates this workflow.

Two upstream details worth recording, both checked rather than assumed. The reusable checks the caller repo out into `$GITHUB_WORKSPACE` and its own checker script into a sibling `_agents_md_integrity/` directory inside that same workspace; `github-workflows` has its own root `AGENTS.md`, which would otherwise look like a nested file to the `check_nested` walk. Upstream already excludes that directory from the walk, so there is no false failure. And the reusable declares no `secrets:` block and only needs `contents: read`, which is what the job grants.

Unrelated observation for whoever owns the variable, flagged rather than acted on since it is outside this ticket: `AGENTS_MD_CALLERS` still lists `Comfy-Org/comfy-local-mcp`, which was renamed to `comfy-mcp`. That stale entry is likely to make the bump dispatcher miss that repo.

This change adds a CI gate rather than denying any capability — it introduces no dead-end or "unsupported" path — and the gate's premise was falsified empirically by running the real upstream checker against a clean `origin/main` export before the caller was written.

Follow-up (human/ops): make `AGENTS.md integrity` a required status check in branch protection.
