### PR TITLE
fix: resolve validate/nodes object_info target via resolve_host_port (config.background parity with run)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -48,9 +48,9 @@ from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import GPU_OPTION, CUDAVersion, ROCmVersion
 from comfy_cli.cuda_detect import DEFAULT_CUDA_TAG, detect_cuda_driver_version, resolve_cuda_wheel
 from comfy_cli.discovery import build_discovery
-from comfy_cli.env_checker import EnvChecker
+from comfy_cli.env_checker import EnvChecker, _bracket_host, _unbracket_host
 from comfy_cli.help_json import build_help_json
-from comfy_cli.host_port import DEFAULT_HOST, DEFAULT_PORT, validate_host
+from comfy_cli.host_port import validate_host
 from comfy_cli.output import Renderer, get_renderer, rprint, set_renderer
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.skills import command as skill_command
@@ -1104,17 +1104,14 @@ def validate(
         )
         raise typer.Exit(code=1)
 
-    # Load graph
-    mode = "local"
-    if where:
-        mode = where
-    else:
-        config = ConfigManager()
-        try:
-            decision = where_module.resolve(flag=None, config_value=config.get(where_module.CONFIG_KEY_WHERE_DEFAULT))
-            mode = decision.target.value
-        except Exception:
-            pass
+    # Load graph. Route through the shared resolver rather than trusting the raw
+    # `--where` string: it normalizes case/whitespace (`--where LOCAL` is the
+    # same target as `local`) and emits a `where_invalid` envelope instead of
+    # letting an unknown value escape as a bare ValueError traceback. Everything
+    # below then branches on the resolved enum, so no routing decision is ever
+    # made by string-comparing user input.
+    decision = where_module.resolve_default_or_exit(flag=where)
+    mode = decision.target.value
 
     # Resolve the local object_info server the same way `comfy run` does —
     # flag > COMFY_LOCAL_URL > config.background > 127.0.0.1:8188. Without the
