### PR TITLE
feat(jobs): carry the failure cause on `jobs ls` rows via `error_code`

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -216,6 +216,23 @@ def _emit_terminal(renderer, payload: dict, *, command: str, where: str | None =
 # meaningful alongside. `completed` is terminal but deliberately absent.
 _ERROR_STATUSES = frozenset({"error", "cancelled"})
 
+# Cloud's raw job statuses → the row vocabulary above. Mirrors
+# ``job_watcher._CLOUD_STATUS_MAP`` (kept as a local copy rather than imported:
+# ``job_watcher`` imports this module, so the dependency only runs one way).
+# The failure spellings matter here — an unmapped `non_retryable_error` /
+# `lost` / `canceled` misses `_ERROR_STATUSES` and silently drops the state
+# file's `error_code` for exactly the jobs that failed.
+_CLOUD_ROW_STATUS_MAP = {
+    "success": "completed",
+    "completed": "completed",
+    "failed": "error",
+    "error": "error",
+    "non_retryable_error": "error",
+    "lost": "error",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
+}
+
 
 @dataclass(frozen=True)
 class JobRow:
@@ -231,23 +248,57 @@ class JobRow:
     # `error.code` off the state file (e.g. "server_died", "execution_error",
     # "watcher_crashed"). Without it a listing can say a job is in `error` and
     # name its workflow, but never say *why* — which is the whole point of the
-    # state file surviving a server death. None for rows the server produced
-    # (/queue and /history carry no code) and for every non-error row.
+    # state file surviving a server death. Only ever set alongside a status in
+    # `_ERROR_STATUSES`: the watcher parks a transient `watcher_poll_error` on
+    # the state file of a job that is still healthily `running`, and that is a
+    # poll blip, not this row's failure cause.
     error_code: str | None = None
 
 
-def _state_error_code(err: Any) -> str | None:
+def _state_error_code(err: Any, status: Any) -> str | None:
     """Pull ``error.code`` out of a state file's ``error`` blob, or None.
 
-    ``jobs_state.read`` keeps unknown keys' values untouched, so a hand-edited
-    or truncated file can carry a non-dict ``error`` (or a non-string ``code``)
-    — neither may reach the emitted envelope, where ``error_code`` is typed
+    Returns None unless ``status`` is one of ``_ERROR_STATUSES``. A non-failed
+    job can carry an ``error`` blob: ``job_watcher._poll_local_once`` /
+    ``_poll_cloud_once`` record ``watcher_poll_error`` when a single poll
+    raises, leave the status at ``queued``/``running``, and only clear it on a
+    later poll that actually returns a snapshot — so an in-flight job can hold
+    that code for many cycles. Surfacing it as ``error_code`` would advertise a
+    failure cause for a job that has not failed.
+
+    ``jobs_state.read`` keeps known keys' values untouched, so a hand-edited or
+    truncated file can carry a non-dict ``error`` (or a non-string ``code``) —
+    neither may reach the emitted envelope, where ``error_code`` is typed
     ``string | null``.
     """
+    if status not in _ERROR_STATUSES:
+        return None
     if not isinstance(err, dict):
         return None
     code = err.get("code")
     return code if isinstance(code, str) and code else None
+
+
+def _state_str(value: Any) -> str | None:
+    """Narrow a state-file value to ``str | None`` for the emitted envelope.
+
+    Same defensiveness as ``_state_error_code``, for the fields published as
+    ``string | null``: ``jobs_state.read`` type-checks nothing it keeps, and a
+    numeric ``updated_at`` from a hand-edited or legacy file would otherwise
+    reach ``_merge_jobs``'s ``sort_key`` and raise ``TypeError`` comparing int
+    against str — aborting the whole listing, not just one row.
+    """
+    return value if isinstance(value, str) and value else None
+
+
+def _state_where(value: Any) -> str:
+    """Narrow a state file's ``where`` to the published ``local``/``cloud`` enum.
+
+    Missing, empty, or unrecognized (a legacy ``"remote"``) reads as ``local``,
+    matching the filter in ``_gather_local_state_files`` — so a row can never be
+    scoped as local yet report a ``where`` the schema rejects.
+    """
+    return value if value in ("local", "cloud") else "local"
 
 
 def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where: str | None = None) -> list[JobRow]:
@@ -304,7 +355,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
         # Scope to the resolved --where target. Done *after* the stale-watcher
         # reap above so cleanup stays where-agnostic no matter which view the
         # caller asked for.
-        if where is not None and (state.where or "local") != where:
+        if where is not None and _state_where(state.where) != where:
             continue
         if orphaned_only:
             err = state.error or {}
@@ -318,13 +369,13 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
                 elapsed_seconds=None,
                 workflow_size=None,
                 outputs=len(state.outputs or []),
-                # Same missing/empty -> "local" reading the filter above uses,
-                # so a row can never be scoped as local yet report `where: null`
-                # (JobRow.where is typed `str` and defaults to "local").
-                where=state.where or "local",
-                workflow_path=state.workflow,
-                updated_at=state.updated_at,
-                error_code=_state_error_code(state.error),
+                # Same narrowing the filter above uses, so a row can never be
+                # scoped as local yet report a `where` outside the published
+                # enum (JobRow.where is typed `str` and defaults to "local").
+                where=_state_where(state.where),
+                workflow_path=_state_str(state.workflow),
+                updated_at=_state_str(state.updated_at),
+                error_code=_state_error_code(state.error, state.status),
             )
         )
         if len(rows) >= limit:
