### PR TITLE
fix: stop an explicit --port 0 being swallowed by --host h:p

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1003,7 +1003,11 @@ def run(
 
         if host:
             host, parsed_port = parse_host_port_arg(host)
-            if not port and parsed_port is not None:
+            # ``port is None``, not ``not port``: a typed ``--port`` always wins
+            # over one embedded in ``--host h:p``, including ``--port 0``, which
+            # ``resolve_host_port`` then rejects as out of range instead of
+            # silently running against the embedded port.
+            if port is None and parsed_port is not None:
                 port = parsed_port
 
         host, port = resolve_host_port(host, port)

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -1478,7 +1478,11 @@ def run_template_cmd(
 
     if host:
         host, parsed_port = parse_host_port_arg(host)
-        if not port and parsed_port is not None:
+        # ``port is None``, not ``not port``: a typed ``--port`` always wins over
+        # one embedded in ``--host h:p``, including ``--port 0``, which
+        # ``resolve_host_port`` then rejects as out of range instead of silently
+        # running against the embedded port.
+        if port is None and parsed_port is not None:
             port = parsed_port
     host, port = resolve_host_port(host, port)
 

--- a/comfy_cli/host_port.py
+++ b/comfy_cli/host_port.py
@@ -145,6 +145,11 @@ def resolve_host_port(host: str | None, port: int | None) -> tuple[str, int]:
     An explicitly-passed ``host``/``port`` is validated *before* the precedence
     chain runs, because that chain treats every falsy value as "not passed" and
     would otherwise swallow the bad input and resolve to a different server.
+    This function owns the range check for the separate ``--port`` flag on
+    behalf of every caller (``run``, ``templates run``, ``jobs``, ``validate``,
+    ``nodes``), so call sites must not re-implement it — they only need to keep
+    an explicit ``--port`` distinguishable from an absent one (``port is None``,
+    never ``not port``) so a ``--port 0`` reaches this guard.
     """
     from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port

--- a/tests/comfy_cli/command/test_run_template.py
+++ b/tests/comfy_cli/command/test_run_template.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import typer
@@ -242,6 +243,35 @@ def test_server_not_running_short_circuits(app, gallery_file, template_body, run
     env = _envelope(result.output)
     assert env["error"]["code"] == "server_not_running"
     assert run_spy.calls == []
+
+
+def test_explicit_port_zero_is_rejected_not_overridden_by_host_port(
+    app, gallery_file, template_body, run_spy, monkeypatch
+):
+    """`--port 0` is an out-of-range port, not "no port given" — it must not be
+    silently replaced by the port embedded in `--host h:p` (BE-6486).
+
+    The check lives in the shared `resolve_host_port`, so the failure is a click
+    usage error (exit 2) raised before the server probe.
+    """
+    probe = MagicMock(return_value=True)
+    monkeypatch.setattr("comfy_cli.env_checker.check_comfy_server_running", probe)
+    result = CliRunner().invoke(
+        app,
+        ["run-template", "--gallery", gallery_file, "image_local_sd", "--host", "127.0.0.1:9100", "--port", "0"],
+    )
+    assert result.exit_code == 2, result.output
+    probe.assert_not_called()
+    assert run_spy.calls == []
+
+
+def test_explicit_port_wins_over_embedded_host_port(app, gallery_file, template_body, server_up, run_spy):
+    result = CliRunner().invoke(
+        app,
+        ["run-template", "--gallery", gallery_file, "image_local_sd", "--host", "127.0.0.1:9100", "--port", "9200"],
+    )
+    assert result.exit_code == 0, result.output
+    assert [(c["host"], c["port"]) for c in run_spy.calls] == [("127.0.0.1", 9200)]
 
 
 def test_unknown_param_key_lists_available_slots(app, gallery_file, template_body, server_up, run_spy):

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -214,6 +214,64 @@ def test_run_unsafe_host_exits_before_execute(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# `--port` beats the port embedded in a combined `--host h:p` (BE-6486)
+# ---------------------------------------------------------------------------
+#
+# The combined-host sites used to merge the two with `if not port and
+# parsed_port is not None`, which reads an explicit `--port 0` as "not passed"
+# and silently runs against the embedded port. They test `port is None`, so a
+# typed `--port` — including the out-of-range `0` — always wins and reaches the
+# range guard in `resolve_host_port`.
+
+
+def test_run_explicit_port_zero_is_rejected_not_overridden_by_host_port(tmp_path):
+    from typer.testing import CliRunner
+
+    from comfy_cli.cmdline import app
+
+    with patch("comfy_cli.command.run.execute") as mock_execute:
+        result = CliRunner().invoke(
+            app,
+            ["run", "--workflow", _write_workflow(tmp_path), "--host", "127.0.0.1:9100", "--port", "0"],
+            env={"COMFY_WHERE": "local"},
+        )
+    assert result.exit_code == 2, result.output
+    mock_execute.assert_not_called()
+
+
+def test_run_explicit_port_wins_over_embedded_host_port(tmp_path, monkeypatch):
+    monkeypatch.delenv("COMFY_LOCAL_URL", raising=False)
+    from typer.testing import CliRunner
+
+    from comfy_cli.cmdline import app
+
+    with patch("comfy_cli.command.run.execute") as mock_execute:
+        result = CliRunner().invoke(
+            app,
+            ["run", "--workflow", _write_workflow(tmp_path), "--host", "127.0.0.1:9100", "--port", "9200"],
+            env={"COMFY_WHERE": "local"},
+        )
+    assert result.exit_code == 0, result.output
+    args, _ = mock_execute.call_args
+    # execute(workflow, host, port, ...)
+    assert args[1] == "127.0.0.1"
+    assert args[2] == 9200
+
+
+def test_jobs_status_out_of_range_port_is_rejected():
+    """The guard lives in the shared resolver, so the `comfy jobs` sites — which
+    have no combined-host form — inherit it without their own check."""
+    from typer.testing import CliRunner
+
+    from comfy_cli.cmdline import app
+
+    with patch("comfy_cli.command.jobs._server_or_error") as mock_probe:
+        result = CliRunner().invoke(app, ["jobs", "status", "abc123", "--port", "0"])
+    assert result.exit_code == 2, result.output
+    mock_probe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # explicit-flag validation at the shared choke point (BE-6306 review)
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## ELI-5

`comfy run` lets you write the address two ways: `--host 127.0.0.1 --port 9100`, or all in one go as `--host 127.0.0.1:9100`. When you used both at once, the code picked between them with "if the `--port` is empty, use the one from the host string" — and Python thinks the number `0` is empty. So `comfy run --host 127.0.0.1:9100 --port 0` quietly threw your `--port 0` away and ran against 9100, instead of telling you that 0 isn't a real port. Now it checks "was `--port` actually given?" rather than "is it truthy", so a port you typed always wins, and a nonsense one gets a clean error instead of a silent surprise.

## What changed

- `comfy_cli/cmdline.py` (`comfy run`) and `comfy_cli/command/templates.py` (`comfy run-template`): `if not port and parsed_port is not None` → `if port is None and parsed_port is not None`, with a comment explaining the precedence contract.
- `comfy_cli/host_port.py`: a docstring note that `resolve_host_port` owns the range check for the separate `--port` flag on behalf of every caller, so call sites only need to keep an explicit port distinguishable from an absent one.
- Tests in `tests/comfy_cli/test_host_port.py` (`comfy run`, `comfy jobs status`) and `tests/comfy_cli/command/test_run_template.py` (`comfy run-template`).

The range guard itself (`validate_port`, called from `resolve_host_port`) already landed in #667, along with its unit tests and the `port is None` form at the third combined-host site (`comfy validate`). This PR is the remaining half: the two sites that still swallowed an explicit `0`.

## Behavior

| command | before | after |
|---|---|---|
| `comfy run --host 127.0.0.1:9100 --port 0` | ran against **9100** | exit 2, `invalid port: 0 is out of range (1-65535)` |
| `comfy run-template <name> --host 127.0.0.1:9100 --port 0` | ran against **9100** | exit 2, same error |
| `comfy run --host 127.0.0.1:9100 --port 9200` | ran against 9200 | unchanged |
| `comfy run --host 127.0.0.1:9100` | ran against 9100 | unchanged |
| `comfy jobs … --port 0` / `--port 70000` | already exit 2 (via #667) | unchanged — covered by a new test so the resolver placement stays load-bearing |

The only input whose behavior changes is an explicit `--port 0` alongside a combined `--host h:p`. Every `--port` param on these paths is typed `int | None` defaulting to `None`, so no caller can reach the branch with a non-`None` "unset" value; negative and out-of-range values were already truthy and so already reached the guard.

## Falsification of the deny path

This diff makes a previously-accepted invocation fail, so before shipping it I checked empirically that no working capability is being removed. Against `main` (`5798668`), with `comfy_cli.command.run.execute` stubbed:

```
comfy run --workflow wf.json --host 127.0.0.1:9100 --port 0
  -> exit 0, execute() called with host/port ('127.0.0.1', 9100)
```

So `--port 0` was never honored — it was discarded, and the run went to the embedded port. There is no "connect to port 0" behavior to preserve (port 0 is not a connectable TCP destination; it is only meaningful for `bind`), and `comfy launch` — the one command that binds rather than connects — does not route through `resolve_host_port` at all (`git grep resolve_host_port` shows only the run/jobs/validate/nodes/templates client paths). `--port 0` on its own already errored on `main` via #667; this only makes the combined-host path agree.

## Testing

- Red→green: with the source change stashed, exactly the two new `--port 0` tests fail (`assert 0 == 2` — the pre-fix run reaching the stubbed execute path); with it applied, all pass.
- `pytest tests/comfy_cli/test_host_port.py tests/comfy_cli/test_local_address.py tests/comfy_cli/command/test_run_template.py tests/comfy_cli/command/test_templates.py tests/comfy_cli/command/test_nodes_cli.py tests/comfy_cli/command/test_run_cli.py tests/comfy_cli/command/test_run.py tests/comfy_cli/jobs` → **504 passed**.
- `ruff check .` and `ruff format --check .` → clean.

## Judgment calls

- **The whole-repo `pytest` run was not completed locally.** It exceeded a 10-minute foreground budget, so I scoped verification to every suite that touches the changed code paths (the 504 above) plus lint/format, and left the full run to CI. Flagging it rather than claiming a green full suite.
- **The templates test lives in `tests/comfy_cli/command/test_run_template.py`, not `tests/comfy_cli/test_host_port.py`.** The gallery-index fixture, workflow-fetch stub and run spy that a `run-template` CLI test needs are ~100 lines already built there; duplicating them into `test_host_port.py` to satisfy file placement seemed strictly worse. The `run` and `jobs` CLI tests are in `test_host_port.py` as intended.
- **The command is `comfy run-template <name>`, not `comfy templates run <name>`** — `run_template_cmd` is registered on the top-level app, not on the `templates` sub-app. Same code path either way; noting it because the description says otherwise.
- I also added the positive-direction assertions (`--port 9200` beats an embedded `:9100`) at both sites. They pass before and after, but they are what pins the precedence contract the `port is None` form exists to express.
