### PR TITLE
fix(models): make model downloads atomic — stream to a .part sibling, rename on completion

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -862,8 +862,14 @@ def _download_worker(
     except DownloadCancelled:
         state.status = "cancelled"
         state.error = None
-        with contextlib.suppress(OSError):
-            pathlib.Path(state.dest).unlink(missing_ok=True)
+        # Same split as `download_cancel`: only aria2 wrote to the destination, so
+        # only aria2's leftovers are ours to delete. The httpx path raises this
+        # from inside the transfer loop, before the rename, and unwinds through
+        # `_download_file_httpx`'s own cleanup — the `.part` is already gone and
+        # anything at `dest` predates this download.
+        if state.downloader == "aria2":
+            with contextlib.suppress(OSError):
+                pathlib.Path(state.dest).unlink(missing_ok=True)
         state.completed_bytes = 0
         with contextlib.suppress(OSError):
             download_state.write_path(path, state)
@@ -933,8 +939,9 @@ def _reconciled(state: download_state.DownloadState) -> tuple[download_state.Dow
     Only a status change is written back. Persisting the byte counts a reader
     derived would let a poll racing a live worker rewind the file to whatever
     this reader happened to load a moment earlier — the worker is the only
-    writer of progress, and mid-flight its state file is the sole source of
-    truth (the destination doesn't exist yet; see :func:`download_state.reconcile`).
+    writer of progress, and mid-flight its state file is normally the sole source
+    of truth (the destination isn't written until the transfer completes; see
+    :func:`download_state.reconcile` for the caveat).
     """
     fresh = download_state.reconcile(state)
     changed = fresh.status != state.status
@@ -1014,9 +1021,30 @@ def download_cancel(
                 download_state.write(workspace, state)
 
     if state.status in download_state.TERMINAL_STATUSES:
+        # Reaching a terminal status is not the same as having reclaimed the disk.
+        # A SIGKILLed worker's *first* `download-status` poll persists reconcile's
+        # `failed` verdict, and from then on this command short-circuits here — so
+        # the only path that sweeps the `.part` file would never run, and multi-GB
+        # of it would sit there with no command able to reclaim it (unlike the old
+        # truncated file at `dest`, a `.part` is invisible to `model list` and
+        # `model remove`). Sweep here too, but only once the worker is confirmed
+        # gone: a `cancelled` record can have been written while its worker was
+        # still running (that is what the "worker may still be running" error
+        # says), and that worker would re-create whatever we removed — or worse,
+        # find the temp it is streaming into deleted underneath it.
+        reclaimed = 0
+        if state.status != "completed" and not download_state.worker_alive(state):
+            reclaimed = cleanup_partials(pathlib.Path(state.dest))
+            if reclaimed:
+                state.completed_bytes = 0
+                with contextlib.suppress(OSError, ValueError):
+                    download_state.write(workspace, state)
         payload = download_state.status_payload(state)
-        print(f"Download {download_id} is already {state.status}; nothing to cancel.")
-        renderer.emit(payload, command="model download-cancel", changed=False)
+        if reclaimed:
+            print(f"Download {download_id} is already {state.status}; reclaimed its partial file.")
+        else:
+            print(f"Download {download_id} is already {state.status}; nothing to cancel.")
+        renderer.emit(payload, command="model download-cancel", changed=bool(reclaimed))
         return
 
     # Sentinel first, then the signal. The sentinel is what a worker that is
@@ -1059,10 +1087,17 @@ def download_cancel(
             state.completed_bytes = size
     else:
         if stopped:
-            if size is not None:
-                # aria2 writes straight to the destination (it resumes from its own
-                # control file), so an unfinished aria2 transfer still leaves its
-                # bytes here.
+            # Only aria2 writes straight to the destination (it resumes from its
+            # own control file), so only an unfinished *aria2* transfer leaves its
+            # bytes here. The httpx path never writes through the destination, so
+            # a file sitting at `dest` after an httpx cancel is either one that
+            # predates this download — which `download_file` promises survives
+            # either way — or a rename that just landed, e.g. an unknown-length
+            # transfer (`total_bytes` is None, so the `finished` check above can't
+            # see it) whose worker was killed between the rename and persisting
+            # `completed`. Deleting it would destroy a complete model this command
+            # never wrote.
+            if size is not None and state.downloader == "aria2":
                 with contextlib.suppress(OSError):
                     partial.unlink()
                     removed = True

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -21,6 +21,7 @@ from comfy_cli.file_utils import (
     DownloadException,
     _friendly_network_error,
     check_unauthorized,
+    cleanup_partials,
     download_file,
 )
 from comfy_cli.output import get_renderer
@@ -929,10 +930,11 @@ def _render_download_rows(rows: list[dict]) -> None:
 def _reconciled(state: download_state.DownloadState) -> tuple[download_state.DownloadState, bool]:
     """Reconcile ``state`` against reality, persisting a *status* correction.
 
-    Only a status change is written back. Byte counts are re-derived from
-    ``stat(dest)`` on every poll anyway, so persisting them buys nothing — and
-    would let a poll racing a live worker rewind the file to whatever this
-    reader happened to load a moment earlier.
+    Only a status change is written back. Persisting the byte counts a reader
+    derived would let a poll racing a live worker rewind the file to whatever
+    this reader happened to load a moment earlier — the worker is the only
+    writer of progress, and mid-flight its state file is the sole source of
+    truth (the destination doesn't exist yet; see :func:`download_state.reconcile`).
     """
     fresh = download_state.reconcile(state)
     changed = fresh.status != state.status
@@ -1056,9 +1058,20 @@ def download_cancel(
         if size is not None:
             state.completed_bytes = size
     else:
-        if stopped and size is not None:
-            with contextlib.suppress(OSError):
-                partial.unlink()
+        if stopped:
+            if size is not None:
+                # aria2 writes straight to the destination (it resumes from its own
+                # control file), so an unfinished aria2 transfer still leaves its
+                # bytes here.
+                with contextlib.suppress(OSError):
+                    partial.unlink()
+                    removed = True
+            # The httpx downloader streams into a `.part` sibling and only renames
+            # onto the destination once the transfer completes, so a worker killed
+            # mid-flight leaves its gigabytes *there*, not at `dest`. Without this
+            # sweep the cancel would report success and reclaim nothing — the exact
+            # hand-cleanup this command exists to spare the user.
+            if cleanup_partials(partial):
                 removed = True
         state.status = "cancelled"
         state.error = None if stopped else "worker may still be running; partial file left in place"

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -422,7 +422,14 @@ def reconcile(state: DownloadState, *, pid_alive=None) -> DownloadState:
     stranger who inherited its pid (see :func:`worker_alive`). Corrections:
 
     * ``completed_bytes`` prefers a live ``stat(dest)`` over the last value the
-      worker managed to persist — the file on disk is the ground truth.
+      worker managed to persist — when there *is* a file at ``dest``, it is the
+      ground truth. The httpx downloader writes atomically (into a ``.part``
+      sibling, renamed on completion), so mid-flight that stat finds nothing and
+      the worker's own progress writes stand unmodified — which is what we want:
+      a truncated file's length was never a meaningful progress reading, and the
+      state file is the contract `download-status` reports from. Keep the stat:
+      it is what turns "worker SIGKILLed after the rename but before it could
+      write ``completed``" into ``completed`` rather than ``failed``.
     * a ``starting`` record that hasn't claimed a pid yet is left alone for
       :data:`STARTUP_GRACE_S`; that window is the worker's interpreter startup.
     * an active status whose worker is gone becomes ``completed`` when the file

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -422,14 +422,18 @@ def reconcile(state: DownloadState, *, pid_alive=None) -> DownloadState:
     stranger who inherited its pid (see :func:`worker_alive`). Corrections:
 
     * ``completed_bytes`` prefers a live ``stat(dest)`` over the last value the
-      worker managed to persist — when there *is* a file at ``dest``, it is the
-      ground truth. The httpx downloader writes atomically (into a ``.part``
-      sibling, renamed on completion), so mid-flight that stat finds nothing and
-      the worker's own progress writes stand unmodified — which is what we want:
-      a truncated file's length was never a meaningful progress reading, and the
-      state file is the contract `download-status` reports from. Keep the stat:
-      it is what turns "worker SIGKILLed after the rename but before it could
-      write ``completed``" into ``completed`` rather than ``failed``.
+      worker managed to persist — when there *is* a file at ``dest``, it is taken
+      as ground truth. The httpx downloader writes atomically (into a ``.part``
+      sibling, renamed on completion), so for the case the submit path guarantees
+      — a destination that was absent when the download started — that stat finds
+      nothing mid-flight and the worker's own progress writes stand unmodified,
+      which is what we want: a truncated file's length was never a meaningful
+      progress reading, and the state file is the contract `download-status`
+      reports from. Keep the stat: it is what turns "worker SIGKILLed after the
+      rename but before it could write ``completed``" into ``completed`` rather
+      than ``failed``. The stat cannot, however, tell a landed rename apart from
+      a file something *else* dropped at ``dest`` after submission; such a file's
+      size is then adopted as this download's progress.
     * a ``starting`` record that hasn't claimed a pid yet is left alone for
       :data:`STARTUP_GRACE_S`; that window is the worker's interpreter startup.
     * an active status whose worker is gone becomes ``completed`` when the file

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -16,28 +16,47 @@ from pathspec import PathSpec
 from comfy_cli import constants, ui
 from comfy_cli.output.sanitize import sanitize_value
 
+# The process umask, captured once at import. os has no getter, so reading it
+# means the classic set-and-restore dance; doing it here (single-threaded under
+# the import lock) avoids re-running that dance per write, where it would leave
+# a window in which any *other* thread's file lands at 0666/0777 — and where two
+# overlapping probes can restore each other's zero and strand the umask at 0.
+# Same reasoning, same idiom as `comfy_cli.command.transfer`.
+_UMASK = os.umask(0)
+os.umask(_UMASK)
 
-def _apply_destination_mode(tmp_name: str, path: pathlib.Path) -> None:
+
+def _apply_destination_mode(fd: int, path: pathlib.Path) -> None:
     """Give a mkstemp tmp file the permissions its destination should end up with.
 
     ``tempfile.mkstemp`` hardcodes the tmp file to 0600, and ``os.replace`` carries
     that mode onto the destination — so without this, writing through a tmp sibling
     would quietly strip the group/other read access a plain ``open(path, "w")``
     would have granted, turning a shared model file owner-only. Reuse the existing
-    destination's bits when there is one, else fall back to the umask-derived
-    default a fresh ``open()`` would have produced (0666 & ~umask).
+    destination's permission bits when there is one, else fall back to the
+    umask-derived default a fresh ``open()`` would have produced (0666 & ~umask).
 
-    Best-effort: a filesystem without POSIX permissions (Windows) is left alone,
-    matching the surrounding fsync handling.
+    Only the 0o777 bits are copied: ``os.replace`` would otherwise carry a set-ID
+    (or sticky) destination's bits onto freshly downloaded, network-controlled
+    bytes, where an in-place write would have cleared them.
+
+    Applied to the open descriptor rather than the tmp file's *name*: ``os.chmod``
+    resolves a path and follows symlinks, so a name swap between ``mkstemp`` and
+    the chmod would retarget the mode change at an arbitrary file (CWE-59) —
+    reopening the exact race ``mkstemp``'s ``O_EXCL`` was chosen to close.
+
+    Best-effort: a platform without POSIX permissions (Windows has no ``fchmod``)
+    is left alone, matching the surrounding fsync handling.
     """
+    fchmod = getattr(os, "fchmod", None)
+    if fchmod is None:
+        return
     try:
-        dest_mode = stat.S_IMODE(os.stat(path).st_mode)
+        dest_mode = stat.S_IMODE(os.stat(path).st_mode) & 0o777
     except OSError:
-        umask = os.umask(0)
-        os.umask(umask)
-        dest_mode = 0o666 & ~umask
+        dest_mode = 0o666 & ~_UMASK
     try:
-        os.chmod(tmp_name, dest_mode)
+        fchmod(fd, dest_mode)
     except OSError:
         pass
 
@@ -77,7 +96,9 @@ def atomic_write_text(path: pathlib.Path, content: str, *, fsync: bool = False) 
                     os.fsync(f.fileno())  # O_RDWR fd, so fsync works on Windows too
                 except OSError:
                     pass
-        _apply_destination_mode(tmp_name, path)
+            # Inside the `with`: the mode is applied through this descriptor, so
+            # it has to happen before the file object closes it.
+            _apply_destination_mode(f.fileno(), path)
         os.replace(tmp_name, path)
         if fsync:
             # Also fsync the parent directory so the rename itself is durable.
@@ -379,6 +400,36 @@ _PART_SUFFIX = ".part"
 # unrelated user file that happens to sit beside the model and end in ".part".
 _MKSTEMP_TOKEN_LEN = 8
 _MKSTEMP_TOKEN_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
+# A filesystem caps one path *component* (NAME_MAX: 255 bytes on Linux/ext4,
+# APFS and NTFS the same in practice), and mkstemp builds `<prefix><8><suffix>`
+# — so the prefix has to leave 8 + len(".part") bytes free or the create fails
+# with ENAMETOOLONG where the old `open(dest, "wb")` succeeded. Destination
+# names come from remote metadata (CivitAI `file["name"]`, HF path) and from
+# `--filename`, none of which cap length, so this is reachable input rather
+# than a hypothetical.
+_NAME_MAX = 255
+# What is left for the destination name once the separating ".", mkstemp's token
+# and the ".part" suffix have taken their share.
+_PART_STEM_MAX = _NAME_MAX - len(".") - _MKSTEMP_TOKEN_LEN - len(_PART_SUFFIX)
+
+
+def _part_prefix(name: str) -> str:
+    """The mkstemp ``prefix`` used for ``name``'s ``.part`` siblings.
+
+    Normally just ``name + "."``. A destination name too long to also carry the
+    token and suffix is truncated to fit — on a *byte* basis, since NAME_MAX
+    counts bytes, but on a character boundary so the result stays valid UTF-8.
+    The trailing ``"."`` is appended after the cut, so the prefix always ends in
+    the separator :func:`partial_paths_for` slices on.
+
+    Two destination names agreeing for that many bytes then share a temp
+    namespace, which only affects which temps :func:`cleanup_partials` claims —
+    a far smaller problem than being unable to name a temp at all.
+    """
+    encoded = name.encode("utf-8", "surrogatepass")
+    if len(encoded) > _PART_STEM_MAX:
+        name = encoded[:_PART_STEM_MAX].decode("utf-8", "ignore")
+    return name + "."
 
 
 def partial_paths_for(local_filepath: pathlib.Path) -> list[pathlib.Path]:
@@ -388,7 +439,7 @@ def partial_paths_for(local_filepath: pathlib.Path) -> list[pathlib.Path]:
     own cleanup, so its ``.part`` file outlives it. This is how the cancel path
     finds those bytes; nothing else on disk is ever matched.
     """
-    prefix = local_filepath.name + "."
+    prefix = _part_prefix(local_filepath.name)
     try:
         entries = list(local_filepath.parent.iterdir())
     except OSError:
@@ -513,14 +564,26 @@ def _download_file_httpx(
         # pre-planted symlink can't redirect the write (CWE-377).
         fd, tmp_name = tempfile.mkstemp(
             dir=str(local_filepath.parent),
-            prefix=local_filepath.name + ".",
+            prefix=_part_prefix(local_filepath.name),
             suffix=_PART_SUFFIX,
         )
-        if state is not None:
-            state["file_opened"] = True
-            state["part_path"] = tmp_name
         try:
-            with os.fdopen(fd, "wb") as f:
+            try:
+                part_file = os.fdopen(fd, "wb")
+            except BaseException:
+                # fdopen only fails *before* taking ownership of the descriptor,
+                # so this is the one place the raw fd still has to be closed by
+                # hand; everywhere below, closing is the file object's job.
+                os.close(fd)
+                raise
+            if state is not None:
+                # Path first, flag second. `download_file`'s interrupt prompt is
+                # gated on the flag but deletes via the path, so the reverse order
+                # lets a KeyboardInterrupt landing in between ask the user about a
+                # partial it then silently declines to remove.
+                state["part_path"] = tmp_name
+                state["file_opened"] = True
+            with part_file as f:
                 # Announce the size (and the zeroed counter) before the first chunk
                 # so a background observer stops reporting `total_bytes: null` as
                 # soon as the headers are in.
@@ -534,7 +597,7 @@ def _download_file_httpx(
                     f.write(data)
                     completed += len(data)
                     _report_progress(progress_callback, completed, total)
-            _apply_destination_mode(tmp_name, local_filepath)
+                _apply_destination_mode(f.fileno(), local_filepath)
             os.replace(tmp_name, local_filepath)
         except KeyboardInterrupt:
             # The one failure that leaves the partial behind: download_file prompts

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -17,6 +17,31 @@ from comfy_cli import constants, ui
 from comfy_cli.output.sanitize import sanitize_value
 
 
+def _apply_destination_mode(tmp_name: str, path: pathlib.Path) -> None:
+    """Give a mkstemp tmp file the permissions its destination should end up with.
+
+    ``tempfile.mkstemp`` hardcodes the tmp file to 0600, and ``os.replace`` carries
+    that mode onto the destination — so without this, writing through a tmp sibling
+    would quietly strip the group/other read access a plain ``open(path, "w")``
+    would have granted, turning a shared model file owner-only. Reuse the existing
+    destination's bits when there is one, else fall back to the umask-derived
+    default a fresh ``open()`` would have produced (0666 & ~umask).
+
+    Best-effort: a filesystem without POSIX permissions (Windows) is left alone,
+    matching the surrounding fsync handling.
+    """
+    try:
+        dest_mode = stat.S_IMODE(os.stat(path).st_mode)
+    except OSError:
+        umask = os.umask(0)
+        os.umask(umask)
+        dest_mode = 0o666 & ~umask
+    try:
+        os.chmod(tmp_name, dest_mode)
+    except OSError:
+        pass
+
+
 def atomic_write_text(path: pathlib.Path, content: str, *, fsync: bool = False) -> None:
     """Atomically write ``content`` to ``path`` via a sibling tmp file + ``os.replace``.
 
@@ -52,22 +77,7 @@ def atomic_write_text(path: pathlib.Path, content: str, *, fsync: bool = False) 
                     os.fsync(f.fileno())  # O_RDWR fd, so fsync works on Windows too
                 except OSError:
                     pass
-        # mkstemp hardcodes the tmp file to 0600, and os.replace carries that mode
-        # onto the destination — so without this a first atomic write would quietly
-        # strip the group/other read access a shared output is meant to have. Restore
-        # the intended mode before the rename: reuse the existing destination's bits,
-        # else fall back to the umask-derived default (0666 & ~umask) for a new file.
-        try:
-            dest_mode = stat.S_IMODE(os.stat(path).st_mode)
-        except OSError:
-            umask = os.umask(0)
-            os.umask(umask)
-            dest_mode = 0o666 & ~umask
-        try:
-            os.chmod(tmp_name, dest_mode)
-        except OSError:
-            # Windows / filesystems without POSIX perms: best-effort, matching fsync.
-            pass
+        _apply_destination_mode(tmp_name, path)
         os.replace(tmp_name, path)
         if fsync:
             # Also fsync the parent directory so the rename itself is durable.
@@ -357,6 +367,61 @@ def _cleanup_partial(filepath: pathlib.Path) -> None:
         pass
 
 
+# The httpx downloader streams into a sibling of the destination named
+# ``<dest name>.<mkstemp token>.part`` and renames it onto the destination only
+# once the last byte has landed. The suffix is public in the sense that a killed
+# transfer leaves one on disk, so `download-cancel` has to be able to find it —
+# hence `partial_paths_for` below rather than an ad-hoc glob at the call site.
+_PART_SUFFIX = ".part"
+# ``tempfile.mkstemp`` fills the middle with exactly 8 characters from this
+# alphabet (``tempfile._RandomNameSequence``). Matching its shape — not just the
+# prefix and suffix — is what stops `partial_paths_for` from claiming an
+# unrelated user file that happens to sit beside the model and end in ".part".
+_MKSTEMP_TOKEN_LEN = 8
+_MKSTEMP_TOKEN_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789_")
+
+
+def partial_paths_for(local_filepath: pathlib.Path) -> list[pathlib.Path]:
+    """Every ``.part`` sibling this module would have created for ``local_filepath``.
+
+    A transfer killed uncleanly (SIGKILL, OOM, power loss) never gets to run its
+    own cleanup, so its ``.part`` file outlives it. This is how the cancel path
+    finds those bytes; nothing else on disk is ever matched.
+    """
+    prefix = local_filepath.name + "."
+    try:
+        entries = list(local_filepath.parent.iterdir())
+    except OSError:
+        return []
+
+    matches = []
+    for entry in entries:
+        name = entry.name
+        if not name.startswith(prefix) or not name.endswith(_PART_SUFFIX):
+            continue
+        token = name[len(prefix) : -len(_PART_SUFFIX)]
+        if len(token) != _MKSTEMP_TOKEN_LEN or not set(token) <= _MKSTEMP_TOKEN_CHARS:
+            continue
+        matches.append(entry)
+    return sorted(matches)
+
+
+def cleanup_partials(local_filepath: pathlib.Path) -> int:
+    """Best-effort removal of every ``.part`` sibling; returns how many went away.
+
+    Used by `download-cancel`, which promises to reclaim the disk a dead worker
+    was using. The destination itself is never touched here.
+    """
+    removed = 0
+    for partial in partial_paths_for(local_filepath):
+        try:
+            partial.unlink()
+        except OSError:
+            continue
+        removed += 1
+    return removed
+
+
 def _friendly_network_error(exc: Exception) -> str:
     """Return a user-friendly description of a network error."""
     if isinstance(exc, _TransientHTTPStatusError):
@@ -392,16 +457,29 @@ def _download_file_httpx(
 ) -> None:
     """Download a file using httpx streaming. Raises on HTTP or network errors.
 
+    The bytes stream into a uniquely-named ``.part`` sibling of ``local_filepath``
+    and are renamed onto it with ``os.replace`` only after the last chunk lands, so
+    the destination only ever transitions absent→complete (or old-complete→
+    new-complete). A transfer killed uncleanly — SIGKILL, OOM, power loss, none of
+    which run any Python cleanup — therefore leaves a ``.part`` file rather than a
+    truncated model at the path ComfyUI is about to load from. Same-directory
+    sibling keeps the rename on one filesystem, and therefore atomic, exactly as
+    :func:`atomic_write_text` documents for text.
+
     ``progress_callback`` (optional) receives ``(completed_bytes, total_bytes)``
     as chunks land — ``total_bytes`` comes from Content-Length and is None when
     the server doesn't send one. It fires once with ``(0, total)`` before the
     first chunk so a caller learns the size as soon as the headers are read.
 
     If ``state`` is provided, ``state["file_opened"]`` is set to True immediately
-    after the output file is opened for writing. Callers use this to distinguish
-    failures raised *before* the destination was touched (HTTP errors, ConnectError,
-    etc.) from failures raised *after* writing started (mid-stream ReadTimeout),
-    so they can avoid deleting an unrelated pre-existing file at the destination.
+    after the output file is opened for writing, and ``state["part_path"]`` holds
+    that file's path. Callers use the flag to distinguish failures raised *before*
+    any bytes were written (HTTP errors, ConnectError, etc.) from failures raised
+    *after* writing started (mid-stream ReadTimeout) — it now guards the temp file
+    rather than the destination, since the destination is no longer written
+    through. Every failure path unlinks the temp before re-raising, with one
+    deliberate exception: a :class:`KeyboardInterrupt` leaves it in place so
+    :func:`download_file` can ask the user whether to keep the partial.
     """
     with httpx.stream("GET", url, follow_redirects=True, headers=headers, timeout=_DOWNLOAD_TIMEOUT) as response:
         if response.status_code != 200:
@@ -430,22 +508,44 @@ def _download_file_httpx(
         else:
             description = "Downloading..."
 
-        with open(local_filepath, "wb") as f:
-            if state is not None:
-                state["file_opened"] = True
-            # Announce the size (and the zeroed counter) before the first chunk
-            # so a background observer stops reporting `total_bytes: null` as
-            # soon as the headers are in.
-            _report_progress(progress_callback, 0, total)
-            completed = 0
-            for data in ui.show_progress(
-                response.iter_bytes(),
-                total,
-                description=description,
-            ):
-                f.write(data)
-                completed += len(data)
-                _report_progress(progress_callback, completed, total)
+        # O_CREAT | O_EXCL and no symlink following, in the destination's own
+        # directory: concurrent transfers never collide on a shared name, and a
+        # pre-planted symlink can't redirect the write (CWE-377).
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(local_filepath.parent),
+            prefix=local_filepath.name + ".",
+            suffix=_PART_SUFFIX,
+        )
+        if state is not None:
+            state["file_opened"] = True
+            state["part_path"] = tmp_name
+        try:
+            with os.fdopen(fd, "wb") as f:
+                # Announce the size (and the zeroed counter) before the first chunk
+                # so a background observer stops reporting `total_bytes: null` as
+                # soon as the headers are in.
+                _report_progress(progress_callback, 0, total)
+                completed = 0
+                for data in ui.show_progress(
+                    response.iter_bytes(),
+                    total,
+                    description=description,
+                ):
+                    f.write(data)
+                    completed += len(data)
+                    _report_progress(progress_callback, completed, total)
+            _apply_destination_mode(tmp_name, local_filepath)
+            os.replace(tmp_name, local_filepath)
+        except KeyboardInterrupt:
+            # The one failure that leaves the partial behind: download_file prompts
+            # the user about it, and deleting it here would make "no" unanswerable.
+            raise
+        except BaseException:
+            # BaseException, not Exception, so a DownloadCancelled (or anything
+            # else a progress callback throws through the transfer loop) still
+            # reclaims the temp file's disk.
+            _cleanup_partial(pathlib.Path(tmp_name))
+            raise
 
 
 def download_file(
@@ -462,6 +562,17 @@ def download_file(
     size is known. When a retry discards a partial file the callback is reset to
     ``(0, None)`` first, so an observer never sees a counter run backwards from
     a stale high-water mark.
+
+    **The two downloaders differ in how the destination is written, deliberately.**
+    The httpx path is atomic: it streams into a ``.part`` sibling and renames onto
+    ``local_filepath`` only once the transfer completes, so no kill can strand a
+    truncated file where a complete model belongs, and each retry attempt gets its
+    own temp rather than reusing a half-written destination. ``aria2`` is left
+    writing straight to the destination on purpose — it owns its own ``.aria2``
+    control file next to the output and resumes from it, and renaming the output
+    from under aria2 would break that resume. So a killed aria2 transfer can still
+    leave a partial at the destination; that is aria2's resume state, not corruption
+    this module introduced, and `download-cancel` cleans up both shapes.
     """
     if downloader not in _VALID_DOWNLOADERS:
         raise DownloadException(
@@ -474,19 +585,21 @@ def download_file(
         return _download_file_aria2(url, local_filepath, headers, progress_callback)
 
     last_exc: Exception | None = None
-    state: dict = {"file_opened": False}
+    state: dict = {"file_opened": False, "part_path": None}
 
     for attempt in range(_DOWNLOAD_MAX_RETRIES):
         state["file_opened"] = False
+        state["part_path"] = None
         try:
             _download_file_httpx(url, local_filepath, headers, state=state, progress_callback=progress_callback)
             return
         except _RETRIABLE_EXCEPTIONS as exc:
             last_exc = exc
-            # Only clean up if _download_file_httpx actually opened the destination —
-            # otherwise we'd delete an unrelated pre-existing file at the same path.
+            # The temp file this attempt was writing is already gone (the helper
+            # unlinks it on the way out) and the destination was never touched, so
+            # there is nothing here to delete — only an observer to correct: it
+            # last heard a byte count for bytes that no longer exist anywhere.
             if state["file_opened"]:
-                _cleanup_partial(local_filepath)
                 _report_progress(progress_callback, 0, None)
             if attempt < _DOWNLOAD_MAX_RETRIES - 1:
                 wait = _DOWNLOAD_RETRY_BACKOFF * (attempt + 1)
@@ -499,17 +612,20 @@ def download_file(
             # so callers only need to handle one error type.
             # InvalidURL inherits directly from Exception (not HTTPError), hence the
             # explicit inclusion.
-            if state["file_opened"]:
-                _cleanup_partial(local_filepath)
+            # No cleanup needed: the helper already removed its temp file, and the
+            # destination is never written through.
             raise DownloadException(f"Download failed: {_friendly_network_error(exc)}") from exc
         except KeyboardInterrupt:
-            # Only prompt/cleanup if we actually opened the destination this attempt.
-            # If the interrupt arrived during connection setup, there is no partial
-            # file and the destination may hold an unrelated pre-existing file.
+            # Only prompt if we actually started writing this attempt. If the
+            # interrupt arrived during connection setup there is no partial file to
+            # ask about. The helper deliberately leaves the interrupted `.part` on
+            # disk for exactly this question; whichever way it is answered, the
+            # destination is untouched — a pre-existing file there survives either
+            # way, which is why only the temp is ever a candidate for deletion.
             if state["file_opened"]:
                 delete_eh = ui.prompt_confirm_action("Download interrupted, cleanup files?", True)
-                if delete_eh:
-                    _cleanup_partial(local_filepath)
+                if delete_eh and state["part_path"]:
+                    _cleanup_partial(pathlib.Path(state["part_path"]))
             raise
 
     raise DownloadException(

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -851,10 +851,18 @@ class TestPollVerbs:
         assert env["data"] == {"total": 0, "downloads": []}
 
     def test_cancel_kills_the_worker_and_removes_the_partial(self, workspace, json_renderer, tmp_path):
+        # aria2 is the downloader that writes straight to the destination, so it
+        # is the one whose unfinished bytes are found *at* `dest`.
         dest = tmp_path / "m.safetensors"
         dest.write_bytes(b"x" * 10)
         state = _state(
-            dest=str(dest), status="downloading", pid=5150, pid_create_time=1.0, total_bytes=100, completed_bytes=10
+            dest=str(dest),
+            status="downloading",
+            downloader="aria2",
+            pid=5150,
+            pid_create_time=1.0,
+            total_bytes=100,
+            completed_bytes=10,
         )
         download_state.write(workspace, state)
 
@@ -903,7 +911,9 @@ class TestPollVerbs:
     def test_cancel_of_a_dead_worker_still_clears_the_partial(self, workspace, json_renderer, tmp_path):
         dest = tmp_path / "m.safetensors"
         dest.write_bytes(b"x" * 10)
-        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        state = _state(
+            dest=str(dest), status="downloading", downloader="aria2", pid=5150, total_bytes=100, completed_bytes=10
+        )
         download_state.write(workspace, state)
 
         with patch.object(download_state, "is_worker_process", return_value=False):
@@ -911,6 +921,39 @@ class TestPollVerbs:
 
         assert not dest.exists()
         assert json_renderer()["data"]["status"] == "cancelled"
+
+    def test_cancel_of_an_httpx_download_never_deletes_the_destination(self, workspace, json_renderer, tmp_path):
+        """The httpx downloader only ever writes `dest` via the final rename, so
+        a file sitting there mid-transfer is one this download did not create —
+        `download_file` promises such a file survives either way — or a rename
+        that just landed. Deleting it is data loss for a file we never wrote."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"someone else's model")
+        state = _state(dest=str(dest), status="downloading", pid=5150, total_bytes=100, completed_bytes=10)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            models.download_cancel(None, download_id=state.id)
+
+        assert dest.read_bytes() == b"someone else's model"
+        assert json_renderer()["data"]["status"] == "cancelled"
+
+    def test_cancel_keeps_an_unknown_length_file_that_the_rename_just_landed(
+        self, workspace, json_renderer, monkeypatch, tmp_path
+    ):
+        """With no Content-Length there is no `total_bytes`, so the `finished`
+        check cannot recognise a complete download — and an httpx worker killed
+        between its rename and persisting `completed` leaves exactly that. The
+        file at `dest` is the finished model; deleting it is silent data loss."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"the whole model")
+        state = _state(dest=str(dest), status="downloading", pid=None, total_bytes=None)
+        download_state.write(workspace, state)
+
+        monkeypatch.setattr(download_state, "stop_worker", lambda *_a, **_k: True)
+        models.download_cancel(None, download_id=state.id)
+
+        assert dest.read_bytes() == b"the whole model"
 
     def test_cancel_of_a_terminal_download_is_a_no_op(self, workspace, json_renderer, tmp_path):
         dest = tmp_path / "m.safetensors"
@@ -1076,8 +1119,10 @@ class TestCancellationReachesTheWorker:
         assert not dest.exists()
 
     def test_worker_aborts_mid_transfer_and_clears_the_partial(self, workspace, monkeypatch, tmp_path):
+        # aria2 writes through the destination, so that is where its abandoned
+        # bytes are; see the httpx counterpart below.
         dest = tmp_path / "m.safetensors"
-        state = _state(dest=str(dest), status="starting", pid=None)
+        state = _state(dest=str(dest), status="starting", downloader="aria2", pid=None)
         path = download_state.write(workspace, state)
 
         def transfer(url, filepath, headers, downloader, progress_callback):
@@ -1096,6 +1141,30 @@ class TestCancellationReachesTheWorker:
         final = download_state.read(workspace, state.id)
         assert (final.status, final.completed_bytes) == ("cancelled", 0)
         assert not dest.exists(), "the partial file must not survive the cancel"
+
+    def test_worker_cancel_on_httpx_leaves_the_destination_alone(self, workspace, monkeypatch, tmp_path):
+        """`DownloadCancelled` unwinds out of the httpx transfer *before* the
+        rename, and `_download_file_httpx` reclaims its own `.part` on the way —
+        so the worker has nothing at `dest` to delete, and whatever is there
+        belongs to someone else."""
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"a neighbour's file")
+        state = _state(dest=str(dest), status="starting", pid=None)
+        path = download_state.write(workspace, state)
+
+        def transfer(url, filepath, headers, downloader, progress_callback):
+            download_state.request_cancel(download_state.cancel_path(workspace, state.id))
+            progress_callback(7, 4096)
+
+        monkeypatch.setattr(models, "download_file", transfer)
+        monkeypatch.setattr(download_state, "PROGRESS_THROTTLE_S", 0.0)
+
+        with pytest.raises(typer.Exit) as exc:
+            models._download_worker(state_file=str(path))
+
+        assert exc.value.exit_code == 0
+        assert download_state.read(workspace, state.id).status == "cancelled"
+        assert dest.read_bytes() == b"a neighbour's file"
 
     def test_a_transfer_that_beat_the_cancel_keeps_its_file(self, workspace, json_renderer, monkeypatch, tmp_path):
         """Both sides have to agree on this one, or cancel deletes a model that
@@ -1137,6 +1206,49 @@ class TestCancellationReachesTheWorker:
         assert not dest.exists()
         payload = json_renderer()["data"]
         assert (payload["status"], payload["completed_bytes"]) == ("cancelled", 0)
+
+    def test_cancel_reclaims_the_part_of_an_already_failed_record(self, workspace, json_renderer, tmp_path):
+        """The realistic ordering: the SIGKILLed worker's *first* `download-status`
+        poll persists reconcile's `failed` verdict, so by the time the user runs
+        `download-cancel` the record is already terminal. If that short-circuits
+        without sweeping, the multi-GB `.part` is unreclaimable — it is invisible
+        to `model list` and `model remove`, which only know about `dest`."""
+        dest = tmp_path / "m.safetensors"
+        part = tmp_path / "m.safetensors.a1b2c3d4.part"
+        part.write_bytes(b"y" * 3600)
+        state = _state(
+            dest=str(dest),
+            status="failed",
+            error="worker died before the download finished",
+            pid=5150,
+            total_bytes=13000,
+            completed_bytes=3600,
+        )
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            models.download_cancel(None, download_id=state.id)
+
+        assert not part.exists(), "a terminal record's orphaned partial is still the user's disk"
+        env = json_renderer()
+        assert env["changed"] is True
+        assert env["data"]["completed_bytes"] == 0
+        assert download_state.read(workspace, state.id).completed_bytes == 0
+
+    def test_cancel_of_a_failed_record_whose_worker_is_alive_sweeps_nothing(self, workspace, json_renderer, tmp_path):
+        """A `.part` under an live worker's pen is not ours to delete."""
+        dest = tmp_path / "m.safetensors"
+        part = tmp_path / "m.safetensors.a1b2c3d4.part"
+        part.write_bytes(b"y" * 3600)
+        state = _state(dest=str(dest), status="failed", pid=5150, pid_create_time=1.0, total_bytes=13000)
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=True):
+            with patch("comfy_cli.utils.is_running", return_value=True):
+                models.download_cancel(None, download_id=state.id)
+
+        assert part.exists()
+        assert json_renderer()["changed"] is False
 
     def test_cancel_leaves_an_unrelated_neighbour_alone(self, workspace, json_renderer, monkeypatch, tmp_path):
         dest = tmp_path / "m.safetensors"

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -1118,6 +1118,38 @@ class TestCancellationReachesTheWorker:
         assert dest.exists()
         assert json_renderer()["data"]["status"] == "completed"
 
+    def test_cancel_reclaims_the_part_file_a_killed_worker_left(self, workspace, json_renderer, monkeypatch, tmp_path):
+        """The httpx downloader streams into a `.part` sibling, so a SIGKILLed
+        worker's gigabytes are *there*, not at `dest`. Cancel has to sweep them or
+        it reports success while reclaiming nothing — the by-hand cleanup this
+        command exists to spare the user.
+        """
+        dest = tmp_path / "m.safetensors"
+        part = tmp_path / "m.safetensors.a1b2c3d4.part"
+        part.write_bytes(b"y" * 3600)
+        state = _state(dest=str(dest), status="downloading", pid=None, total_bytes=13000, completed_bytes=3600)
+        download_state.write(workspace, state)
+
+        monkeypatch.setattr(download_state, "stop_worker", lambda *_a, **_k: True)
+        models.download_cancel(None, download_id=state.id)
+
+        assert not part.exists(), "the killed worker's partial must be reclaimed"
+        assert not dest.exists()
+        payload = json_renderer()["data"]
+        assert (payload["status"], payload["completed_bytes"]) == ("cancelled", 0)
+
+    def test_cancel_leaves_an_unrelated_neighbour_alone(self, workspace, json_renderer, monkeypatch, tmp_path):
+        dest = tmp_path / "m.safetensors"
+        neighbour = tmp_path / "m.safetensors.notes.part"
+        neighbour.write_bytes(b"a user's own file")
+        state = _state(dest=str(dest), status="downloading", pid=None, total_bytes=13000)
+        download_state.write(workspace, state)
+
+        monkeypatch.setattr(download_state, "stop_worker", lambda *_a, **_k: True)
+        models.download_cancel(None, download_id=state.id)
+
+        assert neighbour.read_bytes() == b"a user's own file"
+
     def test_cancel_does_not_delete_a_finished_file_when_the_total_was_unknown(
         self, workspace, json_renderer, monkeypatch, tmp_path
     ):

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -843,12 +843,18 @@ class TestTempFileNaming:
         mock_stream.return_value = _make_ok_response(content=b"v2")
         dest = tmp_path / "model.bin"
         dest.write_bytes(b"v1")
-        os.chmod(dest, 0o4755)
+        # Owner-only under the set-ID bits: the group/other bits are what a
+        # real 4755 binary carries, but they play no part in what this asserts
+        # (that the 0o777 mask drops set-ID), and granting them here is an
+        # overly-permissive chmod in its own right. Group/other preservation is
+        # covered by test_replacing_a_file_keeps_its_permissions.
+        os.chmod(dest, stat.S_ISUID | stat.S_ISGID | stat.S_IRWXU)
+        assert dest.stat().st_mode & stat.S_ISUID, "the fixture must really carry a set-ID bit"
 
         download_file("http://example.com/model.bin", dest)
 
         mode = dest.stat().st_mode
-        assert stat.S_IMODE(mode) == 0o755
+        assert stat.S_IMODE(mode) == 0o700
         assert not mode & (stat.S_ISUID | stat.S_ISGID)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -1,5 +1,8 @@
 import json
+import os
 import pathlib
+import stat
+import sys
 from unittest.mock import Mock, patch
 
 import httpx
@@ -12,9 +15,11 @@ from comfy_cli.file_utils import (
     _friendly_network_error,
     _TransientHTTPStatusError,
     check_unauthorized,
+    cleanup_partials,
     download_file,
     extract_package_as_zip,
     guess_status_code_reason,
+    partial_paths_for,
     upload_file_to_signed_url,
 )
 
@@ -560,11 +565,17 @@ class TestDownloadPartialCleanup:
 
         mock_prompt.assert_called_once()
         assert not dest.exists()
+        assert partial_paths_for(dest) == []
 
     @patch("comfy_cli.file_utils.ui.prompt_confirm_action", return_value=False)
     @patch("httpx.stream")
     def test_keyboard_interrupt_keeps_partial_when_user_declines(self, mock_stream, mock_prompt, tmp_path):
-        """On KeyboardInterrupt the user is prompted; declining keeps the partial file on disk."""
+        """On KeyboardInterrupt the user is prompted; declining keeps the partial bytes.
+
+        They are kept as the `.part` sibling, never at the destination — the whole
+        point of the atomic write is that an interrupted transfer can't leave
+        something that looks like a finished model where ComfyUI will load it.
+        """
         resp = Mock()
         resp.status_code = 200
         resp.headers = {}
@@ -578,8 +589,261 @@ class TestDownloadPartialCleanup:
             download_file("http://example.com/model.bin", dest)
 
         mock_prompt.assert_called_once()
-        assert dest.exists()
-        assert dest.read_bytes() == b"partial data"
+        assert not dest.exists()
+        parts = partial_paths_for(dest)
+        assert len(parts) == 1
+        assert parts[0].read_bytes() == b"partial data"
+
+
+class _HardKill(BaseException):
+    """Stands in for a signal: derives from BaseException, so no `except Exception`
+    anywhere in the download path can quietly turn it into an ordinary failure."""
+
+
+class TestAtomicDestination:
+    """The destination only ever goes absent→complete (or old-complete→new-complete).
+
+    A killed transfer used to leave a truncated file sitting exactly where a
+    finished model belongs, with nothing to mark it — `search_models` and ComfyUI
+    both see a plausible file, and loading it fails far from the download that
+    caused it.
+    """
+
+    @patch("httpx.stream")
+    def test_completed_download_lands_via_rename(self, mock_stream, tmp_path):
+        """The bytes reach the destination through os.replace from a sibling temp,
+        and nothing is left behind."""
+        mock_stream.return_value = _make_ok_response(content=b"full model", content_length=10)
+        dest = tmp_path / "model.safetensors"
+
+        real_replace = os.replace
+        renames = []
+
+        def spy(src, dst, *args, **kwargs):
+            renames.append((str(src), str(dst)))
+            return real_replace(src, dst, *args, **kwargs)
+
+        with patch("comfy_cli.file_utils.os.replace", side_effect=spy):
+            download_file("http://example.com/model.safetensors", dest)
+
+        assert dest.read_bytes() == b"full model"
+        assert len(renames) == 1
+        src, dst = renames[0]
+        assert dst == str(dest)
+        assert src.startswith(str(dest) + ".") and src.endswith(".part")
+        # The temp was consumed by the rename, not left alongside the model.
+        assert partial_paths_for(dest) == []
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["model.safetensors"]
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_hard_kill_mid_transfer_leaves_nothing_at_the_destination(self, mock_stream, mock_sleep, tmp_path):
+        """Mid-stream, the destination does not exist yet — the bytes are in a
+        `.part` sibling. That is precisely the on-disk state a SIGKILL freezes,
+        and the assertion is made *from inside the stream* so no cleanup handler
+        can have run first. The stream then raises a BaseException, which no
+        `except Exception` in the download path converts into a tidy failure.
+        """
+        dest = tmp_path / "checkpoint.safetensors"
+        observed = {}
+
+        chunk = b"x" * 65536
+
+        def killed_iter():
+            # Keep streaming until bytes have actually reached the disk (a SIGKILL
+            # loses the writer's buffer too, and the question here is where the
+            # bytes that *did* land ended up), then freeze that instant.
+            for _ in range(32):
+                yield chunk
+                parts = partial_paths_for(dest)
+                if parts and parts[0].stat().st_size:
+                    # What an operator would find on disk at the moment of the kill.
+                    observed["dest_exists"] = dest.exists()
+                    observed["parts"] = [(p.name, p.read_bytes()) for p in parts]
+                    raise _HardKill("SIGKILL")
+            raise AssertionError("no bytes ever reached a .part file")
+
+        resp = Mock()
+        resp.status_code = 200
+        resp.headers = {"Content-Length": "13000000000"}
+        resp.iter_bytes = Mock(side_effect=killed_iter)
+        resp.__enter__ = Mock(return_value=resp)
+        resp.__exit__ = Mock(return_value=None)
+        mock_stream.return_value = resp
+
+        with pytest.raises(_HardKill):
+            download_file("http://example.com/checkpoint.safetensors", dest)
+
+        assert observed["dest_exists"] is False, "a truncated file must never appear at the final path"
+        assert len(observed["parts"]) == 1
+        part_name, part_bytes = observed["parts"][0]
+        assert part_name.endswith(".part")
+        # The landed bytes are a prefix of the stream (the tail may still be in the
+        # writer's buffer) — and they are in the `.part`, not at the destination.
+        assert part_bytes and part_bytes.strip(b"x") == b""
+        # And after the unwind the destination is still absent.
+        assert not dest.exists()
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_retries_never_expose_a_truncated_file_at_the_destination(self, mock_stream, mock_sleep, tmp_path):
+        """Between attempts there is nothing at the destination for a reader to
+        mistake for a finished model."""
+        dest = tmp_path / "model.bin"
+        seen_between_attempts = []
+
+        fail_resp = Mock()
+        fail_resp.status_code = 200
+        fail_resp.headers = {}
+        fail_resp.iter_bytes = Mock(side_effect=_make_failing_iter(b"stale bytes"))
+        fail_resp.__enter__ = Mock(return_value=fail_resp)
+        fail_resp.__exit__ = Mock(return_value=None)
+
+        def stream(*args, **kwargs):
+            seen_between_attempts.append((dest.exists(), len(partial_paths_for(dest))))
+            return fail_resp if len(seen_between_attempts) == 1 else _make_ok_response(content=b"fresh data")
+
+        mock_stream.side_effect = stream
+        download_file("http://example.com/model.bin", dest)
+
+        assert seen_between_attempts == [(False, 0), (False, 0)]
+        assert dest.read_bytes() == b"fresh data"
+        assert partial_paths_for(dest) == []
+
+    @patch("comfy_cli.file_utils.time.sleep")
+    @patch("httpx.stream")
+    def test_preexisting_complete_file_survives_a_failed_redownload(self, mock_stream, mock_sleep, tmp_path):
+        """A failure *after* bytes started flowing no longer destroys what was
+        already at the destination — previously the transfer had truncated it on
+        open before it ever knew whether it would succeed."""
+        resp = Mock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.iter_bytes = Mock(side_effect=_make_failing_iter(b"half a model"))
+        resp.__enter__ = Mock(return_value=resp)
+        resp.__exit__ = Mock(return_value=None)
+        mock_stream.return_value = resp
+
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"COMPLETE existing model")
+
+        with pytest.raises(DownloadException, match="Download failed after 3 attempts"):
+            download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"COMPLETE existing model"
+        assert partial_paths_for(dest) == []
+
+    @patch("httpx.stream")
+    def test_a_successful_download_replaces_an_existing_file(self, mock_stream, tmp_path):
+        """old-complete→new-complete is the other legal transition."""
+        mock_stream.return_value = _make_ok_response(content=b"v2")
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"v1")
+
+        download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"v2"
+        assert partial_paths_for(dest) == []
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    @patch("httpx.stream")
+    def test_destination_permissions_match_a_plain_write(self, mock_stream, tmp_path):
+        """mkstemp creates 0600 and os.replace carries the mode across, so without
+        an explicit chmod every downloaded model would silently become owner-only."""
+        mock_stream.return_value = _make_ok_response(content=b"data")
+        dest = tmp_path / "model.bin"
+        download_file("http://example.com/model.bin", dest)
+
+        reference = tmp_path / "reference.bin"
+        with open(reference, "wb") as f:
+            f.write(b"data")
+
+        assert stat.S_IMODE(dest.stat().st_mode) == stat.S_IMODE(reference.stat().st_mode)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    @patch("httpx.stream")
+    def test_replacing_a_file_keeps_its_permissions(self, mock_stream, tmp_path):
+        mock_stream.return_value = _make_ok_response(content=b"v2")
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"v1")
+        dest.chmod(0o640)
+
+        download_file("http://example.com/model.bin", dest)
+
+        assert stat.S_IMODE(dest.stat().st_mode) == 0o640
+
+
+class TestPartialPaths:
+    """`download-cancel` finds a dead worker's bytes through these, so the match
+    has to be tight: too loose and it deletes a user's unrelated file."""
+
+    def _make_part(self, dest, token=b"a1b2c3d4", data=b"bytes"):
+        p = dest.parent / f"{dest.name}.{token.decode()}.part"
+        p.write_bytes(data)
+        return p
+
+    def test_finds_the_temp_a_download_would_create(self, tmp_path):
+        dest = tmp_path / "model.safetensors"
+        part = self._make_part(dest)
+        assert partial_paths_for(dest) == [part]
+
+    def test_ignores_unrelated_part_files(self, tmp_path):
+        dest = tmp_path / "model.safetensors"
+        keep = [
+            tmp_path / "model.safetensors.part",  # no mkstemp token
+            tmp_path / "model.safetensors.backup.part",  # wrong token shape
+            tmp_path / "model.safetensors.a1b2c3d4.tmp",  # wrong suffix
+            tmp_path / "other.safetensors.a1b2c3d4.part",  # another download
+            tmp_path / "model.safetensors.A1B2C3D4.part",  # mkstemp never uppercases
+        ]
+        for f in keep:
+            f.write_bytes(b"do not touch")
+
+        assert partial_paths_for(dest) == []
+        assert cleanup_partials(dest) == 0
+        assert all(f.exists() for f in keep)
+
+    def test_cleanup_removes_every_match_and_reports_the_count(self, tmp_path):
+        dest = tmp_path / "model.safetensors"
+        self._make_part(dest, token=b"aaaaaaaa")
+        self._make_part(dest, token=b"bbbbbbbb")
+        unrelated = tmp_path / "keep.bin"
+        unrelated.write_bytes(b"keep")
+
+        assert cleanup_partials(dest) == 2
+        assert partial_paths_for(dest) == []
+        assert unrelated.exists()
+
+    def test_missing_directory_is_not_an_error(self, tmp_path):
+        dest = tmp_path / "nope" / "model.safetensors"
+        assert partial_paths_for(dest) == []
+        assert cleanup_partials(dest) == 0
+
+    def test_a_real_download_produces_a_matching_name(self, tmp_path):
+        """Guards the coupling between mkstemp's naming and the matcher above:
+        if either drifts, a cancel silently stops reclaiming anything."""
+        dest = tmp_path / "model.safetensors"
+
+        def killed_iter():
+            yield b"partial"
+            raise KeyboardInterrupt()
+
+        resp = Mock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.iter_bytes = Mock(side_effect=killed_iter)
+        resp.__enter__ = Mock(return_value=resp)
+        resp.__exit__ = Mock(return_value=None)
+
+        with (
+            patch("httpx.stream", return_value=resp),
+            patch("comfy_cli.file_utils.ui.prompt_confirm_action", return_value=False),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            download_file("http://example.com/model.safetensors", dest)
+
+        assert [p.read_bytes() for p in partial_paths_for(dest)] == [b"partial"]
+        assert cleanup_partials(dest) == 1
 
 
 class TestDownloadHTTPStatusRetry:

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 import requests
 
+from comfy_cli import file_utils
 from comfy_cli.file_utils import (
     DownloadException,
     _cleanup_partial,
@@ -771,6 +772,117 @@ class TestAtomicDestination:
         download_file("http://example.com/model.bin", dest)
 
         assert stat.S_IMODE(dest.stat().st_mode) == 0o640
+
+
+class TestTempFileNaming:
+    """The temp name is derived from the destination name, so the destination's
+    own length and the destination's mode both have to survive the round trip."""
+
+    @patch("httpx.stream")
+    def test_a_maximum_length_destination_name_still_downloads(self, mock_stream, tmp_path):
+        """mkstemp appends 13 bytes to the prefix, so an un-truncated prefix makes
+        any name over NAME_MAX-14 fail with ENAMETOOLONG — where the old
+        `open(dest, "wb")` succeeded. Names come from remote metadata (CivitAI
+        `file["name"]`, the HF path) and `--filename`, none of which cap length.
+        """
+        mock_stream.return_value = _make_ok_response(content=b"data")
+        # 250 bytes: a name the filesystem itself accepts (NAME_MAX is 255), but
+        # 9 bytes too long to also carry mkstemp's token and suffix.
+        dest = tmp_path / ("m" * 238 + ".safetensors")
+        assert 241 < len(dest.name.encode()) <= 255
+
+        download_file("http://example.com/model.safetensors", dest)
+
+        assert dest.read_bytes() == b"data"
+        assert partial_paths_for(dest) == []
+
+    @patch("httpx.stream")
+    def test_a_long_name_partial_is_still_reclaimable(self, mock_stream, tmp_path):
+        """Truncating the prefix is only safe if the matcher truncates identically
+        — otherwise `download-cancel` silently stops finding these."""
+        dest = tmp_path / ("m" * 238 + ".safetensors")
+
+        def killed_iter():
+            yield b"partial"
+            raise KeyboardInterrupt()
+
+        resp = Mock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.iter_bytes = Mock(side_effect=killed_iter)
+        resp.__enter__ = Mock(return_value=resp)
+        resp.__exit__ = Mock(return_value=None)
+        mock_stream.return_value = resp
+
+        with (
+            patch("comfy_cli.file_utils.ui.prompt_confirm_action", return_value=False),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            download_file("http://example.com/model.safetensors", dest)
+
+        assert [p.read_bytes() for p in partial_paths_for(dest)] == [b"partial"]
+        assert cleanup_partials(dest) == 1
+
+    def test_a_non_ascii_name_is_truncated_on_a_character_boundary(self, tmp_path):
+        """NAME_MAX counts bytes, so the cut is a byte cut — but it must not
+        produce an invalid-UTF-8 name that no filesystem call can round-trip."""
+        dest = tmp_path / ("é" * 200 + ".safetensors")
+        prefix = file_utils._part_prefix(dest.name)
+
+        assert len(prefix.encode()) <= file_utils._PART_STEM_MAX + 1
+        assert prefix.encode().decode() == prefix  # valid UTF-8, no split codepoint
+        assert prefix.endswith("."), "the matcher slices on this separator"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    @patch("httpx.stream")
+    def test_a_setuid_destination_does_not_pass_its_set_id_bits_on(self, mock_stream, tmp_path):
+        """`os.replace` carries the temp's mode onto the destination, so copying
+        the old file's full 12-bit mode would stamp setuid/setgid onto freshly
+        downloaded, network-controlled bytes — which an in-place write would have
+        cleared."""
+        mock_stream.return_value = _make_ok_response(content=b"v2")
+        dest = tmp_path / "model.bin"
+        dest.write_bytes(b"v1")
+        os.chmod(dest, 0o4755)
+
+        download_file("http://example.com/model.bin", dest)
+
+        mode = dest.stat().st_mode
+        assert stat.S_IMODE(mode) == 0o755
+        assert not mode & (stat.S_ISUID | stat.S_ISGID)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    @patch("httpx.stream")
+    def test_the_mode_is_applied_through_the_descriptor_not_the_name(self, mock_stream, tmp_path):
+        """chmod-by-path follows symlinks, so a name swap between mkstemp and the
+        chmod would retarget it at an arbitrary file (CWE-59) — reopening the race
+        mkstemp's O_EXCL closed. fchmod on the open fd cannot be redirected."""
+        mock_stream.return_value = _make_ok_response(content=b"data")
+        dest = tmp_path / "model.bin"
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("the temp file must never be chmod'ed by path")
+
+        with patch("comfy_cli.file_utils.os.chmod", side_effect=refuse):
+            download_file("http://example.com/model.bin", dest)
+
+        assert dest.read_bytes() == b"data"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX umask")
+    @patch("httpx.stream")
+    def test_a_download_never_touches_the_process_umask(self, mock_stream, tmp_path):
+        """Probing the umask means setting it to 0 and restoring it — a window in
+        which any *other* thread's new file lands world-writable, and which two
+        overlapping probes can leave stranded at 0. It belongs at import, once."""
+        mock_stream.return_value = _make_ok_response(content=b"data")
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("the umask must not be probed per download")
+
+        with patch("comfy_cli.file_utils.os.umask", side_effect=refuse):
+            download_file("http://example.com/model.bin", tmp_path / "model.bin")
+
+        assert (tmp_path / "model.bin").read_bytes() == b"data"
 
 
 class TestPartialPaths:


### PR DESCRIPTION
## ELI-5

When you download a model, the CLI used to write the bytes straight into the file's final name. If the download got killed halfway — a client timeout that kills the process group, the machine running out of memory, a crash, someone pulling the plug — a half-a-model file was left sitting exactly where a finished model belongs, with nothing to say it was broken. ComfyUI would happily try to load it and fail in a confusing way much later.

Now the bytes go into a scratch file next to the destination, named `model.safetensors.<random>.part`, and it only gets renamed onto the real name once the very last byte has arrived. A rename within one directory is atomic, so the destination is only ever "not there" or "the whole thing" — never something in between. Kill the download at any moment and you get an obviously-named `.part` file you can delete, instead of a booby-trapped model.

## What changed

- `comfy_cli/file_utils.py` — `_download_file_httpx` streams into a `tempfile.mkstemp` sibling of the destination (`O_CREAT | O_EXCL`, no symlink following, so concurrent transfers can't collide and a pre-planted symlink can't redirect the write) and `os.replace`s it onto the destination only after the stream completes. Same-directory sibling keeps the rename on one filesystem, and therefore atomic — the same idiom `atomic_write_text` in this module already documents for text.
- Every failure path unlinks the temp before re-raising. That is `except BaseException`, not `except Exception`, so a `DownloadCancelled` raised through a progress callback still reclaims the disk. The one deliberate exception is `KeyboardInterrupt`, which leaves the temp in place so `download_file`'s existing "Download interrupted, cleanup files?" prompt still has something to be about.
- `state["file_opened"]` keeps its contract for callers, retargeted: it now marks "the temp was opened", and `state["part_path"]` carries which one. Since the destination is never written through, the concern that flag originally existed for — don't delete an unrelated pre-existing file — collapses to temp-file cleanup, and the destination-preservation tests now hold for a much broader set of failures.
- The retry loop no longer touches the destination at all. It still resets the progress callback to `(0, None)` after a failed attempt so an observer doesn't hold a stale high-water mark.
- Permissions are preserved. `mkstemp` hardcodes 0600 and `os.replace` carries the mode across, so without an explicit `chmod` every downloaded model would silently have become owner-only. The mode logic `atomic_write_text` already had is factored into `_apply_destination_mode` and shared (behaviour for text writes is unchanged), with a test comparing a downloaded file's mode against a plain `open(..., "wb")` write.
- `download-cancel` sweeps the `.part` siblings. A SIGKILLed worker's bytes now live in the `.part`, not at `dest`, so without this the cancel would report success and reclaim nothing — the exact by-hand cleanup this command exists to spare the user. `partial_paths_for` matches only names of the shape `<dest name>.<8 mkstemp chars>.part`, not any neighbouring `.part` file, and there is a test asserting an unrelated `model.safetensors.notes.part` survives.
- `_download_file_aria2` is untouched on purpose. aria2 resumes from its own `.aria2` control file beside the output, and renaming that output would break resume, so it still writes straight to the destination. The asymmetry is documented in `download_file`'s docstring, and `download-cancel` cleans up both shapes.

## Acceptance criteria

- **Hard kill mid-transfer leaves nothing at the final path, only a `*.part` sibling** — `test_hard_kill_mid_transfer_leaves_nothing_at_the_destination`. See the caveat below on how faithfully this is simulated.
- **A completed download lands via rename, byte-identical** — `test_completed_download_lands_via_rename` spies on `os.replace` and asserts the source is the `.part`, the destination is the model, and nothing is left in the directory afterwards. The pre-existing content assertions across the suite (`test_download_file_success` and friends) are unchanged and still pass.
- **Retries never expose a truncated file; a pre-existing complete file survives a failed re-download** — `test_retries_never_expose_a_truncated_file_at_the_destination` probes the destination from inside each retry attempt, and `test_preexisting_complete_file_survives_a_failed_redownload` covers the mid-stream-failure case that previously truncated the old file on open.
- **`download-status` behaviour unchanged, state file remains the source of truth** — verified by reading, not just by tests; see the note below.
- **`pytest` + `ruff check` green** — full suite `3888 passed, 37 skipped`. `ruff check` and `ruff format --diff` clean under the version CI pins (0.15.15).

## Verification note on `download-status`

`download_state.reconcile` does stat `dest` on every poll, so I checked what atomicity does to it rather than assuming. Mid-flight the destination no longer exists, so that stat finds nothing and the worker's own throttled progress writes stand unmodified — which is the behaviour the state-file-is-the-contract rule wants, and strictly better than what it replaced: a truncated file's length was never a meaningful progress reading in the first place.

I deliberately did **not** remove the stat. It is load-bearing for one case: a worker SIGKILLed *after* the rename but *before* it could persist `completed` is resolved to `completed` rather than `failed` precisely because reconcile can see the finished file. Removing it in the name of "never stat dest" would regress that. Both `reconcile`'s docstring and `_reconciled`'s now say so, so a future reader doesn't undo it. No behavioural code change in `download_state.py`.

## Judgment calls

- **The kill simulation is in-process, not a real SIGKILL.** The test asserts the on-disk state *from inside the byte stream* — destination absent, one `.part` holding the bytes that landed — which is exactly the state a `SIGKILL` freezes, and it does so before any handler could have run. It then raises a `BaseException` subclass that no `except Exception` in the download path can convert into a tidy failure. A subprocess-and-signal integration test would be more faithful but flaky and slow in CI; the in-process probe is deterministic and asserts the same fact.
- **The matcher depends on `tempfile.mkstemp`'s naming (8 chars from a fixed alphabet).** If CPython ever changed that, `download-cancel` would silently stop reclaiming anything. `test_a_real_download_produces_a_matching_name` runs a real interrupted download through the actual code path and asserts the matcher finds its file, so the coupling fails loudly rather than silently.
- **Ctrl-C immediately after the last chunk now keeps the completed file.** Previously the prompt would delete it (the rename hadn't conceptually happened yet, so "the partial" was the finished file). Now only the temp is ever a deletion candidate, so a download that actually finished is kept. This is a small behaviour change and I think it is the right one; flagging it rather than burying it.
- **`comfy model list` will show an in-flight or orphaned `.part` file** (it lists every file under the models dir). This is not a regression in row count — during a download that row previously existed too, under the model's real name — and the new name is self-describing, so an orphan is now visible and removable rather than masquerading as a model. I did not filter `.part` out of the listing on purpose: hiding orphans is what makes them accumulate.
- **Two concurrent background downloads to the same destination**: each gets its own temp (an improvement — they previously interleaved writes into one file), but cancelling one sweeps the other's `.part`. This is a pre-existing and much-reduced edge case; I did not add locking for it.

## Negative-claim falsification

Not applicable — this diff denies no capability. It adds no "not supported"/"unavailable"/dead-end path, no throw-and-stop, and flips no test to assert a dead-end. The only behaviour removed is "an interrupted download leaves a truncated file at the final model path", which is the defect being fixed. The nearest thing to a capability change is that declining the Ctrl-C cleanup prompt no longer leaves bytes at the destination — but the bytes are still preserved, in the `.part` sibling, so nothing a user could do before is now impossible. Resuming from a `.part` is explicitly out of scope for this change; the naming leaves room for it.

## Out of scope

Resuming `.part` files, the aria2 downloader path (documented instead), and any quarantine/cleanup policy above the CLI.