@@ -347,18 +398,51 @@ def _merge_jobs(state_rows: list[JobRow], server_rows: list[JobRow]) -> list[Job
     files fill in everything else (jobs the server doesn't see, e.g. cloud
     jobs viewed from a local-only `jobs ls`).
 
-    The one thing the server's row cannot supply is ``error_code``: neither
-    ``/queue``/``/history`` nor the cloud job list carries one, so a server row
-    that supersedes a state-file row would otherwise *lose* the cause the state
-    file recorded. Carry it across when the server also calls the job failed —
-    and only then, so a state file left holding a stale ``server_died`` can't
-    contradict a server that now reports the prompt as completed.
+    "Wins" is per-row, not per-field: several fields exist only on the state
+    file, and a server row that supersedes one would otherwise blank them.
+
+    - ``error_code``: neither ``/queue``/``/history`` nor the cloud job list
+      carries one, so the cause the state file recorded would be lost. Carried
+      across only when *both* views call the job failed — the state file's,
+      because a code recorded next to a healthy status is a watcher poll blip
+      rather than this job's cause; the server's, so a state file left holding
+      a stale ``server_died`` can't contradict a server that now reports the
+      prompt as completed.
+    - ``workflow_path`` / ``updated_at``: also state-file-only. Blanking
+      ``workflow_path`` drops the one field that says *which workflow* a
+      prompt_id was, and blanking ``updated_at`` sorts a terminal row to epoch
+      0 below every dated one, where the caller's ``[:limit]`` slice can drop a
+      fresh completion. Carried whenever the server row has nothing to say.
+
+    ``where`` is deliberately *not* carried: server rows now set it themselves
+    (``_cloud_job_to_row`` marks cloud, ``_gather_jobs`` is local by
+    construction), so the server row is authoritative.
+
+    The prior row is looked up from a snapshot of ``state_rows`` rather than
+    from the accumulating map: ``/queue`` and ``/history`` are fetched
+    separately, so one gather can yield two rows for a transitioning prompt
+    (``running``, then ``error``), and reading the map would let the first one
+    clobber the state row before the second one gets to inherit from it.
     """
-    by_id: dict[str, JobRow] = {r.prompt_id: r for r in state_rows}
+    state_by_id: dict[str, JobRow] = {r.prompt_id: r for r in state_rows}
+    by_id: dict[str, JobRow] = dict(state_by_id)
     for r in server_rows:
-        prior = by_id.get(r.prompt_id)
-        if r.error_code is None and prior is not None and prior.error_code is not None and r.status in _ERROR_STATUSES:
-            r = replace(r, error_code=prior.error_code)
+        prior = state_by_id.get(r.prompt_id)
+        if prior is not None:
+            carried: dict[str, Any] = {}
+            if (
+                r.error_code is None
+                and prior.error_code is not None
+                and prior.status in _ERROR_STATUSES
+                and r.status in _ERROR_STATUSES
+            ):
+                carried["error_code"] = prior.error_code
+            if r.workflow_path is None and prior.workflow_path is not None:
+                carried["workflow_path"] = prior.workflow_path
+            if r.updated_at is None and prior.updated_at is not None:
+                carried["updated_at"] = prior.updated_at
+            if carried:
+                r = replace(r, **carried)
         by_id[r.prompt_id] = r
 
     # Sort: non-terminal first (running/pending/allocated/executing), then
@@ -1922,10 +2006,17 @@ def _is_cloud(where: str | None) -> bool:
 
 
 def _cloud_job_to_row(j: dict) -> JobRow:
-    """Map a /api/jobs entry to our JobRow shape."""
-    status_map = {"completed": "completed", "success": "completed", "failed": "error", "error": "error"}
+    """Map a /api/jobs entry to our JobRow shape.
+
+    Statuses go through the same map the watcher uses, so cloud's other failure
+    spellings (``non_retryable_error``, ``lost``, ``canceled``) normalize to the
+    row vocabulary instead of passing through raw. Beyond keeping the rendered
+    status consistent with `jobs status`/`jobs watch`, it is what lets
+    ``_merge_jobs`` recognize those rows as failures and keep the state file's
+    ``error_code`` — the failures that most need a named cause.
+    """
     raw_status = (j.get("status") or "").lower()
-    status = status_map.get(raw_status, raw_status or "pending")
+    status = _CLOUD_ROW_STATUS_MAP.get(raw_status, raw_status or "pending")
     outputs = int(j.get("outputs_count") or 0)
     return JobRow(
         prompt_id=str(j.get("id") or ""),
@@ -1934,6 +2025,11 @@ def _cloud_job_to_row(j: dict) -> JobRow:
         elapsed_seconds=None,
         workflow_size=None,
         outputs=outputs,
+        # These rows come from the cloud job list; without this they'd take
+        # JobRow's "local" default and supersede the state row that correctly
+        # said "cloud", so `jobs ls --where cloud` would emit an envelope
+        # saying cloud with every row inside claiming local.
+        where="cloud",
     )
 
 
@@ -1968,14 +2064,10 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     if status is None:
         return None
     raw = (status.get("status") or "").lower()
-    state = {
-        "success": "completed",
-        "completed": "completed",
-        "failed": "error",
-        "error": "error",
-        "non_retryable_error": "error",
-        "lost": "error",
-    }.get(raw, raw or "pending")
+    # Shared with `jobs ls` (and the watcher) so the same cloud job can't be
+    # `cancelled` in one command and `canceled` in another — the latter isn't
+    # in the published `status` enum this file's schema declares.
+    state = _CLOUD_ROW_STATUS_MAP.get(raw, raw or "pending")
 
     outputs: list[str] = []
     outputs_by_node: dict[str, list[str]] = {}

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -25,7 +25,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -212,6 +212,11 @@ def _emit_terminal(renderer, payload: dict, *, command: str, where: str | None =
 # ---------------------------------------------------------------------------
 
 
+# Row statuses that mean "this job failed" — the ones an `error_code` is
+# meaningful alongside. `completed` is terminal but deliberately absent.
+_ERROR_STATUSES = frozenset({"error", "cancelled"})
+
+
 @dataclass(frozen=True)
 class JobRow:
     prompt_id: str
@@ -223,6 +228,26 @@ class JobRow:
     where: str = "local"  # "local" | "cloud"
     workflow_path: str | None = None  # set when sourced from a state file
     updated_at: str | None = None  # ISO timestamp, set for state-file rows
+    # `error.code` off the state file (e.g. "server_died", "execution_error",
+    # "watcher_crashed"). Without it a listing can say a job is in `error` and
+    # name its workflow, but never say *why* — which is the whole point of the
+    # state file surviving a server death. None for rows the server produced
+    # (/queue and /history carry no code) and for every non-error row.
+    error_code: str | None = None
+
+
+def _state_error_code(err: Any) -> str | None:
+    """Pull ``error.code`` out of a state file's ``error`` blob, or None.
+
+    ``jobs_state.read`` keeps unknown keys' values untouched, so a hand-edited
+    or truncated file can carry a non-dict ``error`` (or a non-string ``code``)
+    — neither may reach the emitted envelope, where ``error_code`` is typed
+    ``string | null``.
+    """
+    if not isinstance(err, dict):
+        return None
+    code = err.get("code")
+    return code if isinstance(code, str) and code else None
 
 
 def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where: str | None = None) -> list[JobRow]:
@@ -299,6 +324,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
                 where=state.where or "local",
                 workflow_path=state.workflow,
                 updated_at=state.updated_at,
+                error_code=_state_error_code(state.error),
             )
         )
         if len(rows) >= limit:
@@ -320,9 +346,19 @@ def _merge_jobs(state_rows: list[JobRow], server_rows: list[JobRow]) -> list[Job
     """Server's view wins for prompts it knows about (fresher status); state
     files fill in everything else (jobs the server doesn't see, e.g. cloud
     jobs viewed from a local-only `jobs ls`).
+
+    The one thing the server's row cannot supply is ``error_code``: neither
+    ``/queue``/``/history`` nor the cloud job list carries one, so a server row
+    that supersedes a state-file row would otherwise *lose* the cause the state
+    file recorded. Carry it across when the server also calls the job failed —
+    and only then, so a state file left holding a stale ``server_died`` can't
+    contradict a server that now reports the prompt as completed.
     """
     by_id: dict[str, JobRow] = {r.prompt_id: r for r in state_rows}
     for r in server_rows:
+        prior = by_id.get(r.prompt_id)
+        if r.error_code is None and prior is not None and prior.error_code is not None and r.status in _ERROR_STATUSES:
+            r = replace(r, error_code=prior.error_code)
         by_id[r.prompt_id] = r
 
     # Sort: non-terminal first (running/pending/allocated/executing), then
@@ -642,6 +678,10 @@ def _row_to_dict(r: JobRow) -> dict:
         "where": r.where,
         "workflow_path": r.workflow_path,
         "updated_at": r.updated_at,
+        # Why an `error` row failed, when the state file knows. `jobs status`
+        # points callers at `comfy jobs ls` as the escape hatch after a server
+        # death, so the hatch has to be able to name the cause.
+        "error_code": r.error_code,
     }
 
 

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -2064,10 +2064,21 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     if status is None:
         return None
     raw = (status.get("status") or "").lower()
-    # Shared with `jobs ls` (and the watcher) so the same cloud job can't be
-    # `cancelled` in one command and `canceled` in another — the latter isn't
-    # in the published `status` enum this file's schema declares.
-    state = _CLOUD_ROW_STATUS_MAP.get(raw, raw or "pending")
+    # Deliberately NOT _CLOUD_ROW_STATUS_MAP: this map lacks cloud's two cancel
+    # spellings, so a cancelled cloud job snapshots as the raw `canceled` — not
+    # in the published `status` enum, not in `_cloud_watch`'s terminal set (so
+    # `jobs watch --where cloud` spins to `cloud_timeout`), and not in
+    # `_TERMINAL_VERDICT` (so `jobs status` reports it ok:true/exit 0 instead of
+    # the documented 130). Real bugs, but adding the aliases here changes an
+    # exit code on a path this PR does not otherwise touch — see BE-6612.
+    state = {
+        "success": "completed",
+        "completed": "completed",
+        "failed": "error",
+        "error": "error",
+        "non_retryable_error": "error",
+        "lost": "error",
+    }.get(raw, raw or "pending")
 
     outputs: list[str] = []
     outputs_by_node: dict[str, list[str]] = {}

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -389,6 +389,29 @@ def execute(
             # the only place the in-flight prompt_id survives. Status is
             # "running" rather than "queued": this foreground process is
             # actively watching it, not leaving it detached in the queue.
+            #
+            # DOCUMENTED LIMIT — `--wait` spawns no background watcher, by
+            # design; this process *is* the watcher. Every ordinary outcome is
+            # still recorded, because the handlers below run: a node failure and
+            # a cancel via `_mark_watch_exit`/`_mark_cancelled`, and a server
+            # that dies mid-run via the `server_died` write in the
+            # WebSocketException/OSError handler. What is NOT covered is this
+            # process being killed from OUTSIDE (a caller-imposed timeout
+            # SIGKILLing the process group, the terminal going away): no handler
+            # runs, the record stays at the submit-time `running`, and since no
+            # `watcher_pid` is recorded, `jobs ls`'s stale-watcher reap — which
+            # only fires on a recorded *and* dead pid — won't finalize it
+            # either. `comfy jobs status` still names the job and its
+            # last-known status, so attribution is degraded rather than lost;
+            # callers that expect to outlive their patience should submit
+            # WITHOUT `--wait`, whose detached watcher gets its own session and
+            # survives the parent. Spawning one here too was considered and
+            # rejected: it would put a second, independent writer on the state
+            # file this branch already finalizes, add a second server
+            # connection per foreground run, and leave a background process
+            # behind after a synchronous command returns. See
+            # docs/json-output.md, "Known limit: `--wait` has no background
+            # watcher".
             wait_state = jobs_state.new(
                 prompt_id=execution.prompt_id,
                 client_id=execution.client_id,
@@ -531,6 +554,12 @@ def execute(
             )
         # The job may genuinely still be running server-side, so the
         # submit-time "running" record is left as-is — not marked terminal.
+        # Consequence of the no-watcher limit documented at the submit-time
+        # write above: nothing is left watching the prompt after this returns,
+        # so if the server dies later no `server_died` is ever written. The
+        # record stays `running` until the caller asks
+        # `comfy jobs status <prompt_id>`, which infers the death from a
+        # server that is down (or came back with no record of the prompt).
         details = {"timeout": timeout}
         prompt_id = _submitted_prompt_id(execution)
         if prompt_id is not None:

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -43,16 +43,23 @@
         "required": ["prompt_id", "status"],
         "properties": {
           "prompt_id": {"type": "string"},
-          "status": {"type": "string"},
+          "status": {
+            "type": "string",
+            "description": "Deliberately unconstrained, unlike the top-level `status`: a cloud status this CLI does not yet know is passed through raw rather than dropped, so a new server-side spelling widens this field instead of breaking the listing."
+          },
           "queue_position": {"type": ["integer", "null"]},
           "workflow_size": {"type": ["integer", "null"]},
           "outputs": {"type": "integer"},
-          "where": {"type": "string", "enum": ["local", "cloud"]},
+          "where": {
+            "type": "string",
+            "enum": ["local", "cloud"],
+            "description": "Which target this row's job was submitted to — the per-row discriminator for dispatching a follow-up `jobs status`/`jobs cancel`. Always matches the envelope's `where` for rows the server produced."
+          },
           "workflow_path": {"type": ["string", "null"]},
           "updated_at": {"type": ["string", "null"]},
           "error_code": {
             "type": ["string", "null"],
-            "description": "Why an `error`/`cancelled` row failed, copied from the job's state file (`error.code` — e.g. `server_died`, `execution_error`, `watcher_crashed`). Null on rows the server produced, since neither `/queue`/`/history` nor the cloud job list carries a code, and on every non-error row. This is what lets `comfy jobs ls` — the escape hatch `jobs status` points at after a server death — name the cause rather than just report `status: \"error\"`."
+            "description": "Why an `error`/`cancelled` row failed, from the job's state file (`error.code` — e.g. `server_died`, `execution_error`, `watcher_crashed`). Null on every non-failed row, and on failed rows with no state file (the server's `/queue`/`/history` and the cloud job list carry no code of their own, so a row only the server knows about has nothing to attribute). This is what lets `comfy jobs ls` — the escape hatch `jobs status` points at after a server death — name the cause rather than just report `status: \"error\"`."
           }
         }
       }

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -46,7 +46,14 @@
           "status": {"type": "string"},
           "queue_position": {"type": ["integer", "null"]},
           "workflow_size": {"type": ["integer", "null"]},
-          "outputs": {"type": "integer"}
+          "outputs": {"type": "integer"},
+          "where": {"type": "string", "enum": ["local", "cloud"]},
+          "workflow_path": {"type": ["string", "null"]},
+          "updated_at": {"type": ["string", "null"]},
+          "error_code": {
+            "type": ["string", "null"],
+            "description": "Why an `error`/`cancelled` row failed, copied from the job's state file (`error.code` — e.g. `server_died`, `execution_error`, `watcher_crashed`). Null on rows the server produced, since neither `/queue`/`/history` nor the cloud job list carries a code, and on every non-error row. This is what lets `comfy jobs ls` — the escape hatch `jobs status` points at after a server death — name the cause rather than just report `status: \"error\"`."
+          }
         }
       }
     }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -309,6 +309,38 @@ Without `--wait` (the default), the stream ends at the `queued` envelope
 watcher keeps the state file updated; follow up with
 `comfy jobs watch <prompt_id>` or `comfy jobs status <prompt_id>`.
 
+### Known limit: `--wait` has no background watcher
+
+`--wait` writes the job's state file at submit and finalizes it in the
+foreground — it does **not** spawn the detached watcher the async path does
+(`data.watcher_spawned` is an async-path field only). Every ordinary outcome is
+still recorded: a node failure, a cancel, and a lost connection to a dying
+server all run through the foreground handlers, which write `error.code`
+(the classified execution verdict or `execution_error`; `cancelled`;
+`server_died`) before exiting.
+
+The gap is a `--wait` process that is **killed from outside** — a caller-imposed
+timeout (`SIGKILL`/`SIGTERM` on the process group), a terminal going away, the
+OS reaping the CLI alongside the server. No handler runs, so the state file is
+left at its submit-time `running`, and because `--wait` records no
+`watcher_pid`, `jobs ls`'s stale-watcher reap — which only fires on a recorded
+*and* dead pid — will not finalize it either. If the server then dies, nothing
+writes `server_died`.
+
+Attribution is degraded there, not lost: `comfy jobs status <prompt_id>` still
+names the job, its last-known status, and its workflow via `server_not_running`
+/ `prompt_not_found`. **For runs that may outlive the caller's patience, submit
+without `--wait`** — the async path spawns a watcher that survives the parent
+(its own session/process group), and it is the watcher that writes `server_died`
+when the server disappears mid-job. `comfy jobs ls` then reports both the status
+and the `error_code`.
+
+A watcher is deliberately *not* spawned on `--wait`: it would put a second,
+independent writer on the state file the foreground already finalizes, add a
+second server connection per foreground run, and leave a background process
+behind after a synchronous command returns — a real regression on the common
+path in exchange for a case the async path already covers.
+
 ## `comfy validate --json` envelope
 
 `comfy validate --workflow <file> --json` checks a workflow without submitting

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2903,3 +2903,152 @@ def test_untracked_prompt_keeps_the_default_hints(monkeypatch: pytest.MonkeyPatc
     result = _invoke_status("no-such-id", "--host", "127.0.0.1", "--port", "65431")
     assert result.exit_code == 1, result.output
     assert _last_json(result.stdout)["error"]["hint"] == "run: comfy launch"
+
+
+# ---------------------------------------------------------------------------
+# `jobs ls` rows carry the server-death attribution (`error_code`)
+# ---------------------------------------------------------------------------
+
+
+def test_state_error_code_extraction_is_defensive():
+    """Only a non-empty string `error.code` survives — a state file is
+    hand-editable, and `error_code` is typed `string | null` in the schema."""
+    assert jobs_mod._state_error_code({"code": "server_died"}) == "server_died"
+    assert jobs_mod._state_error_code(None) is None
+    assert jobs_mod._state_error_code({}) is None
+    assert jobs_mod._state_error_code({"code": ""}) is None
+    assert jobs_mod._state_error_code({"code": 500}) is None
+    assert jobs_mod._state_error_code("server_died") is None
+    assert jobs_mod._state_error_code(["server_died"]) is None
+
+
+def test_gather_local_state_files_carries_error_code():
+    """A state-file row reports why the job failed, not just that it did."""
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(
+        state_dir,
+        "died-job",
+        status="error",
+        error={"code": "server_died", "message": "Lost connection while job died-job was running"},
+    )
+    _write_state(state_dir, "ok-job", status="completed")
+
+    rows = {r.prompt_id: r for r in jobs_mod._gather_local_state_files(limit=100)}
+    assert rows["died-job"].error_code == "server_died"
+    assert rows["ok-job"].error_code is None, "a healthy row must not invent an error code"
+
+
+def test_gather_local_state_files_reports_the_reaped_watcher_code(monkeypatch):
+    """The stale-watcher reap rewrites the file to `watcher_crashed`; the row it
+    then builds must carry that code, or `--orphaned` still can't say why."""
+    from comfy_cli import jobs_state
+
+    monkeypatch.setattr(jobs_mod, "_is_watcher_alive", lambda state: False)
+    _write_state(jobs_state.state_dir(), "reaped", status="running", watcher_pid=999999)
+
+    (row,) = jobs_mod._gather_local_state_files(limit=100)
+    assert row.status == "error"
+    assert row.error_code == "watcher_crashed"
+
+
+def _row(prompt_id: str, status: str, **kw) -> jobs_mod.JobRow:
+    return jobs_mod.JobRow(
+        prompt_id=prompt_id,
+        status=status,
+        queue_position=None,
+        elapsed_seconds=None,
+        workflow_size=None,
+        outputs=0,
+        **kw,
+    )
+
+
+def test_merge_carries_error_code_onto_a_superseding_server_row():
+    """`/queue` and `/history` carry no error code, so a server row that wins
+    the merge would otherwise drop the cause the state file recorded."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("job-1", "error", error_code="execution_error", updated_at="2026-08-04T00:00:00+00:00")],
+            [_row("job-1", "error")],
+        )
+    }
+    assert merged["job-1"].error_code == "execution_error"
+
+
+def test_merge_drops_a_stale_error_code_when_the_server_says_completed():
+    """The carry-over is scoped to failure statuses: a server that reports the
+    prompt as completed must not be annotated with a stale `server_died`."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("job-2", "error", error_code="server_died")],
+            [_row("job-2", "completed")],
+        )
+    }
+    assert merged["job-2"].status == "completed"
+    assert merged["job-2"].error_code is None
+
+
+def test_merge_prefers_the_server_rows_own_error_code():
+    """Carry-over only fills a gap — it never overwrites a code the server row
+    already has."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("job-3", "error", error_code="server_died")],
+            [_row("job-3", "error", error_code="execution_error")],
+        )
+    }
+    assert merged["job-3"].error_code == "execution_error"
+
+
+def test_ls_payload_names_the_server_death(capsys, monkeypatch):
+    """Acceptance: after a server death, `comfy jobs ls` — the escape hatch
+    `jobs status` points at — reports both the failure and its cause."""
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(
+        state_dir,
+        "oom-job",
+        status="error",
+        error={"code": "server_died", "message": "Lost connection to ComfyUI while job oom-job was running"},
+    )
+    _write_state(state_dir, "fine-job", status="completed")
+    monkeypatch.delenv("COMFY_WHERE", raising=False)
+
+    data = _ls_payload(capsys, limit=100)
+    by_id = {j["prompt_id"]: j for j in data["jobs"]}
+    assert by_id["oom-job"]["status"] == "error"
+    assert by_id["oom-job"]["error_code"] == "server_died"
+    assert by_id["oom-job"]["workflow_path"] == "/tmp/oom-job.json"
+    # Present on every row (agents can index it unconditionally), null when
+    # there is nothing to attribute.
+    assert by_id["fine-job"]["error_code"] is None
+
+
+def test_ls_payload_validates_against_the_jobs_schema(capsys, monkeypatch):
+    """`error_code` is a published contract field, not just an emitted one."""
+    import jsonschema
+
+    from comfy_cli import jobs_state
+
+    _write_state(
+        jobs_state.state_dir(),
+        "sch-job",
+        status="cancelled",
+        error={"code": "cancelled", "message": "Cancelled by user"},
+    )
+    monkeypatch.delenv("COMFY_WHERE", raising=False)
+    data = _ls_payload(capsys, limit=100)
+
+    schema_path = Path(jobs_mod.__file__).parent.parent / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    jsonschema.Draft202012Validator(schema).validate(data)
+    # `cancelled` reaches the payload from the state file, so it has to be in
+    # the published status enum too.
+    assert "cancelled" in schema["properties"]["status"]["enum"]
+    assert data["jobs"][0]["error_code"] == "cancelled"

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2913,13 +2913,59 @@ def test_untracked_prompt_keeps_the_default_hints(monkeypatch: pytest.MonkeyPatc
 def test_state_error_code_extraction_is_defensive():
     """Only a non-empty string `error.code` survives — a state file is
     hand-editable, and `error_code` is typed `string | null` in the schema."""
-    assert jobs_mod._state_error_code({"code": "server_died"}) == "server_died"
-    assert jobs_mod._state_error_code(None) is None
-    assert jobs_mod._state_error_code({}) is None
-    assert jobs_mod._state_error_code({"code": ""}) is None
-    assert jobs_mod._state_error_code({"code": 500}) is None
-    assert jobs_mod._state_error_code("server_died") is None
-    assert jobs_mod._state_error_code(["server_died"]) is None
+    assert jobs_mod._state_error_code({"code": "server_died"}, "error") == "server_died"
+    assert jobs_mod._state_error_code(None, "error") is None
+    assert jobs_mod._state_error_code({}, "error") is None
+    assert jobs_mod._state_error_code({"code": ""}, "error") is None
+    assert jobs_mod._state_error_code({"code": 500}, "error") is None
+    assert jobs_mod._state_error_code("server_died", "error") is None
+    assert jobs_mod._state_error_code(["server_died"], "error") is None
+
+
+@pytest.mark.parametrize("status", ["queued", "running", "pending", "executing", "completed"])
+def test_state_error_code_ignores_a_code_on_a_job_that_has_not_failed(status):
+    """`job_watcher._poll_local_once`/`_poll_cloud_once` park a transient
+    `watcher_poll_error` on the state file *without* moving the status off
+    `queued`/`running`, and only clear it on a later poll that returns a
+    snapshot — so a healthy in-flight job holds that code for many cycles.
+    Surfacing it would advertise a failure cause for a job that hasn't failed
+    (and contradict the schema, which promises null on every non-failed row)."""
+    assert jobs_mod._state_error_code({"code": "watcher_poll_error"}, status) is None
+
+
+def test_gather_local_state_files_ignores_a_poll_error_on_a_running_job():
+    """End to end through the gather, not just the helper: a running job whose
+    last poll blipped must still list as running with no cause attached."""
+    from comfy_cli import jobs_state
+
+    _write_state(
+        jobs_state.state_dir(),
+        "blipped",
+        status="running",
+        error={"code": "watcher_poll_error", "message": "Connection reset by peer"},
+    )
+
+    (row,) = jobs_mod._gather_local_state_files(limit=100)
+    assert row.status == "running"
+    assert row.error_code is None
+
+
+def test_state_scalar_narrowing_keeps_a_bad_state_file_from_breaking_the_listing():
+    """`jobs_state.read` type-checks nothing it keeps, so `where`,
+    `workflow_path`, and `updated_at` — all published with strict types — need
+    the same defensiveness `error_code` gets. A numeric `updated_at` is the
+    sharp case: it reaches `_merge_jobs`'s `sort_key` and raises `TypeError`
+    comparing int against str, aborting the whole listing rather than one row."""
+    assert jobs_mod._state_str("2026-08-04T00:00:00+00:00") == "2026-08-04T00:00:00+00:00"
+    assert jobs_mod._state_str(None) is None
+    assert jobs_mod._state_str("") is None
+    assert jobs_mod._state_str(1754265600) is None
+    assert jobs_mod._state_where("cloud") == "cloud"
+    assert jobs_mod._state_where("local") == "local"
+    # Missing, empty, or a legacy/hand-edited value outside the published enum.
+    assert jobs_mod._state_where(None) == "local"
+    assert jobs_mod._state_where("") == "local"
+    assert jobs_mod._state_where("remote") == "local"
 
 
 def test_gather_local_state_files_carries_error_code():
@@ -3005,6 +3051,111 @@ def test_merge_prefers_the_server_rows_own_error_code():
     assert merged["job-3"].error_code == "execution_error"
 
 
+def test_merge_reads_the_prior_row_from_the_state_snapshot_not_the_running_map():
+    """`/queue` and `/history` are fetched separately, so one gather can yield
+    two rows for a prompt caught mid-transition. Looking the prior code up from
+    the accumulating map lets the `running` row clobber the state row first,
+    and the `error` row that follows then finds nothing to inherit."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("job-4", "error", error_code="execution_error")],
+            [_row("job-4", "running"), _row("job-4", "error")],
+        )
+    }
+    assert merged["job-4"].status == "error"
+    assert merged["job-4"].error_code == "execution_error"
+
+
+def test_merge_ignores_a_code_recorded_next_to_a_healthy_state_status():
+    """The gate is on both sides: a code sitting next to a non-failure state
+    status is a watcher poll blip, not this job's cause, so a server row that
+    genuinely failed must not be attributed to it."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("job-5", "running", error_code="watcher_poll_error")],
+            [_row("job-5", "error")],
+        )
+    }
+    assert merged["job-5"].status == "error"
+    assert merged["job-5"].error_code is None
+
+
+def test_merge_carries_the_other_state_only_fields_onto_a_server_row():
+    """`workflow_path` and `updated_at` are state-file-only too. Blanking the
+    first drops the only field that says which workflow a prompt_id was;
+    blanking the second sorts a terminal row to epoch 0, below every dated row,
+    where the caller's `[:limit]` slice can drop a fresh completion."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [
+                _row(
+                    "job-6",
+                    "completed",
+                    workflow_path="/tmp/wf.json",
+                    updated_at="2026-08-04T00:00:00+00:00",
+                )
+            ],
+            [_row("job-6", "completed")],
+        )
+    }
+    assert merged["job-6"].workflow_path == "/tmp/wf.json"
+    assert merged["job-6"].updated_at == "2026-08-04T00:00:00+00:00"
+
+
+def test_merge_keeps_fresh_server_side_completions_within_the_limit():
+    """The consequence the carry-over above prevents, end to end: without an
+    `updated_at`, the freshly completed job the server knows about sorts below
+    a week-old one and falls outside a caller's `[:1]` slice."""
+    fresh = _row("fresh", "completed", updated_at="2026-08-04T00:00:00+00:00")
+    stale = _row("stale", "completed", updated_at="2026-07-28T00:00:00+00:00")
+    merged = jobs_mod._merge_jobs([fresh, stale], [_row("fresh", "completed")])
+    assert [r.prompt_id for r in merged][:1] == ["fresh"]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("non_retryable_error", "error"),
+        ("lost", "error"),
+        ("canceled", "cancelled"),
+        ("cancelled", "cancelled"),
+        ("failed", "error"),
+        ("success", "completed"),
+    ],
+)
+def test_cloud_row_normalizes_the_failure_spellings(raw, expected):
+    """Cloud's other failure spellings used to pass through raw, missing
+    `_ERROR_STATUSES` — so the merge dropped the state file's `error_code` for
+    exactly the jobs that had failed."""
+    assert jobs_mod._cloud_job_to_row({"id": "j", "status": raw}).status == expected
+
+
+def test_cloud_row_is_marked_as_a_cloud_row():
+    """`where` is published with an enum as a per-row discriminator for a
+    follow-up `jobs status`/`jobs cancel`. Taking JobRow's "local" default here
+    made every row under `jobs ls --where cloud` claim `local` while the
+    envelope said `cloud`, superseding the state row that had it right."""
+    assert jobs_mod._cloud_job_to_row({"id": "j", "status": "running"}).where == "cloud"
+
+
+def test_merge_keeps_the_state_error_code_for_a_cloud_failure_spelling():
+    """The two fixes above together: a cloud `non_retryable_error` row now
+    normalizes to `error`, so it clears the gate and keeps the cause."""
+    merged = {
+        r.prompt_id: r
+        for r in jobs_mod._merge_jobs(
+            [_row("cj", "error", where="cloud", error_code="server_died")],
+            [jobs_mod._cloud_job_to_row({"id": "cj", "status": "non_retryable_error"})],
+        )
+    }
+    assert merged["cj"].status == "error"
+    assert merged["cj"].where == "cloud"
+    assert merged["cj"].error_code == "server_died"
+
+
 def test_ls_payload_names_the_server_death(capsys, monkeypatch):
     """Acceptance: after a server death, `comfy jobs ls` — the escape hatch
     `jobs status` points at — reports both the failure and its cause."""
