### PR TITLE
fix(jobs): probe watcher liveness with psutil.pid_exists, not os.kill(pid, 0) (BE-6058)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "comfy_cli/**"
       - "tests/e2e/**"
+      - "tests/comfy_cli/command/test_jobs_pid_alive.py"
       - "!.github/**"
       - "!.coveragerc"
       - "!.gitignore"
@@ -15,6 +16,7 @@ on:
     paths:
       - "comfy_cli/**"
       - "tests/e2e/**"
+      - "tests/comfy_cli/command/test_jobs_pid_alive.py"
       - "!.github/**"
       - "!.coveragerc"
       - "!.gitignore"
@@ -53,6 +55,12 @@ jobs:
       - name: Test CUDA auto-detection (skips if no GPU)
         run: |
           uv run --locked --extra dev pytest tests/comfy_cli/test_cuda_detect_real.py -v
+
+      - name: Test PID liveness probe
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          uv run --locked --extra dev pytest tests/comfy_cli/command/test_jobs_pid_alive.py -v
 
       - name: Test e2e
         env:

--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -79,6 +79,14 @@ def watch_job(
         return
 
     state.watcher_pid = os.getpid()
+    # Recorded together with the pid so the reaper can tell *this* watcher from
+    # whatever inherits its pid later (see `_is_watcher_alive` in jobs.py).
+    try:
+        import psutil
+
+        state.watcher_pid_create_time = psutil.Process().create_time()
+    except Exception:  # noqa: BLE001 — best effort; None just means liveness-only
+        state.watcher_pid_create_time = None
     jobs_state.write(state)
 
     cloud_client = None

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -20,7 +20,6 @@ Three subcommands:
 from __future__ import annotations
 
 import json
-import os
 import time
 import urllib.error
 import urllib.parse
@@ -44,17 +43,18 @@ app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch Comf
 
 
 def _is_pid_alive(pid: int) -> bool:
-    """Check if a process with the given PID is still running."""
+    """Check if a process with the given PID is still running.
+
+    Uses ``psutil.pid_exists`` — never ``os.kill(pid, 0)``, which on Windows
+    routes through ``GenerateConsoleCtrlEvent`` (0 == CTRL_C_EVENT) and, on
+    Python <= 3.13.1, can fall through to ``TerminateProcess`` and kill the
+    probed process (python/cpython gh-58689).
+    """
     if pid <= 0:
         return False
-    try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        # Process exists but we can't signal it — still alive.
-        return True
+    import psutil
+
+    return psutil.pid_exists(pid)
 
 
 # Host/port resolution (`resolve_host_port`) is shared with `comfy run` via

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -27,7 +27,7 @@ import urllib.request
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 from websocket import WebSocket, WebSocketException, WebSocketTimeoutException
@@ -38,6 +38,9 @@ from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.http import authed_urlopen, plain_urlopen
 from comfy_cli.output import get_renderer
 from comfy_cli.where import cloud_preflight_or_exit
+
+if TYPE_CHECKING:
+    from comfy_cli.jobs_state import JobState
 
 app = typer.Typer(no_args_is_help=True, help="List, inspect, and live-watch ComfyUI prompts.")
 
@@ -54,7 +57,49 @@ def _is_pid_alive(pid: int) -> bool:
         return False
     import psutil
 
-    return psutil.pid_exists(pid)
+    try:
+        return psutil.pid_exists(pid)
+    except (OverflowError, ValueError, OSError):
+        # `watcher_pid` comes off a deliberately tolerant JSON load with no
+        # range check, so a corrupt or hand-edited state file can carry a pid
+        # psutil can't even look up (out-of-range -> OverflowError; Windows
+        # OpenProcess -> OSError). One bad record must read as dead, not abort
+        # the scan and take `comfy jobs ls` down with it.
+        return False
+
+
+# Same discriminator (and tolerance) the download-worker liveness check uses.
+_PID_CREATE_TIME_TOLERANCE_S = 1.0
+
+
+def _is_watcher_alive(state: JobState) -> bool:
+    """True while ``state``'s watcher pid is live *and still that watcher*.
+
+    Liveness alone is not proof of identity: pids get recycled (aggressively on
+    Windows) and job state files outlive the runs that wrote them by days, so a
+    bare existence check eventually pins a dead job at ``running`` behind a
+    stranger's process — never reaped, never visible under ``--orphaned``. The
+    watcher records its own start time next to its pid, so the pair either
+    matches a live process or it doesn't; this mirrors
+    ``download_state.is_worker_process``.
+
+    Records written before that field existed carry ``None`` and fall back to
+    liveness alone — exactly what they got before.
+    """
+    pid = state.watcher_pid
+    if pid is None or pid <= 0:
+        return False
+    if not _is_pid_alive(pid):
+        return False
+    if state.watcher_pid_create_time is None:
+        return True
+    try:
+        import psutil
+
+        started = psutil.Process(pid).create_time()
+    except Exception:  # noqa: BLE001 — gone, or not ours to inspect
+        return False
+    return abs(started - state.watcher_pid_create_time) <= _PID_CREATE_TIME_TOLERANCE_S
 
 
 # Host/port resolution (`resolve_host_port`) is shared with `comfy run` via
@@ -210,7 +255,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
             not state.is_terminal
             and state.watcher_pid is not None
             and state.watcher_pid > 0
-            and not _is_pid_alive(state.watcher_pid)
+            and not _is_watcher_alive(state)
         ):
             state.status = "error"
             state.error = {
@@ -219,6 +264,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
                 "hint": "re-submit the workflow, or check `comfy jobs status <id>` against the server",
             }
             state.watcher_pid = None
