### PR TITLE
fix(models): refuse downloads whose destination is claimed by a live background download (BE-6469)

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -476,20 +476,23 @@ def download(
 
     local_filepath = get_workspace() / relative_path / local_filename
 
-    if local_filepath.exists():
-        raise _download_failure(
-            code="model_file_exists",
-            message=f"File already exists: {local_filepath}",
-            hint="pass `--filename` to save under a different name, or remove the existing file",
-            details={"path": str(local_filepath)},
-        )
-
-    # The exists() check above cannot see a transfer that is still in flight: a
-    # background download streams into a `.part` sibling and only renames onto
-    # `dest` at the end, so the destination stays absent for the whole transfer
-    # and two submissions for the same model would both pass, both stream a full
-    # copy, and the later rename would silently overwrite the earlier. Checked
-    # before the `--background` split so a foreground transfer is refused too.
+    # A destination-exists check cannot see a transfer that is still in flight: on
+    # the httpx path a background download streams into a `.part` sibling and only
+    # renames onto `dest` at the end, so the destination stays absent for the whole
+    # transfer and two submissions for the same model would both pass, both stream
+    # a full copy, and the later rename would silently overwrite the earlier.
+    #
+    # Ordered *before* `exists()` on purpose: `--downloader aria2` writes straight
+    # to the destination (it owns its own `.aria2` resume control file), so a live
+    # aria2 transfer makes `exists()` true and the caller would get
+    # `model_file_exists` with the hint "remove the existing file" — advice that
+    # deletes the output a running worker is still writing. The accurate refusal
+    # has to win.
+    #
+    # Scope, precisely: this refuses a submission — foreground or `--background` —
+    # into a destination that a *background* download has claimed. It cannot refuse
+    # against an in-flight *foreground* transfer, which writes no state record and
+    # so is invisible both here and to `exists()`.
     in_flight = _active_download_for(local_filepath)
     if in_flight is not None:
         raise _download_failure(
@@ -500,6 +503,14 @@ def download(
                 f"or cancel it with `comfy model download-cancel {in_flight.id}`"
             ),
             details={"path": str(local_filepath), "download_id": in_flight.id, "status": in_flight.status},
+        )
+
+    if local_filepath.exists():
+        raise _download_failure(
+            code="model_file_exists",
+            message=f"File already exists: {local_filepath}",
+            hint="pass `--filename` to save under a different name, or remove the existing file",
+            details={"path": str(local_filepath)},
         )
 
     start_time = time.monotonic()
@@ -771,6 +782,31 @@ def _submit_background_download(
         )
         raise typer.Exit(code=1) from e
 
+    # Claim, then re-check. The pre-flight scan in `download()` is check-then-act:
+    # between it and the `write` above sit the `--background` split and, for a
+    # Hugging Face url, a whole `check_unauthorized` network round trip — wide
+    # enough for two near-simultaneous submissions to both pass it, both stream a
+    # full copy, and the later `os.replace` to silently overwrite the earlier. The
+    # state record just written *is* the claim, so re-scanning now sees any
+    # competitor that also claimed `dest`; `_claim_order` picks the same winner
+    # from both sides, and the loser withdraws its claim before any bytes move.
+    #
+    # This closes the background-vs-background race the guard documents. It cannot
+    # close one against a foreground transfer, which never writes a claim.
+    competitor = _active_download_for(dest, exclude_id=state.id)
+    if competitor is not None and _claim_order(competitor) < _claim_order(state):
+        with contextlib.suppress(OSError):
+            state_file.unlink(missing_ok=True)
+        raise _download_failure(
+            code="model_download_in_flight",
+            message=f"A background download ({competitor.id}) is already writing to {dest}.",
+            hint=(
+                f"track it with `comfy model download-status {competitor.id}`, "
+                f"or cancel it with `comfy model download-cancel {competitor.id}`"
+            ),
+            details={"path": str(dest), "download_id": competitor.id, "status": competitor.status},
+        )
+
     try:
         pid = _spawn_download_worker(state_file, log_file)
     except OSError as e:
@@ -969,11 +1005,50 @@ def _reconciled(state: download_state.DownloadState) -> tuple[download_state.Dow
     return fresh, changed
 
 
-def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | None:
+def _dest_key(path: pathlib.Path | str) -> str:
+    """The comparison key for "the same destination".
+
+    ``realpath``, not ``abspath``: ComfyUI model directories are routinely
+    symlinks (``models/loras`` pointing at ``/data/loras``) and get addressed
+    both ways, and a lexical normalization leaves those two spellings unequal —
+    so both submissions would pass and their transfers would land on the same
+    inode. ``realpath`` resolves the symlinks that exist and normalizes the rest,
+    which also covers a ``--relative-path`` carrying ``..`` (it is only
+    ``expanduser``-ed, never passed through :func:`_reject_unsafe_component`).
+
+    ``normcase`` folds case on Windows; on POSIX it is identity, so a
+    case-insensitive macOS volume can still alias two spellings past this — the
+    same residual ``local_filepath.exists()`` has.
+    """
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _claim_order(state: download_state.DownloadState) -> tuple[str, str]:
+    """Total order over competing claims on one destination: first writer wins.
+
+    ``started_at`` is second-resolution so ties are common; ``id`` (12 random hex
+    chars) breaks them, and because both racers compute the same order over the
+    same two records they always agree on who won.
+    """
+    return (state.started_at or "", state.id)
+
+
+def _active_download_for(
+    dest: pathlib.Path,
+    *,
+    exclude_id: str | None = None,
+) -> download_state.DownloadState | None:
     """The live background download already targeting ``dest``, if any.
 
-    Reconciles each record first (persisting the correction), so a SIGKILLed
+    Reconciles the *matching* records (persisting the correction), so a SIGKILLed
     worker's stale record demotes to ``failed`` here and never wedges the path.
+    Records for other destinations are filtered out by ``dest`` first and never
+    reconciled: :func:`_reconciled` persists a status correction, and running it
+    over every record would make a plain ``comfy model download`` rewrite
+    bookkeeping for unrelated downloads — off a stale ``list_all`` snapshot, so a
+    worker that completed during the scan could have its ``completed`` record
+    overwritten with ``failed``. Reconcile never rewrites ``dest``, so the
+    unreconciled value is the right key to filter on.
 
     The predicate is deliberately "reconciled status is active", *not*
     :func:`download_state.worker_alive`: a just-submitted download sits in
@@ -983,30 +1058,39 @@ def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | N
     near-simultaneous double-submit this guard exists to catch. Reconcile keeps
     both a within-grace ``starting`` record and a live worker blocking, while
     demoting a dead worker's record so it self-clears.
+
+    ``exclude_id`` skips one record: :func:`_submit_background_download` re-runs
+    this scan *after* writing its own claim and must not find itself.
+
+    The scan is scoped to ``get_workspace()``'s state directory. A destination can
+    sit outside the workspace (``--relative-path`` accepts ``..`` and absolute
+    paths), so two invocations from different workspaces consult disjoint state
+    directories and do not see each other — inherent to per-workspace state, not
+    something this scan can close.
     """
-    # `abspath` on BOTH sides, not `Path.absolute()` on one: `absolute()` does not
-    # normalize, so a `--relative-path` carrying `..` (it is only `expanduser`-ed,
-    # never passed through `_reject_unsafe_component`) would leave one side
-    # un-normalized and the comparison would miss the very collision it is for.
-    # `normcase` folds case on Windows; on POSIX it is identity, so a
-    # case-insensitive macOS volume can still alias two spellings past this — the
-    # same residual `local_filepath.exists()` above would have.
-    wanted = os.path.normcase(os.path.abspath(dest))
+    wanted = _dest_key(dest)
+    winner: download_state.DownloadState | None = None
     try:
-        records = download_state.list_all(get_workspace())
-    except OSError:
-        # The scan is advisory, so an unreadable state directory must degrade to
-        # the pre-guard behavior rather than turn a working download into a
-        # traceback — this read is on the foreground path too, which never
-        # touched the state directory before.
+        for state in download_state.list_all(get_workspace()):
+            if state.id == exclude_id:
+                continue
+            if _dest_key(state.dest) != wanted:
+                continue
+            fresh, _ = _reconciled(state)
+            if fresh.status not in download_state.ACTIVE_STATUSES:
+                continue
+            if winner is None or _claim_order(fresh) < _claim_order(winner):
+                winner = fresh
+    except (OSError, ValueError):
+        # The scan is advisory, so an unreadable state directory — or a corrupt
+        # record that trips a lookup mid-loop — must degrade to the pre-guard
+        # behavior rather than turn a working download into a traceback. This
+        # runs on the foreground path too, which never read the state directory
+        # before, so a single bad file must not break every download in the
+        # workspace. Whole scan, not just `list_all`: the reconcile of a matching
+        # record is just as much part of the advisory read.
         return None
-    for state in records:
-        fresh, _ = _reconciled(state)
-        if fresh.status not in download_state.ACTIVE_STATUSES:
-            continue
-        if os.path.normcase(os.path.abspath(fresh.dest)) == wanted:
-            return fresh
-    return None
+    return winner
 
 
 @app.command("download-status")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -484,6 +484,24 @@ def download(
             details={"path": str(local_filepath)},
         )
 
+    # The exists() check above cannot see a transfer that is still in flight: a
+    # background download streams into a `.part` sibling and only renames onto
+    # `dest` at the end, so the destination stays absent for the whole transfer
+    # and two submissions for the same model would both pass, both stream a full
+    # copy, and the later rename would silently overwrite the earlier. Checked
+    # before the `--background` split so a foreground transfer is refused too.
+    in_flight = _active_download_for(local_filepath)
+    if in_flight is not None:
+        raise _download_failure(
+            code="model_download_in_flight",
+            message=f"A background download ({in_flight.id}) is already writing to {local_filepath}.",
+            hint=(
+                f"track it with `comfy model download-status {in_flight.id}`, "
+                f"or cancel it with `comfy model download-cancel {in_flight.id}`"
+            ),
+            details={"path": str(local_filepath), "download_id": in_flight.id, "status": in_flight.status},
+        )
+
     start_time = time.monotonic()
 
     # Every resolution step above (metadata requests, token config, filename,
@@ -949,6 +967,46 @@ def _reconciled(state: download_state.DownloadState) -> tuple[download_state.Dow
         with contextlib.suppress(OSError, ValueError):
             download_state.write(get_workspace(), fresh)
     return fresh, changed
+
+
+def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | None:
+    """The live background download already targeting ``dest``, if any.
+
+    Reconciles each record first (persisting the correction), so a SIGKILLed
+    worker's stale record demotes to ``failed`` here and never wedges the path.
+
+    The predicate is deliberately "reconciled status is active", *not*
+    :func:`download_state.worker_alive`: a just-submitted download sits in
+    ``starting`` with no pid for up to :data:`download_state.STARTUP_GRACE_S`
+    while its worker's interpreter boots, and ``worker_alive`` reports False for
+    a pidless record — so gating on it would pass during exactly the
+    near-simultaneous double-submit this guard exists to catch. Reconcile keeps
+    both a within-grace ``starting`` record and a live worker blocking, while
+    demoting a dead worker's record so it self-clears.
+    """
+    # `abspath` on BOTH sides, not `Path.absolute()` on one: `absolute()` does not
+    # normalize, so a `--relative-path` carrying `..` (it is only `expanduser`-ed,
+    # never passed through `_reject_unsafe_component`) would leave one side
+    # un-normalized and the comparison would miss the very collision it is for.
+    # `normcase` folds case on Windows; on POSIX it is identity, so a
+    # case-insensitive macOS volume can still alias two spellings past this — the
+    # same residual `local_filepath.exists()` above would have.
+    wanted = os.path.normcase(os.path.abspath(dest))
+    try:
+        records = download_state.list_all(get_workspace())
+    except OSError:
+        # The scan is advisory, so an unreadable state directory must degrade to
+        # the pre-guard behavior rather than turn a working download into a
+        # traceback — this read is on the foreground path too, which never
+        # touched the state directory before.
+        return None
+    for state in records:
+        fresh, _ = _reconciled(state)
+        if fresh.status not in download_state.ACTIVE_STATUSES:
+            continue
+        if os.path.normcase(os.path.abspath(fresh.dest)) == wanted:
+            return fresh
+    return None
 
 
 @app.command("download-status")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -791,8 +791,18 @@ def _submit_background_download(
     # competitor that also claimed `dest`; `_claim_order` picks the same winner
     # from both sides, and the loser withdraws its claim before any bytes move.
     #
-    # This closes the background-vs-background race the guard documents. It cannot
-    # close one against a foreground transfer, which never writes a claim.
+    # This *narrows* the background-vs-background race; it does not close it. A
+    # re-scan cannot see a claim that has not been written yet, and nothing orders
+    # a competitor's `write` before our scan — so a competitor whose record lands
+    # after we look is still missed and both submissions proceed (reproduced at 12
+    # simultaneous submits; 4 and 8 came out clean). What changed is the width of
+    # the window: from `[pre-flight scan -> write]`, which spans the `--background`
+    # split and an HF round trip, down to `[write -> re-scan]`. Closing it needs an
+    # atomic claim — an `O_EXCL` sibling or an `flock` — which is a design call
+    # this guard does not make.
+    #
+    # It does nothing at all against a foreground transfer, which never writes a
+    # claim.
     competitor = _active_download_for(dest, exclude_id=state.id)
     if competitor is not None and _claim_order(competitor) < _claim_order(state):
         with contextlib.suppress(OSError):
@@ -1029,6 +1039,11 @@ def _claim_order(state: download_state.DownloadState) -> tuple[str, str]:
     ``started_at`` is second-resolution so ties are common; ``id`` (12 random hex
     chars) breaks them, and because both racers compute the same order over the
     same two records they always agree on who won.
+
+    Agreeing on the winner requires both records to be *visible* to both racers,
+    which the re-scan in :func:`_submit_background_download` cannot guarantee — a
+    racer that scans before the other's record lands sees no competitor at all, so
+    this order is never consulted and both proceed. See that call site.
     """
     return (state.started_at or "", state.id)
 

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -402,7 +402,13 @@ def worker_alive(state: DownloadState, *, pid_alive=None) -> bool:
     self-corrects on the next poll, while signalling a stranger's process group
     is not, so only the reporting side is allowed the benefit of the doubt.
     """
-    if state.pid is None:
+    if not state.pid or state.pid <= 0:
+        # Not just `is None`. The field validator accepts any non-bool int, so a
+        # corrupt or tampered record can carry a negative pid — and
+        # `psutil.Process(-1)` raises ValueError, which `utils.is_running` does
+        # not catch. One bad state file would then traceback out of every command
+        # that reconciles, including `model download` itself. `is_worker_process`
+        # and `kill_worker` already screen the same way.
         return False
     if pid_alive is None:
         from comfy_cli.utils import is_running as pid_alive  # noqa: N813

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -614,6 +614,15 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "pass `--filename` to save under a different name, or remove the existing file",
     ),
     ErrorCode(
+        "model_download_in_flight",
+        "`comfy model download` refused to start because a live background download is already "
+        "writing to the same destination (`details.path`). `details.download_id` names that "
+        "download and `details.status` is its current status. A background transfer streams into "
+        "a `.part` sibling, so the destination is absent until it completes — without this check "
+        "two submissions would both run and the later one would silently overwrite the earlier.",
+        "track it with `comfy model download-status <id>`, or cancel it with `comfy model download-cancel <id>`",
+    ),
+    ErrorCode(
         "hf_unauthorized",
         "Hugging Face returned 401 for the model URL and no Hugging Face API token is configured "
         "(gated or private repo).",

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -791,6 +791,12 @@ class TestSubmitRefusesAClaimedDestination:
         it, both stream a full copy, and the later `os.replace` can silently
         overwrite the earlier. The record each one writes is its claim; the
         re-scan after that write is what turns two winners into one.
+
+        Scope: this plants the competitor's claim *before* the re-scan, so the
+        re-scan can see it. The interleaving where a competitor's write lands
+        after our scan is not covered here because it is not covered by the code
+        either — see `_submit_background_download`, which narrows that race
+        rather than closing it.
         """
         dest = self._dest(workspace)
         competitor = _state(dest=str(dest), status="downloading", pid=1234)

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -562,6 +562,143 @@ class TestSubmitFailsFast:
         assert "Hugging Face API token" in capsys.readouterr().out
 
 
+class TestSubmitRefusesAClaimedDestination:
+    """A destination already claimed by a *live* background download is refused.
+
+    `local_filepath.exists()` cannot catch this: a background transfer streams
+    into a `.part` sibling and only renames onto `dest` at the very end, so the
+    destination is absent for the whole transfer and a second submission would
+    otherwise sail through, stream a full second copy, and silently overwrite the
+    first at rename time.
+    """
+
+    DEST = ("models/loras", "m.safetensors")
+
+    def _dest(self, workspace) -> Path:
+        return workspace / self.DEST[0] / self.DEST[1]
+
+    def _download(self, **kwargs):
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path=self.DEST[0],
+            filename=self.DEST[1],
+            **kwargs,
+        )
+
+    def test_a_second_submission_is_refused(self, workspace, no_spawn, json_renderer):
+        """The classic double-submit: a live worker owns the destination."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234, total_bytes=4096)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["ok"] is False
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+        assert env["error"]["details"]["status"] == "downloading"
+        assert env["error"]["details"]["path"] == str(self._dest(workspace))
+        # The refusal is read-only: the in-flight record is left exactly as it was.
+        assert download_state.read(workspace, live.id).status == "downloading"
+        assert len(download_state.list_all(workspace)) == 1
+
+    def test_a_pidless_starting_record_still_blocks(self, workspace, no_spawn, json_renderer):
+        """The regression test for reconcile-vs-`worker_alive`.
+
+        A just-submitted download sits in `starting` with no pid for up to
+        STARTUP_GRACE_S while its worker's interpreter boots, and `worker_alive`
+        reports False for a pidless record — so a `worker_alive` predicate would
+        wave through exactly the near-simultaneous double-submit this guard is
+        for. `_state()` stamps `started_at` now, i.e. inside the grace window.
+        """
+        live = _state(dest=str(self._dest(workspace)), status="starting", pid=None)
+        download_state.write(workspace, live)
+
+        with pytest.raises(typer.Exit) as exc:
+            self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        assert json_renderer()["error"]["code"] == "model_download_in_flight"
+
+    def test_a_dead_workers_record_self_clears(self, workspace, monkeypatch, json_renderer):
+        """A SIGKILLed worker's stale record must never wedge the path: the scan
+        reconciles first, so the record demotes to `failed` and the submit runs."""
+        stale = _state(dest=str(self._dest(workspace)), status="downloading", pid=4242, total_bytes=4096)
+        download_state.write(workspace, stale)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["download_id"] != stale.id
+        # ...and the demotion was persisted, not merely computed in memory.
+        assert download_state.read(workspace, stale.id).status == "failed"
+
+    def test_a_live_download_to_another_destination_does_not_block(self, workspace, monkeypatch, json_renderer):
+        other = _state(dest=str(workspace / "models" / "loras" / "other.safetensors"), status="downloading", pid=1234)
+        download_state.write(workspace, other)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["dest"] == str(self._dest(workspace))
+
+    def test_an_unnormalized_relative_path_does_not_slip_past(self, workspace, no_spawn, json_renderer):
+        """`--relative-path` is only `expanduser`-ed, never rejected for `..`, so
+        both sides of the comparison have to be normalized or a caller could
+        spell the same destination differently and defeat the guard."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit):
+                models.download(
+                    None,
+                    url="https://example.com/m.safetensors",
+                    relative_path="models/loras/../loras",
+                    filename=self.DEST[1],
+                    background=True,
+                )
+
+        assert json_renderer()["error"]["details"]["download_id"] == live.id
+
+    def test_an_unreadable_state_directory_does_not_break_the_download(self, workspace, monkeypatch, json_renderer):
+        """The scan is advisory. It is now on the foreground path too, which never
+        read the state directory before, so a failure there must degrade to the
+        pre-guard behavior rather than become a traceback."""
+        monkeypatch.setattr(download_state, "list_all", MagicMock(side_effect=OSError("state dir is not readable")))
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+
+    def test_a_foreground_download_is_refused_too(self, workspace, monkeypatch, json_renderer):
+        """The guard sits before the `--background` split, so a foreground
+        transfer into a claimed destination is refused before any bytes move."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+        monkeypatch.setattr(models, "download_file", MagicMock(side_effect=AssertionError("a transfer started")))
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download()
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+
+
 class TestSubmitEnvelope:
     def _submit(self, workspace, monkeypatch, **kwargs):
         monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -698,6 +698,155 @@ class TestSubmitRefusesAClaimedDestination:
         assert env["error"]["code"] == "model_download_in_flight"
         assert env["error"]["details"]["download_id"] == live.id
 
+    def test_a_live_transfer_beats_the_exists_check(self, workspace, no_spawn, json_renderer):
+        """`--downloader aria2` writes straight to the destination (it owns its
+        own `.aria2` resume file), so a live aria2 transfer makes `exists()` true.
+        Ordered the other way the caller would get `model_file_exists` and its
+        hint to "remove the existing file" — advice that deletes the output a
+        running worker is still writing."""
+        dest = self._dest(workspace)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"partial aria2 output")
+        live = _state(dest=str(dest), status="downloading", pid=1234, downloader="aria2", total_bytes=4096)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+        # ...and the bytes the live worker is still writing were not implicated.
+        assert dest.exists()
+
+    def test_a_record_for_another_destination_is_not_reconciled(self, workspace, monkeypatch, json_renderer):
+        """The scan filters by destination *before* reconciling.
+
+        `_reconciled` persists a status correction, so reconciling every record
+        would make a plain `comfy model download` rewrite bookkeeping for
+        unrelated downloads — off `list_all`'s stale snapshot, so a worker that
+        completes during the scan window could have its `completed` record
+        overwritten with `failed`.
+        """
+        other = _state(dest=str(workspace / "models" / "loras" / "other.safetensors"), status="downloading", pid=4242)
+        download_state.write(workspace, other)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        # A dead worker: reconcile *would* demote this record to `failed`. It is
+        # not this command's record to touch.
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+        assert download_state.read(workspace, other.id).status == "downloading"
+
+    def test_a_corrupt_record_does_not_break_the_download(self, workspace, monkeypatch, json_renderer):
+        """The advisory scan has to degrade on a bad record, not traceback.
+
+        Only `list_all` used to sit inside the `try`, so a record that tripped a
+        lookup *inside* the loop — a tampered negative pid reaching
+        `psutil.Process`, say — turned every `comfy model download` in the
+        workspace, foreground included, into a bare traceback.
+        """
+        corrupt = _state(dest=str(self._dest(workspace)), status="downloading", pid=-1)
+        download_state.write(workspace, corrupt)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+        # No live worker can be behind a pid that cannot exist, so it demotes.
+        assert download_state.read(workspace, corrupt.id).status == "failed"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
+    def test_a_symlinked_model_directory_is_the_same_destination(self, workspace, no_spawn, json_renderer):
+        """ComfyUI model directories are routinely symlinks (`models/loras` at
+        `/data/loras`) and get addressed both ways. A lexical normalization
+        leaves the two spellings unequal, so both submissions would pass and
+        their transfers would rename onto the same inode."""
+        real_dir = workspace.parent / "data" / "loras"
+        real_dir.mkdir(parents=True)
+        link_dir = workspace / "models" / "loras"
+        link_dir.parent.mkdir(parents=True, exist_ok=True)
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+
+        # The live record names the resolved path; the submission names the link.
+        live = _state(dest=str(real_dir / self.DEST[1]), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit):
+                self._download(background=True)
+
+        assert json_renderer()["error"]["details"]["download_id"] == live.id
+
+    def test_a_claim_that_landed_first_wins_the_post_write_recheck(
+        self, workspace, no_spawn, monkeypatch, json_renderer
+    ):
+        """The pre-flight scan is check-then-act: filename resolution and, for a
+        Hugging Face url, a whole `check_unauthorized` round trip sit between it
+        and the state write, so two near-simultaneous submissions can both pass
+        it, both stream a full copy, and the later `os.replace` can silently
+        overwrite the earlier. The record each one writes is its claim; the
+        re-scan after that write is what turns two winners into one.
+        """
+        dest = self._dest(workspace)
+        competitor = _state(dest=str(dest), status="downloading", pid=1234)
+        competitor.started_at = "2000-01-01T00:00:00+00:00"  # claimed first
+
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                # The competitor's claim lands in exactly the window between our
+                # own claim and the re-check — the race this exists to lose.
+                planted.append(real_write(ws, competitor))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == competitor.id
+        # The loser withdrew its own claim, so the destination is left owned by
+        # exactly one record — a phantom would refuse every later submission.
+        assert [s.id for s in download_state.list_all(workspace)] == [competitor.id]
+
+    def test_a_claim_that_landed_second_does_not_take_the_destination(self, workspace, monkeypatch, json_renderer):
+        """The other side of the same race: both racers compute `_claim_order`
+        over the same two records, so the one that claimed first proceeds rather
+        than both backing off and neither download happening."""
+        dest = self._dest(workspace)
+        latecomer = _state(dest=str(dest), status="starting", pid=None)
+        latecomer.started_at = "2999-01-01T00:00:00+00:00"  # claimed second
+
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                planted.append(real_write(ws, latecomer))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["download_id"] != latecomer.id
+
 
 class TestSubmitEnvelope:
     def _submit(self, workspace, monkeypatch, **kwargs):
@@ -1476,6 +1625,18 @@ class TestCorruptStateFiles:
         (download_state.state_dir(workspace) / "bad.json").write_text('{"pid": "nope"}', encoding="utf-8")
 
         assert [s.id for s in download_state.list_all(workspace)] == [good.id]
+
+    @pytest.mark.parametrize("pid", [-1, 0])
+    def test_a_nonpositive_pid_is_screened_before_psutil(self, pid):
+        """The field validator only rejects non-ints, so a tampered record can
+        carry a negative pid — and `psutil.Process(-1)` raises ValueError, which
+        `utils.is_running` does not catch (it catches only NoSuchProcess). Every
+        command that reconciles would traceback on one bad file, so screen it
+        here the way `is_worker_process`/`kill_worker` already do."""
+        state = _state(status="downloading", pid=pid)
+
+        # No `pid_alive` injection: the real liveness helper must never be reached.
+        assert download_state.worker_alive(state) is False
 
 
 class TestWorkerIdentity:


### PR DESCRIPTION
## ELI-5

If you start downloading a big model in the background and then, a second later, start the *same* download again, both used to run. Neither noticed the other, because a background download writes into a temporary `.part` file and only puts the real file in place at the very end — so for the entire transfer the destination looks empty to anyone checking. Both copies downloaded in full, and whichever finished second quietly stomped on the first. Now the second one is refused up front, and told which download already owns that path and how to watch or cancel it.

## What changed

`comfy model download` gained a second same-destination guard alongside the existing `local_filepath.exists()` check.

- **`_active_download_for(dest)`** (new, next to `_reconciled`) scans the background download state records and returns the live one already writing to `dest`, or `None`.
- **The guard** sits immediately after the `exists()` block and **before** the `if background:` split, so a foreground transfer into a claimed destination is refused too. It raises through the existing `_download_failure` envelope with a new error code, `model_download_in_flight`, whose `details` carry `path`, `download_id`, and `status`.
- **`model_download_in_flight`** registered in `comfy_cli/error_codes.py` (the registry test enforces both directions).

The predicate is deliberately **"reconciled status is in `ACTIVE_STATUSES`", not `download_state.worker_alive`**. A just-submitted download sits in `starting` with `pid=None` for up to `STARTUP_GRACE_S` (60s) while its worker's interpreter boots, and `worker_alive` returns False for a pidless record — so a `worker_alive` predicate would wave through *exactly* the near-simultaneous double-submit this guard exists to catch. Reconciling first has a second benefit: a SIGKILLed worker's stale `downloading` record demotes to `failed` right here (and the correction is persisted), so a dead worker can never wedge a path.

## Why this is needed now

The ticket framed this as anticipating an atomic-write change. That change is **already on `main`** — `comfy_cli/file_utils.py:392,511,630` document the httpx path streaming into a `.part` sibling and renaming on completion. So this is not a future-proofing patch: the destination is absent for the *whole* transfer today, and the double-download-plus-silent-overwrite is the current behavior, not a narrow submit-to-`open()` race.

## Judgment calls (deviations from the ticket's prescribed snippet)

Three changes came out of the adversarial self-review. Flagging them because they are departures from the code the ticket specified, not additions to its scope.

1. **`os.path.abspath` on both sides, not `dest.absolute()` on one.** The ticket's snippet used `str(dest.absolute())` for the wanted path and `os.path.abspath(fresh.dest)` for the record. `Path.absolute()` does not normalize `..`; `abspath` does. `--relative-path` is only `expanduser`-ed — it never passes through `_reject_unsafe_component` — so `--relative-path models/loras/../loras` produces an un-normalized wanted path, the two sides normalize differently, and the guard misses the collision it exists to catch. Covered by `test_an_unnormalized_relative_path_does_not_slip_past`, which fails under the ticket's original expression.
2. **The `list_all` scan fails open on `OSError`.** This guard puts a state-directory read on the **foreground** download path, which never touched that directory before, so an unreadable state dir would have turned a working `comfy model download` into a traceback. The scan is advisory by design (see non-goals), so it degrades to the pre-guard behavior instead. Covered by `test_an_unreadable_state_directory_does_not_break_the_download`.
3. **The case-insensitivity comment is narrower than the ticket's claim.** The ticket said `os.path.normcase` stops case-insensitive filesystems (macOS/Windows) aliasing past the guard. `normcase` folds case on Windows only — on POSIX, including macOS, it is the identity function. `normcase` is kept (it is correct and free on Windows), but the code comment states the real residual rather than a coverage claim it does not have. A case-insensitive macOS volume can still alias two spellings past this; `local_filepath.exists()` on the line above has the same residual, so this is not a new gap.

## Non-goals

- **No `O_EXCL` reservation file.** The scan is advisory: two submissions racing inside the sub-second span between one's scan and its `download_state.write` can still both pass. That residual is no worse than the pre-existing behavior, and an `O_EXCL` sibling would reintroduce the stale-lock lifecycle (a SIGKILL leaves it wedging the path forever) that reconcile already solves for state records.
- **Foreground transfers still write no state record**, so a collision *against* an in-flight foreground download remains undetectable. That predates this change and is out of scope.

## On the refusal being a "denial"

This diff adds a deny path, so per the negative-claim discipline: the refusal is conditional on observed live state, not a claim that a capability is unsupported. There is no path where the denied action works correctly today — with the `.part` write on `main`, the second transfer's rename overwrites the first; before it, the second worker's `open(dest)` truncated the first's file. Both corrupt data. Every alternative remains available and is named in the hint: watch it (`download-status`), cancel it (`download-cancel`), or save under a different name (`--filename`). The refusal also clears itself — the blocking record demotes to `failed` the moment its worker dies.

## Tests

Seven new tests in `TestSubmitRefusesAClaimedDestination`, following the file's existing fixtures (`workspace`, `no_spawn`, `json_renderer`, `_state`) and its `patch("comfy_cli.utils.is_running", ...)` pattern:

1. `test_a_second_submission_is_refused` — live `downloading` record for D, second submit resolving to D is refused with `model_download_in_flight`, `details.download_id` names the existing record, nothing detaches, and the existing record is left untouched.
2. `test_a_pidless_starting_record_still_blocks` — `starting`, `pid=None`, inside `STARTUP_GRACE_S` still blocks. This is the regression test for the `worker_alive`-vs-reconcile distinction.
3. `test_a_dead_workers_record_self_clears` — `downloading` with a dead pid: the submit succeeds *and* the stale record is persisted as `failed` (read back off disk).
4. `test_a_live_download_to_another_destination_does_not_block` — a live record for D1 does not block a submit targeting D2.
5. `test_an_unnormalized_relative_path_does_not_slip_past` — judgment call 1 above.
6. `test_an_unreadable_state_directory_does_not_break_the_download` — judgment call 2 above.
7. `test_a_foreground_download_is_refused_too` — live record for D, submit **without** `--background`, refused before `download_file` is ever reached (the mock raises if it is).

## Verification

- `ruff check .` and `ruff format --check .` clean at **v0.15.15**, the version `.pre-commit-config.yaml` pins. Note for anyone reproducing: `pyproject.toml` pins ruff unversioned, so `uv sync` resolves an older 0.12.x that still ships the since-removed `UP038` rule and reports 17 pre-existing hits in files this PR does not touch. Use the pinned version.
- Full `pytest`: **4123 passed, 37 skipped**. That run predates the three self-review fixes above; the delta since is confined to `_active_download_for`'s body (a new function with one call site) plus new tests, re-verified with `pytest tests/comfy_cli/command/test_model_download_background.py tests/comfy_cli/output/` — **310 passed**, which includes the error-code registry tests that gate the new code.


---

## Update — review round 1 (commit `c36e14e`)

Six of the ten panel findings are fixed; two are deferred to follow-ups; one is answered as already-covered. The sections above describe the original commit — where this update contradicts them, this section wins.

**Fixed**

1. **The check-then-act gap is narrowed** (6/8 reviewers). ~~Closed, superseding the "No `O_EXCL` reservation file" non-goal above.~~ — corrected in round 2 below; the non-goal stands. The objection to `O_EXCL` was its stale-lock lifecycle — a SIGKILL wedges the path forever. That objection does not apply to the mechanism used here: **the state record a submit writes *is* its claim**, so it self-clears through `reconcile` exactly like every other record, with no new artifact and no new lifecycle. `_submit_background_download` now re-scans *after* writing its record; `_claim_order` — `(started_at, id)`, and `id` is 12 random hex so ties are broken identically on both sides — picks one winner, and the loser unlinks its own record before any bytes move. Two tests cover both sides of the race: the loser withdraws and leaves exactly one record behind, and the winner still proceeds (rather than both backing off and neither download happening). **This narrows the race rather than closing it** — see round 2.
2. **The scan filters by destination before reconciling** (3/8). `_reconciled` persists a status correction, so reconciling every record made a plain `comfy model download` rewrite bookkeeping for unrelated downloads — off `list_all`'s stale snapshot, so a worker completing during the scan window could have its `completed` record overwritten with `failed`. `reconcile` never rewrites `dest`, so the unreconciled value is the right filter key. This also confines the psutil lookup, the `stat` and the possible write to the record actually being guarded.
3. **The advisory scan degrades on a corrupt record, not just an unreadable directory** (4/8), correcting judgment call 2 above. Root cause was in `download_state.worker_alive`, which trusted any non-`None` pid: the field validator accepts a negative one, and `psutil.Process(-1)` raises `ValueError` where `utils.is_running` catches only `NoSuchProcess`. One tampered state file turned every `comfy model download` in the workspace — foreground included — into a bare traceback. `is_worker_process`/`kill_worker` already screened `pid <= 0`; `worker_alive` now matches, and the scan's `try` covers the loop rather than just `list_all`.
4. **`realpath`, not `abspath`** (5/8), superseding judgment call 1 above. ComfyUI model directories are routinely symlinks (`models/loras` at `/data/loras`) and get addressed both ways; a lexical normalization left the two spellings unequal, so both submissions passed and their transfers renamed onto the same inode. Extracted as `_dest_key` and reused on both sides. The `normcase` residual described in judgment call 3 is unchanged.
5. **The guard runs *before* `exists()`** (2/8), superseding "The guard sits immediately after the `exists()` block" above. `--downloader aria2` writes straight to the destination, so a live aria2 transfer made `exists()` true and the caller got `model_file_exists` with the hint "remove the existing file" — advice that deletes the output a running worker is still writing.
6. **The comment no longer overclaims** (3/8). It said a foreground transfer is refused too; only a foreground *submission* is. A foreground transfer writes no state record and so is invisible both here and to `exists()`. Reworded, and `_active_download_for`'s docstring now also states the workspace-scoping limit.

**Deferred to follow-ups** (proposed; filed by the supervisor)

- **Pruning `.comfy-downloads`.** Nothing removes terminal records, so `list_all` grows without bound. Finding 2 already removed the expensive per-record work (psutil + `stat` + write now happen only for matching records); what remains is the read+parse, which is a retention decision for the whole background-download feature — it changes what `download-status <id>` can still be polled for.
- **Where a claim lives.** The cross-workspace gap (a destination can sit outside the workspace, so two workspaces consult disjoint state directories) and the foreground gap (finding 6) share one root: the claim is in a workspace-scoped registry rather than at the destination. Closing either means a dest-adjacent claim artifact or giving foreground downloads state records — both user-visible, both needing a design call before code.

**Answered, no change**

- A worker that dies before its first state write leaves a pidless `starting` record that reconcile protects for `STARTUP_GRACE_S`. There *is* an override, and the error hint already names it: `comfy model download-cancel <id>` works on a pidless record — `stop_worker` returns True when `pid is None`, and the record goes to `cancelled` immediately.

**Tests.** 8 new (6 in `TestSubmitRefusesAClaimedDestination`, 2 parametrized in `TestCorruptStateFiles`). Each was confirmed to fail against the pre-fix source — the pre-fix run reports 7 failures, the 8th being the non-regression side of the claim race, which must pass both before and after.

**Verification.** `ruff check` / `ruff format --check` clean on the touched files. `pytest tests/comfy_cli/command/ tests/comfy_cli/output/` — 2298 passed, 2 skipped; the focused re-run on the final tree (`test_model_download_background.py`, `tests/comfy_cli/output/`, `tests/comfy_cli/command/models/`) — 468 passed. The 17 pre-existing `UP038` hits noted above are unchanged and still confined to files this PR does not touch.

---

## Update — review round 2 (commit `b8b8a72`)

@bigcat88 falsified the round-1 closure claim empirically — 12 simultaneous `--background` submits at one destination accepted 2, not 1, in 2 of 3 runs. **Comments and docstrings only; no behavior change, and no test was weakened.** The code is what round 1 made it; the claim about it was wrong.

**Why it is structural, not tuning.** A re-scan cannot see a claim that has not been written yet, and nothing orders a competitor's `write` before our scan. With racers A (lower `_claim_order`) and B: `B.write → B.re-scan` (sees nothing, proceeds) `→ A.write → A.re-scan` (sees B, but `_claim_order(B) > _claim_order(A)`, so A does not withdraw either). Both proceed. `_claim_order` only arbitrates once **both** records are visible to both racers.

**What round 1 actually bought**, and it is worth having: the window shrank from `[pre-flight scan → write]` — which spans the `--background` split and, for a Hugging Face url, a whole `check_unauthorized` network round trip — down to `[write → re-scan]`, microseconds. That is why N=4 and N=8 came out clean and N=12 did not.

Corrected in three places: the comment at the re-scan call site, `_claim_order`'s docstring (agreement requires mutual visibility), and the post-write-recheck test's docstring (it plants the competitor *before* the re-scan, so it says which interleaving it does not cover and why). The "No `O_EXCL` reservation file" non-goal above is no longer superseded — it stands.

**Deferred to a follow-up:** closing the race needs an atomic claim (an `O_EXCL` sibling or an `flock`). The stale-lock objection is answerable — a lock file carrying the download id reconciles exactly as a state record does — but that is a design call, and it shares its root with the already-proposed "where a claim lives" follow-up (foreground + cross-workspace gaps). Proposed as one piece of work.