@@ -3048,7 +3199,13 @@ def test_ls_payload_validates_against_the_jobs_schema(capsys, monkeypatch):
     schema_path = Path(jobs_mod.__file__).parent.parent / "schemas" / "jobs.json"
     schema = json.loads(schema_path.read_text())
     jsonschema.Draft202012Validator(schema).validate(data)
-    # `cancelled` reaches the payload from the state file, so it has to be in
-    # the published status enum too.
-    assert "cancelled" in schema["properties"]["status"]["enum"]
     assert data["jobs"][0]["error_code"] == "cancelled"
+    # The row `status` this asserts on is validated by `jobs.items`, whose
+    # `status` is a bare string — not by the top-level `status` enum, which
+    # describes the single-job `jobs status` envelope. Row statuses are
+    # deliberately unconstrained (an unrecognized cloud status passes through
+    # raw rather than being dropped), so validate the field that *is* the
+    # contract here — `error_code` alongside a `cancelled` row — rather than
+    # asserting against an enum that never sees this value.
+    assert data["jobs"][0]["status"] == "cancelled"
+    assert schema["properties"]["jobs"]["items"]["properties"]["error_code"]["type"] == ["string", "null"]


### PR DESCRIPTION
## ELI-5

When a local ComfyUI server dies mid-job, `comfy jobs ls` could tell you a job ended in `error` and which workflow it was — but never *why*. `jobs status`'s own message points at `comfy jobs ls` as the place to look after a server death, and the place to look couldn't name a server death. This adds `error_code` to every `jobs ls` row, read off the job's state file, so a listing can say `status: "error", error_code: "server_died"` instead of just "it broke".