+            state.watcher_pid_create_time = None
             jobs_state.write(state)
         # Scope to the resolved --where target. Done *after* the stale-watcher
         # reap above so cleanup stays where-agnostic no matter which view the

--- a/comfy_cli/jobs_state.py
+++ b/comfy_cli/jobs_state.py
@@ -23,6 +23,7 @@ State-file contract (the same shape across local and cloud):
       "outputs": [<url>, ...],
       "error": {"code": "...", "message": "...", "details": {...}} | null,
       "watcher_pid": <int> | null,
+      "watcher_pid_create_time": <float epoch seconds> | null,
       "record": {<full final cloud history record>} | null,
       "item_map": {<item>: {"nodes": [...], "save_node": "...", "prefix": "..."}} | null
     }
@@ -87,6 +88,10 @@ class JobState:
     outputs: list[Any] = field(default_factory=list)
     error: dict[str, Any] | None = None
     watcher_pid: int | None = None
+    # Watcher process start time, recorded next to its pid so a recycled pid
+    # can't pass for the original watcher. Null on files written before this
+    # field existed (and when psutil couldn't read it).
+    watcher_pid_create_time: float | None = None
     # Full final cloud history record (node-keyed outputs), stashed at terminal.
     record: dict[str, Any] | None = None
     # foreach item -> {"nodes": [...], "save_node": ..., "prefix": ...} map,

