### PR TITLE
feat(stop): add `comfy stop --port <p>` — verified stop of an untracked local ComfyUI

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1458,10 +1458,36 @@ def free(
     system_command.free_execute(get_renderer(), where=where, unload_models=unload_models, free_memory=free_memory)
 
 
-@app.command(help="Stop background ComfyUI")
+@app.command(help="Stop background ComfyUI. Use --port to stop an untracked local ComfyUI this CLI didn't start.")
 @tracking.track_command()
-def stop():
+def stop(
+    port: Annotated[
+        int | None,
+        typer.Option(
+            "--port",
+            show_default=False,
+            min=1,
+            max=65535,
+            help="Stop whatever local ComfyUI is listening on this port, even if this CLI didn't start it. "
+            "Refuses anything it cannot positively identify as ComfyUI.",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Report the process that would be stopped and exit 0 without stopping it.",
+        ),
+    ] = False,
+):
     renderer = get_renderer()
+
+    if port is not None:
+        from comfy_cli.command import stop_port
+
+        stop_port.stop_port_execute(renderer, port=port, dry_run=dry_run)
+        return
+
     config = ConfigManager()
     bg_info = config.background if constants.CONFIG_KEY_BACKGROUND in config.config["DEFAULT"] else None
     if not bg_info:
@@ -1473,6 +1499,24 @@ def stop():
                 command="stop",
             )
         raise typer.Exit(code=1)
+
+    if dry_run:
+        rprint(
+            f"[bold yellow]Would stop background ComfyUI.[/bold yellow] ({bg_info[0]}:{bg_info[1]}, pid={bg_info[2]})"
+        )
+        renderer.emit(
+            {
+                "stopped": False,
+                "dry_run": True,
+                "untracked": False,
+                "host": bg_info[0],
+                "port": bg_info[1],
+                "pid": bg_info[2],
+            },
+            command="stop",
+            changed=False,
+        )
+        return
 
     is_killed = utils.kill_all(bg_info[2])
 

--- a/comfy_cli/command/stop_port.py
+++ b/comfy_cli/command/stop_port.py
@@ -14,21 +14,27 @@ wrong process:
   is root-only on macOS, so it is never used here.
 - Identity is proven from the **process table first**: a python-ish ``argv[0]``
   running a ``main.py``. Only then do we ask the server itself
-  (``GET /system_stats``). A port that answers but disagrees with the process
-  table is refused — that is the reverse-proxy false positive.
-- A port that does not answer at all is *still* stopped, on the cmdline
-  evidence alone: a wedged ComfyUI is precisely what this command exists for.
+  (``GET /system_stats``, on the address it actually bound). A port that answers
+  but disagrees with the process table is refused — that is the reverse-proxy
+  false positive.
+- A port that does *not* answer at all — wedged, still starting, or speaking
+  TLS — is stopped only if the ``main.py`` on that command line also lives in a
+  ComfyUI checkout on disk. The cmdline shape alone matches any ``python
+  main.py`` service, and killing one of those is exactly what this must not do.
 - We never stop anything on HTTP evidence alone.
 """
 
 from __future__ import annotations
 
+import http.client
+import ipaddress
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.request
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -47,12 +53,24 @@ HTTP_PROBE_TIMEOUT = 2.0
 TERMINATE_TIMEOUT = 5.0
 KILL_TIMEOUT = 3.0
 
+# `/system_stats` is a small JSON document. `timeout` on urlopen bounds each
+# socket operation, not the whole transfer, so without a cap whatever holds the
+# port could trickle an unbounded body into memory instead.
+MAX_PROBE_BYTES = 1 << 20
+_PROBE_CHUNK = 64 * 1024
+
 # `python`, `python3`, `python3.12`, `pythonw`, `py`, and the macOS framework
 # `Python` — but not `uv`, `node`, `nginx`, or anything else that merely has a
 # `main.py` somewhere on its command line.
 _PYTHON_ARGV0 = re.compile(r"^(python|pythonw|py)[0-9._]*$", re.IGNORECASE)
 
 _EXPECTED_ERRORS = (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError)
+
+# Files and directories that sit next to `main.py` in every ComfyUI checkout —
+# source, portable, and the desktop app's bundle alike. Used as the second
+# signal when the server cannot speak for itself.
+_COMFYUI_TREE_MARKERS = ("nodes.py", "execution.py", "folder_paths.py", "server.py", "comfy", "comfy_extras")
+_COMFYUI_TREE_MIN_MARKERS = 3
 
 
 @dataclass(frozen=True)
@@ -63,6 +81,12 @@ class Listener:
     cmdline: list[str] = field(default_factory=list)
     cwd: str | None = None
     name: str | None = None
+    # The local address of the LISTEN socket we matched, so the probe below
+    # reaches the server we are actually about to stop.
+    laddr_ip: str | None = None
+    # Pid + create_time is the only stable process identity; a bare pid can be
+    # recycled between discovery and teardown.
+    create_time: float | None = None
 
 
 @dataclass(frozen=True)
@@ -70,8 +94,8 @@ class Probe:
     """Outcome of ``GET /system_stats``.
 
     ``answered`` distinguishes "the port produced an HTTP response" (even a 404
-    from a proxy, or a non-JSON body) from "refused / timed out", which is the
-    wedged-server case we deliberately proceed on.
+    from a proxy, or a non-JSON body) from "refused / timed out / not HTTP",
+    which is the wedged-server case.
     """
 
     answered: bool
@@ -85,16 +109,43 @@ class Verdict:
     http: str
 
 
+@dataclass(frozen=True)
+class Teardown:
+    """Result of :func:`kill_process_tree`."""
+
+    ok: bool
+    survivors: list[int]
+    # False when the child list could not be read, so `ok` cannot speak for
+    # anything but the parent — reported rather than silently claimed.
+    children_enumerated: bool = True
+
+
 # --------------------------------------------------------------------------- #
 # Finding the listener
 # --------------------------------------------------------------------------- #
 
 
-def _is_listen_on(conn: Any, port: int) -> bool:
-    if conn.status != psutil.CONN_LISTEN:
-        return False
-    laddr = getattr(conn, "laddr", None)
-    return bool(laddr) and getattr(laddr, "port", None) == port
+def _proc_net_connections(proc: Any, kind: str = "inet"):
+    """``Process.net_connections()``, tolerating psutil < 6.
+
+    psutil 6.0.0 renamed ``Process.connections()`` to ``net_connections()``.
+    ``pyproject.toml`` pins the floor, but an already-provisioned environment
+    can still resolve 5.x, where the missing attribute would escape as a raw
+    ``AttributeError`` traceback instead of a structured error envelope.
+    """
+    getter = getattr(proc, "net_connections", None) or proc.connections
+    return getter(kind=kind)
+
+
+def _listen_match(conns: Iterable[Any], port: int) -> Any | None:
+    """The first LISTEN socket on ``port``, or None."""
+    for conn in conns:
+        if conn.status != psutil.CONN_LISTEN:
+            continue
+        laddr = getattr(conn, "laddr", None)
+        if laddr and getattr(laddr, "port", None) == port:
+            return conn
+    return None
 
 
 def _safe_cwd(proc: psutil.Process) -> str | None:
@@ -102,9 +153,17 @@ def _safe_cwd(proc: psutil.Process) -> str | None:
         return proc.cwd()
     except _EXPECTED_ERRORS:
         # macOS denies cwd() for other users' processes. Not knowing it is fine
-        # — it is reported for the operator's benefit, never used as evidence.
+        # — it is reported for the operator's benefit, and only ever used to
+        # resolve a relative script path (whose absence just means "refuse").
         return None
     except NotImplementedError:  # pragma: no cover - platform-dependent
+        return None
+
+
+def _safe_create_time(proc: psutil.Process) -> float | None:
+    try:
+        return proc.create_time()
+    except _EXPECTED_ERRORS:
         return None
 
 
@@ -117,12 +176,14 @@ def find_listener(port: int) -> Listener | None:
     """
     for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
-            conns = proc.net_connections(kind="inet")
+            conns = _proc_net_connections(proc)
         except _EXPECTED_ERRORS:
             continue
-        if not any(_is_listen_on(c, port) for c in conns):
+        conn = _listen_match(conns, port)
+        if conn is None:
             continue
         info = proc.info or {}
+        laddr = getattr(conn, "laddr", None)
         return Listener(
             pid=proc.pid,
             # AccessDenied on the cmdline leaves it empty — we still report the
@@ -130,6 +191,8 @@ def find_listener(port: int) -> Listener | None:
             cmdline=[str(tok) for tok in (info.get("cmdline") or [])],
             cwd=_safe_cwd(proc),
             name=info.get("name"),
+            laddr_ip=getattr(laddr, "ip", None),
+            create_time=_safe_create_time(proc),
         )
     return None
 
@@ -165,25 +228,137 @@ def looks_like_comfyui(cmdline: Sequence[str]) -> bool:
     Deliberately shape-based, not path-based: `comfy launch` runs
     ``[python, "main.py"]`` from the workspace, a hand-started server uses an
     absolute path, and the desktop app uses its bundled interpreter — all three
-    are the same shape.
+    are the same shape. It is a *necessary* condition, never a sufficient one.
     """
     if len(cmdline) < 2 or not _is_python_ish(cmdline[0]):
         return False
     return _script_tail(cmdline) is not None
 
 
-def probe_system_stats(port: int, *, timeout: float = HTTP_PROBE_TIMEOUT) -> Probe:
-    """``GET http://127.0.0.1:<port>/system_stats`` with a short timeout."""
-    url = f"http://127.0.0.1:{port}/system_stats"
+def _script_path(listener: Listener) -> str | None:
+    """Absolute path of the ``main.py`` this process is running, if resolvable."""
+    tail = _script_tail(listener.cmdline)
+    if not tail:
+        return None
+    script = tail[0]
+    if os.path.isabs(script):
+        return script
+    if not listener.cwd:
+        return None
+    return os.path.join(listener.cwd, script)
+
+
+def looks_like_comfyui_tree(listener: Listener) -> bool:
+    """Does this process's ``main.py`` live in a ComfyUI checkout?
+
+    The second, independent signal for a listener that cannot corroborate
+    itself over HTTP. Every ComfyUI checkout keeps ``main.py`` alongside
+    ``nodes.py`` / ``execution.py`` / ``folder_paths.py`` / ``comfy/``; an
+    unrelated ``python main.py`` service does not.
+    """
+    script = _script_path(listener)
+    if not script:
+        return False
+    root = os.path.dirname(script) or "."
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - fixed loopback http URL
-            body = resp.read()
+        hits = sum(1 for marker in _COMFYUI_TREE_MARKERS if os.path.exists(os.path.join(root, marker)))
+    except OSError:  # pragma: no cover - unreadable directory
+        return False
+    return hits >= _COMFYUI_TREE_MIN_MARKERS
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse redirects on the probe.
+
+    A hostile local listener must not be able to point the probe off-box —
+    either to source a corroborating ``/system_stats`` payload from elsewhere,
+    or to an unreachable URL that would authorize its own termination.
+    Returning None here leaves the 3xx unhandled, so urllib raises ``HTTPError``
+    and the response reads as "answered, but not ComfyUI".
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _open_url(url: str, timeout: float):
+    """Open ``url`` with an opener that cannot be steered off the local machine.
+
+    ``ProxyHandler({})`` because the *default* opener honors
+    ``http_proxy``/``ALL_PROXY``, and urllib's ``proxy_bypass`` consults only
+    ``no_proxy`` — there is no implicit localhost exemption, so without this the
+    probe can leave the box entirely.
+    """
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect)
+    return opener.open(url, timeout=timeout)  # noqa: S310 - callers build a fixed http:// URL
+
+
+def probe_host(laddr_ip: str | None) -> str:
+    """Host component to probe, given the address the listener actually bound.
+
+    ``find_listener`` matches a LISTEN socket on *any* local address, so
+    hardcoding ``127.0.0.1`` would read a server started with ``--listen
+    <lan-ip>``, or bound only to ``::1``, as unreachable — skipping the
+    ``/system_stats`` cross-check exactly where it matters most.
+    """
+    ip = (laddr_ip or "").strip()
+    # A zone id (`fe80::1%en0`) needs RFC 6874 `%25` escaping that urllib does
+    # not accept; loopback is the safe fallback, and a non-answer is handled
+    # conservatively downstream anyway.
+    if not ip or ip == "*" or "%" in ip:
+        return "127.0.0.1"
+    try:
+        parsed = ipaddress.ip_address(ip)
+    except ValueError:
+        # Scoped (`fe80::1%en0`) or otherwise unparseable. Fall back to
+        # loopback; a non-answer here is handled conservatively anyway.
+        return "127.0.0.1"
+    if parsed.version == 4:
+        return "127.0.0.1" if parsed.is_unspecified else ip
+    mapped = parsed.ipv4_mapped
+    if mapped is not None:
+        return "127.0.0.1" if mapped.is_unspecified else str(mapped)
+    return "[::1]" if parsed.is_unspecified else f"[{ip}]"
+
+
+def _read_capped(resp: Any, *, limit: int, deadline: float) -> tuple[bytes, bool]:
+    """Read at most ``limit`` bytes, giving up at ``deadline``.
+
+    Returns ``(body, oversized)``. Raises ``TimeoutError`` (an ``OSError``, so
+    it reads as "did not answer") if the peer trickles past the deadline.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while total <= limit:
+        if time.monotonic() > deadline:
+            raise TimeoutError("timed out reading /system_stats")
+        chunk = resp.read(min(_PROBE_CHUNK, limit + 1 - total))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    return b"".join(chunks), total > limit
+
+
+def probe_system_stats(port: int, *, host: str = "127.0.0.1", timeout: float = HTTP_PROBE_TIMEOUT) -> Probe:
+    """``GET http://<host>:<port>/system_stats`` with a short, bounded timeout."""
+    url = f"http://{host}:{port}/system_stats"
+    deadline = time.monotonic() + timeout
+    try:
+        with _open_url(url, timeout) as resp:
+            body, oversized = _read_capped(resp, limit=MAX_PROBE_BYTES, deadline=deadline)
     except urllib.error.HTTPError:
         # Something is serving this port and it is not ComfyUI's /system_stats.
         return Probe(answered=True)