## The problem

`JobRow` had no error field and `_row_to_dict` emitted none. `_merge_jobs` already keeps the state-file row alive after a relaunch (the server's fresh `/queue`+`/history` don't know the dead prompt), so `comfy jobs ls` — and comfy-mcp's `get_queue`, which wraps it — showed a dead job as `status: "error"` with a `workflow_path` and nothing else. The state file right next to it held `error.code == "server_died"` the whole time.

That matters because `jobs status` emits `hint: "run: comfy launch — then check \`comfy jobs ls\` for the job's last recorded state"`. The documented escape hatch could not carry the attribution the epic exists to produce.

## What changed

**`error_code` on the row (`comfy_cli/command/jobs.py`)**

- New `JobRow.error_code: str | None`, populated in `_gather_local_state_files` from the state file's `error.code` — `server_died`, `execution_error`, `cancelled`, `watcher_crashed`, or the classified execution verdict. It is emitted on every row (null when there's nothing to attribute), so an agent can index it unconditionally.
- Extraction goes through `_state_error_code`, which is defensive on purpose: `jobs_state.read` drops unknown keys but does not type-check the ones it keeps, so a hand-edited or truncated file can carry a non-dict `error` or a non-string `code`. Neither may reach an envelope field typed `string | null`.
- The stale-watcher reap in the same function rewrites the file to `watcher_crashed` *before* the row is built, so `jobs ls --orphaned` rows now say why they were orphaned too.