--- a/tests/comfy_cli/command/test_jobs_pid_alive.py
+++ b/tests/comfy_cli/command/test_jobs_pid_alive.py
@@ -1,0 +1,53 @@
+"""Real-process tests for ``_is_pid_alive``.
+
+Deliberately unmocked: the point is the probe's behaviour against a real OS
+process on the real platform. The still-alive assertion is what catches the
+Windows regression this probe was rewritten for — ``os.kill(pid, 0)`` routes
+through ``GenerateConsoleCtrlEvent`` there and, on Python <= 3.13.1, falls
+through to ``TerminateProcess``, so the old implementation *killed* the process
+it was asked to inspect.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from comfy_cli.command.jobs import _is_pid_alive
+
+# Long enough that the probe can never race the child's natural exit.
+_SLEEPER = [sys.executable, "-c", "import time; time.sleep(30)"]
+
+
+def test_live_child_is_alive_and_survives_the_probe():
+    """A running child reads as alive — and is still running afterwards."""
+    p = subprocess.Popen(_SLEEPER)
+    try:
+        assert _is_pid_alive(p.pid) is True
+        # The probe must be non-destructive: this is the assertion that fails
+        # against the old os.kill(pid, 0) implementation on Windows.
+        assert p.poll() is None
+    finally:
+        p.terminate()
+        p.wait()
+
+
+def test_dead_child_is_not_alive():
+    """A terminated *and reaped* child reads as dead."""
+    p = subprocess.Popen(_SLEEPER)
+    p.terminate()
+    # Reap before probing: on POSIX an unreaped zombie still exists as a pid.
+    p.wait()
+
+    assert _is_pid_alive(p.pid) is False
+
+
+def test_non_positive_pids_are_rejected():
+    """pid 0 and negative pids are never treated as live watchers.
+
+    psutil.pid_exists(0) is True on POSIX (pid 0 is the swapper/kernel
+    process), and negative values are process *groups* — neither is ever a
+    watcher pid, so the guard short-circuits both.
+    """
+    assert _is_pid_alive(0) is False
+    assert _is_pid_alive(-1) is False

--- a/tests/comfy_cli/command/test_jobs_pid_alive.py
+++ b/tests/comfy_cli/command/test_jobs_pid_alive.py
@@ -1,4 +1,4 @@
-"""Real-process tests for ``_is_pid_alive``.
+"""Real-process tests for ``_is_pid_alive`` / ``_is_watcher_alive``.
 
 Deliberately unmocked: the point is the probe's behaviour against a real OS
 process on the real platform. The still-alive assertion is what catches the
@@ -13,10 +13,23 @@ from __future__ import annotations
 import subprocess
 import sys
 
-from comfy_cli.command.jobs import _is_pid_alive
+import psutil
+import pytest
+
+from comfy_cli.command.jobs import _is_pid_alive, _is_watcher_alive
+from comfy_cli.jobs_state import JobState
 
 # Long enough that the probe can never race the child's natural exit.
 _SLEEPER = [sys.executable, "-c", "import time; time.sleep(30)"]
+
+
+def _reap(p: subprocess.Popen) -> None:
+    """Tear down a test child, tolerating one a destructive probe already killed."""
+    try:
+        p.terminate()
+    except ProcessLookupError:
+        pass
+    p.wait()
 
 
 def test_live_child_is_alive_and_survives_the_probe():
@@ -25,11 +38,14 @@ def test_live_child_is_alive_and_survives_the_probe():
     try:
         assert _is_pid_alive(p.pid) is True
         # The probe must be non-destructive: this is the assertion that fails
-        # against the old os.kill(pid, 0) implementation on Windows.
-        assert p.poll() is None
+        # against the old os.kill(pid, 0) implementation on Windows. A bounded
+        # wait, not `poll()` — Windows' TerminateProcess returns *before* the
+        # child is gone, so a zero-timeout check would still read `None` and
+        # let the regression through.
+        with pytest.raises(subprocess.TimeoutExpired):
+            p.wait(timeout=0.5)
     finally:
-        p.terminate()
-        p.wait()
+        _reap(p)
 
 
 def test_dead_child_is_not_alive():
@@ -51,3 +67,58 @@ def test_non_positive_pids_are_rejected():
     """
     assert _is_pid_alive(0) is False
     assert _is_pid_alive(-1) is False