-    except (urllib.error.URLError, OSError):
-        # Refused, reset, or timed out — the wedged-server case.
+    except (urllib.error.URLError, http.client.HTTPException, OSError):
+        # Refused, reset, timed out, or not speaking HTTP at all (a TLS-enabled
+        # ComfyUI lands here) — the server cannot corroborate itself.
+        # `http.client.HTTPException` is neither a URLError nor an OSError:
+        # urllib only wraps OSError from the request, not from reading it.
         return Probe(answered=False)
+    if oversized:
+        # No `/system_stats` is a megabyte long; whatever this is, it isn't one.
+        return Probe(answered=True)
     try:
         payload = json.loads(body.decode("utf-8", "replace"))
     except (ValueError, UnicodeDecodeError):
@@ -210,7 +385,8 @@ def verify_listener(listener: Listener, port: int, *, probe: Probe | None = None
     """Decide whether ``listener`` is positively identifiable as ComfyUI.
 
     Order matters: the cmdline is a precondition, so an HTTP answer alone can
-    never authorize a kill. The probe can only *withdraw* that authorization.
+    never authorize a kill. The probe can only *withdraw* that authorization —
+    or, when it cannot be had at all, hand the decision to the on-disk checkout.
     """
     if not looks_like_comfyui(listener.cmdline):
         return Verdict(
@@ -220,12 +396,26 @@ def verify_listener(listener: Listener, port: int, *, probe: Probe | None = None
         )
 
     if probe is None:
-        probe = probe_system_stats(port)
+        probe = probe_system_stats(port, host=probe_host(listener.laddr_ip))
 
     if not probe.answered:
-        # Wedged or still starting: the process table already says ComfyUI, and
-        # a server that cannot answer is exactly what this command is for.
-        return Verdict(verified=True, reason="identified from the process command line", http="unreachable")
+        # Wedged, still starting, or serving TLS. The process table alone is a
+        # weak signal here — every `python main.py` matches it — so require the
+        # ComfyUI checkout on disk before signalling anything.
+        if not looks_like_comfyui_tree(listener):
+            return Verdict(
+                verified=False,
+                reason=(
+                    "the port did not answer and the `main.py` it is running is not in a ComfyUI checkout "
+                    "(no nodes.py/execution.py/comfy/ beside it)"
+                ),
+                http="unreachable",
+            )
+        return Verdict(
+            verified=True,
+            reason="identified from the process command line and the ComfyUI checkout it is running",
+            http="unreachable",
+        )
 
     stats = probe.stats
     system = stats.get("system") if isinstance(stats, dict) else None
@@ -260,23 +450,48 @@ def verify_listener(listener: Listener, port: int, *, probe: Probe | None = None
 # --------------------------------------------------------------------------- #
 
 
-def kill_process_tree(pid: int, *, terminate_timeout: float = TERMINATE_TIMEOUT, kill_timeout: float = KILL_TIMEOUT):
+def _is_same_process(proc: psutil.Process, create_time: float) -> bool:
+    """Is ``proc`` still the process we identified, or a pid recycled onto it?"""
+    try:
+        return abs(proc.create_time() - create_time) < 0.001
+    except _EXPECTED_ERRORS:
+        return False
+
+
+def kill_process_tree(
+    pid: int,
+    *,
+    create_time: float | None = None,
+    terminate_timeout: float = TERMINATE_TIMEOUT,
+    kill_timeout: float = KILL_TIMEOUT,
+) -> Teardown:
     """Terminate ``pid`` and its recursive children, escalating to SIGKILL.
 
     ``utils.kill_all`` is deliberately not reused: it kills only the *children*
     of the pid it is given, which is right for the recorded wrapper pid but
     would leave a directly-identified listener running.
 
-    Returns ``(ok, survivors)`` — ``ok`` is True only once nothing is left.
+    ``create_time`` (when known) pins process identity: discovery is separated
+    from teardown by an HTTP probe that can block for the full timeout, and a
+    bare pid can be recycled onto an unrelated process in that window.
     """
     try:
         parent = psutil.Process(pid)
     except psutil.NoSuchProcess:
-        return True, []
+        return Teardown(ok=True, survivors=[])
 
+    if create_time is not None and not _is_same_process(parent, create_time):
+        # The process we verified exited on its own and the OS handed its pid to
+        # a stranger. The target is gone; signalling now would hit the stranger.
+        return Teardown(ok=True, survivors=[])
+
+    children_enumerated = True
     try:
         targets = parent.children(recursive=True)
     except _EXPECTED_ERRORS:
+        # We cannot see the children, so `ok` below can only speak for the
+        # parent. Say so rather than reporting a clean stop over live workers.
+        children_enumerated = False
         targets = []
     # Children first so a supervising parent can't respawn one mid-teardown.
     targets.append(parent)
@@ -301,7 +516,57 @@ def kill_process_tree(pid: int, *, terminate_timeout: float = TERMINATE_TIMEOUT,
             continue
 
     _, survivors = psutil.wait_procs(alive, timeout=kill_timeout)
-    return not survivors, [p.pid for p in survivors]
+    return Teardown(
+        ok=not survivors,
+        survivors=[p.pid for p in survivors],
+        children_enumerated=children_enumerated,
+    )
+
+
+def _ancestor_pids(pid: int) -> list[int]:
+    try:
+        return [p.pid for p in psutil.Process(pid).parents()]
+    except _EXPECTED_ERRORS:
+        return []
+
+
+def _is_launch_wrapper(pid: int) -> bool:
+    """Is ``pid`` a ``comfy ... launch`` process?
+
+    Guards the ancestor match below against pid recycling: a recorded pid that
+    has been reused by some unrelated ancestor (a login shell, say) must not
+    make us signal it or forget a background server we still own.
+    """
+    try:
+        cmdline = psutil.Process(pid).cmdline()
+    except _EXPECTED_ERRORS:
+        return False
+    if not cmdline:
+        return False
+    argv0 = os.path.basename(str(cmdline[0])).lower()
+    if argv0.endswith(".exe"):
+        argv0 = argv0[:-4]
+    return argv0 == "comfy" and "launch" in [str(tok) for tok in cmdline[1:]]
+
+
+def _tracked_wrapper_pid(listener: Listener) -> int | None:
+    """The recorded background pid, when *this* listener is that server.
+
+    `comfy launch --background` records the pid of the outer ``comfy ... launch``
+    wrapper, not the ``python main.py`` it spawns — so an exact-pid match against
+    the listener essentially never fires for a server this CLI started. The
+    wrapper is matched as an ancestor too, but only when it really is a
+    ``comfy ... launch`` process.
+    """
+    bg_info = ConfigManager().background
+    if not bg_info:
+        return None
+    bg_pid = bg_info[2]
+    if bg_pid == listener.pid:
+        return bg_pid
+    if bg_pid in _ancestor_pids(listener.pid) and _is_launch_wrapper(bg_pid):
+        return bg_pid
+    return None
 
 
 def _dry_run_payload(listener: Listener, port: int) -> dict[str, Any]:
@@ -364,34 +629,45 @@ def stop_port_execute(renderer: Renderer, *, port: int, dry_run: bool) -> None:
         renderer.emit(_dry_run_payload(listener, port), command="stop", changed=False)
         return
 
-    ok, survivors = kill_process_tree(listener.pid)
-    if not ok:
+    # If this listener is in fact the server `comfy launch --background` started,
+    # tear down from the recorded wrapper: it is the pid `comfy stop` owns, and
+    # its output-redirector threads never exit on their own, so stopping only the
+    # inner python would leak it and leave the background record behind.
+    wrapper_pid = _tracked_wrapper_pid(listener)
+    if wrapper_pid is not None and wrapper_pid != listener.pid:
+        result = kill_process_tree(wrapper_pid)
+    else:
+        result = kill_process_tree(listener.pid, create_time=listener.create_time)
+
+    survivors = list(result.survivors)
+    # The identified process is not necessarily the only thing bound to the port
+    # (SO_REUSEPORT, split v4/v6 sockets), and children we could not enumerate
+    # may still hold it. Confirm the port actually came free.
+    still = find_listener(port)
+    if still is not None and still.pid not in survivors:
+        survivors.append(still.pid)
+
+    if not result.ok or still is not None:
+        message = (
+            f"Stopped pid {listener.pid}, but port {port} is still held by pid {still.pid}."
+            if result.ok and still is not None
+            else f"Failed to stop pid {listener.pid} on port {port}."
+        )
         renderer.error(
             code="stop_failed",
-            message=f"Failed to stop pid {listener.pid} on port {port}.",
+            message=message,
             command="stop",
             details={"port": port, "pid": listener.pid, "survivors": survivors},
         )
         raise typer.Exit(code=1)
 
-    _forget_background_if_same_pid(listener.pid)
+    if wrapper_pid is not None:
+        ConfigManager().remove_background()
 
     renderer.print(f"[bold yellow]ComfyUI on port {port} is stopped.[/bold yellow] (pid={listener.pid})")
-    renderer.emit(
-        {"stopped": True, "pid": listener.pid, "port": port, "untracked": True},
-        command="stop",
-        changed=True,
-    )
-
-
-def _forget_background_if_same_pid(pid: int) -> None:
-    """Drop the recorded background server when we just stopped that exact pid.
-
-    Only on an exact pid match: a port collision alone doesn't prove the record
-    describes the process we killed, and wrongly dropping it would orphan a
-    still-running server this CLI does own.
-    """
-    config = ConfigManager()
-    bg_info = config.background
-    if bg_info and bg_info[2] == pid:
-        config.remove_background()
+    data: dict[str, Any] = {"stopped": True, "pid": listener.pid, "port": port, "untracked": True}
+    if not result.children_enumerated:
+        # Honest about the gap: the parent is gone and the port is free, but the
+        # child list was unreadable, so we cannot claim the whole tree is down.
+        data["children_unknown"] = True
+    renderer.emit(data, command="stop", changed=True)

--- a/comfy_cli/command/stop_port.py
+++ b/comfy_cli/command/stop_port.py
@@ -1,0 +1,397 @@
+"""``comfy stop --port <p>`` — verified stop of an *untracked* local ComfyUI.
+
+Plain ``comfy stop`` can only stop a server this CLI started: it reads the
+recorded ``(host, port, pid)`` out of the config and kills that. The most
+common real-world restart case is the opposite one — a ComfyUI somebody else
+started (the desktop app, a bare ``python main.py``, a wedged server) is
+holding the port and comfy-cli has no handle on it at all.
+
+This module is that handle, and every decision in it is about *not* killing the
+wrong process:
+
+- The listener is found with the **per-process** ``Process.net_connections()``
+  over ``psutil.process_iter()``. The system-wide ``psutil.net_connections()``
+  is root-only on macOS, so it is never used here.
+- Identity is proven from the **process table first**: a python-ish ``argv[0]``
+  running a ``main.py``. Only then do we ask the server itself
+  (``GET /system_stats``). A port that answers but disagrees with the process
+  table is refused — that is the reverse-proxy false positive.
+- A port that does not answer at all is *still* stopped, on the cmdline
+  evidence alone: a wedged ComfyUI is precisely what this command exists for.
+- We never stop anything on HTTP evidence alone.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import psutil
+import typer
+
+from comfy_cli.config_manager import ConfigManager
+from comfy_cli.output import Renderer
+from comfy_cli.output.sanitize import sanitize_markup
+
+# ~2s, per the ticket: long enough for a healthy server to answer on loopback,
+# short enough that probing a wedged one doesn't stall the command.
+HTTP_PROBE_TIMEOUT = 2.0
+
+# Bounded wait for each half of the terminate -> kill escalation.
+TERMINATE_TIMEOUT = 5.0
+KILL_TIMEOUT = 3.0
+
+# `python`, `python3`, `python3.12`, `pythonw`, `py`, and the macOS framework
+# `Python` — but not `uv`, `node`, `nginx`, or anything else that merely has a
+# `main.py` somewhere on its command line.
+_PYTHON_ARGV0 = re.compile(r"^(python|pythonw|py)[0-9._]*$", re.IGNORECASE)
+
+_EXPECTED_ERRORS = (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError)
+
+
+@dataclass(frozen=True)
+class Listener:
+    """Whatever we could read about the process holding the port."""
+
+    pid: int
+    cmdline: list[str] = field(default_factory=list)
+    cwd: str | None = None
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class Probe:
+    """Outcome of ``GET /system_stats``.
+
+    ``answered`` distinguishes "the port produced an HTTP response" (even a 404
+    from a proxy, or a non-JSON body) from "refused / timed out", which is the
+    wedged-server case we deliberately proceed on.
+    """
+
+    answered: bool
+    stats: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class Verdict:
+    verified: bool
+    reason: str
+    http: str
+
+
+# --------------------------------------------------------------------------- #
+# Finding the listener
+# --------------------------------------------------------------------------- #
+
+
+def _is_listen_on(conn: Any, port: int) -> bool:
+    if conn.status != psutil.CONN_LISTEN:
+        return False
+    laddr = getattr(conn, "laddr", None)
+    return bool(laddr) and getattr(laddr, "port", None) == port
+
+
+def _safe_cwd(proc: psutil.Process) -> str | None:
+    try:
+        return proc.cwd()
+    except _EXPECTED_ERRORS:
+        # macOS denies cwd() for other users' processes. Not knowing it is fine
+        # — it is reported for the operator's benefit, never used as evidence.
+        return None
+    except NotImplementedError:  # pragma: no cover - platform-dependent
+        return None
+
+
+def find_listener(port: int) -> Listener | None:
+    """Return the process LISTENing on ``port``, or None.
+
+    Processes we are not allowed to inspect are skipped rather than fatal: on
+    macOS every process owned by another user raises ``AccessDenied`` from
+    ``net_connections()``, and one of those must not hide the one we can read.
+    """
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            conns = proc.net_connections(kind="inet")
+        except _EXPECTED_ERRORS:
+            continue
+        if not any(_is_listen_on(c, port) for c in conns):
+            continue
+        info = proc.info or {}
+        return Listener(
+            pid=proc.pid,
+            # AccessDenied on the cmdline leaves it empty — we still report the
+            # pid, so the caller can say *something* about what it refused.
+            cmdline=[str(tok) for tok in (info.get("cmdline") or [])],
+            cwd=_safe_cwd(proc),
+            name=info.get("name"),
+        )
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Identity
+# --------------------------------------------------------------------------- #
+
+
+def _is_python_ish(argv0: str) -> bool:
+    base = os.path.basename(argv0)
+    if base.lower().endswith(".exe"):
+        base = base[:-4]
+    return bool(_PYTHON_ARGV0.match(base))
+
+
+def _script_tail(cmdline: Sequence[str]) -> list[str] | None:
+    """Return the command line from the ``main.py`` token onward, or None.
+
+    That tail is what the server's own ``sys.argv`` should look like, so it is
+    both the cmdline identity check and the input to the ``/system_stats``
+    cross-check.
+    """
+    for i, tok in enumerate(cmdline[1:], start=1):
+        if os.path.basename(tok) == "main.py":
+            return list(cmdline[i:])
+    return None
+
+
+def looks_like_comfyui(cmdline: Sequence[str]) -> bool:
+    """cmdline evidence: a python-ish ``argv[0]`` running some ``main.py``.
+
+    Deliberately shape-based, not path-based: `comfy launch` runs
+    ``[python, "main.py"]`` from the workspace, a hand-started server uses an
+    absolute path, and the desktop app uses its bundled interpreter — all three
+    are the same shape.
+    """
+    if len(cmdline) < 2 or not _is_python_ish(cmdline[0]):
+        return False
+    return _script_tail(cmdline) is not None
+
+
+def probe_system_stats(port: int, *, timeout: float = HTTP_PROBE_TIMEOUT) -> Probe:
+    """``GET http://127.0.0.1:<port>/system_stats`` with a short timeout."""
+    url = f"http://127.0.0.1:{port}/system_stats"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - fixed loopback http URL
+            body = resp.read()
+    except urllib.error.HTTPError:
+        # Something is serving this port and it is not ComfyUI's /system_stats.
+        return Probe(answered=True)
+    except (urllib.error.URLError, OSError):
+        # Refused, reset, or timed out — the wedged-server case.
+        return Probe(answered=False)
+    try:
+        payload = json.loads(body.decode("utf-8", "replace"))
+    except (ValueError, UnicodeDecodeError):
+        return Probe(answered=True)
+    return Probe(answered=True, stats=payload if isinstance(payload, dict) else None)
+
+
+def _argv_agrees(server_argv: Sequence[Any], cmdline: Sequence[str]) -> bool:
+    """Does the server's own ``sys.argv`` match the process table's cmdline?
+
+    The server reports ``argv[0]`` as it was spelled on the command line, which
+    may be relative (``main.py``) or absolute, so only the basename is compared;
+    the arguments after it must match exactly.
+    """
+    tail = _script_tail(cmdline)
+    if not tail or not server_argv:
+        return False
+    if os.path.basename(str(server_argv[0])) != os.path.basename(tail[0]):
+        return False
+    return [str(a) for a in server_argv[1:]] == list(tail[1:])
+
+
+def verify_listener(listener: Listener, port: int, *, probe: Probe | None = None) -> Verdict:
+    """Decide whether ``listener`` is positively identifiable as ComfyUI.
+
+    Order matters: the cmdline is a precondition, so an HTTP answer alone can
+    never authorize a kill. The probe can only *withdraw* that authorization.
+    """
+    if not looks_like_comfyui(listener.cmdline):
+        return Verdict(
+            verified=False,
+            reason="the process holding the port is not a python `main.py` command line",
+            http="not_probed",
+        )
+
+    if probe is None:
+        probe = probe_system_stats(port)
+
+    if not probe.answered:
+        # Wedged or still starting: the process table already says ComfyUI, and
+        # a server that cannot answer is exactly what this command is for.
+        return Verdict(verified=True, reason="identified from the process command line", http="unreachable")
+
+    stats = probe.stats
+    system = stats.get("system") if isinstance(stats, dict) else None
+    if not isinstance(system, dict) or not system.get("comfyui_version"):
+        return Verdict(
+            verified=False,
+            reason="the port answered but did not return a ComfyUI /system_stats payload",
+            http="disagreed",
+        )
+
+    server_argv = system.get("argv")
+    if isinstance(server_argv, list) and server_argv:
+        if not _argv_agrees(server_argv, listener.cmdline):
+            return Verdict(
+                verified=False,
+                reason="the server on this port reports a different command line than the process holding it",
+                http="disagreed",
+            )
+        return Verdict(verified=True, reason="command line corroborated by /system_stats", http="agreed")
+
+    # Older servers omit `argv`. `comfyui_version` plus the cmdline is still two
+    # independent signals, so this corroborates — it just can't cross-check.
+    return Verdict(
+        verified=True,
+        reason="command line corroborated by /system_stats (server reported no argv)",
+        http="agreed_no_argv",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Stopping
+# --------------------------------------------------------------------------- #
+
+
+def kill_process_tree(pid: int, *, terminate_timeout: float = TERMINATE_TIMEOUT, kill_timeout: float = KILL_TIMEOUT):
+    """Terminate ``pid`` and its recursive children, escalating to SIGKILL.
+
+    ``utils.kill_all`` is deliberately not reused: it kills only the *children*
+    of the pid it is given, which is right for the recorded wrapper pid but
+    would leave a directly-identified listener running.
+
+    Returns ``(ok, survivors)`` — ``ok`` is True only once nothing is left.
+    """
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return True, []
+
+    try:
+        targets = parent.children(recursive=True)
+    except _EXPECTED_ERRORS:
+        targets = []
+    # Children first so a supervising parent can't respawn one mid-teardown.
+    targets.append(parent)
+
+    for proc in targets:
+        try:
+            proc.terminate()
+        except psutil.NoSuchProcess:
+            continue
+        except _EXPECTED_ERRORS:
+            # Can't signal it (not ours). Leave it in the list so the wait below
+            # reports it as a survivor rather than silently claiming success.
+            continue
+
+    _, alive = psutil.wait_procs(targets, timeout=terminate_timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+        except psutil.NoSuchProcess:
+            continue
+        except _EXPECTED_ERRORS:
+            continue
+
+    _, survivors = psutil.wait_procs(alive, timeout=kill_timeout)
+    return not survivors, [p.pid for p in survivors]
+
+
+def _dry_run_payload(listener: Listener, port: int) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        # `stopped` is required by schemas/stop.json and is what a caller
+        # branches on; `dry_run` says why it is False.
+        "stopped": False,
+        "dry_run": True,
+        "verified": True,
+        "untracked": True,
+        "pid": listener.pid,
+        "port": port,
+        "cmdline": list(listener.cmdline),
+    }
+    if listener.cwd:
+        data["cwd"] = listener.cwd
+    return data
+
+
+def stop_port_execute(renderer: Renderer, *, port: int, dry_run: bool) -> None:
+    """Body of ``comfy stop --port <p>``. Raises ``typer.Exit`` on refusal."""
+    listener = find_listener(port)
+    if listener is None:
+        renderer.error(
+            code="port_not_listening",
+            message=f"Nothing is listening on port {port}.",
+            command="stop",
+            details={"port": port},
+        )
+        raise typer.Exit(code=1)
+
+    verdict = verify_listener(listener, port)
+    if not verdict.verified:
+        renderer.error(
+            code="unverified_process",
+            message=(
+                f"Refusing to stop pid {listener.pid} on port {port}: it cannot be identified as ComfyUI "
+                f"({verdict.reason})."
+            ),
+            command="stop",
+            details={
+                "port": port,
+                "pid": listener.pid,
+                "cmdline": list(listener.cmdline),
+                "cwd": listener.cwd,
+                "name": listener.name,
+                "reason": verdict.reason,
+                "http": verdict.http,
+            },
+        )
+        raise typer.Exit(code=1)
+
+    if dry_run:
+        # The cmdline is a foreign process's argv — Rich would happily render
+        # `[red]`/`[link=…]` out of it, or crash on an unbalanced `[/]`.
+        rendered = sanitize_markup(" ".join(listener.cmdline))
+        renderer.print(
+            f"[bold yellow]Would stop ComfyUI on port {port}[/bold yellow] (pid={listener.pid})\n  {rendered}"
+        )
+        renderer.emit(_dry_run_payload(listener, port), command="stop", changed=False)
+        return
+
+    ok, survivors = kill_process_tree(listener.pid)
+    if not ok:
+        renderer.error(
+            code="stop_failed",
+            message=f"Failed to stop pid {listener.pid} on port {port}.",
+            command="stop",
+            details={"port": port, "pid": listener.pid, "survivors": survivors},
+        )
+        raise typer.Exit(code=1)
+
+    _forget_background_if_same_pid(listener.pid)
+
+    renderer.print(f"[bold yellow]ComfyUI on port {port} is stopped.[/bold yellow] (pid={listener.pid})")
+    renderer.emit(
+        {"stopped": True, "pid": listener.pid, "port": port, "untracked": True},
+        command="stop",
+        changed=True,
+    )
+
+
+def _forget_background_if_same_pid(pid: int) -> None:
+    """Drop the recorded background server when we just stopped that exact pid.
+
+    Only on an exact pid match: a port collision alone doesn't prove the record
+    describes the process we killed, and wrongly dropping it would orphan a
+    still-running server this CLI does own.
+    """
+    config = ConfigManager()
+    bg_info = config.background
+    if bg_info and bg_info[2] == pid:
+        config.remove_background()

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -79,6 +79,17 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy stop` could not kill the recorded background ComfyUI process. `details.pid` carries the process id.",
         "kill the process manually if it is still running",
     ),
+    ErrorCode(
+        "port_not_listening",
+        "`comfy stop --port <p>` found no process LISTENing on that port. `details.port` carries the port.",
+        "check the port, or run `comfy stop` to stop the server this CLI started",
+    ),
+    ErrorCode(
+        "unverified_process",
+        "`comfy stop --port <p>` found a listener it could not positively identify as ComfyUI, so it "
+        "refused to stop it. `details` carries the pid, whatever cmdline was readable, and the reason.",
+        "confirm what is on that port and stop it yourself if it really is ComfyUI",
+    ),
     # --- workflow loading ----------------------------------------------------
     ErrorCode(
         "workflow_not_found",

--- a/comfy_cli/schemas/stop.json
+++ b/comfy_cli/schemas/stop.json
@@ -28,6 +28,10 @@
     "cwd": {
       "type": "string",
       "description": "--port --dry-run only: the identified listener's working directory, when readable."
+    },
+    "children_unknown": {
+      "type": "boolean",
+      "description": "--port only: present and true when the target's child processes could not be enumerated, so the stop is confirmed for the listener and the port but not for its whole tree."
     }
   },
   "required": ["stopped"]

--- a/comfy_cli/schemas/stop.json
+++ b/comfy_cli/schemas/stop.json
@@ -7,7 +7,28 @@
     "stopped": { "type": "boolean" },
     "host": { "type": "string" },
     "port": { "type": ["integer", "string"] },
-    "pid": { "type": "integer" }
+    "pid": { "type": "integer" },
+    "dry_run": {
+      "type": "boolean",
+      "description": "True when --dry-run was passed: nothing was stopped and `stopped` is false."
+    },
+    "untracked": {
+      "type": "boolean",
+      "description": "True when the target was found by --port rather than read from this CLI's background record."
+    },
+    "verified": {
+      "type": "boolean",
+      "description": "--port only: the listener was positively identified as ComfyUI before being reported."
+    },
+    "cmdline": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "--port --dry-run only: the identified listener's command line."
+    },
+    "cwd": {
+      "type": "string",
+      "description": "--port --dry-run only: the identified listener's working directory, when readable."
+    }
   },
   "required": ["stopped"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dependencies = [
   "packaging",
   "pathspec",
   "posthog>=6,<8",
-  "psutil",
+  # 6.0.0 renamed Process.connections() to Process.net_connections(), which
+  # `comfy stop --port` needs (the system-wide psutil.net_connections() is
+  # root-only on macOS, so per-process is the only usable form).
+  "psutil>=6",
   "pyyaml",
   "questionary",
   "requests",

--- a/tests/comfy_cli/command/test_launch_stop_envelope.py
+++ b/tests/comfy_cli/command/test_launch_stop_envelope.py
@@ -118,6 +118,46 @@ class TestStopEnvelope:
         cfg.remove_background.assert_not_called()
         assert "Failed to stop" in capsys.readouterr().out
 
+    def test_dry_run_reports_the_recorded_server_and_kills_nothing(self, capsys):
+        _json_renderer("stop")
+        cfg = self._config(("127.0.0.1", 8188, 4242))
+        with (
+            patch("comfy_cli.cmdline.ConfigManager", return_value=cfg),
+            patch("comfy_cli.cmdline.utils.kill_all") as killer,
+        ):
+            stop(dry_run=True)
+
+        killer.assert_not_called()
+        cfg.remove_background.assert_not_called()
+
+        env = _envelopes(capsys.readouterr().out)[-1]
+        assert env["ok"] is True
+        assert env["changed"] is False
+        assert env["data"] == {
+            "stopped": False,
+            "dry_run": True,
+            "untracked": False,
+            "host": "127.0.0.1",
+            "port": 8188,
+            "pid": 4242,
+        }
+
+    def test_port_flag_delegates_to_the_untracked_path(self):
+        # `--port` must never fall through to the recorded-background branch,
+        # even when a background server happens to be recorded.
+        _json_renderer("stop")
+        cfg = self._config(("127.0.0.1", 8188, 4242))
+        with (
+            patch("comfy_cli.cmdline.ConfigManager", return_value=cfg),
+            patch("comfy_cli.cmdline.utils.kill_all") as killer,
+            patch("comfy_cli.command.stop_port.stop_port_execute") as delegate,
+        ):
+            stop(port=9000, dry_run=True)
+
+        killer.assert_not_called()
+        assert delegate.call_count == 1
+        assert delegate.call_args.kwargs == {"port": 9000, "dry_run": True}
+
     def test_pretty_mode_stdout_has_no_json(self, capsys):
         _pretty_renderer("stop")
         cfg = self._config(("127.0.0.1", 8188, 4242))

--- a/tests/comfy_cli/command/test_stop_port.py
+++ b/tests/comfy_cli/command/test_stop_port.py
@@ -1,0 +1,553 @@
+"""``comfy stop --port <p>`` — finding, verifying, and stopping an untracked ComfyUI.
+
+The whole point of this command is that it kills a process comfy-cli never
+started, so these tests are weighted toward the *refusals*: an unidentifiable
+listener, a listener that answers HTTP but disagrees with the process table,
+and the dry run that must touch nothing.
+
+psutil is faked at the two seams the module actually uses — ``process_iter``
+for discovery and ``Process``/``wait_procs`` for the teardown — so the real
+exception classes (``AccessDenied`` &c.) stay real.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import jsonschema
+import psutil
+import pytest
+import typer
+
+from comfy_cli.command import stop_port
+from comfy_cli.output import Renderer, set_renderer
+from comfy_cli.output.renderer import OutputMode, reset_renderer_for_testing
+
+SCHEMAS_DIR = Path(__file__).resolve().parents[3] / "comfy_cli" / "schemas"
+
+
+@pytest.fixture(autouse=True)
+def reset_renderer():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _json_renderer() -> Renderer:
+    r = Renderer(mode=OutputMode.JSON, command="stop")
+    set_renderer(r)
+    return r
+
+
+def _envelope(captured_out: str) -> dict:
+    lines = [ln for ln in captured_out.splitlines() if ln.strip()]
+    return json.loads(lines[-1])
+
+
+# --------------------------------------------------------------------------- #
+# Fake psutil process table
+# --------------------------------------------------------------------------- #
+
+
+def _conn(port: int, status=psutil.CONN_LISTEN):
+    return SimpleNamespace(status=status, laddr=SimpleNamespace(ip="127.0.0.1", port=port))
+
+
+class FakeProc:
+    def __init__(self, pid, cmdline, conns, *, denied=False, cwd="/workspace", name="python"):
+        self.pid = pid
+        self._cmdline = list(cmdline)
+        self._conns = list(conns)
+        self._denied = denied
+        self._cwd = cwd
+        self._name = name
+
+    @property
+    def info(self):
+        return {"pid": self.pid, "name": self._name, "cmdline": list(self._cmdline)}
+
+    def net_connections(self, kind="inet"):
+        if self._denied:
+            raise psutil.AccessDenied(self.pid)
+        return list(self._conns)
+
+    def cwd(self):
+        if self._cwd is None:
+            raise psutil.AccessDenied(self.pid)
+        return self._cwd
+
+
+COMFY_CMDLINE = ["/usr/bin/python3", "main.py", "--port", "8188"]
+
+
+def _table(*procs):
+    return patch.object(stop_port.psutil, "process_iter", return_value=list(procs))
+
+
+class TestFindListener:
+    def test_no_listener(self):
+        with _table(FakeProc(10, ["nginx"], [_conn(80)])):
+            assert stop_port.find_listener(8188) is None
+
+    def test_finds_the_listener(self):
+        with _table(FakeProc(10, ["nginx"], [_conn(80)]), FakeProc(42, COMFY_CMDLINE, [_conn(8188)])):
+            found = stop_port.find_listener(8188)
+        assert found is not None
+        assert found.pid == 42
+        assert found.cmdline == COMFY_CMDLINE
+        assert found.cwd == "/workspace"
+
+    def test_access_denied_process_does_not_hide_the_real_one(self):
+        # On macOS every process owned by another user raises AccessDenied from
+        # net_connections(); one of those must not abort the scan.
+        with _table(FakeProc(9, ["root-thing"], [], denied=True), FakeProc(42, COMFY_CMDLINE, [_conn(8188)])):
+            found = stop_port.find_listener(8188)
+        assert found is not None and found.pid == 42
+
+    def test_access_denied_only_reads_as_no_listener(self):
+        with _table(FakeProc(9, ["root-thing"], [], denied=True)):
+            assert stop_port.find_listener(8188) is None
+
+    def test_established_connection_on_the_port_is_not_a_listener(self):
+        # A *client* connected to 8188 has a conn with that remote port; only
+        # LISTEN counts.
+        with _table(FakeProc(11, COMFY_CMDLINE, [_conn(8188, status=psutil.CONN_ESTABLISHED)])):
+            assert stop_port.find_listener(8188) is None
+
+    def test_unreadable_cmdline_still_yields_the_pid(self):
+        with _table(FakeProc(42, [], [_conn(8188)], cwd=None)):
+            found = stop_port.find_listener(8188)
+        assert found is not None
+        assert found.pid == 42
+        assert found.cmdline == []
+        assert found.cwd is None
+
+
+# --------------------------------------------------------------------------- #
+# cmdline identity
+# --------------------------------------------------------------------------- #
+
+
+class TestLooksLikeComfyui:
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            ["/usr/bin/python3", "main.py"],
+            ["python", "main.py", "--port", "8188"],
+            ["/opt/py/bin/python3.12", "/srv/ComfyUI/main.py"],
+            # Windows interpreter. Spelled with forward slashes so the case is
+            # portable: the module uses `os.path.basename`, which is
+            # `ntpath.basename` on Windows and splits the backslash form there.
+            ["C:/Python311/python.exe", "main.py"],
+            # ComfyUI Desktop: bundled interpreter in the app's managed venv,
+            # absolute path to the checkout's main.py.
+            [
+                "/Users/x/Library/Application Support/ComfyUI/.venv/bin/python",
+                "/Users/x/Documents/ComfyUI/main.py",
+                "--listen",
+                "127.0.0.1",
+            ],
+        ],
+    )
+    def test_accepts_python_running_main_py(self, cmdline):
+        assert stop_port.looks_like_comfyui(cmdline) is True
+
+    @pytest.mark.parametrize(
+        "cmdline",
+        [
+            [],
+            ["/usr/bin/python3"],
+            ["/usr/bin/node", "main.py"],
+            ["nginx: master process /usr/sbin/nginx"],
+            ["/usr/bin/python3", "-m", "http.server", "8188"],
+            # `main.py` must be a *token* basename, not a substring.
+            ["/usr/bin/python3", "notmain.py"],
+            # argv[0] is not python, even though a main.py is on the line.
+            ["/usr/bin/uv", "run", "main.py"],
+        ],
+    )
+    def test_rejects_everything_else(self, cmdline):
+        assert stop_port.looks_like_comfyui(cmdline) is False
+
+
+# --------------------------------------------------------------------------- #
+# HTTP probe + verdict
+# --------------------------------------------------------------------------- #
+
+
+def _stats(argv=None, version="0.3.99"):
+    system = {"comfyui_version": version}
+    if argv is not None:
+        system["argv"] = argv
+    return stop_port.Probe(answered=True, stats={"system": system})
+
+
+class TestProbeSystemStats:
+    def _urlopen(self, body: bytes):
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_parses_json(self):
+        payload = {"system": {"comfyui_version": "0.3.1"}}
+        with patch.object(
+            stop_port.urllib.request, "urlopen", return_value=self._urlopen(json.dumps(payload).encode())
+        ):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is True
+        assert probe.stats == payload
+
+    def test_connection_refused_is_not_answered(self):
+        with patch.object(stop_port.urllib.request, "urlopen", side_effect=urllib.error.URLError("refused")):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is False
+
+    def test_timeout_is_not_answered(self):
+        with patch.object(stop_port.urllib.request, "urlopen", side_effect=TimeoutError()):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is False
+
+    def test_http_error_counts_as_answered(self):
+        # A 404 means something IS serving this port — it is not wedged, it is
+        # simply not ComfyUI.
+        err = urllib.error.HTTPError("http://127.0.0.1:8188/system_stats", 404, "Not Found", {}, None)
+        with patch.object(stop_port.urllib.request, "urlopen", side_effect=err):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is True
+        assert probe.stats is None
+
+    def test_non_json_body_counts_as_answered_without_stats(self):
+        with patch.object(stop_port.urllib.request, "urlopen", return_value=self._urlopen(b"<html>hi</html>")):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is True
+        assert probe.stats is None
+
+
+class TestVerifyListener:
+    def _listener(self, cmdline=None):
+        return stop_port.Listener(pid=42, cmdline=list(cmdline or COMFY_CMDLINE))
+
+    def test_cmdline_is_a_precondition_http_cannot_substitute(self):
+        # A perfect /system_stats answer must NOT verify a listener whose
+        # command line isn't ComfyUI: never kill on HTTP evidence alone.
+        verdict = stop_port.verify_listener(
+            self._listener(["/usr/sbin/nginx"]),
+            8188,
+            probe=_stats(argv=["main.py", "--port", "8188"]),
+        )
+        assert verdict.verified is False
+        assert verdict.http == "not_probed"
+
+    def test_agreeing_server_verifies(self):
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=_stats(argv=["main.py", "--port", "8188"]))
+        assert verdict.verified is True
+        assert verdict.http == "agreed"
+
+    def test_agreeing_server_with_absolute_argv0_verifies(self):
+        listener = self._listener(["/usr/bin/python3", "/srv/ComfyUI/main.py", "--listen"])
+        verdict = stop_port.verify_listener(listener, 8188, probe=_stats(argv=["main.py", "--listen"]))
+        assert verdict.verified is True
+
+    def test_disagreeing_argv_refuses(self):
+        # The reverse-proxy false positive: the port answers like ComfyUI, but
+        # the process holding it was started with different arguments.
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=_stats(argv=["main.py", "--port", "9999"]))
+        assert verdict.verified is False
+        assert verdict.http == "disagreed"
+
+    def test_missing_comfyui_version_refuses(self):
+        probe = stop_port.Probe(answered=True, stats={"system": {"os": "posix"}})
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=probe)
+        assert verdict.verified is False
+        assert verdict.http == "disagreed"
+
+    def test_answered_without_a_json_payload_refuses(self):
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=stop_port.Probe(answered=True))
+        assert verdict.verified is False
+        assert verdict.http == "disagreed"
+
+    def test_unreachable_server_still_verifies_on_cmdline_evidence(self):
+        # The wedged-server case this command exists for.
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=stop_port.Probe(answered=False))
+        assert verdict.verified is True
+        assert verdict.http == "unreachable"
+
+    def test_server_without_argv_verifies_on_version_plus_cmdline(self):
+        verdict = stop_port.verify_listener(self._listener(), 8188, probe=_stats(argv=None))
+        assert verdict.verified is True
+        assert verdict.http == "agreed_no_argv"
+
+
+# --------------------------------------------------------------------------- #
+# Teardown
+# --------------------------------------------------------------------------- #
+
+
+class FakeKillProc:
+    """A process that dies at a configurable point of the escalation."""
+
+    def __init__(self, pid, *, children=(), survives_terminate=False, survives_kill=False, log=None):
+        self.pid = pid
+        self._children = list(children)
+        self._survives_terminate = survives_terminate
+        self._survives_kill = survives_kill
+        self.log = log if log is not None else []
+        self.terminated = False
+        self.killed = False
+
+    def children(self, recursive=False):
+        return list(self._children)
+
+    def terminate(self):
+        self.terminated = True
+        self.log.append(("terminate", self.pid))
+
+    def kill(self):
+        self.killed = True
+        self.log.append(("kill", self.pid))
+
+    @property
+    def gone(self):
+        if self.killed:
+            return not self._survives_kill
+        if self.terminated:
+            return not self._survives_terminate
+        return False
+
+
+def _fake_wait_procs(procs, timeout=None):
+    gone = [p for p in procs if p.gone]
+    alive = [p for p in procs if not p.gone]
+    return gone, alive
+
+
+class TestKillProcessTree:
+    def _run(self, parent):
+        with (
+            patch.object(stop_port.psutil, "Process", return_value=parent),
+            patch.object(stop_port.psutil, "wait_procs", side_effect=_fake_wait_procs),
+        ):
+            return stop_port.kill_process_tree(parent.pid)
+
+    def test_terminates_the_listener_itself_not_only_its_children(self):
+        # The `utils.kill_all` trap: that helper kills only children, which
+        # would leave a directly-identified listener running.
+        log = []
+        parent = FakeKillProc(42, log=log)
+        ok, survivors = self._run(parent)
+        assert ok is True and survivors == []
+        assert parent.terminated is True
+        assert log == [("terminate", 42)]
+
+    def test_reaps_recursive_children_before_the_parent(self):
+        log = []
+        kids = [FakeKillProc(43, log=log), FakeKillProc(44, log=log)]
+        parent = FakeKillProc(42, children=kids, log=log)
+        ok, survivors = self._run(parent)
+        assert ok is True and survivors == []
+        assert [entry[1] for entry in log] == [43, 44, 42]
+        assert all(k.terminated for k in kids)
+
+    def test_escalates_to_kill_when_terminate_is_ignored(self):
+        parent = FakeKillProc(42, survives_terminate=True)
+        ok, survivors = self._run(parent)
+        assert ok is True and survivors == []
+        assert parent.terminated is True and parent.killed is True
+
+    def test_reports_survivors_when_kill_does_not_land(self):
+        parent = FakeKillProc(42, survives_terminate=True, survives_kill=True)
+        ok, survivors = self._run(parent)
+        assert ok is False and survivors == [42]
+
+    def test_already_gone_process_is_a_success(self):
+        with patch.object(stop_port.psutil, "Process", side_effect=psutil.NoSuchProcess(42)):
+            ok, survivors = stop_port.kill_process_tree(42)
+        assert ok is True and survivors == []
+
+
+# --------------------------------------------------------------------------- #
+# The command body: envelopes + the dry run
+# --------------------------------------------------------------------------- #
+
+
+class TestStopPortExecute:
+    def _config(self, bg_info=None):
+        cfg = MagicMock()
+        cfg.background = bg_info
+        return cfg
+
+    def test_no_listener_emits_port_not_listening(self, capsys):
+        renderer = _json_renderer()
+        with patch.object(stop_port, "find_listener", return_value=None):
+            with pytest.raises(typer.Exit) as exc:
+                stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        assert exc.value.exit_code == 1
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "port_not_listening"
+        assert env["error"]["details"]["port"] == 8188
+
+    def test_unverified_listener_is_refused_and_reported(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=99, cmdline=["/usr/sbin/nginx", "-g", "daemon off;"], cwd="/etc")
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "kill_process_tree") as killer,
+        ):
+            with pytest.raises(typer.Exit) as exc:
+                stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        assert exc.value.exit_code == 1
+        killer.assert_not_called()
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["error"]["code"] == "unverified_process"
+        details = env["error"]["details"]
+        assert details["pid"] == 99
+        assert details["cmdline"] == ["/usr/sbin/nginx", "-g", "daemon off;"]
+        assert details["reason"]
+
+    def test_dry_run_reports_the_victim_and_kills_nothing(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd="/srv/ComfyUI")
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_stats(argv=["main.py", "--port", "8188"])),
+            patch.object(stop_port, "kill_process_tree") as killer,
+            patch.object(stop_port, "ConfigManager") as cfg,
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=True)
+
+        killer.assert_not_called()
+        cfg.assert_not_called()
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["ok"] is True
+        assert env["changed"] is False
+        assert env["data"] == {
+            "stopped": False,
+            "dry_run": True,
+            "verified": True,
+            "untracked": True,
+            "pid": 42,
+            "port": 8188,
+            "cmdline": COMFY_CMDLINE,
+            "cwd": "/srv/ComfyUI",
+        }
+
+    def test_dry_run_omits_cwd_when_unreadable(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd=None)
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree"),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=True)
+        assert "cwd" not in _envelope(capsys.readouterr().out)["data"]
+
+    def test_success_envelope(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        cfg = self._config(bg_info=None)
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["ok"] is True
+        assert env["changed"] is True
+        assert env["data"] == {"stopped": True, "pid": 42, "port": 8188, "untracked": True}
+        cfg.remove_background.assert_not_called()
+
+    def test_failed_kill_emits_stop_failed(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree", return_value=(False, [42])),
+            patch.object(stop_port, "ConfigManager") as cfg,
+        ):
+            with pytest.raises(typer.Exit) as exc:
+                stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        assert exc.value.exit_code == 1
+        # A failed stop must not drop the background record.
+        cfg.assert_not_called()
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["error"]["code"] == "stop_failed"
+        assert env["error"]["details"]["survivors"] == [42]
+
+    def test_matching_background_pid_is_forgotten(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        cfg = self._config(bg_info=("127.0.0.1", 8188, 42))
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        cfg.remove_background.assert_called_once()
+        capsys.readouterr()
+
+    def test_different_background_pid_on_the_same_port_is_kept(self, capsys):
+        # Port equality is not identity: dropping the record here would orphan
+        # a still-running server this CLI does own.
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        cfg = self._config(bg_info=("127.0.0.1", 8188, 777))
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        cfg.remove_background.assert_not_called()
+        capsys.readouterr()
+
+    @pytest.mark.parametrize("dry_run", [True, False])
+    def test_payloads_validate_against_the_shipped_schema(self, capsys, dry_run):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd="/srv/ComfyUI")
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            patch.object(stop_port, "ConfigManager", return_value=self._config()),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=dry_run)
+
+        schema = json.loads((SCHEMAS_DIR / "stop.json").read_text())
+        jsonschema.Draft202012Validator(schema).validate(_envelope(capsys.readouterr().out)["data"])
+
+    def test_pretty_mode_dry_run_escapes_foreign_markup(self, capsys):
+        # The cmdline is another process's argv; Rich would otherwise render
+        # markup out of it (or crash on an unbalanced tag).
+        set_renderer(Renderer(mode=OutputMode.PRETTY, command="stop"))
+        renderer = Renderer(mode=OutputMode.PRETTY, command="stop")
+        listener = stop_port.Listener(pid=42, cmdline=["/usr/bin/python3", "main.py", "--x", "[/]"])
+        with (
+            patch.object(stop_port, "find_listener", return_value=listener),
+            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "kill_process_tree") as killer,
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=True)
+        out = capsys.readouterr().out
+        killer.assert_not_called()
+        assert "Would stop ComfyUI on port 8188" in out
+        # Pretty mode emits no envelope.
+        assert "envelope" not in out

--- a/tests/comfy_cli/command/test_stop_port.py
+++ b/tests/comfy_cli/command/test_stop_port.py
@@ -12,8 +12,11 @@ exception classes (``AccessDenied`` &c.) stay real.
 
 from __future__ import annotations
 
+import http.client
+import io
 import json
 import urllib.error
+import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -48,23 +51,36 @@ def _envelope(captured_out: str) -> dict:
     return json.loads(lines[-1])
 
 
+@pytest.fixture
+def comfy_tree(tmp_path) -> Path:
+    """A directory shaped like a real ComfyUI checkout."""
+    root = tmp_path / "ComfyUI"
+    root.mkdir()
+    for name in ("main.py", "nodes.py", "execution.py", "folder_paths.py", "server.py"):
+        (root / name).write_text("")
+    (root / "comfy").mkdir()
+    (root / "comfy_extras").mkdir()
+    return root
+
+
 # --------------------------------------------------------------------------- #
 # Fake psutil process table
 # --------------------------------------------------------------------------- #
 
 
-def _conn(port: int, status=psutil.CONN_LISTEN):
-    return SimpleNamespace(status=status, laddr=SimpleNamespace(ip="127.0.0.1", port=port))
+def _conn(port: int, status=psutil.CONN_LISTEN, ip="127.0.0.1"):
+    return SimpleNamespace(status=status, laddr=SimpleNamespace(ip=ip, port=port))
 
 
 class FakeProc:
-    def __init__(self, pid, cmdline, conns, *, denied=False, cwd="/workspace", name="python"):
+    def __init__(self, pid, cmdline, conns, *, denied=False, cwd="/workspace", name="python", create_time=1000.0):
         self.pid = pid
         self._cmdline = list(cmdline)
         self._conns = list(conns)
         self._denied = denied
         self._cwd = cwd
         self._name = name
+        self._create_time = create_time
 
     @property
     def info(self):
@@ -80,12 +96,57 @@ class FakeProc:
             raise psutil.AccessDenied(self.pid)
         return self._cwd
 
+    def create_time(self):
+        return self._create_time
+
+
+class LegacyFakeProc:
+    """psutil < 6, where the accessor is still spelled ``connections()``.
+
+    Deliberately *not* a FakeProc subclass: the whole point is that
+    ``net_connections`` does not exist on it.
+    """
+
+    def __init__(self, pid, cmdline, conns, *, cwd="/workspace", name="python", create_time=1000.0):
+        self.pid = pid
+        self._cmdline = list(cmdline)
+        self._conns = list(conns)
+        self._cwd = cwd
+        self._name = name
+        self._create_time = create_time
+
+    @property
+    def info(self):
+        return {"pid": self.pid, "name": self._name, "cmdline": list(self._cmdline)}
+
+    def connections(self, kind="inet"):
+        return list(self._conns)
+
+    def cwd(self):
+        return self._cwd
+
+    def create_time(self):
+        return self._create_time
+
 
 COMFY_CMDLINE = ["/usr/bin/python3", "main.py", "--port", "8188"]
 
 
 def _table(*procs):
     return patch.object(stop_port.psutil, "process_iter", return_value=list(procs))
+
+
+# A `/system_stats` answer that omits `argv`: it corroborates any python
+# `main.py` command line without having to match its arguments, so the command
+# tests below can vary the cmdline freely.
+_AGREEING = stop_port.Probe(answered=True, stats={"system": {"comfyui_version": "0.3.99"}})
+
+_TORN_DOWN = stop_port.Teardown(ok=True, survivors=[])
+
+
+def _finds(listener):
+    """``find_listener``: the target, then nothing — the post-kill port recheck."""
+    return patch.object(stop_port, "find_listener", side_effect=[listener, None])
 
 
 class TestFindListener:
@@ -125,6 +186,23 @@ class TestFindListener:
         assert found.pid == 42
         assert found.cmdline == []
         assert found.cwd is None
+
+    def test_carries_the_bound_address_and_create_time(self):
+        # Both are load-bearing downstream: the probe must reach the address the
+        # server actually bound, and create_time pins identity across the probe.
+        with _table(FakeProc(42, COMFY_CMDLINE, [_conn(8188, ip="::1")], create_time=1234.5)):
+            found = stop_port.find_listener(8188)
+        assert found is not None
+        assert found.laddr_ip == "::1"
+        assert found.create_time == 1234.5
+
+    def test_psutil_5_connections_accessor_is_still_understood(self):
+        # `net_connections` is the psutil >= 6 spelling. On 5.x the missing
+        # attribute would otherwise escape as a raw AttributeError traceback
+        # instead of a structured envelope.
+        with _table(LegacyFakeProc(42, COMFY_CMDLINE, [_conn(8188)])):
+            found = stop_port.find_listener(8188)
+        assert found is not None and found.pid == 42
 
 
 # --------------------------------------------------------------------------- #
@@ -186,30 +264,68 @@ def _stats(argv=None, version="0.3.99"):
     return stop_port.Probe(answered=True, stats={"system": system})
 
 
-class TestProbeSystemStats:
-    def _urlopen(self, body: bytes):
-        resp = MagicMock()
-        resp.read.return_value = body
-        resp.__enter__ = MagicMock(return_value=resp)
-        resp.__exit__ = MagicMock(return_value=False)
-        return resp
+class FakeResponse:
+    """Enough of an HTTPResponse for the capped reader: chunked, closeable."""
 
+    def __init__(self, body: bytes, *, chunk: int | None = None):
+        self._buf = io.BytesIO(body)
+        self._chunk = chunk
+
+    def read(self, size=-1):
+        if self._chunk is not None and (size is None or size < 0 or size > self._chunk):
+            size = self._chunk
+        return self._buf.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestProbeSystemStats:
     def test_parses_json(self):
         payload = {"system": {"comfyui_version": "0.3.1"}}
-        with patch.object(
-            stop_port.urllib.request, "urlopen", return_value=self._urlopen(json.dumps(payload).encode())
-        ):
+        with patch.object(stop_port, "_open_url", return_value=FakeResponse(json.dumps(payload).encode())):
             probe = stop_port.probe_system_stats(8188)
         assert probe.answered is True
         assert probe.stats == payload
 
+    def test_probes_the_address_the_listener_bound(self):
+        seen = []
+
+        def _fake_open(url, timeout):
+            seen.append(url)
+            return FakeResponse(b"{}")
+
+        with patch.object(stop_port, "_open_url", side_effect=_fake_open):
+            stop_port.probe_system_stats(8188, host="[::1]")
+        assert seen == ["http://[::1]:8188/system_stats"]
+
     def test_connection_refused_is_not_answered(self):
-        with patch.object(stop_port.urllib.request, "urlopen", side_effect=urllib.error.URLError("refused")):
+        with patch.object(stop_port, "_open_url", side_effect=urllib.error.URLError("refused")):
             probe = stop_port.probe_system_stats(8188)
         assert probe.answered is False
 
     def test_timeout_is_not_answered(self):
-        with patch.object(stop_port.urllib.request, "urlopen", side_effect=TimeoutError()):
+        with patch.object(stop_port, "_open_url", side_effect=TimeoutError()):
+            probe = stop_port.probe_system_stats(8188)
+        assert probe.answered is False
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            http.client.BadStatusLine("\x16\x03\x01"),
+            http.client.IncompleteRead(b"{"),
+            http.client.LineTooLong("header line"),
+        ],
+    )
+    def test_protocol_garbage_is_not_answered_rather_than_a_traceback(self, exc):
+        # `http.client.HTTPException` is neither URLError nor OSError: urllib
+        # wraps OSError from the request, not from reading the response. A port
+        # speaking TLS (a --tls-keyfile ComfyUI) or a server dying mid-body
+        # would otherwise escape as an uncaught traceback with no envelope.
+        with patch.object(stop_port, "_open_url", side_effect=exc):
             probe = stop_port.probe_system_stats(8188)
         assert probe.answered is False
 
@@ -217,16 +333,74 @@ class TestProbeSystemStats:
         # A 404 means something IS serving this port — it is not wedged, it is
         # simply not ComfyUI.
         err = urllib.error.HTTPError("http://127.0.0.1:8188/system_stats", 404, "Not Found", {}, None)
-        with patch.object(stop_port.urllib.request, "urlopen", side_effect=err):
+        with patch.object(stop_port, "_open_url", side_effect=err):
             probe = stop_port.probe_system_stats(8188)
         assert probe.answered is True
         assert probe.stats is None
 
     def test_non_json_body_counts_as_answered_without_stats(self):
-        with patch.object(stop_port.urllib.request, "urlopen", return_value=self._urlopen(b"<html>hi</html>")):
+        with patch.object(stop_port, "_open_url", return_value=FakeResponse(b"<html>hi</html>")):
             probe = stop_port.probe_system_stats(8188)
         assert probe.answered is True
         assert probe.stats is None
+
+    def test_oversized_body_is_capped_not_buffered(self):
+        body = b"x" * (stop_port.MAX_PROBE_BYTES + 4096)
+        with patch.object(stop_port, "_open_url", return_value=FakeResponse(body)):
+            probe = stop_port.probe_system_stats(8188)
+        # Answered (something is serving) but never treated as /system_stats.
+        assert probe.answered is True
+        assert probe.stats is None
+
+    def test_trickling_body_gives_up_at_the_deadline(self):
+        # `timeout` bounds each socket operation, not the whole transfer, so a
+        # peer feeding one byte at a time could hold the command open forever.
+        never_ending = FakeResponse(b"x" * (stop_port.MAX_PROBE_BYTES + 1), chunk=1)
+        with patch.object(stop_port, "_open_url", return_value=never_ending):
+            probe = stop_port.probe_system_stats(8188, timeout=0.0)
+        assert probe.answered is False
+
+    def test_opener_disables_proxies_and_redirects(self):
+        # The default opener honors http_proxy/ALL_PROXY (urllib's proxy_bypass
+        # has no implicit localhost exemption) and follows up to 10 redirects,
+        # so the probe could leave the machine entirely.
+        with patch.object(stop_port.urllib.request, "build_opener") as build:
+            stop_port._open_url("http://127.0.0.1:8188/system_stats", 1.0)
+        handlers = build.call_args.args
+        proxy = next(h for h in handlers if isinstance(h, urllib.request.ProxyHandler))
+        assert proxy.proxies == {}
+        assert stop_port._NoRedirect in handlers
+        # Returning None leaves the 3xx unhandled, so urllib raises HTTPError
+        # and the response reads as "answered, but not ComfyUI".
+        assert stop_port._NoRedirect().redirect_request(None, None, 302, "Found", {}, "http://evil.example/") is None
+
+
+class TestProbeHost:
+    @pytest.mark.parametrize(
+        ("laddr_ip", "expected"),
+        [
+            ("127.0.0.1", "127.0.0.1"),
+            # Wildcard binds: probe the matching loopback.
+            ("0.0.0.0", "127.0.0.1"),
+            ("::", "[::1]"),
+            (None, "127.0.0.1"),
+            ("", "127.0.0.1"),
+            # `--listen <lan-ip>` and v6-only binds were previously probed at
+            # 127.0.0.1, read as unreachable, and fell through uncorroborated.
+            ("192.168.1.50", "192.168.1.50"),
+            ("::1", "[::1]"),
+            ("fd00::5", "[fd00::5]"),
+            # v4-mapped v6 sockets report this shape on some platforms.
+            ("::ffff:0.0.0.0", "127.0.0.1"),
+            ("::ffff:192.168.1.50", "192.168.1.50"),
+            # Scoped/garbage addresses can't be probed; loopback is the safe
+            # fallback and a non-answer is handled conservatively anyway.
+            ("fe80::1%en0", "127.0.0.1"),
+            ("not-an-ip", "127.0.0.1"),
+        ],
+    )
+    def test_maps_bound_address_to_probe_host(self, laddr_ip, expected):
+        assert stop_port.probe_host(laddr_ip) == expected
 
 
 class TestVerifyListener:
@@ -272,16 +446,77 @@ class TestVerifyListener:
         assert verdict.verified is False
         assert verdict.http == "disagreed"
 
-    def test_unreachable_server_still_verifies_on_cmdline_evidence(self):
-        # The wedged-server case this command exists for.
-        verdict = stop_port.verify_listener(self._listener(), 8188, probe=stop_port.Probe(answered=False))
+    def test_unreachable_server_verifies_on_cmdline_plus_the_checkout(self, comfy_tree):
+        # The wedged-server case this command exists for: the server can't
+        # corroborate itself, so the checkout on disk is the second signal.
+        listener = stop_port.Listener(
+            pid=42, cmdline=["/usr/bin/python3", str(comfy_tree / "main.py"), "--port", "8188"]
+        )
+        verdict = stop_port.verify_listener(listener, 8188, probe=stop_port.Probe(answered=False))
         assert verdict.verified is True
         assert verdict.http == "unreachable"
+
+    def test_unreachable_server_relative_script_resolves_against_cwd(self, comfy_tree):
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd=str(comfy_tree))
+        verdict = stop_port.verify_listener(listener, 8188, probe=stop_port.Probe(answered=False))
+        assert verdict.verified is True
+
+    def test_unreachable_non_comfyui_main_py_is_refused(self, tmp_path):
+        # The hole the cmdline check alone leaves open: an unrelated
+        # `python main.py` service that isn't speaking HTTP on the port at all.
+        (tmp_path / "main.py").write_text("")
+        listener = stop_port.Listener(pid=42, cmdline=["/usr/bin/python3", str(tmp_path / "main.py")])
+        verdict = stop_port.verify_listener(listener, 8188, probe=stop_port.Probe(answered=False))
+        assert verdict.verified is False
+        assert verdict.http == "unreachable"
+        assert "ComfyUI checkout" in verdict.reason
+
+    def test_unreachable_unresolvable_script_is_refused(self):
+        # Relative `main.py` with an unreadable cwd: nothing to corroborate with.
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd=None)
+        verdict = stop_port.verify_listener(listener, 8188, probe=stop_port.Probe(answered=False))
+        assert verdict.verified is False
+
+    def test_answering_server_does_not_need_the_checkout_on_disk(self):
+        # `/system_stats` corroboration is the stronger signal; a checkout we
+        # cannot see (container, remote mount) must not veto it.
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd="/nonexistent")
+        verdict = stop_port.verify_listener(listener, 8188, probe=_stats(argv=["main.py", "--port", "8188"]))
+        assert verdict.verified is True
+
+    def test_probes_the_bound_address(self):
+        # Regression: hardcoding 127.0.0.1 made every `--listen <lan-ip>` or
+        # v6-only server read as unreachable, skipping the cross-check.
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, laddr_ip="::1")
+        with patch.object(
+            stop_port, "probe_system_stats", return_value=_stats(argv=["main.py", "--port", "8188"])
+        ) as probe:
+            stop_port.verify_listener(listener, 8188)
+        assert probe.call_args.kwargs["host"] == "[::1]"
 
     def test_server_without_argv_verifies_on_version_plus_cmdline(self):
         verdict = stop_port.verify_listener(self._listener(), 8188, probe=_stats(argv=None))
         assert verdict.verified is True
         assert verdict.http == "agreed_no_argv"
+
+
+class TestLooksLikeComfyuiTree:
+    def test_accepts_a_real_checkout(self, comfy_tree):
+        listener = stop_port.Listener(pid=1, cmdline=["python", str(comfy_tree / "main.py")])
+        assert stop_port.looks_like_comfyui_tree(listener) is True
+
+    def test_rejects_a_bare_main_py(self, tmp_path):
+        (tmp_path / "main.py").write_text("")
+        listener = stop_port.Listener(pid=1, cmdline=["python", str(tmp_path / "main.py")])
+        assert stop_port.looks_like_comfyui_tree(listener) is False
+
+    def test_rejects_a_partial_match(self, tmp_path):
+        # Two markers is under the threshold — one incidental `nodes.py` next to
+        # a `main.py` shouldn't authorize a kill.
+        (tmp_path / "main.py").write_text("")
+        (tmp_path / "nodes.py").write_text("")
+        listener = stop_port.Listener(pid=1, cmdline=["python", str(tmp_path / "main.py")])
+        assert stop_port.looks_like_comfyui_tree(listener) is False
 
 
 # --------------------------------------------------------------------------- #
@@ -292,7 +527,17 @@ class TestVerifyListener:
 class FakeKillProc:
     """A process that dies at a configurable point of the escalation."""
 
-    def __init__(self, pid, *, children=(), survives_terminate=False, survives_kill=False, log=None):
+    def __init__(
+        self,
+        pid,
+        *,
+        children=(),
+        survives_terminate=False,
+        survives_kill=False,
+        log=None,
+        create_time=1000.0,
+        children_denied=False,
+    ):
         self.pid = pid
         self._children = list(children)
         self._survives_terminate = survives_terminate
@@ -300,8 +545,15 @@ class FakeKillProc:
         self.log = log if log is not None else []
         self.terminated = False
         self.killed = False
+        self._create_time = create_time
+        self._children_denied = children_denied
+
+    def create_time(self):
+        return self._create_time
 
     def children(self, recursive=False):
+        if self._children_denied:
+            raise psutil.AccessDenied(self.pid)
         return list(self._children)
 
     def terminate(self):
@@ -328,20 +580,20 @@ def _fake_wait_procs(procs, timeout=None):
 
 
 class TestKillProcessTree:
-    def _run(self, parent):
+    def _run(self, parent, **kwargs):
         with (
             patch.object(stop_port.psutil, "Process", return_value=parent),
             patch.object(stop_port.psutil, "wait_procs", side_effect=_fake_wait_procs),
         ):
-            return stop_port.kill_process_tree(parent.pid)
+            return stop_port.kill_process_tree(parent.pid, **kwargs)
 
     def test_terminates_the_listener_itself_not_only_its_children(self):
         # The `utils.kill_all` trap: that helper kills only children, which
         # would leave a directly-identified listener running.
         log = []
         parent = FakeKillProc(42, log=log)
-        ok, survivors = self._run(parent)
-        assert ok is True and survivors == []
+        result = self._run(parent)
+        assert result.ok is True and result.survivors == []
         assert parent.terminated is True
         assert log == [("terminate", 42)]
 
@@ -349,26 +601,50 @@ class TestKillProcessTree:
         log = []
         kids = [FakeKillProc(43, log=log), FakeKillProc(44, log=log)]
         parent = FakeKillProc(42, children=kids, log=log)
-        ok, survivors = self._run(parent)
-        assert ok is True and survivors == []
+        result = self._run(parent)
+        assert result.ok is True and result.survivors == []
         assert [entry[1] for entry in log] == [43, 44, 42]
         assert all(k.terminated for k in kids)
 
     def test_escalates_to_kill_when_terminate_is_ignored(self):
         parent = FakeKillProc(42, survives_terminate=True)
-        ok, survivors = self._run(parent)
-        assert ok is True and survivors == []
+        result = self._run(parent)
+        assert result.ok is True and result.survivors == []
         assert parent.terminated is True and parent.killed is True
 
     def test_reports_survivors_when_kill_does_not_land(self):
         parent = FakeKillProc(42, survives_terminate=True, survives_kill=True)
-        ok, survivors = self._run(parent)
-        assert ok is False and survivors == [42]
+        result = self._run(parent)
+        assert result.ok is False and result.survivors == [42]
 
     def test_already_gone_process_is_a_success(self):
         with patch.object(stop_port.psutil, "Process", side_effect=psutil.NoSuchProcess(42)):
-            ok, survivors = stop_port.kill_process_tree(42)
-        assert ok is True and survivors == []
+            result = stop_port.kill_process_tree(42)
+        assert result.ok is True and result.survivors == []
+
+    def test_recycled_pid_is_not_signalled(self):
+        # Discovery and teardown are separated by an HTTP probe that can block
+        # for the full timeout. If the listener exits in that window and the OS
+        # hands its pid to a stranger, the stranger's whole tree must not die.
+        stranger = FakeKillProc(42, create_time=9999.0)
+        result = self._run(stranger, create_time=1000.0)
+        assert result.ok is True and result.survivors == []
+        assert stranger.terminated is False and stranger.killed is False
+
+    def test_matching_create_time_still_signals(self):
+        parent = FakeKillProc(42, create_time=1000.0)
+        result = self._run(parent, create_time=1000.0)
+        assert result.ok is True
+        assert parent.terminated is True
+
+    def test_unreadable_children_are_reported_not_silently_dropped(self):
+        # `ok` can only speak for the parent when the child list can't be read;
+        # claiming a clean stop over live workers holding GPU memory is worse
+        # than admitting the gap.
+        parent = FakeKillProc(42, children_denied=True)
+        result = self._run(parent)
+        assert result.ok is True
+        assert result.children_enumerated is False
 
 
 # --------------------------------------------------------------------------- #
@@ -446,7 +722,7 @@ class TestStopPortExecute:
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd=None)
         with (
             patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
             patch.object(stop_port, "kill_process_tree"),
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=True)
@@ -457,9 +733,9 @@ class TestStopPortExecute:
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
         cfg = self._config(bg_info=None)
         with (
-            patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
-            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN),
             patch.object(stop_port, "ConfigManager", return_value=cfg),
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
@@ -473,34 +749,113 @@ class TestStopPortExecute:
     def test_failed_kill_emits_stop_failed(self, capsys):
         renderer = _json_renderer()
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        cfg = self._config(bg_info=("127.0.0.1", 8188, 42))
         with (
-            patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
-            patch.object(stop_port, "kill_process_tree", return_value=(False, [42])),
-            patch.object(stop_port, "ConfigManager") as cfg,
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=stop_port.Teardown(ok=False, survivors=[42])),
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
         ):
             with pytest.raises(typer.Exit) as exc:
                 stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
         assert exc.value.exit_code == 1
         # A failed stop must not drop the background record.
-        cfg.assert_not_called()
+        cfg.remove_background.assert_not_called()
 
         env = _envelope(capsys.readouterr().out)
         assert env["error"]["code"] == "stop_failed"
         assert env["error"]["details"]["survivors"] == [42]
+
+    def test_port_still_held_after_a_clean_kill_is_not_reported_as_success(self, capsys):
+        # SO_REUSEPORT, split v4/v6 sockets, or children we could not enumerate:
+        # the identified process died, but the port never came free.
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        sibling = stop_port.Listener(pid=43, cmdline=COMFY_CMDLINE)
+        cfg = self._config(bg_info=None)
+        with (
+            patch.object(stop_port, "find_listener", side_effect=[listener, sibling]),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN),
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            with pytest.raises(typer.Exit) as exc:
+                stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        assert exc.value.exit_code == 1
+        cfg.remove_background.assert_not_called()
+
+        env = _envelope(capsys.readouterr().out)
+        assert env["error"]["code"] == "stop_failed"
+        assert env["error"]["details"]["survivors"] == [43]
+
+    def test_unenumerable_children_are_flagged_in_the_envelope(self, capsys):
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
+        teardown = stop_port.Teardown(ok=True, survivors=[], children_enumerated=False)
+        with (
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=teardown),
+            patch.object(stop_port, "ConfigManager", return_value=self._config()),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        assert _envelope(capsys.readouterr().out)["data"]["children_unknown"] is True
 
     def test_matching_background_pid_is_forgotten(self, capsys):
         renderer = _json_renderer()
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
         cfg = self._config(bg_info=("127.0.0.1", 8188, 42))
         with (
-            patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
-            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN),
             patch.object(stop_port, "ConfigManager", return_value=cfg),
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
         cfg.remove_background.assert_called_once()
+        capsys.readouterr()
+
+    def test_recorded_launch_wrapper_is_torn_down_with_its_listener(self, capsys):
+        # `comfy launch --background` records the *wrapper's* pid, not the
+        # `python main.py` it spawns, so the exact-pid match below could never
+        # fire for a server this CLI started: the record outlived every
+        # `comfy stop --port`, and the wrapper (whose redirector threads never
+        # exit on their own) leaked.
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, create_time=1000.0)
+        cfg = self._config(bg_info=("127.0.0.1", 8188, 7))
+        with (
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "_ancestor_pids", return_value=[7, 1]),
+            patch.object(stop_port, "_is_launch_wrapper", return_value=True),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN) as killer,
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        killer.assert_called_once_with(7)
+        cfg.remove_background.assert_called_once()
+        capsys.readouterr()
+
+    def test_recycled_ancestor_pid_is_not_mistaken_for_the_wrapper(self, capsys):
+        # The recorded pid being an ancestor is not enough: it could have been
+        # recycled onto an unrelated ancestor (a login shell). Signalling that
+        # tree, or forgetting a background server we still own, would be worse
+        # than leaving a stale record.
+        renderer = _json_renderer()
+        listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, create_time=1000.0)
+        cfg = self._config(bg_info=("127.0.0.1", 8188, 7))
+        with (
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "_ancestor_pids", return_value=[7, 1]),
+            patch.object(stop_port, "_is_launch_wrapper", return_value=False),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN) as killer,
+            patch.object(stop_port, "ConfigManager", return_value=cfg),
+        ):
+            stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
+        killer.assert_called_once_with(42, create_time=1000.0)
+        cfg.remove_background.assert_not_called()
         capsys.readouterr()
 
     def test_different_background_pid_on_the_same_port_is_kept(self, capsys):
@@ -510,9 +865,10 @@ class TestStopPortExecute:
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE)
         cfg = self._config(bg_info=("127.0.0.1", 8188, 777))
         with (
-            patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
-            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "_ancestor_pids", return_value=[]),
+            patch.object(stop_port, "kill_process_tree", return_value=_TORN_DOWN),
             patch.object(stop_port, "ConfigManager", return_value=cfg),
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=False)
@@ -523,10 +879,11 @@ class TestStopPortExecute:
     def test_payloads_validate_against_the_shipped_schema(self, capsys, dry_run):
         renderer = _json_renderer()
         listener = stop_port.Listener(pid=42, cmdline=COMFY_CMDLINE, cwd="/srv/ComfyUI")
+        teardown = stop_port.Teardown(ok=True, survivors=[], children_enumerated=False)
         with (
-            patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
-            patch.object(stop_port, "kill_process_tree", return_value=(True, [])),
+            _finds(listener),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
+            patch.object(stop_port, "kill_process_tree", return_value=teardown),
             patch.object(stop_port, "ConfigManager", return_value=self._config()),
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=dry_run)
@@ -542,7 +899,7 @@ class TestStopPortExecute:
         listener = stop_port.Listener(pid=42, cmdline=["/usr/bin/python3", "main.py", "--x", "[/]"])
         with (
             patch.object(stop_port, "find_listener", return_value=listener),
-            patch.object(stop_port, "probe_system_stats", return_value=stop_port.Probe(answered=False)),
+            patch.object(stop_port, "probe_system_stats", return_value=_AGREEING),
             patch.object(stop_port, "kill_process_tree") as killer,
         ):
             stop_port.stop_port_execute(renderer, port=8188, dry_run=True)

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ requires-dist = [
     { name = "pathspec" },
     { name = "posthog", specifier = ">=6,<8" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "psutil" },
+    { name = "psutil", specifier = ">=6" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pyyaml" },


### PR DESCRIPTION
## ELI-5

`comfy stop` could only stop a ComfyUI that *this CLI* started — it looks up a `(host, port, pid)` it wrote down at launch time, and if there isn't one it just says "no background server" and gives up. So the most common real restart case (a ComfyUI started by the desktop app, or by hand with `python main.py`, or one that has wedged) was unreachable: the port is busy, and comfy-cli has no handle on whatever is holding it.

This adds `comfy stop --port <p>`: find whatever is LISTENing on that port, *prove* it is ComfyUI, and stop it — plus `--dry-run`, which names the exact victim and touches nothing, so an agent can put it in front of a human before anything dies.

## What it does

**Find the listener.** Iterates `psutil.process_iter()` and uses the **per-process** `Process.net_connections()`, skipping `AccessDenied`. The system-wide `psutil.net_connections()` is never used — it is root-only on macOS. No listener → `port_not_listening`.

**Prove identity, process table first.** The cmdline must be a python-ish `argv[0]` running a token whose basename is `main.py`. Only then do we ask the server: `GET /system_stats` on the address the listener actually bound, with a ~2s timeout, a 1 MiB body cap, and an opener that has proxies and redirects disabled.

| `/system_stats` | outcome |
|---|---|
| answers, `system.comfyui_version` present, `argv` tail agrees with the psutil cmdline | verified |
| answers, no `argv` reported (older servers) | verified — version + cmdline are still two signals, we just can't cross-check |
| answers, but no `comfyui_version` / not JSON / a 404 from something else on the port | `unverified_process` — this is the reverse-proxy (and generic `python main.py`) false positive |
| refused / timed out / not HTTP (a TLS-enabled ComfyUI) | **verified only if the `main.py` also lives in a ComfyUI checkout** (>= 3 of `nodes.py` / `execution.py` / `folder_paths.py` / `server.py` / `comfy/` / `comfy_extras/` beside it) — the wedged server is exactly what this exists for, but the cmdline shape alone matches any `python main.py` |
| cmdline is not a python `main.py` | `unverified_process`, and the HTTP probe never even runs |

Nothing is ever stopped on HTTP evidence alone: the cmdline check is a precondition, and the probe can only *withdraw* authorization.

**Stop.** Terminates the identified listener **and** its recursive children (children first), escalates `terminate` → `kill` with a bounded wait, verifies exit, and emits `{"stopped": true, "pid": …, "port": …, "untracked": true}`. `utils.kill_all` is deliberately not reused — it kills only the *children* of the pid it is given, which is correct for the recorded wrapper pid and would leave a directly-identified listener running. If the stopped pid equals `config.background`'s recorded pid, the record is dropped too (exact pid match only — a port collision is not identity).

**New error codes:** `port_not_listening`, `unverified_process`. `schemas/stop.json` gains the additive `dry_run` / `untracked` / `verified` / `cmdline` / `cwd` fields.

Plain `comfy stop` is unchanged.

## Verified against real processes, not just mocks

Every path below was exercised end-to-end against real listening processes on this machine (envelopes abridged):

| scenario | result |
|---|---|
| real ComfyUI-shaped server (`python main.py --port 18188`, serving a real `/system_stats`), `--dry-run` | `ok:true`, `{"stopped":false,"dry_run":true,"verified":true,"pid":27351,"cmdline":[…],"cwd":"/private/tmp/fakecomfy"}`, exit 0, **process still alive afterwards** |
| same server, real run | `{"stopped":true,"pid":27351,"port":18188,"untracked":true}`, exit 0, process gone |
| nothing on the port | `port_not_listening`, exit 1 |
| `python -m http.server 18189` | `unverified_process` ("not a python `main.py` command line"), exit 1, process untouched |
| **impostor `python main.py 18190`** that is not ComfyUI (404s on `/system_stats`) | `unverified_process` ("the port answered but did not return a ComfyUI /system_stats payload"), exit 1, process untouched — the cmdline check alone would have killed this one |

## Negative-claim falsification

The diff adds a refusal path (`unverified_process`, "Refusing to stop…"), so the falsification rule fires. It is a *safety* refusal, not a capability denial — I checked that no existing path is being dead-ended:

- `comfy stop` with an untracked server live on port 18191: `{"ok":false,"error":{"code":"no_background_server"}}`, exit 1. That is the entire pre-existing surface — there is no port/pid path on `main` to redirect anyone to.
- `comfy stop --port 18191 --dry-run` on this branch: `ok:true`, victim named.

So the change is strictly capability-*adding*: before it, comfy-cli refused **every** untracked server; after it, it refuses only the ones it cannot identify, and the error carries the pid, the readable cmdline, the cwd, and the specific reason so the caller can act. Nothing that previously worked now denies.

## Judgment calls

- **Not confirmed: the ComfyUI Desktop cmdline shape.** The ticket asked for this to be checked against a real install; there is no ComfyUI Desktop on this machine (`/Applications` has no ComfyUI bundle, no `main.py` process running), so I could not. The detector is deliberately *shape*-based rather than path-based — python-ish `argv[0]` + a `main.py` token — which covers the bundled-interpreter form (`…/ComfyUI/.venv/bin/python …/ComfyUI/main.py --listen …`) and is pinned as a test case. **If Desktop launches its backend through a frozen/renamed binary rather than a `python`-named interpreter, this would refuse it** (safely — `unverified_process`, nothing killed) and the `_PYTHON_ARGV0` regex needs widening. Worth one check by anyone with Desktop installed.
- **`--dry-run` also works on the plain (tracked) path**, emitting `{"stopped":false,"dry_run":true,"untracked":false,"host","port","pid"}` and exiting 0. The ticket only specified it under `--port`, but erroring on `comfy stop --dry-run` would be a dead end for no reason.
- **The dry-run envelope carries `"stopped": false` in addition to the ticket's `{pid, cmdline, cwd?, port, verified}`.** `stopped` is `required` by `schemas/stop.json`, and it is what a caller branches on; `dry_run: true` says why it is false.
- **A server that answers `/system_stats` with `comfyui_version` but no `argv` is accepted.** The ticket says to require an agreeing `argv` tail; absence isn't disagreement, and refusing would break older servers. Disagreeing `argv` is refused, which is the case the rule is actually defending.
- **An HTTP status other than 200 counts as "answered", not "unreachable".** A 404 means something is serving the port — it isn't wedged, it just isn't ComfyUI. This is what catches the generic `python main.py` impostor above; treating it as unreachable would have killed it.
- **`find_listener` returns the first match in pid order.** Two processes can share a port under `SO_REUSEPORT`; that is not a ComfyUI configuration, and each `comfy stop --port` invocation stops one verified listener.
- **`utils.kill_all` was left alone** (Chesterton's fence): on POSIX the recorded background pid *is* the python process, so kill_all killing only children looks wrong there too — but that is the tracked path's pre-existing behavior and out of scope for this ticket.

## Testing

- `tests/comfy_cli/command/test_stop_port.py` (new, 47 cases): fake psutil table (no listener / non-ComfyUI listener / ComfyUI listener / `AccessDenied` not hiding a readable process / ESTABLISHED-is-not-LISTEN / unreadable cmdline still yields the pid); the full HTTP agree-disagree-timeout-404-non-JSON matrix; cmdline identity accept/reject table incl. the Desktop shape; teardown (listener itself terminated, recursive children reaped *before* the parent, terminate→kill escalation, survivors reported, already-gone is success); dry-run kills nothing and never touches `ConfigManager`; both envelopes validated against the shipped `stop.json`; error codes pinned; pretty-mode markup escaping of a foreign process's argv.
- `tests/comfy_cli/command/test_launch_stop_envelope.py`: tracked `--dry-run`, and that `--port` never falls through to the recorded-background branch even when a record exists.
- Full suite: **4065 passed, 37 skipped**. `ruff check` + `ruff format --check` clean under the CI-pinned `ruff==0.15.15` (the local env had 0.12.7, whose UP038 output is version drift, not a real finding).



---

## Review round 2 — Cursor panel (10 findings, all addressed in 1bd6436)

Every finding was on the identity/teardown path. Thread-by-thread detail is in the replies; the behaviour changes worth reading the diff for:

- **The unreachable path is no longer cmdline-only.** A listener whose port does not answer is stopped only if its `main.py` also sits in a ComfyUI checkout on disk. Verified against a real unrelated `python main.py` bound to a raw socket: it is now refused (`unverified_process`, exit 1, untouched) where the first revision would have SIGTERMed it. This is the one behaviour change to the shipped surface, and it is a tightening — the identity table above is updated.
- **The probe follows the socket.** `find_listener` carries the matched `laddr` through and the probe targets it, so a `--listen <lan-ip>` or `::1`-only server is cross-checked instead of reading as unreachable — and the process cross-checked is the process killed. Verified on a real IPv6-only server: `http='agreed'`, where a `127.0.0.1` probe of the same process returns `answered=False`.
- **The probe cannot be steered off-box.** `ProxyHandler({})` plus a no-redirect handler; verified with `http_proxy`/`ALL_PROXY` pointed at a black hole.
- **Teardown targets the recorded `comfy … launch` wrapper** when the listener is its child. The record holds the wrapper's pid, so the old exact-pid match could never fire for a server this CLI started — the record outlived every `comfy stop --port`, and the wrapper (non-daemon redirector threads) leaked. The ancestor must actually be a `comfy … launch` process, so a recycled pid cannot make us forget a server we still own.
- **Honest failure.** `create_time` pins identity across the probe window; the port is re-checked after the kill (a sibling still holding it is `stop_failed`, not a false success); an unreadable child list surfaces as `children_unknown: true` rather than a clean-stop claim.
- **`psutil>=6`** floor plus a `Process.connections()` fallback, and `http.client.HTTPException` is caught — both were raw-traceback paths.

`schemas/stop.json` gains one additive field (`children_unknown`). Tests: `tests/comfy_cli/command/test_stop_port.py` grows to 92 cases (psutil-5 accessor, the `probe_host` address matrix, protocol-garbage/oversized/trickling probe bodies, the opener's proxy+redirect handlers, the checkout-marker table, pid recycling in both the listener and ancestor positions, port-still-held, `children_unknown`). `ruff check` + `ruff format --check` clean under the CI-pinned `ruff==0.15.15`.