**`_merge_jobs` no longer drops the cause**

Server rows win the merge for prompts the server knows about, and no server source carries an error code — not `/queue`, not `/history`, not the cloud job list. So a job the server still remembers as failed would have lost the state file's code purely by being fresher. The merge now carries the code across, gated two ways: only when the *server* row's status is itself a failure (`error`/`cancelled`), and only into a row that has no code of its own. The gate is the point — a state file left holding a stale `server_died` must not annotate a prompt the server now reports as `completed`.

**`schemas/jobs.json`**

`error_code` documented on the row shape, with the null cases spelled out. While there: `where`, `workflow_path` and `updated_at` were added too — `_row_to_dict` has emitted all three for a while and the published row contract didn't mention them, so adding `error_code` alone would have left the contract half-true. Flagging that as a judgment call; it's documentation-only, no behavior rides on it.

## The `--wait` watcher: documented, not spawned

The ticket asked for a decision. **Decision: document the limit.**

`--wait` records no `watcher_pid` and spawns no watcher — `_spawn_watcher` is called only on the async branch, in both the local (`run/__init__.py:498`) and cloud (`:962`) paths. Every *ordinary* outcome is still recorded, because the foreground handlers run: `_mark_watch_exit` writes the classified verdict or `execution_error`, `_mark_cancelled` writes `cancelled`, and the `WebSocketException`/`OSError` handler writes `server_died`. The uncovered case is narrower than "the `--wait` path has no attribution": it is a `--wait` process **killed from outside** — a caller-imposed timeout SIGKILLing the process group, the terminal going away. No handler runs, the record stays at its submit-time `running`, and `jobs ls`'s stale-watcher reap can't finalize it either, since that only fires on a pid that is both *recorded* and dead.