@@ -1125,12 +1122,18 @@ def validate(
     # not consult `config.background` on purpose (other callers, e.g. transfer
     # and system, must not), so — as its docstring says — the callers that do
     # honor it resolve upstream, here.
-    if input_path is None and mode == "local":
+    is_local_fetch = input_path is None and decision.target is where_module.WhereTarget.LOCAL
+    if is_local_fetch:
         from comfy_cli.host_port import parse_host_port_arg, resolve_host_port
 
-        if host:
+        # `host is not None` (not `if host:`): `--host ""` must reach the parser
+        # and be rejected, not be read as "no --host given". Likewise the port
+        # merge tests `is None`, so an explicit `--port 0` isn't silently
+        # overridden by a port embedded in the combined `--host h:p` form —
+        # `resolve_host_port` rejects it as out of range instead.
+        if host is not None:
             host, parsed_port = parse_host_port_arg(host)
-            if not port and parsed_port is not None:
+            if port is None and parsed_port is not None:
                 port = parsed_port
         host, port = resolve_host_port(host, port)
 
@@ -1204,12 +1207,14 @@ def validate(
         # Name the server (or file) the verdict was computed against, so an
         # agent comparing `validate` with `run` can see whether they consulted
         # the same object_info. Populated from the values resolved above, so a
-        # local run reports the concrete host/port actually queried.
+        # local run reports the concrete host/port actually queried. `host` is
+        # reported unbracketed, matching `Target.host` — brackets belong to the
+        # URL composed for display, not to the address itself.
         "object_info_source": (
             {"mode": "file", "path": str(input_path)}
             if input_path is not None
-            else {"mode": mode, "host": host or DEFAULT_HOST, "port": port or DEFAULT_PORT}
-            if mode == "local"
+            else {"mode": mode, "host": _unbracket_host(host), "port": port}
+            if is_local_fetch
             else {"mode": mode}
         ),
     }
@@ -1225,11 +1230,15 @@ def validate(
         # escape it — same reason the partner-node line below does.
         from rich.markup import escape as _escape
 
+        # Branch on the same flags that built the payload, not on its "mode"
+        # string: "file" is an offline sentinel that shares a key with the
+        # routing targets, so a mode-string branch couples display to a value
+        # the routing layer also owns.
         source = payload["object_info_source"]
-        if source["mode"] == "file":
+        if input_path is not None:
             where_oi = _escape(source["path"])
-        elif source["mode"] == "local":
-            where_oi = _escape(f"http://{source['host']}:{source['port']}")
+        elif is_local_fetch:
+            where_oi = _escape(f"http://{_bracket_host(source['host'])}:{source['port']}")
         else:
             where_oi = _escape(source["mode"])
         rprint(f"[dim]object_info from {where_oi}[/dim]")

--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -50,7 +50,7 @@ from comfy_cli.cuda_detect import DEFAULT_CUDA_TAG, detect_cuda_driver_version, 
 from comfy_cli.discovery import build_discovery
 from comfy_cli.env_checker import EnvChecker
 from comfy_cli.help_json import build_help_json
-from comfy_cli.host_port import validate_host
+from comfy_cli.host_port import DEFAULT_HOST, DEFAULT_PORT, validate_host
 from comfy_cli.output import Renderer, get_renderer, rprint, set_renderer
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.skills import command as skill_command
@@ -1064,11 +1064,15 @@ def validate(
     ] = None,
     host: Annotated[
         str | None,
-        typer.Option(show_default=False, help="ComfyUI host (default 127.0.0.1)."),
+        typer.Option(
+            show_default=False, help="ComfyUI host (defaults to COMFY_LOCAL_URL, the background server, or 127.0.0.1)."
+        ),
     ] = None,
     port: Annotated[
         int | None,
-        typer.Option(show_default=False, help="ComfyUI port (default 8188)."),
+        typer.Option(
+            show_default=False, help="ComfyUI port (defaults to COMFY_LOCAL_URL, the background server, or 8188)."
+        ),
     ] = None,
     input_path: Annotated[
         str | None,
@@ -1111,6 +1115,24 @@ def validate(
             mode = decision.target.value
         except Exception:
             pass
+
+    # Resolve the local object_info server the same way `comfy run` does —
+    # flag > COMFY_LOCAL_URL > config.background > 127.0.0.1:8188. Without the
+    # `config.background` step validate would consult whatever answers on the
+    # default port while `run` submits to the background server comfy-cli
+    # launched on another one, making the verdict meaningless for the server
+    # that will actually execute the workflow (BE-6299). `resolve_target` does
+    # not consult `config.background` on purpose (other callers, e.g. transfer
+    # and system, must not), so — as its docstring says — the callers that do
+    # honor it resolve upstream, here.
+    if input_path is None and mode == "local":
+        from comfy_cli.host_port import parse_host_port_arg, resolve_host_port
+
+        if host:
+            host, parsed_port = parse_host_port_arg(host)
+            if not port and parsed_port is not None:
+                port = parsed_port
+        host, port = resolve_host_port(host, port)
 
     try:
         graph = Graph.load(mode=mode, input_path=input_path, host=host, port=port)
@@ -1179,6 +1201,17 @@ def validate(
         "warnings": result["warnings"],
         "partner_nodes": partner_nodes,
         "spends_credits": bool(partner_nodes),
+        # Name the server (or file) the verdict was computed against, so an
+        # agent comparing `validate` with `run` can see whether they consulted
+        # the same object_info. Populated from the values resolved above, so a
+        # local run reports the concrete host/port actually queried.
+        "object_info_source": (
+            {"mode": "file", "path": str(input_path)}
+            if input_path is not None
+            else {"mode": mode, "host": host or DEFAULT_HOST, "port": port or DEFAULT_PORT}
+            if mode == "local"
+            else {"mode": mode}
+        ),
     }
     if converted_from_ui:
         # Signal that validation ran against the converted graph, not the file's
@@ -1187,6 +1220,19 @@ def validate(
         payload["converted_node_count"] = len(wf_data)
 
     if renderer.is_pretty():
+        # Name the object_info source in one dim line. A file path (and, in
+        # principle, a hostname) can contain Rich-markup metacharacters, so
+        # escape it — same reason the partner-node line below does.
+        from rich.markup import escape as _escape
+
+        source = payload["object_info_source"]
+        if source["mode"] == "file":
+            where_oi = _escape(source["path"])
+        elif source["mode"] == "local":
+            where_oi = _escape(f"http://{source['host']}:{source['port']}")
+        else:
+            where_oi = _escape(source["mode"])
+        rprint(f"[dim]object_info from {where_oi}[/dim]")
         if result["valid"]:
             rprint(f"[bold green]✓[/bold green] workflow is valid ({len(wf_data)} nodes)")
             for w in result["warnings"]:

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -10,7 +10,9 @@ grammar. Three primitives:
 
 All three resolve the graph in this order:
     1. ``--input <path>`` to an object_info dump (offline mode)
-    2. ``--host:--port`` live ComfyUI server (default 127.0.0.1:8188)
+    2. a live ComfyUI server, addressed exactly as ``comfy run`` addresses it:
+       ``--host``/``--port`` > ``COMFY_LOCAL_URL`` > the persisted
+       ``config.background`` server > 127.0.0.1:8188
 
 Backed by the pure-Python CQL engine (``comfy_cli.cql.engine.Graph``).
 """
@@ -63,12 +65,26 @@ def _get_graph(
 
     Routing follows the standard precedence: explicit ``--where`` > env
     (``COMFY_WHERE``) > config (``where_default``) > local default. The
-    ``--input <path>`` flag short-circuits everything (offline mode).
+    ``--input <path>`` flag short-circuits everything (offline mode). For a
+    live local target the address is resolved with ``resolve_host_port`` —
+    ``--host``/``--port`` > ``COMFY_LOCAL_URL`` > ``config.background`` >
+    127.0.0.1:8188 — so discovery reads the same server ``comfy run`` submits to.
 
     ``on_stale``, if provided, is forwarded to ``resilient_load_object_info``
     and fired when a stale-cache fallback occurs (see loader for signature).
     """
     mode = _resolved_where(where)
+    # Resolve the local server the same way `comfy run` / `comfy jobs` do —
+    # flag > COMFY_LOCAL_URL > config.background > 127.0.0.1:8188. `resolve_target`
+    # deliberately skips the `config.background` step (other callers must not
+    # honor it), so callers that do resolve it upstream. Without this, an agent
+    # discovering nodes here would read a different server's object_info than the
+    # one `comfy run` submits to whenever ComfyUI was launched in the background
+    # on a non-default port (BE-6299).
+    if input_path is None and mode == "local":
+        from comfy_cli.host_port import resolve_host_port
+
+        host, port = resolve_host_port(host, port)
     try:
         if input_path is not None:
             # Explicit offline dump — let Graph.load read + annotate it.
@@ -171,11 +187,15 @@ def ls_cmd(
     ] = None,
     host: Annotated[
         str | None,
-        typer.Option(show_default=False, help="ComfyUI host (default 127.0.0.1)."),
+        typer.Option(
+            show_default=False, help="ComfyUI host (defaults to COMFY_LOCAL_URL, the background server, or 127.0.0.1)."
+        ),
     ] = None,
     port: Annotated[
         int | None,
-        typer.Option(show_default=False, help="ComfyUI port (default 8188)."),
+        typer.Option(
+            show_default=False, help="ComfyUI port (defaults to COMFY_LOCAL_URL, the background server, or 8188)."
+        ),
     ] = None,
     where: Annotated[
         str | None,
@@ -310,11 +330,15 @@ def show_cmd(
     ] = None,
     host: Annotated[
         str | None,
-        typer.Option(show_default=False, help="ComfyUI host (default 127.0.0.1)."),
+        typer.Option(
+            show_default=False, help="ComfyUI host (defaults to COMFY_LOCAL_URL, the background server, or 127.0.0.1)."
+        ),
     ] = None,
     port: Annotated[
         int | None,
-        typer.Option(show_default=False, help="ComfyUI port (default 8188)."),
+        typer.Option(
+            show_default=False, help="ComfyUI port (defaults to COMFY_LOCAL_URL, the background server, or 8188)."
+        ),
     ] = None,
 ):
     renderer = get_renderer()
@@ -419,11 +443,15 @@ def search_cmd(
     ] = None,
     host: Annotated[
         str | None,
-        typer.Option(show_default=False, help="ComfyUI host (default 127.0.0.1)."),
+        typer.Option(
+            show_default=False, help="ComfyUI host (defaults to COMFY_LOCAL_URL, the background server, or 127.0.0.1)."
+        ),
     ] = None,
     port: Annotated[
         int | None,
-        typer.Option(show_default=False, help="ComfyUI port (default 8188)."),
+        typer.Option(
+            show_default=False, help="ComfyUI port (defaults to COMFY_LOCAL_URL, the background server, or 8188)."
+        ),
     ] = None,
     where: Annotated[
         str | None,

--- a/comfy_cli/env_checker.py
+++ b/comfy_cli/env_checker.py
@@ -81,6 +81,20 @@ def _bracket_host(host: str) -> str:
     return host
 
 
+def _unbracket_host(host: str) -> str:
+    """Inverse of :func:`_bracket_host` — ``[::1]`` -> ``::1``.
+
+    Brackets are a *URL* encoding of an IPv6 literal, not part of the address.
+    Structured output reports the raw literal (matching ``Target.host``, which
+    is unbracketed) and re-brackets only where a URL is composed, so the same
+    server isn't named two different ways across a payload and its display line.
+    Idempotent for unbracketed input.
+    """
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
 def check_comfy_server_running(port=8188, host="localhost", timeout: float = 5.0):
     """
     Checks if the Comfy server is running by making a GET request to the /history endpoint.

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -120,14 +120,43 @@ def _to_port(s: str, original: str) -> int:
     return port
 
 
+def validate_port(port: int) -> int:
+    """Reject a ``--port`` outside the TCP range.
+
+    ``resolve_local_host_port`` resolves the port as ``port or env or bg or
+    DEFAULT``, so a falsy ``--port 0`` is indistinguishable from "not passed"
+    and silently resolves to some *other* server; an out-of-range ``--port
+    99999`` is worse, flowing straight into ``http://{host}:99999`` to fail at
+    connect time with no hint that the flag was the problem. Reject both here,
+    matching the range check :func:`_to_port` already applies to the port half
+    of a combined ``host:port`` string.
+    """
+    if not (1 <= port <= 65535):
+        raise typer.BadParameter(f"invalid port: {port} is out of range (1-65535)")
+    return port
+
+
 def resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
     """Resolve host/port by precedence — explicit flag > ``COMFY_LOCAL_URL``
     env > ``config.background`` > defaults — then validate and bracket IPv6
     literals so callers building ``'http://{host}:{port}'`` get a well-formed
-    URL (e.g. ``'::1'`` -> ``'[::1]'``)."""
+    URL (e.g. ``'::1'`` -> ``'[::1]'``).
+
+    An explicitly-passed ``host``/``port`` is validated *before* the precedence
+    chain runs, because that chain treats every falsy value as "not passed" and
+    would otherwise swallow the bad input and resolve to a different server.
+    """
     from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port
 
+    # ``--host ""`` is not "no host": a wrapper interpolating an unset variable
+    # would silently retarget the request at the env/background/default server.
+    # ``validate_host`` already rejects a blank host (see its comment) — it just
+    # never sees one, because the ``host or …`` fallback below drops it first.
+    if host is not None and not host.strip():
+        validate_host(host)
+    if port is not None:
+        validate_port(port)
     cfg = ConfigManager()
     host, port = resolve_local_host_port(host, port, background=cfg.background)
     # Validate BEFORE bracketing: ``validate_host``'s unsafe-char set does not

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -1,12 +1,14 @@
 """Shared host/port parsing + resolution for local ComfyUI commands.
 
-``comfy run``, every ``comfy jobs`` subcommand, and ``comfy upload`` accept a
-``--host`` / ``--port`` pair. ``run``/``jobs`` resolve it here — falling back
-to the persisted ``config.background`` server, then to ``DEFAULT_HOST`` /
-``DEFAULT_PORT``; ``comfy upload`` only borrows :func:`validate_host` and hands
-the pair to ``target.resolve_target``, which skips the background server (env
-override, then the defaults). In addition, ``comfy run`` accepts a combined
-``host[:port]`` string (parsed via ``parse_host_port_arg``); the ``comfy jobs``
+``comfy run``, every ``comfy jobs`` subcommand, ``comfy validate``, the
+``comfy nodes`` subcommands, and ``comfy upload`` accept a ``--host`` /
+``--port`` pair. ``run``/``jobs``/``validate``/``nodes`` resolve it here —
+falling back to the persisted ``config.background`` server, then to
+``DEFAULT_HOST`` / ``DEFAULT_PORT``; ``comfy upload`` only borrows
+:func:`validate_host` and hands the pair to ``target.resolve_target``, which
+skips the background server (env override, then the defaults). In addition,
+``comfy run`` and ``comfy validate`` accept a combined ``host[:port]`` string
+(parsed via ``parse_host_port_arg``); the ``comfy jobs`` / ``comfy nodes``
 subcommands and ``comfy upload`` only take the separate ``--host`` / ``--port``
 options. All of them feed the resolved host straight into URLs like
 ``http://{host}:{port}/prompt`` / ``ws://{host}:{port}/ws``, so the value must

--- a/comfy_cli/local_address.py
+++ b/comfy_cli/local_address.py
@@ -45,6 +45,23 @@ _UNSAFE_HOST_CHARS = frozenset("/@?#[]")
 # invoked at several sites per command doesn't spam identical warnings.
 _warned: set[str] = set()
 
+# A recorded background server's host is the ``--listen`` value ComfyUI *bound*
+# to, not an address to connect to. ``--listen 0.0.0.0`` / ``::`` means "every
+# interface"; as a destination a wildcard is not a real address — Windows
+# refuses to connect to it outright, and the object_info fetch's loopback guard
+# (``cql.engine._load_from_target``) rejects it as a non-loopback local host, so
+# passing it through turns a perfectly reachable background server into a hard
+# failure. Map it to the loopback of the same family, which is what the operator
+# meant and what every other caller of the record already assumes.
+_WILDCARD_BIND_HOSTS = {"0.0.0.0": DEFAULT_HOST, "::": "::1", "[::]": "::1"}
+
+
+def _connectable_bind_host(host: str | None) -> str | None:
+    """Canonicalize a wildcard *bind* address into a connectable loopback one."""
+    if host is None:
+        return None
+    return _WILDCARD_BIND_HOSTS.get(host.strip(), host)
+
 
 def parse_local_url(value: str) -> tuple[str, int | None]:
     """Parse a local ComfyUI address into ``(host, port)``.
@@ -184,11 +201,13 @@ def resolve_local_host_port(
     no ``--host`` still picks up the env var's host, and vice-versa.
 
     ``background`` is the persisted ``ConfigManager().background`` tuple
-    (``(host, port)``) or ``None``. The returned host is *raw* (unbracketed);
+    (``(host, port)``) or ``None``; its host is a *bind* address, so a wildcard
+    (``0.0.0.0`` / ``::``) is canonicalized to the matching loopback — see
+    :func:`_connectable_bind_host`. The returned host is *raw* (unbracketed);
     callers building a URL bracket IPv6 literals themselves.
     """
     env_host, env_port = _env_local_host_port(env)
-    bg_host = background[0] if background else None
+    bg_host = _connectable_bind_host(background[0]) if background else None
     bg_port = background[1] if background else None
     resolved_host = host or env_host or bg_host or DEFAULT_HOST
     resolved_port = port or env_port or bg_port or DEFAULT_PORT

--- a/comfy_cli/target.py
+++ b/comfy_cli/target.py
@@ -108,8 +108,8 @@ def resolve_target(
 
     # Local — resolve host/port by precedence: explicit flag > COMFY_LOCAL_URL
     # env > 127.0.0.1:8188. host/port may be None here; callers that also honor
-    # a persisted background server (run/jobs) resolve that upstream via
-    # host_port.resolve_host_port before reaching us.
+    # a persisted background server (run/jobs, and validate/nodes since BE-6306)
+    # resolve that upstream via host_port.resolve_host_port before reaching us.
     from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port
 

--- a/tests/comfy_cli/command/test_nodes_cli.py
+++ b/tests/comfy_cli/command/test_nodes_cli.py
@@ -204,3 +204,96 @@ class TestQueryFlagRemoved:
         runner = CliRunner()
         result = runner.invoke(nodes_cmd.app, ["ls", "--query", "produces IMAGE"])
         assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# local target resolution — config.background parity with `comfy run` (BE-6306)
+# ---------------------------------------------------------------------------
+#
+# `comfy nodes` is the agent's node-discovery surface, so it must read the same
+# server `comfy run` submits to. It used to resolve `--host`/`--port` >
+# COMFY_LOCAL_URL > 127.0.0.1:8188, skipping the persisted `config.background`
+# step that `run`/`jobs` honor via `host_port.resolve_host_port` — so with
+# ComfyUI launched in the background on a non-default port, discovery listed a
+# different server's nodes than the one the workflow would execute on (BE-6299).
+
+
+BACKGROUND_PORT = 8388
+
+
+def _set_background(monkeypatch, background):
+    """Point `host_port.resolve_host_port` at a synthetic `config.background`.
+
+    ConfigManager already drops a record whose pid is dead, so a tuple here
+    stands for a LIVE background server.
+    """
+
+    class _FakeConfigManager:
+        def __init__(self):
+            self.background = background
+
+    monkeypatch.setattr("comfy_cli.host_port.ConfigManager", _FakeConfigManager)
+    monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+
+
+@pytest.fixture
+def captured_target(monkeypatch):
+    """Stub the resilient live loader, recording the host/port it was handed."""
+    seen: dict[str, Any] = {}
+
+    def _fake_resilient_load(*, mode="local", host=None, port=None, input_path=None, on_stale=None):
+        seen.update(mode=mode, host=host, port=port)
+        return _fake_object_info()
+
+    monkeypatch.setattr("comfy_cli.cql.loader.resilient_load_object_info", _fake_resilient_load)
+    monkeypatch.setattr(nodes_cmd, "_resolved_where", lambda where: "local")
+    return seen
+
+
+class TestLocalTargetResolution:
+    def test_ls_honors_background_server(self, monkeypatch, capsys, captured_target):
+        """No flags + a live background server on a non-default port → discovery
+        queries THAT server, not 127.0.0.1:8188."""
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+        env = _run(["ls", "--limit", "1"], capsys)
+
+        assert env["ok"] is True
+        assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", BACKGROUND_PORT)
+
+    def test_ls_explicit_flags_beat_background(self, monkeypatch, capsys, captured_target):
+        """Precedence unchanged: explicit `--host`/`--port` still win."""
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+        _run(["ls", "--limit", "1", "--host", "127.0.0.1", "--port", "9000"], capsys)
+
+        assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", 9000)
+
+    def test_ls_without_background_defaults_to_8188(self, monkeypatch, capsys, captured_target):
+        """With nothing recorded, the default target is unchanged."""
+        _set_background(monkeypatch, None)
+
+        _run(["ls", "--limit", "1"], capsys)
+
+        assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", 8188)
+
+    def test_show_honors_background_server(self, monkeypatch, capsys, captured_target):
+        """The same resolution applies to every `comfy nodes` subcommand — they
+        all share `_get_graph`."""
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+        _run(["show", "KSampler"], capsys)
+
+        assert captured_target["port"] == BACKGROUND_PORT
+
+    def test_input_path_skips_host_resolution(self, monkeypatch, tmp_path, capsys):
+        """`--input` is offline mode: no live fetch, and the recorded background
+        server is never consulted."""
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+        monkeypatch.setattr(nodes_cmd, "_resolved_where", lambda where: "local")
+        dump = tmp_path / "oi.json"
+        dump.write_text(json.dumps(_fake_object_info()), encoding="utf-8")
+
+        env = _run(["ls", "--limit", "1", "--input", str(dump)], capsys)
+
+        assert env["ok"] is True

--- a/tests/comfy_cli/command/test_nodes_cli.py
+++ b/tests/comfy_cli/command/test_nodes_cli.py
@@ -286,14 +286,49 @@ class TestLocalTargetResolution:
 
         assert captured_target["port"] == BACKGROUND_PORT
 
-    def test_input_path_skips_host_resolution(self, monkeypatch, tmp_path, capsys):
+    def test_input_path_skips_host_resolution(self, monkeypatch, tmp_path, capsys, captured_target):
         """`--input` is offline mode: no live fetch, and the recorded background
         server is never consulted."""
         _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
-        monkeypatch.setattr(nodes_cmd, "_resolved_where", lambda where: "local")
         dump = tmp_path / "oi.json"
         dump.write_text(json.dumps(_fake_object_info()), encoding="utf-8")
 
         env = _run(["ls", "--limit", "1", "--input", str(dump)], capsys)
 
         assert env["ok"] is True
+        # The live loader is stubbed by `captured_target`; asserting it stayed
+        # untouched is what actually pins the `input_path is None` guard. Without
+        # it a regression would fall through to a real request and could still
+        # pass off a stale on-disk cache.
+        assert captured_target == {}
+
+    def test_wildcard_background_host_is_canonicalized(self, monkeypatch, capsys, captured_target):
+        """`comfy launch -- --listen 0.0.0.0` records the wildcard BIND address.
+        Used as a destination it trips the object_info loopback guard, and here
+        the resulting LoadError is swallowed by `resilient_load_object_info` — so
+        `nodes ls/show/search` would serve the last cached dump while claiming to
+        read the live server. It is canonicalized to loopback instead."""
+        _set_background(monkeypatch, ("0.0.0.0", BACKGROUND_PORT, 4242))
+
+        _run(["ls", "--limit", "1"], capsys)
+
+        assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", BACKGROUND_PORT)
+
+    def test_empty_host_flag_is_rejected(self, monkeypatch, captured_target):
+        """`--host ""` must error rather than falling through to the background
+        server — the same guard `comfy run` gets from `resolve_host_port`."""
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+        result = CliRunner().invoke(nodes_cmd.app, ["ls", "--limit", "1", "--host", ""])
+
+        assert result.exit_code == 2
+        assert captured_target == {}
+
+    @pytest.mark.parametrize("bad_port", ["0", "99999"])
+    def test_out_of_range_port_flag_is_rejected(self, monkeypatch, captured_target, bad_port):
+        _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+        result = CliRunner().invoke(nodes_cmd.app, ["ls", "--limit", "1", "--port", bad_port])
+
+        assert result.exit_code == 2
+        assert captured_target == {}

--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -308,3 +308,190 @@ def test_partner_node_name_with_markup_does_not_crash_pretty(runner, tmp_path):
     assert result.exception is None, result.exception
     # The name is still shown (escaped) in the paid-nodes advisory.
     assert name in result.stdout
+
+
+# --- object_info target resolution (BE-6306) ------------------------------------
+#
+# `validate` used to resolve its local object_info server as
+# `--host`/`--port` > COMFY_LOCAL_URL > 127.0.0.1:8188, skipping the
+# `config.background` step `comfy run` honors via `host_port.resolve_host_port`.
+# With ComfyUI running as a comfy-cli background server on a non-8188 port, that
+# made validate consult a DIFFERENT server than the one `run` submits to, so its
+# verdict was meaningless (BE-6299: validate passed a workflow `run` rejected for
+# a missing node class). It now resolves through the same chain, and reports the
+# resolved target in the payload as `object_info_source`.
+
+BACKGROUND_PORT = 8388
+
+
+@pytest.fixture
+def no_background(monkeypatch):
+    """Neutralize the developer's real `config.background` (and COMFY_LOCAL_URL)
+    so the tests below observe only what they set themselves."""
+    return _set_background(monkeypatch, None)
+
+
+def _set_background(monkeypatch, background):
+    """Point `host_port.resolve_host_port` at a synthetic `config.background`.
+
+    `resolve_host_port` reads `ConfigManager().background`, and ConfigManager
+    already drops a record whose pid is dead — so a tuple here stands for a LIVE
+    background server.
+    """
+
+    class _FakeConfigManager:
+        def __init__(self):
+            self.background = background
+
+    monkeypatch.setattr("comfy_cli.host_port.ConfigManager", _FakeConfigManager)
+    monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+
+
+@pytest.fixture
+def captured_target(monkeypatch, tmp_path):
+    """Stub the live object_info fetch, recording the host/port it was handed.
+
+    Returns the dict the engine call is recorded into (`{}` until the fetch
+    runs), so a test can assert on the server validate actually queried.
+    """
+    seen: dict = {}
+
+    def _fake_load_from_target(*, mode="local", host=None, port=None):
+        seen.update(mode=mode, host=host, port=port)
+        return {"PlainSave": _node_info(category="image")}
+
+    monkeypatch.setattr("comfy_cli.cql.engine._load_from_target", _fake_load_from_target)
+    return seen
+
+
+def _valid_workflow(tmp_path: Path) -> Path:
+    """A one-node API workflow that validates clean against `PlainSave`."""
+    return _write(tmp_path, "wf.json", {"1": {"class_type": "PlainSave", "inputs": {}}})
+
+
+def _validate_live(runner: CliRunner, workflow: Path, *args: str, json_mode: str = "--json"):
+    """Invoke `comfy validate` against a (stubbed) LIVE server — no `--input`."""
+    return runner.invoke(
+        app,
+        [json_mode, "validate", "--workflow", str(workflow), *args],
+        env={"COMFY_WHERE": "local"},
+    )
+
+
+def test_local_target_honors_background_server(runner, tmp_path, monkeypatch, captured_target):
+    """Acceptance: with a live `config.background` on a non-default port and no
+    `--host`/`--port`/`COMFY_LOCAL_URL`, validate fetches object_info from the
+    BACKGROUND server — the same one `comfy run` submits to — not 127.0.0.1:8188."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path))
+
+    assert result.exit_code == 0, result.stdout
+    assert captured_target["port"] == BACKGROUND_PORT
+    assert captured_target["host"] == "127.0.0.1"
+
+
+def test_explicit_flags_beat_background_server(runner, tmp_path, monkeypatch, captured_target):
+    """Precedence is unchanged: explicit `--host`/`--port` still win over a
+    recorded background server."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "127.0.0.1", "--port", "9000")
+
+    assert result.exit_code == 0, result.stdout
+    assert captured_target["port"] == 9000
+    assert captured_target["host"] == "127.0.0.1"
+
+
+def test_combined_host_port_flag_is_split(runner, tmp_path, monkeypatch, captured_target):
+    """Sharing `comfy run`'s resolution also gives validate `run`'s combined
+    `--host host:port` form. It previously flowed through unsplit and produced a
+    bogus `http://[127.0.0.1:9100]:8188` URL."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "127.0.0.1:9100")
+
+    assert result.exit_code == 0, result.stdout
+    assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", 9100)
+
+
+def test_malformed_host_is_a_usage_error(runner, tmp_path, no_background, captured_target):
+    """A URL-unsafe `--host` is now rejected as a usage error (exit 2) by the
+    shared validator, the same way `comfy run` and `comfy upload` reject it,
+    instead of being built into a URL and failing at fetch time."""
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "evil.example.com/path")
+
+    assert result.exit_code == 2
+    assert captured_target == {}  # no fetch was attempted
+
+
+def test_env_local_url_beats_background_server(runner, tmp_path, monkeypatch, captured_target):
+    """`COMFY_LOCAL_URL` also still outranks the background server."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+    monkeypatch.setenv("COMFY_LOCAL_URL", "http://127.0.0.1:9500")
+
+    result = _validate_live(runner, _valid_workflow(tmp_path))
+
+    assert result.exit_code == 0, result.stdout
+    assert captured_target["port"] == 9500
+
+
+def test_no_background_still_defaults_to_8188(runner, tmp_path, no_background, captured_target):
+    """With nothing recorded and no flags, the default target is unchanged."""
+    result = _validate_live(runner, _valid_workflow(tmp_path))
+
+    assert result.exit_code == 0, result.stdout
+    assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", 8188)
+
+
+def test_payload_names_resolved_local_source(runner, tmp_path, monkeypatch, captured_target):
+    """The `--json` envelope names the object_info source, carrying the RESOLVED
+    host/port (the background server), so an agent can see which server answered."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path))
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["object_info_source"] == {"mode": "local", "host": "127.0.0.1", "port": BACKGROUND_PORT}
+
+
+def test_payload_names_file_source_under_input(runner, tmp_path, monkeypatch):
+    """`--input` is offline mode: the source is the file, and no host/port
+    resolution happens (a recorded background server is irrelevant)."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+    oi = _write(tmp_path, "oi.json", {"PlainSave": _node_info(category="image")})
+    wf = _valid_workflow(tmp_path)
+
+    result = _validate_against(runner, wf, oi)
+
+    assert result.exit_code == 0, result.stdout
+    data = _envelope(result)["data"]
+    assert data["object_info_source"] == {"mode": "file", "path": str(oi)}
+
+
+def test_payload_names_cloud_source(runner, tmp_path, monkeypatch, captured_target):
+    """Cloud mode is unchanged — no local host/port resolution — and the payload
+    names the source as `cloud` only."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = runner.invoke(
+        app,
+        ["--json", "validate", "--workflow", str(_valid_workflow(tmp_path)), "--where", "cloud"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    # The background server must not leak into a cloud fetch.
+    assert captured_target["mode"] == "cloud"
+    assert (captured_target["host"], captured_target["port"]) == (None, None)
+    assert _envelope(result)["data"]["object_info_source"] == {"mode": "cloud"}
+
+
+def test_pretty_mode_prints_resolved_source(runner, tmp_path, monkeypatch, captured_target):
+    """Pretty mode prints one dim line naming the server that answered."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path), json_mode="--no-json")
+
+    assert result.exit_code == 0, result.stdout
+    assert f"object_info from http://127.0.0.1:{BACKGROUND_PORT}" in result.stdout

--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -495,3 +496,89 @@ def test_pretty_mode_prints_resolved_source(runner, tmp_path, monkeypatch, captu
 
     assert result.exit_code == 0, result.stdout
     assert f"object_info from http://127.0.0.1:{BACKGROUND_PORT}" in result.stdout
+
+
+# --- review follow-ups on the BE-6306 resolution block ---------------------------
+
+
+def test_wildcard_background_host_is_canonicalized(runner, tmp_path, monkeypatch, captured_target):
+    """`comfy launch -- --listen 0.0.0.0` records the wildcard BIND address in
+    `config.background`. Passing it through as a destination trips the
+    object_info loopback guard, so validate hard-failed with "Refusing to fetch
+    object_info from non-loopback host" where it previously succeeded — the exact
+    opposite of the `comfy run` parity this block is for (`run`'s own object_info
+    fetch fails open). It is canonicalized to loopback instead."""
+    _set_background(monkeypatch, ("0.0.0.0", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path))
+
+    assert result.exit_code == 0, result.stdout
+    assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", BACKGROUND_PORT)
+
+
+def test_where_flag_is_normalized_before_routing(runner, tmp_path, monkeypatch, captured_target):
+    """`--where` is normalized through the shared resolver, not string-compared
+    raw: `--where LOCAL` must take the local path (splitting a combined `--host`,
+    consulting the background server) rather than skipping the whole block and
+    building `http://[127.0.0.1:9100]:8188`."""
+    _set_background(monkeypatch, ("127.0.0.1", BACKGROUND_PORT, 4242))
+
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--where", "LOCAL", "--host", "127.0.0.1:9100")
+
+    assert result.exit_code == 0, result.stdout
+    assert (captured_target["host"], captured_target["port"]) == ("127.0.0.1", 9100)
+    assert _envelope(result)["data"]["object_info_source"]["mode"] == "local"
+
+
+@pytest.mark.parametrize("bad_where", ["bogus", "file"])
+def test_invalid_where_emits_envelope_not_traceback(runner, tmp_path, no_background, bad_where):
+    """An unknown `--where` used to escape as a bare ValueError traceback with no
+    envelope at all. (`file` is doubly interesting: it is the offline sentinel
+    `object_info_source.mode` also uses.)"""
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--where", bad_where)
+
+    assert result.exit_code == 1
+    assert _envelope(result)["error"]["code"] == "where_invalid"
+
+
+def test_empty_host_flag_is_rejected(runner, tmp_path, no_background, captured_target):
+    """`--host ""` is not "no host" — it must be rejected rather than silently
+    resolving to COMFY_LOCAL_URL / the background server / 127.0.0.1."""
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "")
+
+    assert result.exit_code == 2
+    assert captured_target == {}
+
+
+@pytest.mark.parametrize("bad_port", ["0", "99999"])
+def test_out_of_range_port_flag_is_rejected(runner, tmp_path, no_background, captured_target, bad_port):
+    """An out-of-range `--port` is a usage error. `0` in particular used to read
+    as "not passed" and silently resolve to some other server."""
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--port", bad_port)
+
+    assert result.exit_code == 2
+    assert captured_target == {}
+
+
+def test_explicit_port_zero_is_not_overridden_by_combined_host(runner, tmp_path, no_background, captured_target):
+    """The combined-host port merge tests `is None`, so an explicit (invalid)
+    `--port 0` is reported as such instead of being quietly replaced by the port
+    embedded in `--host h:p`."""
+    result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "127.0.0.1:9100", "--port", "0")
+
+    assert result.exit_code == 2
+    assert captured_target == {}
+
+
+def test_ipv6_source_is_unbracketed_in_payload_and_bracketed_for_display(runner, tmp_path, no_background):
+    """Brackets are a URL encoding, not part of the address: the payload carries
+    the raw literal (matching `Target.host`) and only the display URL brackets it."""
+    with patch("comfy_cli.cql.engine._load_from_target", return_value={"PlainSave": _node_info(category="image")}):
+        result = _validate_live(runner, _valid_workflow(tmp_path), "--host", "::1", "--port", "9000")
+        assert result.exit_code == 0, result.stdout
+        assert _envelope(result)["data"]["object_info_source"] == {"mode": "local", "host": "::1", "port": 9000}
+
+        pretty = _validate_live(
+            runner, _valid_workflow(tmp_path), "--host", "::1", "--port", "9000", json_mode="--no-json"
+        )
+    assert "object_info from http://[::1]:9000" in pretty.stdout

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -211,3 +211,47 @@ def test_run_unsafe_host_exits_before_execute(tmp_path):
         )
     assert result.exit_code != 0
     mock_execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# explicit-flag validation at the shared choke point (BE-6306 review)
+# ---------------------------------------------------------------------------
+#
+# `resolve_local_host_port` resolves each half as `value or env or bg or
+# DEFAULT`, so every FALSY explicit flag reads as "not passed" and silently
+# retargets the request at a different server. `resolve_host_port` therefore
+# validates an explicitly-passed host/port BEFORE that chain runs.
+
+
+def test_empty_host_flag_is_rejected():
+    """`--host ""` (a wrapper interpolating an unset variable) must error, not
+    fall through to the env/background/default server."""
+    with pytest.raises(typer.BadParameter, match="empty host"):
+        resolve_host_port("", None)
+
+
+def test_blank_host_flag_is_rejected():
+    with pytest.raises(typer.BadParameter, match="empty host"):
+        resolve_host_port("   ", None)
+
+
+@pytest.mark.parametrize("bad_port", [0, -1, 65536, 99999])
+def test_out_of_range_port_flag_is_rejected(bad_port):
+    with pytest.raises(typer.BadParameter, match="out of range"):
+        resolve_host_port(None, bad_port)
+
+
+def test_none_host_and_port_still_resolve(monkeypatch):
+    """The guards fire only on an EXPLICIT value — `None` still means absent."""
+    monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+    with patch("comfy_cli.host_port.ConfigManager") as cm:
+        cm.return_value.background = None
+        assert resolve_host_port(None, None) == (DEFAULT_HOST, DEFAULT_PORT)
+
+
+def test_boundary_ports_are_accepted(monkeypatch):
+    monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+    with patch("comfy_cli.host_port.ConfigManager") as cm:
+        cm.return_value.background = None
+        assert resolve_host_port(None, 1)[1] == 1
+        assert resolve_host_port(None, 65535)[1] == 65535

--- a/tests/comfy_cli/test_local_address.py
+++ b/tests/comfy_cli/test_local_address.py
@@ -289,3 +289,43 @@ def test_job_watcher_state_beats_env(monkeypatch):
     with patch("comfy_cli.command.jobs._snapshot", side_effect=fake_snapshot):
         job_watcher._poll_local_once(state, host=None, port=None)
     assert (captured["h"], captured["p"]) == ("recorded-host", 9999)
+
+
+# ---------------------------------------------------------------------------
+# wildcard bind-address canonicalization (BE-6306 review)
+# ---------------------------------------------------------------------------
+#
+# `config.background` records the raw `--listen` value `comfy launch` passed to
+# ComfyUI — a BIND address. `--listen 0.0.0.0` (or `::`) means "every
+# interface"; as a *destination* it isn't a real address. Windows refuses to
+# connect to it, and the object_info fetch's loopback guard rejects it as a
+# non-loopback local host — so feeding it through unchanged turned a reachable
+# background server into a hard failure for `comfy validate` / `comfy nodes`.
+
+
+@pytest.mark.parametrize(
+    ("listen", "expected"),
+    [
+        ("0.0.0.0", DEFAULT_HOST),
+        ("::", "::1"),
+        ("[::]", "::1"),
+        (" 0.0.0.0 ", DEFAULT_HOST),  # the recorded value is not pre-stripped
+    ],
+)
+def test_wildcard_background_host_becomes_loopback(listen, expected, monkeypatch):
+    monkeypatch.delenv(ENV_LOCAL_URL, raising=False)
+    assert resolve_local_host_port(None, None, background=(listen, 8388, 42)) == (expected, 8388)
+
+
+def test_non_wildcard_background_host_is_untouched(monkeypatch):
+    """Only the wildcards are rewritten — a real recorded address passes through."""
+    monkeypatch.delenv(ENV_LOCAL_URL, raising=False)
+    assert resolve_local_host_port(None, None, background=("::1", 8388, 42)) == ("::1", 8388)
+
+
+def test_explicit_wildcard_host_flag_is_not_rewritten(monkeypatch):
+    """The canonicalization is scoped to the recorded BIND address. An explicit
+    `--host 0.0.0.0` is the user naming a destination; leave it alone so the
+    downstream guards judge what they were actually given."""
+    monkeypatch.delenv(ENV_LOCAL_URL, raising=False)
+    assert resolve_local_host_port("0.0.0.0", None, background=("127.0.0.1", 8388, 42)) == ("0.0.0.0", 8388)


### PR DESCRIPTION
## ELI-5

If you start ComfyUI in the background on a non-default port (`comfy launch --background`, which is what comfy-mcp's `launch_comfyui` does), `comfy run` talks to that server — but `comfy validate` and `comfy nodes` were still talking to whatever happens to answer on `127.0.0.1:8188`. So validate could hand back a confident "your workflow is valid" after asking a completely different ComfyUI, while the very same workflow blew up on the server that actually runs it. This makes both commands address the server the same way `run` does.

## What changed

`comfy run` / `comfy jobs` resolve their local address through `host_port.resolve_host_port` — **flag > `COMFY_LOCAL_URL` > `config.background` > `127.0.0.1:8188`**. `validate` and `nodes` went straight to `target.resolve_target`, which deliberately *omits* the `config.background` step (other callers — transfer, system — must not honor it, and `resolve_target`'s own comment says the callers that do honor it resolve upstream). They now do that upstream resolution, at the two call sites, instead of changing the shared resolver:

- `comfy_cli/cmdline.py` — `validate` resolves host/port before `Graph.load(...)`, only for `mode == "local"` with no `--input`. Mirrors `run`'s block verbatim, including `parse_host_port_arg` for the combined `--host host:port` form.
- `comfy_cli/command/nodes.py` — `_get_graph` (shared by `ls` / `show` / `search` / `upstream` / `downstream`) does the same before the live fetch.
- `comfy_cli/host_port.py`, `comfy_cli/target.py` — docstring/comment updates so the two modules that describe this split stay accurate.

`validate`'s payload also gains **`object_info_source`**, naming the source the verdict was computed against — `{"mode": "local", "host": …, "port": …}`, `{"mode": "cloud"}`, or `{"mode": "file", "path": …}` — plus one dim `object_info from http://<host>:<port>` line in pretty mode. That is the piece that makes a validate/run disagreement diagnosable instead of mysterious.

Precedence is unchanged (flag > env > background > default). Cloud mode is untouched. `--input` offline mode is untouched. No changes to `comfy_cli/cql/engine.py` validation logic or `comfy_cli/workflow_to_api.py`.

## Provenance / verification

Reproduced the failure and the fix end-to-end, not just in unit tests: an isolated `HOME` with `background = ('127.0.0.1', 8388, <live pid>)` in `config.ini`, and two stub `/object_info` servers — `:8188` serving a `DWPreprocessor` entry, `:8388` (the "background server") serving one without it — then `comfy validate --workflow <frontend-format file>` with no `--host`/`--port`/`COMFY_LOCAL_URL`.

**Before** (the QA false pass, verbatim): `"valid": true, "error_count": 0` — validate read `:8188` and never saw that the real server lacks the node. `comfy nodes search DWPreprocessor` returned 1 row from the wrong server.

**After**: `"valid": false`, `unknown_class_type: class_type 'DWPreprocessor' not found in object_info`, `"object_info_source": {"mode": "local", "host": "127.0.0.1", "port": 8388}` — the same verdict `comfy run` gives. `comfy nodes search DWPreprocessor` returns 0 rows, correctly.

Tests: 12 new cases across `tests/comfy_cli/command/test_validate_command.py` and `test_nodes_cli.py` (background respected; explicit flags win; `COMFY_LOCAL_URL` wins; no-background still defaults to 8188; the `object_info_source` payload in local/cloud/file mode; the pretty line). Verified they are real guards — 10 of them fail against the pre-fix source. Full suite green (`3887 passed, 37 skipped`); `ruff check` + `ruff format --check` clean under CI's pinned `ruff==0.15.15`.

## Judgment calls worth a reviewer's attention

- **Two deliberate side effects of adopting `run`'s resolution on `validate`/`nodes`.** (1) A URL-unsafe `--host` (e.g. `evil.example.com/path`) is now a usage error (exit 2) from the shared `validate_host`, where before it was built into a URL and failed later at fetch time — this matches what `comfy run` and `comfy upload` already do, and there is a test pinning it. (2) `validate --host 127.0.0.1:9100` now splits correctly; previously it produced a bogus `http://[127.0.0.1:9100]:8188` URL. Both are strict improvements, but they are behavior changes, so they are called out rather than buried.
- **`object_info_source` is on the success payload only.** When the fetch itself fails, the `cql_no_graph` error envelope already carries the target in `details.url`, so the source is still named — just via the existing field rather than a duplicated one.
- **`comfy_cli/command/workflow.py`'s sibling `_get_graph` has the identical gap** (it feeds `comfy workflow slots` / `set-slot` / `vary`). It is outside this change's stated scope, so it is left alone here and flagged for a follow-up rather than fixed as a drive-by.
