### PR TITLE
fix(run): emit the `queued` NDJSON event only after the job state file is persisted

### DIFF
--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -385,6 +385,12 @@ def execute(
             wait_state.status = "running"
             _write_state(wait_state)
 
+            # Only now, with the durable record on disk, announce the queue.
+            # The event-order contract (docs/json-output.md) is
+            # `prompt_preview → queued → node events`, so this must also
+            # precede `watch_execution`'s WebSocket stream.
+            _emit_queued(renderer, execution)
+
             # `watch_execution` reports a terminal server event by rendering
             # the error and raising `typer.Exit` (1 for `execution_error`, 130
             # for `execution_interrupted`) — the ordinary failure path, not an
@@ -460,6 +466,10 @@ def execute(
             state_file = jobs_state.write(state)
             watcher_spawned = _spawn_watcher(execution.prompt_id, where="local", host=host, port=port, notify=notify)
 
+            # Emitted after the state file and the watcher spawn attempt, so a
+            # consumer reading this line can already `comfy jobs status` it.
+            _emit_queued(renderer, execution)
+
             if renderer.is_pretty():
                 from comfy_cli.output.glyphs import status_glyph
 
@@ -527,6 +537,12 @@ def execute(
         )
         raise typer.Exit(code=1)
     except (WebSocketException, ConnectionError, OSError) as e:
+        if isinstance(e, BrokenPipeError):
+            # A closed stdout is the consumer leaving, not the server dying —
+            # let click/__main__ turn it into the documented silent exit 0 and
+            # leave the just-written state record untouched. Same principle as
+            # `completed_payload` being emitted outside this try.
+            raise
         # If we closed the WebSocket ourselves in response to Ctrl-C, the recv
         # loop exits with a WebSocketException that *looks* like the server
         # vanished. Check the cancellation token first so we emit the right
@@ -592,6 +608,24 @@ def execute(
             elapsed = timedelta(seconds=completed_payload["elapsed_seconds"])
             pprint(f"[bold green]\nWorkflow execution completed ({elapsed})[/bold green]")
         renderer.emit(completed_payload, command="run", where="local")
+
+
+def _emit_queued(renderer, execution) -> None:
+    """Emit the contractual local `queued` event (docs/json-output.md#queued).
+
+    Lives in the caller rather than ``WorkflowExecution.queue()`` so it can be
+    emitted *after* the job's state file is persisted — a consumer that sees
+    this line can immediately `comfy jobs status <prompt_id>` / see the job in
+    `jobs ls`, and a `BrokenPipeError` here can no longer abort setup before
+    the durable record exists. The field set is unchanged.
+    """
+    renderer.event(
+        "queued",
+        prompt_id=execution.prompt_id,
+        client_id=execution.client_id,
+        validation_warnings=execution.validation_warnings,
+        nodes=execution.workflow_manifest(),
+    )
 
 
 def _write_state(state):
@@ -860,7 +894,8 @@ def execute_cloud(
     # with `queued` (async) / `executing` (--wait) carrying {workflow, base_url}
     # — both wrong per docs/json-output.md: `queued` means "the server accepted
     # the prompt" (so it cannot precede the POST), and `executing` is a per-node
-    # event. The contractual `queued` is emitted after submit, below.
+    # event. The contractual `queued` is emitted after submit *and* after the
+    # job state file is written, below.
 
     try:
         if not wait and renderer.is_pretty():
@@ -915,19 +950,27 @@ def execute_cloud(
         raise typer.Exit(code=1)
 
     # The contractual `queued`: the server has the prompt. Same shape the local
-    # path emits from `WorkflowExecution.queue()` (docs/json-output.md#queued),
-    # plus `base_url` so a cloud consumer still learns the target.
-    # `validation_warnings` is always empty here — unlike local, the cloud
-    # treats any `node_errors` on an accepted submit as a hard `prompt_rejected`
-    # above, so a partially-valid graph never reaches this line.
-    renderer.event(
-        "queued",
-        prompt_id=submit.prompt_id,
-        client_id=client_id,
-        validation_warnings=[],
-        nodes=workflow_manifest(parsed_workflow),
-        base_url=target.base_url,
-    )
+    # path emits (docs/json-output.md#queued), plus `base_url` so a cloud
+    # consumer still learns the target. `validation_warnings` is always empty
+    # here — unlike local, the cloud treats any `node_errors` on an accepted
+    # submit as a hard `prompt_rejected` above, so a partially-valid graph
+    # never reaches this line.
+    #
+    # Deliberately NOT emitted at this point: both branches below emit it only
+    # once the job's state file (and, on the async branch, the watcher) exist.
+    # A `BrokenPipeError` here — `comfy run --where cloud --json-stream … |
+    # head -n1`, where the NDJSON renderer flushes every line — used to abort
+    # setup before `jobs_state.write` ran while `__main__` still exited 0,
+    # leaving a billable cloud job with no journal entry, state file or watcher.
+    def _emit_queued_cloud() -> None:
+        renderer.event(
+            "queued",
+            prompt_id=submit.prompt_id,
+            client_id=client_id,
+            validation_warnings=[],
+            nodes=workflow_manifest(parsed_workflow),
+            base_url=target.base_url,
+        )
 
     if not wait:
         state = jobs_state.new(
@@ -941,6 +984,9 @@ def execute_cloud(
         state_file = jobs_state.write(state)
         _journal_run(workflow_name, submit.prompt_id, "cloud")
         watcher_spawned = _spawn_watcher(submit.prompt_id, where="cloud", notify=notify)
+
+        # Durable record + watcher exist: safe to announce.
+        _emit_queued_cloud()
 
         if renderer.is_pretty():
             from comfy_cli.output.glyphs import status_glyph
@@ -990,6 +1036,12 @@ def execute_cloud(
     state.item_map = (compose_meta or {}).get("items")
     state_file = jobs_state.write(state)
     _journal_run(workflow_name, submit.prompt_id, "cloud")
+
+    # Announced once the record is durable, and *outside* the polling try below
+    # — none of its handlers should ever see (and rewrite state for) a
+    # BrokenPipeError raised by this emit. It propagates to click/`__main__`,
+    # which exits 0 silently, with the job already recorded.
+    _emit_queued_cloud()
 
     try:
 

--- a/comfy_cli/command/run/execution.py
+++ b/comfy_cli/command/run/execution.py
@@ -163,6 +163,12 @@ class WorkflowExecution:
         # compute nodes that never fire a server-side `executed` event.
         self.cached_node_ids: list[str] = []
         self.executed_node_ids: list[str] = []
+        # Per-node issues the server reported alongside a successful (HTTP 200)
+        # queue, stashed by ``queue()`` for the caller's `queued` event. The
+        # event itself is emitted by ``comfy_cli.command.run.execute`` — only
+        # *after* the job's state file is persisted — so a consumer sees it and
+        # can immediately rely on `comfy jobs status` / `jobs ls` finding it.
+        self.validation_warnings: list[dict] = []
         # Classified verdict of a terminal server-side `execution_error`,
         # stashed by `on_error` before it raises `typer.Exit`. The `--wait`
         # caller only sees the exit, so this is how the real cause reaches
@@ -289,16 +295,11 @@ class WorkflowExecution:
 
         # 200 may still carry node_errors if some output chains failed
         # validation but others passed — surface as warnings, not a failure.
+        # Stored rather than emitted here: the contractual `queued` event is
+        # emitted by the caller once the job state file exists (see
+        # ``validation_warnings`` above and ``run._emit_queued``).
         node_errors = body.get("node_errors") if isinstance(body, dict) else None
-        validation_warnings = _node_errors_to_list(node_errors)
-
-        self.renderer.event(
-            "queued",
-            prompt_id=prompt_id,
-            client_id=self.client_id,
-            validation_warnings=validation_warnings,
-            nodes=self.workflow_manifest(),
-        )
+        self.validation_warnings = _node_errors_to_list(node_errors)
 
     def watch_execution(self):
         if self.ws is None:

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -238,7 +238,8 @@ final envelope and exits 0 without queuing.
 ### `queued`
 
 Emitted after the submit request returns success — `POST /prompt` returning
-200 locally, the equivalent cloud submit under `--where cloud`.
+200 locally, the equivalent cloud submit under `--where cloud` — **and** after
+the job's state file has been persisted.
 
 ```json
 {
@@ -262,8 +263,12 @@ Emitted after the submit request returns success — `POST /prompt` returning
 | `nodes`               | array of dict | Manifest of every node in the submitted (post-conversion) workflow: `node_id` (str), `class_type` (str), `title` (str). Lets piped consumers render a per-node UI without the workflow file. |
 | `base_url`            | str           | **Cloud only.** The cloud endpoint the prompt was submitted to. Absent on `--where local`. |
 
-`queued` is emitted **after** the submit call returns successfully, on both
-targets — it means the server has the prompt. A run whose submit fails emits
+`queued` is emitted **after** the submit call returns successfully **and after
+the job's state file has been persisted** — on the async (`--no-wait`) paths,
+after the background watcher spawn attempt too. On both targets it therefore
+means more than "the server has the prompt": the durable record exists, so a
+consumer may run `comfy jobs status <prompt_id>` — or expect the job in
+`comfy jobs ls` — the moment it reads this line. A run whose submit fails emits
 its error envelope with no `queued` line at all.
 
 ### `executing`

--- a/tests/comfy_cli/command/test_run_json.py
+++ b/tests/comfy_cli/command/test_run_json.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import tempfile
 import urllib.error
 from unittest.mock import MagicMock, patch
@@ -2035,3 +2036,240 @@ class TestMalformedRejectionPayloadStillYieldsAnEnvelope:
         assert exit_code == 1
         assert _envelope(lines)["error"]["code"] == "prompt_rejected"
         assert "node 1 (X): bad" in _envelope(lines)["error"]["hint"]
+
+
+# --------------------------------------------------------------------------
+# `queued` is emitted only after the job's durable state exists (BE-6072)
+#
+# The event used to precede `jobs_state.write` on every path. That made
+# state-file-backed follow-ups (`jobs ls`, `jobs wait`, compose's item_map)
+# raceable against a just-queued job, and — worse — let a `BrokenPipeError` at
+# the emit (`comfy run … --json-stream | head -n1`) abort setup before the
+# record was ever written, while `__main__`'s broken-pipe handling still exited
+# 0: a billable cloud job with no journal entry, no state file and no watcher.
+# These tests pin the ordering and the propagation on all four paths.
+# --------------------------------------------------------------------------
+
+
+class _TapStream:
+    """Stand-in for the renderer's machine stream.
+
+    `on_line` sees every NDJSON line before it is written and may raise to
+    simulate a closed stdout. Writes delegate to ``sys.stdout`` at call time so
+    `capsys` still captures the stream.
+    """
+
+    def __init__(self, on_line):
+        self.on_line = on_line
+
+    def write(self, s: str) -> int:
+        self.on_line(s)
+        return sys.stdout.write(s)
+
+    def flush(self) -> None:
+        sys.stdout.flush()
+
+
+def _tap_queued(renderer, callback):
+    """Invoke `callback` just before each `queued` line reaches the stream."""
+
+    def on_line(s: str) -> None:
+        try:
+            payload = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            return
+        if isinstance(payload, dict) and payload.get("type") == "queued":
+            callback()
+
+    renderer.machine_stream = _TapStream(on_line)
+
+
+def _raise_broken_pipe() -> None:
+    """What writing an NDJSON line to a closed stdout (`… | head -n1`) does."""
+    raise BrokenPipeError(32, "Broken pipe")
+
+
+def _recording_write(writes: list):
+    """A ``jobs_state.write`` stand-in that records each persisted prompt_id."""
+
+    def fake_write(state):
+        writes.append(state.prompt_id)
+        return "/tmp/s.json"
+
+    return fake_write
+
+
+def _recording_spawn(spawned: list):
+    """A ``_spawn_watcher`` stand-in that records each spawn attempt."""
+
+    def fake_spawn(prompt_id, **_kw):
+        spawned.append(prompt_id)
+        return True
+
+    return fake_spawn
+
+
+def _log_state_writes(monkeypatch, log):
+    """Record every ``jobs_state.write`` (which ``_write_state`` delegates to)
+    in `log`, keeping the real return contract (a path)."""
+    from comfy_cli import jobs_state as jobs_state_mod
+
+    def fake_write(state):
+        log.append(("state_write",))
+        return "/tmp/state.json"
+
+    monkeypatch.setattr(jobs_state_mod, "write", fake_write)
+
+
+def _local_ws_that_finishes(MockWs):
+    ws_instance = MagicMock()
+    MockWs.return_value = ws_instance
+    ws_instance.recv.side_effect = [
+        json.dumps({"type": "executing", "data": {"prompt_id": "p", "node": None}}),
+    ]
+    return ws_instance
+
+
+class TestQueuedFollowsStatePersistence:
+    """Ordering spies: `state_write` must precede `queued_emit` on all four
+    target × wait-mode combinations."""
+
+    def test_local_async(self, monkeypatch, workflow_file, capsys, ndjson_renderer):
+        log: list[tuple] = []
+        _log_state_writes(monkeypatch, log)
+        _tap_queued(ndjson_renderer, lambda: log.append(("queued_emit",)))
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open,
+            patch("comfy_cli.command.run._spawn_watcher", return_value=True),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "p"}).encode()
+            _lines, exit_code = _run_execute_capture(workflow_file, capsys, wait=False)
+        assert exit_code == 0
+        assert ("queued_emit",) in log
+        assert log.index(("state_write",)) < log.index(("queued_emit",))
+
+    def test_local_wait(self, monkeypatch, workflow_file, capsys, ndjson_renderer):
+        log: list[tuple] = []
+        _log_state_writes(monkeypatch, log)
+        _tap_queued(ndjson_renderer, lambda: log.append(("queued_emit",)))
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open,
+            patch("comfy_cli.command.run.WebSocket") as MockWs,
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "p"}).encode()
+            _local_ws_that_finishes(MockWs)
+            _lines, exit_code = _run_execute_capture(workflow_file, capsys, wait=True)
+        assert exit_code == 0
+        assert ("queued_emit",) in log
+        assert log.index(("state_write",)) < log.index(("queued_emit",))
+
+    @pytest.mark.parametrize("wait", [False, True])
+    def test_cloud(self, monkeypatch, workflow_file, capsys, ndjson_renderer, wait):
+        log: list[tuple] = []
+        _install_cloud_stubs(monkeypatch, client_cls=_fake_client())
+        # After the stubs, so this write spy wins over their no-op one.
+        _log_state_writes(monkeypatch, log)
+        _tap_queued(ndjson_renderer, lambda: log.append(("queued_emit",)))
+        _lines, exit_code = _cloud_capture(capsys, workflow_file, wait=wait, timeout=5)
+        assert exit_code == 0
+        assert ("queued_emit",) in log
+        assert log.index(("state_write",)) < log.index(("queued_emit",))
+
+
+class TestBrokenPipeAtTheQueuedEmit:
+    """A closed stdout at the `queued` line is the consumer leaving. It must
+    propagate as itself — `__main__` turns that into the documented silent exit
+    0 — and only ever after the durable record (and the watcher) exist."""
+
+    def test_local_async_persists_before_it_raises(self, monkeypatch, workflow_file, capsys, ndjson_renderer):
+        writes: list[str] = []
+        spawned: list[str] = []
+        from comfy_cli import jobs_state as jobs_state_mod
+
+        monkeypatch.setattr(jobs_state_mod, "write", _recording_write(writes))
+        _tap_queued(ndjson_renderer, _raise_broken_pipe)
+
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open,
+            patch("comfy_cli.command.run._spawn_watcher", side_effect=_recording_spawn(spawned)),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "p"}).encode()
+            with pytest.raises(BrokenPipeError):
+                execute(workflow_file, host="127.0.0.1", port=8188, wait=False, verbose=False, timeout=30)
+        capsys.readouterr()
+        assert writes == ["p"]
+        assert spawned == ["p"]
+
+    def test_cloud_async_persists_before_it_raises(self, monkeypatch, workflow_file, capsys, ndjson_renderer):
+        from comfy_cli.command.run import execute_cloud
+
+        writes: list[str] = []
+        spawned: list[str] = []
+        _install_cloud_stubs(monkeypatch, client_cls=_fake_client())
+        from comfy_cli import jobs_state as jobs_state_mod
+        from comfy_cli.command import run as run_pkg
+
+        monkeypatch.setattr(jobs_state_mod, "write", _recording_write(writes))
+        monkeypatch.setattr(run_pkg, "_spawn_watcher", _recording_spawn(spawned))
+        _tap_queued(ndjson_renderer, _raise_broken_pipe)
+
+        with pytest.raises(BrokenPipeError):
+            execute_cloud(workflow_file, wait=False, timeout=5)
+        capsys.readouterr()
+        assert writes == ["cloud-pid"]
+        assert spawned == ["cloud-pid"]
+
+    def test_local_wait_leaves_the_running_record_intact(self, monkeypatch, workflow_file, capsys, ndjson_renderer):
+        """The relocated emit sits inside the `except (WebSocketException,
+        ConnectionError, OSError)` block's try. Without the handler's
+        BrokenPipeError guard a closed stdout would be misreported as
+        `ws_disconnected` *and* rewrite this healthy record to error/server_died."""
+        from comfy_cli import jobs_state as jobs_state_mod
+
+        _tap_queued(ndjson_renderer, _raise_broken_pipe)
+        with (
+            patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
+            patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open,
+            patch("comfy_cli.command.run.WebSocket") as MockWs,
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "p"}).encode()
+            _local_ws_that_finishes(MockWs)
+            with pytest.raises(BrokenPipeError):
+                execute(workflow_file, host="127.0.0.1", port=8188, wait=True, verbose=False, timeout=30)
+        capsys.readouterr()
+        record = jobs_state_mod.read("p")
+        assert record is not None, "the submit-time state file must exist"
+        assert record.status == "running"
+        assert record.error is None
+
+
+class TestQueueStashesWarningsWithoutEmitting:
+    """`WorkflowExecution.queue()` no longer emits — it stashes the warnings so
+    the caller can emit the identical event after persisting state."""
+
+    def test_queue_emits_nothing_and_stashes_the_warnings(self, simple_workflow, capsys):
+        ex = _make_workflow_execution(simple_workflow)
+        body = json.dumps(
+            {
+                "prompt_id": "p",
+                "node_errors": {"3": {"errors": [{"type": "x", "message": "skipped"}], "class_type": "X"}},
+            }
+        ).encode()
+        with patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = body
+            ex.queue()
+        out, _err = capsys.readouterr()
+        assert "queued" not in out, f"queue() must not emit the event itself: {out!r}"
+        assert ex.prompt_id == "p"
+        assert ex.validation_warnings[0]["node_id"] == "3"
+
+    def test_no_node_errors_leaves_the_warnings_empty(self, simple_workflow, capsys):
+        ex = _make_workflow_execution(simple_workflow)
+        with patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "p"}).encode()
+            ex.queue()
+        capsys.readouterr()
+        assert ex.validation_warnings == []


### PR DESCRIPTION
> **STACKED — merging lands on `matt/be-6039-run-json-cloud-event-contract` (owned by #656, @mattmillerai), NOT `main`.** #656 introduces the contractual cloud `queued` event this PR relocates and touches the same lines. Review the net diff (3 files); do **not** treat this as ready to merge to `main` until #656 lands, at which point GitHub retargets this PR.

## ELI-5

`comfy run --json-stream` prints a `queued` line meaning "the server took your job." It printed that line *before* writing the little file on disk that `comfy jobs ls` / `comfy jobs status` read. So a script that saw `queued` and immediately asked "where's my job?" could be told it doesn't exist.

Worse on cloud: if the thing reading the stream had already walked away (`… | head -n1`), printing that line blew up — and it blew up *before* the file was written. The CLI's global broken-pipe handling then exited 0, so you got a cloud job you're paying for with no record of it anywhere: no journal entry, no state file, no background watcher.

This moves the line to after the record is written, on all four paths (local/cloud × `--wait`/`--no-wait`). Same line, same fields — just later.

## What changed

**Cloud (`execute_cloud`)** — the `queued` emit moves out of the shared post-submit position into each branch:
- `--no-wait`: after `jobs_state.write` + `_journal_run` + `_spawn_watcher`, before the pretty print / envelope.
- `--wait`: after `jobs_state.write` + `_journal_run`, and **outside** the polling `try` — so none of its handlers can see a `BrokenPipeError` from this emit and rewrite state for it. It propagates to click/`__main__` (silent exit 0) with the durable record already on disk, which is the correct semantics.

Both branches call one local closure so the six-field payload can't drift between them.

**Local (`WorkflowExecution.queue()` + `execute`)** — `queue()` no longer emits; it stashes `self.validation_warnings` (new, defaults `[]`) and the caller emits the identical field set via `_emit_queued()`:
- `--wait`: after `_write_state(wait_state)`, before `watch_execution()` — the documented `prompt_preview → queued → node events` order still holds.
- `--no-wait`: after `jobs_state.write` + `_spawn_watcher`, before the pretty print / envelope.

**The load-bearing guard.** Both local emit points sit inside the `try` whose handler is `except (WebSocketException, ConnectionError, OSError)`. `BrokenPipeError` is a `ConnectionError` subclass, so without a guard a closed stdout at the relocated emit would be misreported as `ws_disconnected` **and** rewrite the just-persisted healthy `running` record to `error`/`server_died`. The handler now re-raises `BrokenPipeError` as its first statement — the same principle already documented where `completed_payload` is emitted outside the `try`.

**Docs** — `docs/json-output.md#queued` now states `queued` is emitted after the submit succeeds *and* after the state file is persisted (and after the watcher spawn attempt on the async paths), so a consumer may rely on `comfy jobs status` / `jobs ls` the moment it reads the line. The field set is unchanged.

## Tests

`tests/comfy_cli/command/test_run_json.py`, ~9 new cases:

- **Ordering spies**, all four target × wait-mode combinations: `jobs_state.write` and the `queued` line each append to a shared log via a stream tap; `state_write` must precede `queued_emit`.
- **Broken pipe at the emit, async paths (local + cloud)**: the stream raises `BrokenPipeError` on the `queued` line only; asserts `jobs_state.write` and `_spawn_watcher` both ran first, and that the propagated exception is `BrokenPipeError` itself (not swallowed, not converted) so `__main__` can produce its exit 0.
- **Broken pipe at the emit, local `--wait`**: asserts the persisted record still reads `status == "running"` with no error — pinning the handler guard.
- **`queue()` stashes without emitting**, including the non-empty `validation_warnings` case (200 + `node_errors`); the existing `test_validation_warnings_on_200_with_partial_node_errors` still asserts the same warnings surface on the `queued` event in the caller's output, unchanged.

Mutation-checked both ways: dropping the handler guard fails the two broken-pipe tests (with exactly the `ws_disconnected` + state-rewrite symptom described above); hoisting either emit back above its state write fails the ordering tests.

Verification: full `pytest` green, `ruff check` / `ruff format --check` clean on every touched file. (The repo has 17 pre-existing `UP038` findings and one unformatted file, `tests/comfy_cli/command/github/test_pr.py` — none in files this PR touches.)

## Judgment calls / residual risk for the reviewer

1. **Stacked rather than blocked.** The ticket said to hand this back if #656 was still open. #656 is open but has a buildable branch, so this stacks on it per the always-stack convention instead of idling. The net diff here is only this change.

2. **The guard widens slightly beyond the relocated emit** — it catches *any* `BrokenPipeError` in that `try`, not just one from the `queued` line. Two consequences worth a reviewer's eye, neither of which any test in this PR pins:
   - A `BrokenPipeError` from the WebSocket handshake in `connect()` (before any prompt exists) now propagates as a silent exit 0 instead of `ws_disconnected` / exit 1. Narrow — a handshake failure normally surfaces as `ConnectionRefusedError`, a timeout, or a `WebSocketException`, and EPIPE on our own stdout is by far the likelier source — but it is a behavior delta.
   - A `BrokenPipeError` mid-`watch_execution` now exits 0 leaving a `running` record rather than marking `server_died`. Mid-watch broken-pipe behavior was explicitly scoped out of this change, but the guard necessarily covers it; a WS read failure yields `ConnectionResetError`, not EPIPE, so in practice this path is also a closed stdout and exiting 0 is the intended semantics. Happy to narrow the guard to the emit specifically if you'd rather keep those two cases exactly as they were.

3. **Negative-claim falsification: not applicable.** This diff adds no capability denial — no "not supported"/"unavailable" string, no new throw/deny dead-end, no test flipped to assert one. The single added `raise` is a *re-raise* that restores the CLI's already-documented broken-pipe behavior (silent exit 0) on a path that was swallowing it.