Spawning a watcher there was considered and rejected: it puts a second, independent writer on a state file the foreground already finalizes, adds a second server connection per foreground run, and leaves a background process behind after a *synchronous* command returns. That is a real regression on the common path, bought for a case the async path already covers — and comfy-mcp already routes long runs to `wait=False`, which does spawn a watcher that survives its parent (`start_new_session=True` / `DETACHED_PROCESS`).

So the limit is written down at both code sites (the submit-time state write and the `ws_timeout` handler, which is where the consequence actually bites) and in `docs/json-output.md` under **"Known limit: `--wait` has no background watcher"**, with the redirect: for runs that may outlive the caller's patience, submit without `--wait`.

## The `status` enum nit was already fixed

Item 3 of the ticket — `"cancelled"` missing from the `status` enum in `schemas/jobs.json` — **is already on `main`**, added by #674 (commit 5798668) along with the comment explaining why it belongs there. The ticket was written against a tree that predated that merge. No change needed; instead there's now a test asserting the enum contains it, so it can't regress silently.

## Test coverage

Nine tests in `tests/comfy_cli/jobs/test_jobs.py`:

- `_state_error_code` against the malformed shapes: `None`, `{}`, empty code, integer code, a bare string `error`, a list `error`.
- A state-file row reports `server_died`; a healthy row does not invent a code.
- The reaped-watcher path reports `watcher_crashed` (with `_is_watcher_alive` stubbed dead).
- The three merge branches: carry-over onto a failing server row, *no* carry-over when the server says `completed`, and no clobbering of a code the server row already has.
- Acceptance: a `jobs ls` payload after a server death carries `status: "error"`, `error_code: "server_died"` and the workflow path, with `error_code: null` on the healthy row alongside it.
- The emitted payload validates against `schemas/jobs.json` with `jsonschema`, which also pins the `cancelled` enum entry.