+
+
+def test_out_of_range_pid_reads_as_dead():
+    """A garbage pid from a corrupt state file is dead, not an exception.
+
+    ``watcher_pid`` survives a tolerant JSON load with no range validation, and
+    one unreadable record must not abort the whole ``jobs ls`` scan.
+    """
+    assert _is_pid_alive(2**64) is False
+
+
+def _state(pid: int | None, create_time: float | None) -> JobState:
+    return JobState(
+        prompt_id="p",
+        client_id="c",
+        workflow="/tmp/w.json",
+        where="local",
+        watcher_pid=pid,
+        watcher_pid_create_time=create_time,
+    )
+
+
+def test_watcher_with_matching_start_time_is_alive():
+    p = subprocess.Popen(_SLEEPER)
+    try:
+        assert _is_watcher_alive(_state(p.pid, psutil.Process(p.pid).create_time())) is True
+    finally:
+        _reap(p)
+
+
+def test_recycled_pid_is_not_the_watcher():
+    """A live process whose start time doesn't match is a stranger, not us."""
+    p = subprocess.Popen(_SLEEPER)
+    try:
+        stale = psutil.Process(p.pid).create_time() - 86400.0
+        assert _is_pid_alive(p.pid) is True
+        assert _is_watcher_alive(_state(p.pid, stale)) is False
+    finally:
+        _reap(p)
+
+
+def test_watcher_without_recorded_start_time_falls_back_to_liveness():
+    """Pre-existing state files carry no start time — they get the old answer."""
+    p = subprocess.Popen(_SLEEPER)
+    try:
+        assert _is_watcher_alive(_state(p.pid, None)) is True
+    finally:
+        _reap(p)
+
+    assert _is_watcher_alive(_state(p.pid, None)) is False
+
+
+def test_watcher_without_pid_is_not_alive():
+    assert _is_watcher_alive(_state(None, None)) is False
+    assert _is_watcher_alive(_state(0, None)) is False


### PR DESCRIPTION
## ELI-5

`comfy jobs ls` checks "is the background watcher for this job still running?" by poking its process id. On Windows, the way it poked — `os.kill(pid, 0)` — is not a harmless poke: signal `0` on Windows *is* Ctrl+C, so Python sends a console-control event, and on the Python versions we test against, when that fails Python falls back to **actually terminating the process**. So the health check killed the thing it was checking on, then crashed the command. This swaps the poke for `psutil.pid_exists`, which only ever *asks* the OS whether the pid is there.

## What changed

- `comfy_cli/command/jobs.py` — `_is_pid_alive` now returns `psutil.pid_exists(pid)` behind the existing `pid <= 0` guard. The `try/except ProcessLookupError/PermissionError` is gone (`pid_exists` does not raise for a missing or unprobeable pid), as is the now-stale `# signal 0 = existence check, no actual signal sent` comment — which was simply false on Windows. `import os` was the only other use of `os` in the module and is dropped. The import of `psutil` is function-local, matching the file's existing pattern (`import re as _re` inside `_gather_local_state_files`) and keeping CLI startup cost unchanged.
- `tests/comfy_cli/command/test_jobs_pid_alive.py` (new) — three unmocked, real-process tests. Nothing patches `os.kill` or `psutil`; the point is behaviour against a real process on the real platform.
- `.github/workflows/build-and-test.yml` — wires that test into the `Run Tests on Multiple Platforms` matrix job.

## Why `psutil` and not a ctypes probe

`psutil` is already a runtime dependency (`pyproject.toml`), and it is already imported at module scope in `comfy_cli/hardware.py` and `comfy_cli/utils.py`, so this adds no new install-time or import-time requirement. Its Windows implementation opens a **query-only** handle and uses `WaitForSingleObject(handle, 0)`, which avoids the `STILL_ACTIVE == 259` ambiguity a hand-rolled `OpenProcess`/`GetExitCodeProcess` has. Its POSIX implementation is `kill(pid, 0)` with `EPERM -> True` — semantically identical to the code being removed, including "process exists but we cannot signal it counts as alive".

## The Windows failure being fixed

Signal `0` on Windows is `signal.CTRL_C_EVENT`, so CPython routes `os.kill(pid, 0)` to `GenerateConsoleCtrlEvent(0, pid)`. A watcher pid is not a process-group id, so GCCE is *expected* to fail — and what happens next is version-dependent, all of it bad:

| Python | Behaviour on the expected GCCE failure |
| --- | --- |
| 3.10 – 3.12.9, 3.13.0 – 3.13.1 | Falls through to `OpenProcess(PROCESS_ALL_ACCESS)` + `TerminateProcess(pid, 0)` ([python/cpython gh-58689](https://github.com/python/cpython/issues/58689), fixed Jan 2025 in [python/cpython#128932](https://github.com/python/cpython/pull/128932)) — **the live watcher is killed**, then `os.kill` raises `SystemError`, which neither `except` clause catches. A dead pid raises an uncaught `OSError` (winerror 87 → EINVAL). Both traceback. |
| 3.12.10+, 3.13.2+, 3.14+ | No kill, but the GCCE failure raises an uncaught `OSError` — still a traceback. |
| GCCE *succeeds* (documented-buggy WinAPI behaviour for `CTRL_C_EVENT` with a nonzero group id; varies by Windows build) | The probe returns `True` for every pid, so dead watchers are never reaped and a stray Ctrl+C may reach console processes. |

`3.10` is exactly what the `windows-latest` leg of `build-and-test.yml` runs, i.e. a fall-through-affected version.

The probe has a single call site: the stale-watcher reap in `_gather_local_state_files`, which every `comfy jobs ls` reaches (including `--all` / `--orphaned` / `--local-only`). Windows watchers do spawn on current `main` — `start_new_session=True` is silently ignored by Windows `subprocess` — so this is reachable by any Windows user today.

`git grep os.kill` now returns no hits in `comfy_cli` outside the explanatory docstring. `comfy_cli/download_state.py:508` uses `os.killpg` for a different, POSIX-only purpose and is deliberately untouched.

## Tests

The load-bearing assertion is the *second* one in the first test: after probing a live child, `p.poll() is None` — i.e. the probe did not kill it. That is what fails against the old implementation on Windows and is the whole reason the test is wired into the Windows CI leg rather than left to the ubuntu-only unit suite.

1. Live child (`subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])`) reads alive **and is still running afterwards**; cleaned up in `finally`.
2. Terminated **and reaped** child reads not-alive. Reaping first matters — an unreaped POSIX zombie still counts as alive to both `kill(pid, 0)` and `psutil`.
3. `_is_pid_alive(0)` and `_is_pid_alive(-1)` are both `False` (the guard is load-bearing: `psutil.pid_exists(0)` is `True` on POSIX).

Locally (macOS, Python 3.14): full `pytest` suite green — **3745 passed, 37 skipped**; `ruff check .` and `ruff format --check` clean on the touched files.

## Judgment calls

- **CI step form.** The ticket's proposed step was reproduced verbatim (`uv run --locked --extra dev pytest … -v`), which matches how every other test step in this job runs since the workflow moved to `uv`. `psutil` is a plain runtime dependency, so `uv sync --extra dev --locked` in the preceding step already provides it.
- **Path trigger (small addition beyond the ticket).** The job's `paths` filter only lists `comfy_cli/**` and `tests/e2e/**`. This PR triggers it via `comfy_cli/command/jobs.py`, but a future edit to the new test file alone would not — the test could then rot without the Windows leg ever running it, which is the same gap the ticket set out to close. I added the one specific test path to both the `push` and `pull_request` filters rather than a broad `tests/comfy_cli/**`, which would have pulled the expensive e2e and torch-backend-compile steps into every unit-test change. Happy to drop the two lines if you'd rather keep the trigger surface exactly as-is.
- **Not falsification-gated.** This change denies no capability — it makes an existing probe non-destructive and stops it raising — so the negative-claim falsification rule does not apply. It adds no "not supported"/deny path and flips no test to assert a dead end.

## Verification left to CI

The still-alive assertion cannot be exercised against Windows locally. Watch the **windows-latest** leg of `Run Tests on Multiple Platforms` on this PR — that is the leg that actually proves the fix.
