### PR TITLE
fix(jobs): consult the job state file when a live server has no record of the prompt (BE-4749)

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -718,7 +718,11 @@ def _state_file_snapshot(st: JobState, *, prompt_id: str, host: str, port: int, 
     return {
         "prompt_id": prompt_id,
         "status": st.status,
-        "outputs": list(st.outputs or []),
+        # `jobs_state.read` drops unknown keys but does not type-check the ones
+        # it keeps, so a hand-edited or truncated file can carry a non-list
+        # `outputs`. `list()` would shred a str into characters and raise on a
+        # scalar — only trust an actual list.
+        "outputs": list(st.outputs) if isinstance(st.outputs, list) else [],
         "error": st.error,
         "host": host,
         "port": port,
@@ -728,6 +732,75 @@ def _state_file_snapshot(st: JobState, *, prompt_id: str, host: str, port: int, 
         "updated_at": st.updated_at,
         "workflow": st.workflow,
     }
+
+
+def _state_file_for_local_target(prompt_id: str, *, host: str, port: int) -> JobState | None:
+    """Read `prompt_id`'s state file, but only if it answers for THIS local target.
+
+    The file is keyed by prompt_id alone, so an unscoped read will happily
+    return a cloud run, or a job from a second local instance on another port,
+    and `_state_file_snapshot` would then stamp the *queried* host/port onto
+    output URLs belonging to a different server. Everything below is a reason
+    the record is not an answer about ``host:port``.
+    """
+    from comfy_cli import jobs_state
+
+    try:
+        st = jobs_state.read(prompt_id)
+    except ValueError:  # unsafe prompt_id — no state file to read
+        return None
+    except OSError:
+        # `read` goes through `state_path` -> `state_dir`, which mkdirs the
+        # config root and can fail (read-only or permission-denied home). A
+        # traceback here would replace a clean envelope, so treat it as absent
+        # — the same guard `_gather_waitable_ids` puts on this call.
+        return None
+    if st is None:
+        return None
+    # `state_path` maps "/" and "\" to "_" *before* validating, so read("a/b")
+    # resolves to the file for the distinct prompt "a_b". Require the record to
+    # name the id we actually asked about.
+    if st.prompt_id != prompt_id:
+        return None
+    if st.where != "local":
+        return None
+    # host/port are None on files written before they were recorded, so only a
+    # positive mismatch disqualifies a record.
+    if st.host is not None and st.host != host:
+        return None
+    if st.port is not None and str(st.port) != str(port):
+        return None
+    return st
+
+
+def _server_confirms_no_record(host: str, port: int, prompt_id: str) -> bool:
+    """True only if both `/queue` and `/history` answered and neither knows `prompt_id`.
+
+    `_snapshot` returns None for two very different things: the server has no
+    record, or the fetch failed (every `_http_get_json` failure is a
+    `RuntimeError`, and `_snapshot` swallows it). Only the first licenses the
+    "this job died with an earlier process" inference — reading a stale verdict
+    out of a busy or briefly unreachable server would manufacture a
+    `server_died` report for a job that is still running fine. The watcher is
+    equally careful here (it keeps a grace window before drawing the same
+    conclusion), so this demands a positive confirmation rather than trusting
+    an absence of evidence.
+    """
+    try:
+        q = _http_get_json(f"http://{host}:{port}/queue")
+        hist = _http_get_json(f"http://{host}:{port}/history/{prompt_id}")
+    except RuntimeError:
+        return False
+    if not isinstance(q, dict) or not isinstance(hist, dict):
+        return False
+    if prompt_id in hist:
+        return False
+    for key in ("queue_running", "queue_pending"):
+        for entry in q.get(key) or []:
+            pid, _wf = _safe_queue_entry(entry)
+            if pid == prompt_id:
+                return False
+    return True
 
 
 @app.command("status", help="Show the status of a single prompt_id (local or --where cloud).")
@@ -751,12 +824,7 @@ def status_cmd(
         # maintained by the async watcher) still knows what this prompt was
         # doing when the server was last seen — a bare `server_not_running`
         # throws that attribution away.
-        from comfy_cli import jobs_state
-
-        try:
-            st = jobs_state.read(prompt_id)
-        except ValueError:  # unsafe prompt_id — no state file to read
-            st = None
+        st = _state_file_for_local_target(prompt_id, host=h, port=p)
 
         if st is None:
             # Untracked prompt: same envelope as before, byte for byte.
@@ -816,18 +884,18 @@ def status_cmd(
         # prompt missing from a server that came back is finalized as
         # `server_died`. `jobs status` reading the file it wrote keeps the two
         # in agreement rather than having them contradict each other.
-        from comfy_cli import jobs_state
+        st = _state_file_for_local_target(prompt_id, host=h, port=p)
 
-        try:
-            st = jobs_state.read(prompt_id)
-        except ValueError:  # unsafe prompt_id — no state file to read
-            st = None
+        # `_snapshot` returning None is not by itself proof the server has no
+        # record — it swallows fetch failures too. Confirm before inferring.
+        confirmed_absent = _server_confirms_no_record(h, p, prompt_id) if st is not None else False
 
-        if st is not None and st.is_terminal:
-            # The state file holds a final verdict for this prompt — emit it as
-            # a normal result, exactly as the server-down path does. The one
-            # difference is `server_running: True`, so a caller can tell it is
-            # looking at a live server with no record rather than a dead one.
+        if st is not None and st.is_terminal and confirmed_absent:
+            # The state file holds a final verdict and the server has positively
+            # disowned the prompt — emit the verdict as a normal result, exactly
+            # as the server-down path does. The one difference is
+            # `server_running: True`, so a caller can tell it is looking at a
+            # live server with no record rather than a dead one.
             snapshot = _state_file_snapshot(st, prompt_id=prompt_id, host=h, port=p, server_running=True)
             if renderer.is_pretty():
                 _render_status_pretty(snapshot, host=h, port=p)
@@ -835,17 +903,24 @@ def status_cmd(
             return
 
         if st is not None:
-            # Tracked but non-terminal: the watcher never got to write a
-            # verdict (it may still be inside its grace window, or it died
-            # too). Keep the `prompt_not_found` code — callers key on it — and
-            # attach what the file does know, mirroring the server-down
-            # non-terminal branch above.
+            # Either the record is non-terminal (the watcher never got to write
+            # a verdict — it may still be inside its grace window, or it died
+            # too), or the server would not confirm the absence. Keep the
+            # `prompt_not_found` code — callers key on it — and attach what the
+            # file does know, mirroring the server-down non-terminal branch.
+            if confirmed_absent:
+                tail = "The server may have been restarted since, in which case the job died with the previous process."
+            else:
+                # Don't assert a death the code has not established.
+                tail = (
+                    "The server did not answer /queue and /history reliably, so whether it still has a "
+                    "record of this job is unknown — retry before treating this as the job's outcome."
+                )
             renderer.error(
                 code="prompt_not_found",
                 message=(
                     f"No prompt with id {prompt_id!r} on {h}:{p} — the local state file last recorded it as "
-                    f"{st.status!r} (submitted {st.submitted_at}, last update {st.updated_at}). The server may "
-                    f"have been restarted since, in which case the job died with the previous process."
+                    f"{st.status!r} (submitted {st.submitted_at}, last update {st.updated_at}). {tail}"
                 ),
                 hint="check `comfy jobs ls`; very old prompts may have been pruned from /history",
                 details={
@@ -856,6 +931,7 @@ def status_cmd(
                     "submitted_at": st.submitted_at,
                     "updated_at": st.updated_at,
                     "workflow": st.workflow,
+                    "server_confirmed_no_record": confirmed_absent,
                 },
             )
             raise typer.Exit(code=1)

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -723,6 +723,15 @@ def _state_file_snapshot(st: JobState, *, prompt_id: str, host: str, port: int, 
         # `outputs`. `list()` would shred a str into characters and raise on a
         # scalar — only trust an actual list.
         "outputs": list(st.outputs) if isinstance(st.outputs, list) else [],
+        # Every live `_snapshot()` result carries these three, so a consumer
+        # that indexes them on a `jobs status` success payload would hit a
+        # `KeyError` on this source alone. The state file records output URLs
+        # flat, with no node or item association, so the grouped views cannot
+        # be reconstructed from it — they are present but empty, which is the
+        # same thing the live queue-hit payload emits.
+        "outputs_by_node": {},
+        "outputs_by_item": {},
+        "workflow_size": None,
         "error": st.error,
         "host": host,
         "port": port,
@@ -809,6 +818,27 @@ def _state_file_for_local_target(prompt_id: str, *, host: str, port: int) -> Job
     return st
 
 
+def _hint_for_missing_local(prompt_id: str, default: str) -> str:
+    """Redirect to `--where cloud` when that is why the local lookup came up empty.
+
+    ``_state_file_for_local_target`` rejects a cloud record silently, which
+    leaves the commonest mistake — a cloud job asked about without
+    ``--where cloud`` — indistinguishable from a job that never existed. The
+    default hints both point at ``comfy jobs ls``, whose scope follows the same
+    resolved target, so it would not list that job either. Name the query that
+    does work instead.
+    """
+    from comfy_cli import jobs_state
+
+    try:
+        st = jobs_state.read(prompt_id)
+    except (ValueError, OSError):
+        return default
+    if st is None or st.prompt_id != prompt_id or st.where != "cloud":
+        return default
+    return f"this prompt_id is tracked as a cloud job — try: comfy jobs status {prompt_id} --where cloud"
+
+
 def _server_confirms_no_record(host: str, port: int, prompt_id: str) -> bool:
     """True only if both `/queue` and `/history` answered and neither knows `prompt_id`.
 
@@ -867,7 +897,7 @@ def status_cmd(
             renderer.error(
                 code="server_not_running",
                 message=f"ComfyUI not running on {h}:{p}",
-                hint="run: comfy launch",
+                hint=_hint_for_missing_local(prompt_id, "run: comfy launch"),
                 details={"host": h, "port": p},
             )
             raise typer.Exit(code=1)
@@ -976,7 +1006,9 @@ def status_cmd(
         renderer.error(
             code="prompt_not_found",
             message=f"No prompt with id {prompt_id!r} on {h}:{p}.",
-            hint="check `comfy jobs ls`; very old prompts may have been pruned from /history",
+            hint=_hint_for_missing_local(
+                prompt_id, "check `comfy jobs ls`; very old prompts may have been pruned from /history"
+            ),
             details={"prompt_id": prompt_id, "host": h, "port": p},
         )
         raise typer.Exit(code=1)

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -707,6 +707,29 @@ def _render_jobs_pretty(rows: list[JobRow], *, host: str, port: int) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _state_file_snapshot(st: JobState, *, prompt_id: str, host: str, port: int, server_running: bool) -> dict:
+    """Shape a `jobs status` payload out of the on-disk state file.
+
+    Used by both fallback paths — the server being down, and a live server
+    that has no record of the prompt — so the two agree on field names.
+    ``server_running`` is the one thing that differs between them, and it is
+    what tells the caller which fallback it is looking at.
+    """
+    return {
+        "prompt_id": prompt_id,
+        "status": st.status,
+        "outputs": list(st.outputs or []),
+        "error": st.error,
+        "host": host,
+        "port": port,
+        "server_running": server_running,
+        "source": "state_file",
+        "submitted_at": st.submitted_at,
+        "updated_at": st.updated_at,
+        "workflow": st.workflow,
+    }
+
+
 @app.command("status", help="Show the status of a single prompt_id (local or --where cloud).")
 @tracking.track_command("jobs")
 def status_cmd(
@@ -749,19 +772,7 @@ def status_cmd(
             # The job finished before the server stopped — the state file is
             # the authoritative record, so this is a normal result, not an
             # error. Callers branch on `status`/`error`.
-            snapshot = {
-                "prompt_id": prompt_id,
-                "status": st.status,
-                "outputs": list(st.outputs or []),
-                "error": st.error,
-                "host": h,
-                "port": p,
-                "server_running": False,
-                "source": "state_file",
-                "submitted_at": st.submitted_at,
-                "updated_at": st.updated_at,
-                "workflow": st.workflow,
-            }
+            snapshot = _state_file_snapshot(st, prompt_id=prompt_id, host=h, port=p, server_running=False)
             if renderer.is_pretty():
                 _render_status_pretty(snapshot, host=h, port=p)
             renderer.emit(snapshot, command="jobs status")
@@ -792,6 +803,64 @@ def status_cmd(
 
     snapshot = _snapshot(h, p, prompt_id)
     if snapshot is None:
+        # The server answered, but neither /queue nor /history knows this
+        # prompt. That is *not* only "pruned from /history": the documented
+        # recovery from a server death is `comfy launch` and then check, and a
+        # relaunched ComfyUI is a FRESH process — its empty /queue and /history
+        # are precisely what a job that died with the old process looks like.
+        # So the state file, which still holds the verdict the watcher wrote
+        # (e.g. error.code == "server_died"), is the better answer here.
+        #
+        # This is the same inference the async watcher already makes: see
+        # `_LOST_AFTER_RESTART_S` in `comfy_cli/command/job_watcher.py`, where a
+        # prompt missing from a server that came back is finalized as
+        # `server_died`. `jobs status` reading the file it wrote keeps the two
+        # in agreement rather than having them contradict each other.
+        from comfy_cli import jobs_state
+
+        try:
+            st = jobs_state.read(prompt_id)
+        except ValueError:  # unsafe prompt_id — no state file to read
+            st = None
+
+        if st is not None and st.is_terminal:
+            # The state file holds a final verdict for this prompt — emit it as
+            # a normal result, exactly as the server-down path does. The one
+            # difference is `server_running: True`, so a caller can tell it is
+            # looking at a live server with no record rather than a dead one.
+            snapshot = _state_file_snapshot(st, prompt_id=prompt_id, host=h, port=p, server_running=True)
+            if renderer.is_pretty():
+                _render_status_pretty(snapshot, host=h, port=p)
+            renderer.emit(snapshot, command="jobs status")
+            return
+
+        if st is not None:
+            # Tracked but non-terminal: the watcher never got to write a
+            # verdict (it may still be inside its grace window, or it died
+            # too). Keep the `prompt_not_found` code — callers key on it — and
+            # attach what the file does know, mirroring the server-down
+            # non-terminal branch above.
+            renderer.error(
+                code="prompt_not_found",
+                message=(
+                    f"No prompt with id {prompt_id!r} on {h}:{p} — the local state file last recorded it as "
+                    f"{st.status!r} (submitted {st.submitted_at}, last update {st.updated_at}). The server may "
+                    f"have been restarted since, in which case the job died with the previous process."
+                ),
+                hint="check `comfy jobs ls`; very old prompts may have been pruned from /history",
+                details={
+                    "prompt_id": prompt_id,
+                    "host": h,
+                    "port": p,
+                    "last_known_status": st.status,
+                    "submitted_at": st.submitted_at,
+                    "updated_at": st.updated_at,
+                    "workflow": st.workflow,
+                },
+            )
+            raise typer.Exit(code=1)
+
+        # Untracked prompt: same envelope as before, byte for byte.
         renderer.error(
             code="prompt_not_found",
             message=f"No prompt with id {prompt_id!r} on {h}:{p}.",

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -734,6 +734,40 @@ def _state_file_snapshot(st: JobState, *, prompt_id: str, host: str, port: int, 
     }
 
 
+# Spellings that all name "the local machine". Folded together before a
+# state file's recorded host is compared with the queried one, because the two
+# are written by different code paths that do NOT agree on spelling:
+#
+#   * `comfy run`'s `execute()` substitutes the wildcard bind `0.0.0.0` with
+#     `127.0.0.1` before it writes the state file, while `resolve_host_port`
+#     canonicalizes a wildcard only when it came from `config.background` — an
+#     explicit `--host 0.0.0.0`, or a `COMFY_LOCAL_URL` naming it, reaches
+#     `jobs status` verbatim. Same env var, same server, two spellings.
+#   * `localhost` vs `127.0.0.1` is just which flag the caller happened to type;
+#     `resolve_host_port` passes both through unchanged.
+#
+# A missed match here is a silent FALSE NEGATIVE — the record is discarded and
+# the command falls back to the bare `prompt_not_found` envelope, throwing away
+# the very `server_died` attribution this fallback exists to preserve.
+_LOOPBACK_HOST_SPELLINGS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0", "::"})
+
+
+def _canonical_local_host(host: str) -> str:
+    """Fold one host spelling into a form comparable for same-server checks.
+
+    Unbrackets IPv6 literals (``[::1]`` and ``::1`` are the same address —
+    brackets are a URL encoding, and `Target.host` stores the raw literal while
+    `resolve_host_port` returns the bracketed one), lowercases (hostnames are
+    case-insensitive), and collapses every loopback/wildcard spelling onto one.
+    Anything else is returned as-is, so a genuinely different host still fails
+    the comparison.
+    """
+    from comfy_cli.env_checker import _unbracket_host
+
+    h = _unbracket_host(str(host).strip()).lower()
+    return "127.0.0.1" if h in _LOOPBACK_HOST_SPELLINGS else h
+
+
 def _state_file_for_local_target(prompt_id: str, *, host: str, port: int) -> JobState | None:
     """Read `prompt_id`'s state file, but only if it answers for THIS local target.
 
@@ -765,8 +799,10 @@ def _state_file_for_local_target(prompt_id: str, *, host: str, port: int) -> Job
     if st.where != "local":
         return None
     # host/port are None on files written before they were recorded, so only a
-    # positive mismatch disqualifies a record.
-    if st.host is not None and st.host != host:
+    # positive mismatch disqualifies a record. Compare canonicalized spellings:
+    # a literal `!=` rejects `localhost` against `127.0.0.1` (see
+    # `_canonical_local_host`), which would silently break this whole fallback.
+    if st.host is not None and _canonical_local_host(st.host) != _canonical_local_host(host):
         return None
     if st.port is not None and str(st.port) != str(port):
         return None

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -179,9 +179,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "prompt_not_found",
         "Asked about a prompt_id the server doesn't know. `comfy jobs status` only reports this once the "
-        "local state file has been checked too: if that file holds a terminal verdict (e.g. the job died "
-        "with an earlier server), the verdict is returned as a normal result instead. When a non-terminal "
-        "state file exists, `details` carries `last_known_status`, `submitted_at`, `updated_at`, `workflow`.",
+        "local state file has been checked too — and only a file that names this same prompt on this same "
+        "target counts, so a cloud job or another local instance's job is never the answer here (when it "
+        "is a cloud one, `hint` redirects to `--where cloud`). If that file holds a terminal verdict (e.g. "
+        "the job died with an earlier server) AND the live server confirmed it has no record, the verdict "
+        "is returned as a normal result instead. When a matching file exists but that pair does not hold — "
+        "the record is non-terminal, or `/queue` and `/history` did not answer — `details` carries "
+        "`last_known_status`, `submitted_at`, `updated_at`, `workflow`, and `server_confirmed_no_record` "
+        "(false means the absence is unverified, so it is not the job's outcome).",
         "`comfy jobs ls` to find a valid prompt_id",
     ),
     ErrorCode(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -178,7 +178,10 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "prompt_not_found",
-        "Asked about a prompt_id the server doesn't know.",
+        "Asked about a prompt_id the server doesn't know. `comfy jobs status` only reports this once the "
+        "local state file has been checked too: if that file holds a terminal verdict (e.g. the job died "
+        "with an earlier server), the verdict is returned as a normal result instead. When a non-terminal "
+        "state file exists, `details` carries `last_known_status`, `submitted_at`, `updated_at`, `workflow`.",
         "`comfy jobs ls` to find a valid prompt_id",
     ),
     ErrorCode(

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -12,7 +12,8 @@
     "prompt_id": {"type": "string"},
     "status": {
       "type": "string",
-      "enum": ["running", "pending", "queued", "completed", "error", "unknown", "watching"]
+      "description": "`cancelled` is one of `jobs_state.TERMINAL_STATUSES` and is copied verbatim out of a job's state file into a `jobs status` payload, so it belongs in this enum alongside the statuses the live `/queue` + `/history` snapshot produces.",
+      "enum": ["running", "pending", "queued", "completed", "error", "cancelled", "unknown", "watching"]
     },
     "queue_position": {"type": ["integer", "null"]},
     "workflow_size": {"type": ["integer", "null"]},

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -566,6 +566,11 @@ class TestStatusServerUpNoRecord:
         assert err["code"] == "prompt_not_found"
         # Falls all the way through to the bare envelope — no cloud data leaks.
         assert err["details"] == {"prompt_id": "cloud-run", "host": "127.0.0.1", "port": 8188}
+        # ...but not into a dead end: `comfy jobs ls` follows the same resolved
+        # target and would not list this job either, so name the query that works.
+        assert (
+            err["hint"] == "this prompt_id is tracked as a cloud job — try: comfy jobs status cloud-run --where cloud"
+        )
 
     def test_a_job_from_another_local_port_is_ignored(self, monkeypatch: pytest.MonkeyPatch):
         """Two local ComfyUI instances: port 8189's job is not port 8188's
@@ -2841,3 +2846,54 @@ def test_jobs_ls_survives_an_oversize_queue_response(monkeypatch: pytest.MonkeyP
     # command still succeeds — what matters is that ResponseTooLarge never
     # escapes as an uncaught exception. A non-zero exit here would mean it did.
     assert result.exit_code == 0, result.output
+
+
+def test_state_file_payload_carries_the_grouped_output_keys(monkeypatch: pytest.MonkeyPatch):
+    """Shape parity with the live snapshot. `_snapshot` always emits
+    `outputs_by_node`, `outputs_by_item` and `workflow_size`; a consumer that
+    indexes them on a `jobs status` success payload would hit a `KeyError` on
+    the state-file source alone. They are present but empty — the file records
+    output URLs flat, so the grouping genuinely cannot be reconstructed."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    st = jobs_state.new(prompt_id="shape-run", client_id="c", workflow="/tmp/wf.json", where="local")
+    st.status = "completed"
+    st.outputs = ["http://127.0.0.1:8188/view?filename=out.png"]
+    jobs_state.write(st)
+
+    result = _invoke_status("shape-run", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 0, result.output
+    data = _last_json(result.stdout)["data"]
+    assert data["outputs"] == ["http://127.0.0.1:8188/view?filename=out.png"]
+    assert data["outputs_by_node"] == {}
+    assert data["outputs_by_item"] == {}
+    assert data["workflow_size"] is None
+
+
+def test_server_down_cloud_job_hint_points_at_the_cloud_query(monkeypatch: pytest.MonkeyPatch):
+    """Server-down twin of the same redirect: a cloud-tracked prompt asked
+    about locally is told to use `--where cloud`, not "run: comfy launch"."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    st = jobs_state.new(
+        prompt_id="cloud-down", client_id="c", workflow="/tmp/wf.json", where="cloud", base_url="https://example"
+    )
+    st.status = "completed"
+    jobs_state.write(st)
+
+    result = _invoke_status("cloud-down", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 1, result.output
+    err = _last_json(result.stdout)["error"]
+    assert err["code"] == "server_not_running"
+    assert "--where cloud" in err["hint"]
+
+
+def test_untracked_prompt_keeps_the_default_hints(monkeypatch: pytest.MonkeyPatch):
+    """The redirect is conditional: with no state file at all, both bare
+    envelopes keep the hint they have always carried."""
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    result = _invoke_status("no-such-id", "--host", "127.0.0.1", "--port", "65431")
+    assert result.exit_code == 1, result.output
+    assert _last_json(result.stdout)["error"]["hint"] == "run: comfy launch"

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -647,6 +647,114 @@ class TestStatusServerUpNoRecord:
         data = _last_json(result.stdout)["data"]
         assert data["outputs"] == []
 
+    @pytest.mark.parametrize(
+        ("recorded_host", "queried_host"),
+        [
+            ("127.0.0.1", "localhost"),  # `run --host localhost`, status with defaults
+            ("localhost", "127.0.0.1"),  # and the reverse
+            ("127.0.0.1", "0.0.0.0"),  # COMFY_LOCAL_URL=http://0.0.0.0:8188 — see below
+            ("127.0.0.1", "LOCALHOST"),  # hostnames are case-insensitive
+            ("[::1]", "::1"),  # brackets are a URL encoding, not the address
+        ],
+    )
+    def test_a_loopback_alias_is_not_treated_as_a_different_server(
+        self, monkeypatch: pytest.MonkeyPatch, recorded_host: str, queried_host: str
+    ):
+        """Scoping the read to the queried target must not reject the SAME
+        server spelled differently — that is a silent false negative that
+        discards the `server_died` attribution this fallback exists to keep.
+
+        These spellings genuinely diverge in practice: `comfy run`'s `execute()`
+        rewrites the wildcard bind `0.0.0.0` to `127.0.0.1` before writing the
+        state file, while `resolve_host_port` only canonicalizes a wildcard that
+        came from `config.background` — so one `COMFY_LOCAL_URL=http://0.0.0.0:8188`
+        makes `run` store `127.0.0.1` and `jobs status` ask about `0.0.0.0`.
+        """
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="alias-run",
+            client_id="c",
+            workflow="/tmp/wf.json",
+            where="local",
+            host=recorded_host,
+            port=8188,
+        )
+        st.status = "error"
+        st.error = {"code": "server_died", "message": "died", "details": {}}
+        jobs_state.write(st)
+
+        result = _invoke_status("alias-run", "--host", queried_host, "--port", "8188")
+        assert result.exit_code == 0, result.output
+        data = _last_json(result.stdout)["data"]
+        assert data["error"]["code"] == "server_died"
+        assert data["source"] == "state_file"
+
+    def test_a_genuinely_different_host_is_still_rejected(self, monkeypatch: pytest.MonkeyPatch):
+        """The alias folding must not over-reach: a non-loopback host is a
+        different server and its record is still not this query's answer."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="remote-run",
+            client_id="c",
+            workflow="/tmp/wf.json",
+            where="local",
+            host="192.168.1.50",
+            port=8188,
+        )
+        st.status = "completed"
+        st.outputs = ["http://192.168.1.50:8188/view?filename=remote.png"]
+        jobs_state.write(st)
+
+        result = _invoke_status("remote-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        env = _last_json(result.stdout)
+        assert env["error"]["code"] == "prompt_not_found"
+        assert env["error"]["details"] == {"prompt_id": "remote-run", "host": "127.0.0.1", "port": 8188}
+        # The other server's artifact URLs must not leak into this answer.
+        assert "remote.png" not in json.dumps(env)
+
+    def test_a_cancelled_state_file_payload_is_schema_valid(self, monkeypatch: pytest.MonkeyPatch):
+        """`cancelled` is terminal in `jobs_state` and is copied verbatim into
+        the payload, so this path can emit it — `schemas/jobs.json` must accept
+        it. Without the enum entry the published contract rejects a payload the
+        command legitimately produces."""
+        import jsonschema
+
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="cancelled-run",
+            client_id="c",
+            workflow="/tmp/wf.json",
+            where="local",
+            host="127.0.0.1",
+            port=8188,
+        )
+        st.status = "cancelled"
+        jobs_state.write(st)
+
+        result = _invoke_status("cancelled-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 0, result.output
+        data = _last_json(result.stdout)["data"]
+        assert data["status"] == "cancelled"
+
+        schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+        jsonschema.Draft202012Validator(json.loads(schema_path.read_text())).validate(data)
+
+    def test_jobs_schema_status_enum_covers_every_terminal_state(self):
+        """Every `jobs_state.TERMINAL_STATUSES` value reaches a `jobs status`
+        payload verbatim, so each must be a legal `status` in the schema."""
+        from comfy_cli import jobs_state
+
+        schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+        enum = set(json.loads(schema_path.read_text())["properties"]["status"]["enum"])
+        assert jobs_state.TERMINAL_STATUSES <= enum, sorted(jobs_state.TERMINAL_STATUSES - enum)
+
 
 # ---------------------------------------------------------------------------
 # `jobs ls --orphaned` — surface watcher_crashed jobs for cleanup

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -329,8 +329,14 @@ def test_jobs_status_server_down_terminal_state_emits_ok_envelope(monkeypatch: p
 
 
 def test_jobs_status_server_up_still_uses_live_snapshot(monkeypatch: pytest.MonkeyPatch):
-    """Server up: the live `/history` snapshot wins — the state file is never
-    consulted and the payload carries no state-file markers."""
+    """Server up *and it has a record for the prompt*: the live `/queue`
+    `/history` snapshot wins — the state file is not consulted and the payload
+    carries no state-file markers.
+
+    The state file is only a fallback, never an override: it is read when the
+    live server has nothing to say about the prompt (see the
+    `TestStatusServerUpNoRecord` cases below), not when it does.
+    """
     from comfy_cli import jobs_state
 
     monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: True)
@@ -344,12 +350,157 @@ def test_jobs_status_server_up_still_uses_live_snapshot(monkeypatch: pytest.Monk
     st.status = "completed"
     jobs_state.write(st)
 
+    reads: list[str] = []
+    real_read = jobs_state.read
+
+    def spy_read(pid):
+        reads.append(pid)
+        return real_read(pid)
+
+    monkeypatch.setattr(jobs_state, "read", spy_read)
+
     result = _invoke_status("live-run", "--host", "127.0.0.1", "--port", "8188")
     assert result.exit_code == 0, result.output
     data = _last_json(result.stdout)["data"]
     assert data["status"] == "running"
     assert "source" not in data
     assert "server_running" not in data
+    # The live snapshot answered, so the fallback never ran.
+    assert reads == []
+
+
+def test_jobs_status_server_down_surfaces_server_died_verdict(monkeypatch: pytest.MonkeyPatch):
+    """The composite the epic exists for: the watcher recorded `server_died`,
+    the server is still down, and `jobs status` hands that verdict back.
+
+    The two halves — a terminal state file being emitted, and `server_died`
+    being written — are each covered elsewhere; this pins the seam between
+    them, which is the only thing a caller actually sees.
+    """
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: False)
+    st = jobs_state.new(prompt_id="oom-run", client_id="c", workflow="/tmp/oom.json", where="local")
+    st.status = "error"
+    st.error = {
+        "code": "server_died",
+        "message": "ComfyUI server 127.0.0.1:8188 stopped answering while job oom-run was 'running'.",
+        "details": {"host": "127.0.0.1", "port": 8188, "last_status": "running"},
+    }
+    jobs_state.write(st)
+
+    result = _invoke_status("oom-run", "--host", "127.0.0.1", "--port", "8188")
+    assert result.exit_code == 0, result.output
+    env = _last_json(result.stdout)
+    assert env["ok"] is True
+    data = env["data"]
+    assert data["status"] == "error"
+    assert data["error"]["code"] == "server_died"
+    assert data["source"] == "state_file"
+    assert data["server_running"] is False
+    assert data["prompt_id"] == "oom-run"
+    assert data["workflow"] == "/tmp/oom.json"
+
+
+class TestStatusServerUpNoRecord:
+    """Server UP but neither `/queue` nor `/history` knows the prompt.
+
+    This is what the documented crash recovery ("relaunch, then check")
+    produces: a fresh ComfyUI answers the port with an empty history, so the
+    live snapshot comes back None. Before BE-4749 that unconditionally emitted
+    `prompt_not_found` and discarded the `server_died` verdict already sitting
+    on disk.
+    """
+
+    @staticmethod
+    def _server_up_with_no_record(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: True)
+        monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: None)
+
+    def test_terminal_state_file_wins_over_prompt_not_found(self, monkeypatch: pytest.MonkeyPatch):
+        """Terminal record -> emit it as a normal result, exit 0. This is the
+        relaunch-then-check path that used to throw the attribution away."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(prompt_id="relaunched-run", client_id="c", workflow="/tmp/oom.json", where="local")
+        st.status = "error"
+        st.error = {"code": "server_died", "message": "the server died under this job", "details": {}}
+        jobs_state.write(st)
+
+        result = _invoke_status("relaunched-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 0, result.output
+        env = _last_json(result.stdout)
+        assert env["ok"] is True
+        data = env["data"]
+        assert data["status"] == "error"
+        assert data["error"]["code"] == "server_died"
+        assert data["source"] == "state_file"
+        # The distinguishing field: the port answers, it just has no record.
+        assert data["server_running"] is True
+        assert data["prompt_id"] == "relaunched-run"
+        assert data["workflow"] == "/tmp/oom.json"
+        assert data["submitted_at"] == st.submitted_at
+
+    def test_terminal_completed_state_file_is_also_returned(self, monkeypatch: pytest.MonkeyPatch):
+        """Not just failures: a completed job pruned from `/history` still has
+        its outputs on disk, and they are worth more than `prompt_not_found`."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(prompt_id="pruned-run", client_id="c", workflow="/tmp/wf.json", where="local")
+        st.status = "completed"
+        st.outputs = ["http://127.0.0.1:8188/view?filename=out.png"]
+        jobs_state.write(st)
+
+        result = _invoke_status("pruned-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 0, result.output
+        data = _last_json(result.stdout)["data"]
+        assert data["status"] == "completed"
+        assert data["outputs"] == ["http://127.0.0.1:8188/view?filename=out.png"]
+        assert data["error"] is None
+        assert data["source"] == "state_file"
+        assert data["server_running"] is True
+
+    def test_non_terminal_state_file_keeps_the_code_but_enriches_details(self, monkeypatch: pytest.MonkeyPatch):
+        """Non-terminal record -> still `prompt_not_found` (callers key on the
+        code) but carrying the last-known state, like the server-down twin."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(prompt_id="inflight-run", client_id="c", workflow="/tmp/wf.json", where="local")
+        st.status = "running"
+        jobs_state.write(st)
+
+        result = _invoke_status("inflight-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        env = _last_json(result.stdout)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "prompt_not_found"
+        assert "inflight-run" in err["message"]
+        assert "'running'" in err["message"]
+        details = err["details"]
+        assert details["prompt_id"] == "inflight-run"
+        assert details["last_known_status"] == "running"
+        assert details["workflow"] == "/tmp/wf.json"
+        assert details["submitted_at"] == st.submitted_at
+        assert details["updated_at"] == st.updated_at
+
+    def test_no_state_file_keeps_the_bare_envelope(self, monkeypatch: pytest.MonkeyPatch):
+        """No record anywhere -> today's envelope, byte for byte. An untracked
+        prompt id must not start reporting on jobs that never existed."""
+        self._server_up_with_no_record(monkeypatch)
+
+        result = _invoke_status("never-existed", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        env = _last_json(result.stdout)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "prompt_not_found"
+        assert err["message"] == "No prompt with id 'never-existed' on 127.0.0.1:8188."
+        assert err["hint"] == "check `comfy jobs ls`; very old prompts may have been pruned from /history"
+        assert err["details"] == {"prompt_id": "never-existed", "host": "127.0.0.1", "port": 8188}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -507,6 +507,12 @@ class TestStatusServerUpNoRecord:
         assert details["workflow"] == "/tmp/wf.json"
         assert details["submitted_at"] == st.submitted_at
         assert details["updated_at"] == st.updated_at
+        # The confirmed side of the fork: the server *did* disown the prompt —
+        # only the record is non-terminal — so the message may say the job died
+        # with the previous process. The unconfirmed twin below asserts the
+        # opposite flag and the hedged tail.
+        assert details["server_confirmed_no_record"] is True
+        assert "died with the previous process" in err["message"]
 
     def test_no_state_file_keeps_the_bare_envelope(self, monkeypatch: pytest.MonkeyPatch):
         """No record anywhere -> today's envelope, byte for byte. An untracked

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -414,8 +414,29 @@ class TestStatusServerUpNoRecord:
 
     @staticmethod
     def _server_up_with_no_record(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Server answers, empty `/queue` and `/history` — a fresh relaunch."""
         monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: True)
         monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: None)
+
+        # `_server_confirms_no_record` re-queries to prove the absence is real
+        # rather than a swallowed fetch error, so it needs a live-looking server.
+        def fake_get(url, timeout=10.0):
+            if url.endswith("/queue"):
+                return {"queue_running": [], "queue_pending": []}
+            return {}
+
+        monkeypatch.setattr(jobs_mod, "_http_get_json", fake_get)
+
+    @staticmethod
+    def _server_up_but_flaky(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Port answers the health probe, but `/queue` and `/history` fail."""
+        monkeypatch.setattr(jobs_mod, "check_comfy_server_running", lambda port, host: True)
+        monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: None)
+
+        def boom(url, timeout=10.0):
+            raise RuntimeError("connection reset")
+
+        monkeypatch.setattr(jobs_mod, "_http_get_json", boom)
 
     def test_terminal_state_file_wins_over_prompt_not_found(self, monkeypatch: pytest.MonkeyPatch):
         """Terminal record -> emit it as a normal result, exit 0. This is the
@@ -501,6 +522,130 @@ class TestStatusServerUpNoRecord:
         assert err["message"] == "No prompt with id 'never-existed' on 127.0.0.1:8188."
         assert err["hint"] == "check `comfy jobs ls`; very old prompts may have been pruned from /history"
         assert err["details"] == {"prompt_id": "never-existed", "host": "127.0.0.1", "port": 8188}
+
+    def test_unconfirmed_absence_does_not_manufacture_a_death_verdict(self, monkeypatch: pytest.MonkeyPatch):
+        """A busy server whose `/queue` and `/history` fetches fail must NOT be
+        read as 'the job died'. `_snapshot` returns None for a swallowed fetch
+        error too, so the terminal state file stays unpublished and the message
+        claims no death."""
+        from comfy_cli import jobs_state
+
+        self._server_up_but_flaky(monkeypatch)
+        st = jobs_state.new(prompt_id="flaky-run", client_id="c", workflow="/tmp/wf.json", where="local")
+        st.status = "error"
+        st.error = {"code": "server_died", "message": "died", "details": {}}
+        jobs_state.write(st)
+
+        result = _invoke_status("flaky-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        env = _last_json(result.stdout)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "prompt_not_found"
+        # The honest phrasing: unknown, not dead.
+        assert "unknown" in err["message"]
+        assert "died with the previous process" not in err["message"]
+        assert err["details"]["server_confirmed_no_record"] is False
+
+    def test_a_cloud_state_file_is_not_an_answer_about_a_local_target(self, monkeypatch: pytest.MonkeyPatch):
+        """State files are keyed by prompt_id alone. A cloud run must not be
+        returned as an authoritative local result with local output URLs."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="cloud-run", client_id="c", workflow="/tmp/wf.json", where="cloud", base_url="https://example"
+        )
+        st.status = "completed"
+        st.outputs = ["https://cloud.example/out.png"]
+        jobs_state.write(st)
+
+        result = _invoke_status("cloud-run", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        err = _last_json(result.stdout)["error"]
+        assert err["code"] == "prompt_not_found"
+        # Falls all the way through to the bare envelope — no cloud data leaks.
+        assert err["details"] == {"prompt_id": "cloud-run", "host": "127.0.0.1", "port": 8188}
+
+    def test_a_job_from_another_local_port_is_ignored(self, monkeypatch: pytest.MonkeyPatch):
+        """Two local ComfyUI instances: port 8189's job is not port 8188's
+        answer, and its output URLs must not be restamped with 8188."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="other-port", client_id="c", workflow="/tmp/wf.json", where="local", host="127.0.0.1", port=8189
+        )
+        st.status = "completed"
+        jobs_state.write(st)
+
+        result = _invoke_status("other-port", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        err = _last_json(result.stdout)["error"]
+        assert err["code"] == "prompt_not_found"
+        assert err["details"] == {"prompt_id": "other-port", "host": "127.0.0.1", "port": 8188}
+
+    def test_a_record_whose_host_and_port_match_is_still_used(self, monkeypatch: pytest.MonkeyPatch):
+        """The scoping must not break the case it exists to protect: a record
+        naming this exact host:port is still the answer."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(
+            prompt_id="same-port", client_id="c", workflow="/tmp/wf.json", where="local", host="127.0.0.1", port=8188
+        )
+        st.status = "error"
+        st.error = {"code": "server_died", "message": "died", "details": {}}
+        jobs_state.write(st)
+
+        result = _invoke_status("same-port", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 0, result.output
+        data = _last_json(result.stdout)["data"]
+        assert data["error"]["code"] == "server_died"
+        assert data["source"] == "state_file"
+        assert data["server_running"] is True
+
+    def test_a_slash_bearing_id_does_not_borrow_another_jobs_record(self, monkeypatch: pytest.MonkeyPatch):
+        """`state_path` maps "/" to "_" before validating, so read("a/b") lands
+        on the file for the distinct prompt "a_b". That record must not be
+        reported under the queried id."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(prompt_id="a_b", client_id="c", workflow="/tmp/wf.json", where="local")
+        st.status = "completed"
+        st.outputs = ["http://127.0.0.1:8188/view?filename=ab.png"]
+        jobs_state.write(st)
+
+        result = _invoke_status("a/b", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 1, result.output
+        env = _last_json(result.stdout)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "prompt_not_found"
+        # Crucially: not a'b's outputs reported as a/b's.
+        assert "ab.png" not in json.dumps(env)
+
+    def test_a_non_list_outputs_field_does_not_crash(self, monkeypatch: pytest.MonkeyPatch):
+        """`jobs_state.read` type-checks nothing it keeps, so a mangled
+        `outputs` must degrade to [] rather than shred a string into characters
+        or raise inside the envelope builder."""
+        from comfy_cli import jobs_state
+
+        self._server_up_with_no_record(monkeypatch)
+        st = jobs_state.new(prompt_id="bad-outputs", client_id="c", workflow="/tmp/wf.json", where="local")
+        st.status = "completed"
+        jobs_state.write(st)
+        # Corrupt the file the way a hand-edit would.
+        path = jobs_state.state_path("bad-outputs")
+        blob = json.loads(path.read_text())
+        blob["outputs"] = "not-a-list"
+        path.write_text(json.dumps(blob))
+
+        result = _invoke_status("bad-outputs", "--host", "127.0.0.1", "--port", "8188")
+        assert result.exit_code == 0, result.output
+        data = _last_json(result.stdout)["data"]
+        assert data["outputs"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

BE-4748 gave `comfy jobs status` a state-file fallback so that a job whose ComfyUI died reports its last-known verdict — `error.code == "server_died"` — instead of a bare `server_not_running`. That works.

**But the fallback is gated on the server being DOWN.** And the remediation we document everywhere after a crash is *"relaunch the server, then check."* Relaunching makes the port answer again from a **fresh process** with no `/queue` or `/history` record of the dead prompt. `_snapshot()` returns `None`, and `jobs status` emitted `prompt_not_found` — throwing away the verdict already sitting on disk.

Reproduction (verified end-to-end):

```
state file has error.code="server_died"; server relaunched
comfy jobs status <id>  ->  exit 1, ok=false, error.code="prompt_not_found"
```

So the documented recovery step destroyed the exact attribution the epic exists to provide. The user does what we told them to do, and the answer gets worse.

## Why the state file is the right answer here

A live server with no record of a job it once had is not merely "pruned from `/history`" — it *is* the watcher's own death signal. `job_watcher` already makes precisely this inference: see `_LOST_AFTER_RESTART_S` (`comfy_cli/command/job_watcher.py`), where a prompt missing from a server that came back is finalized as `server_died`. Having `jobs status` read the file the watcher wrote keeps the two in agreement rather than having them contradict each other.

Corroborating this: **`jobs wait` was already correct.** `_wait_fetch_snapshot` falls through to the state file when a live `_snapshot` comes back empty (`jobs.py:1015-1018`). `jobs status` was the inconsistent one — so this restores internal consistency rather than inventing a new policy.

## What changed

- **Extracted** the state-file snapshot builder — previously inlined inside the server-down branch — into a module-level `_state_file_snapshot()` helper, so both fallbacks shape an identical payload and can't drift.
- **On a live server with no record**, read `jobs_state`:
  - **Terminal record** → emit it as a normal result: `source: "state_file"`, `server_running: True`, exit 0. (`server_running` is the one field that differs from the server-down path, and it's what tells a caller which fallback it's looking at.)
  - **Non-terminal record** → keep the `prompt_not_found` code, since callers key on it, but enrich `details` with `last_known_status`, `submitted_at`, `updated_at`, `workflow` — mirroring the server-down non-terminal branch.
  - **No record** → today's envelope, byte for byte. An untracked prompt id must not start reporting on jobs that never existed.
- Noted the shifted semantics in the `prompt_not_found` entry of the error-code registry, which previously described only "the server doesn't know".

## Test coverage

- **Narrowed** `test_jobs_status_server_up_still_uses_live_snapshot` from "the state file is *never* consulted" — now too strong — to "not consulted when the server **has** a record for the prompt," preserving its real intent that a live snapshot must beat a stale file. Also made that claim actually *verifiable* by spying on `jobs_state.read` rather than inferring it from the absence of payload markers.
- **Added the missing composite**: server DOWN + a terminal state file carrying `server_died` → `ok=true`, `status: "error"`, `error.code: "server_died"`, `source: "state_file"`, with `prompt_id` and `workflow` present. Both halves were tested separately; the seam between them never was, and the seam is the only thing a caller sees.
- **Added `TestStatusServerUpNoRecord`** covering the three new branches with the server UP: terminal error, terminal completed (a pruned-but-successful job still has its outputs on disk), non-terminal, and absent.

I verified the tests earn their keep: the three behavior-changing branches **fail** against the unmodified `jobs.py`. The untracked-prompt and live-snapshot cases pass either way by design — that's what makes them regression guards rather than new assertions.

## Verification

```
pytest tests/comfy_cli/jobs/test_jobs.py tests/comfy_cli/test_jobs_state.py \
       tests/comfy_cli/command/test_run.py -q     ->  237 passed
ruff check .          ->  All checks passed!
ruff format --check . ->  272 files already formatted
ruff format --diff .  ->  272 files already formatted   (what CI runs)
```

Lint/format were run with **ruff 0.15.15**, the version CI pins. Worth flagging for anyone verifying locally: `pyproject.toml` leaves the `ruff` dev extra unpinned, so a fresh `pip install -e '.[dev]'` pulls 0.16.1, which added Markdown code-block formatting and therefore reports `docs/DESIGN-uv-compile.md` as unformatted. That file is byte-identical to `main` and unrelated to this PR; CI's pinned 0.15.15 does not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)