## Verification

- `pytest` — **4126 passed, 37 skipped** (full suite, ~7.5 min).
- `ruff check .` and `ruff format --check .` — clean, run with **ruff 0.15.15**, the version CI pins in `ruff_check.yml`. (Worth knowing: a newer ruff — 0.16.x — reports 17 pre-existing `UP038` errors across `workflow_to_api.py`, `cql/`, `cloud/oauth.py` etc., all untouched by this PR. Pin-drift, not breakage.)
- Environment: `uv sync --frozen --extra dev`, macOS, Python 3.12.

On the ticket's "also worth a look" note: `tests/comfy_cli/command/test_run_json.py::TestErrorPathCoverage::test_object_info_timeout_routes_to_connection_error` **passes here**, both in isolation and in the full run, as does everything else. The ~12 failures that note describes did not reproduce in a uv-synced, non-sandboxed checkout — consistent with the environment-sensitivity theory, but this is a non-reproduction rather than a diagnosis.

## Judgment calls

1. **Pretty-mode output is unchanged.** `_render_jobs_pretty` and the `--watch` live table don't show `error_code`; both are fixed-width tables where a mostly-`—` column is noise, and the consumer this ticket names is the JSON row. A human still gets the full record from `comfy jobs status <id>`.
2. **Cloud server rows carry no `error_code`.** The cloud `/jobs` list entries have no code field — only free text elsewhere in the API (`error_message`) — and mapping prose into a code field would be worse than null. Cloud jobs submitted through this CLI still get their code via the state file and the merge carry-over.
3. **Schema fields beyond `error_code`** — see above.
