### PR TITLE
fix(cql): report COMBO fields with zero installed options instead of skipping them (BE-6585)

### DIFF
--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -49,6 +49,13 @@ class Port:
     required: bool = False
     is_link: bool = False
     enum_values: list[Any] = field(default_factory=list)  # preserves the option's real type (int combos stay int)
+    # True when object_info shipped an explicit choice list for this input —
+    # *including an empty one*. An empty declared list means "the server has
+    # zero options here" (a model folder with no files installed), which is a
+    # different statement from "the choices aren't in object_info at all"
+    # (remote/dynamic combos, whose options the frontend fetches at runtime).
+    # Only the former is safe to validate against.
+    enum_declared: bool = False
     options: PortOptions = field(default_factory=PortOptions)
     # The verbatim ``INPUT_TYPES`` spec this port was parsed from. Retained
     # (by reference — no copy) because a dynamic combo's sub-input schema lives
@@ -132,6 +139,26 @@ class Port:
                         "valid_options": list(self.enum_values),
                     }
                 )
+        elif self.type == "COMBO" and self.enum_declared:
+            # The server declared this field's choices and shipped NONE of them:
+            # the folder backing it is empty — no models (or inputs) installed.
+            # An empty option list is STRONGER evidence the value is unavailable
+            # than a populated one, not weaker: the server rejects every value
+            # against an empty list (`execution.validate_inputs` →
+            # "Value not in list"), so skipping the check here just defers the
+            # failure to run time — and it fails hardest on the fresh install
+            # this check exists to serve, where the big downloads (UNETLoader,
+            # CLIPLoader) have no built-in options to compare against.
+            # Ports whose options are not in object_info at all keep
+            # `enum_declared=False` and stay unconstrained (see the field).
+            warnings.append(
+                {
+                    "code": "no_options_available",
+                    "field": self.name,
+                    "message": f"{value!r} is unavailable: the server reports 0 installed options for {self.name}",
+                    "valid_options": [],
+                }
+            )
         if self.type in ("INT", "FLOAT", "NUMBER") and isinstance(value, int | float):
             if self.options.min is not None and value < self.options.min:
                 warnings.append(
@@ -258,13 +285,21 @@ def _control_after_generate_set(val: Any) -> bool:
     return True
 
 
-def _parse_input_spec(spec: Any) -> tuple[str, bool, list[Any], PortOptions]:
-    """Returns (type_id, is_enum, enum_values, options)."""
+def _parse_input_spec(spec: Any) -> tuple[str, bool, list[Any], PortOptions, bool]:
+    """Returns (type_id, is_enum, enum_values, options, enum_declared).
+
+    ``enum_declared`` is True when the spec shipped an explicit choice list —
+    *including an empty one* — so validation can tell "this server has zero
+    options for the field" from "this field's options aren't in object_info".
+    It is deliberately separate from ``is_enum`` (which stays truthiness-based)
+    because ``is_enum`` also decides link-vs-widget, and an empty option list
+    must not move a port between those.
+    """
     if isinstance(spec, str):
-        return spec, False, [], PortOptions()
+        return spec, False, [], PortOptions(), False
 
     if not isinstance(spec, list) or len(spec) == 0:
-        return "UNKNOWN", False, [], PortOptions()
+        return "UNKNOWN", False, [], PortOptions(), False
 
     opts_raw = spec[1] if len(spec) > 1 and isinstance(spec[1], dict) else {}
     port_opts = _parse_port_options(opts_raw)
@@ -278,18 +313,26 @@ def _parse_input_spec(spec: Any) -> tuple[str, bool, list[Any], PortOptions]:
         # enum-check them — exactly the partner nodes (ByteDance, BFL, …)
         # where the choices array is the precision check.
         options = opts_raw.get("options")
-        if isinstance(options, list) and options and all(_is_scalar_choice(v) for v in options):
+        if isinstance(options, list) and all(_is_scalar_choice(v) for v in options):
             # Keep each option's real type: an int-valued combo (Sora-2/LTXV
             # `duration`) must stay [4, 8, 12], not ["4","8","12"], so `nodes
             # show` is truthful and agents pass the type the cloud accepts.
-            return first, True, list(options), port_opts
-        return first, False, [], port_opts
+            # An EMPTY list is a declared-but-unpopulated combo — still not an
+            # enum for wiring purposes (`is_enum` stays False, exactly as
+            # before), but flagged as declared so validate can say "0 options
+            # installed" instead of silently skipping the check.
+            return first, bool(options), list(options), port_opts, True
+        # No usable `options` key at all: a remote/dynamic combo whose choices
+        # the frontend fetches at runtime. Unknowable here — stay unconstrained.
+        return first, False, [], port_opts, False
 
     if isinstance(first, list):
-        # Same: preserve the option types for the classic list-form combo.
-        return "COMBO", True, list(first), port_opts
+        # Same: preserve the option types for the classic list-form combo. The
+        # list IS the declaration, so an empty one (a model folder with nothing
+        # installed) is declared-but-empty, not unconstrained.
+        return "COMBO", True, list(first), port_opts, True
 
-    return "UNKNOWN", False, [], port_opts
+    return "UNKNOWN", False, [], port_opts, False
 
 
 def _is_scalar_choice(v: Any) -> bool:
@@ -317,7 +360,7 @@ def _parse_inputs(raw: dict, order: list[str] | None, required: bool) -> list[Po
     ports: list[Port] = []
     for name in _ordered_names(raw, order):
         spec = raw[name]
-        type_id, is_enum, enum_values, opts = _parse_input_spec(spec)
+        type_id, is_enum, enum_values, opts, enum_declared = _parse_input_spec(spec)
         ports.append(
             Port(
                 name=name,
@@ -325,6 +368,7 @@ def _parse_inputs(raw: dict, order: list[str] | None, required: bool) -> list[Po
                 required=required,
                 is_link=_is_link(type_id, is_enum, opts.force_input),
                 enum_values=enum_values,
+                enum_declared=enum_declared,
                 options=opts,
                 raw_spec=spec,
             )
@@ -1077,6 +1121,30 @@ def _validate_catalog_value(
                     "valid_options": list(port.enum_values),
                 }
             )
+        elif w["code"] == "no_options_available":
+            # Declared-but-empty option list: the server has nothing installed
+            # for this field, so it rejects EVERY value (value_not_in_list
+            # against an empty list — execution.py:1035-1067). Same hard-error
+            # tier as unknown_enum_value, and for the same reason; the only
+            # difference is that there is no option to suggest. This is the
+            # fresh-install case the membership check used to skip in silence:
+            # UNETLoader/CLIPLoader ship no built-in options, so on a bare
+            # install the two largest missing downloads went unreported while a
+            # half-populated install got warned.
+            errors.append(
+                {
+                    "node_id": node_id,
+                    "field": input_name,
+                    "code": "no_options_available",
+                    "message": w["message"],
+                    "hint": (
+                        f"the server has no files installed for {input_name!r} on {class_type} — "
+                        f"install it (e.g. `comfy model download`) or point this input at an installed file"
+                    ),
+                    "suggestions": [],
+                    "valid_options": [],
+                }
+            )
         elif w["code"] in ("below_min", "above_max"):
             # The server hard-rejects out-of-range values
             # (value_smaller_than_min / value_bigger_than_max, execution.py:1008-1033),
@@ -1311,13 +1379,14 @@ def _check_dynamic_combo_sub(
     same ``_parse_input_spec`` / :class:`Port` machinery as a top-level input and
     inherits identical shape and enum/range semantics.
     """
-    type_id, is_enum, enum_values, opts = _parse_input_spec(sub_spec)
+    type_id, is_enum, enum_values, opts, enum_declared = _parse_input_spec(sub_spec)
     port = Port(
         name=dotted,
         type=type_id,
         required=sub_required,
         is_link=_is_link(type_id, is_enum, opts.force_input),
         enum_values=enum_values,
+        enum_declared=enum_declared,
         options=opts,
         raw_spec=sub_spec,
     )

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -999,6 +999,199 @@ class TestValidateServerParity:
         assert [e for e in result["errors"] if e.get("node_id") == "_meta"] == []
 
 
+class TestValidateEmptyCombo:
+    """A COMBO whose option list is declared but EMPTY means the server has zero
+    files installed for that field — it rejects every value against it — so it
+    must be reported, not skipped (BE-6585).
+
+    Before this, the membership check was gated on ``self.enum_values`` being
+    truthy, so detection got *worse* the emptier the install: ``VAELoader``
+    ships one built-in option and its missing model was caught, while
+    ``UNETLoader``/``CLIPLoader`` (no built-ins, and the two largest downloads)
+    were silent on a fresh install — the exact user this check exists to serve.
+    """
+
+    def _object_info(self, **extra) -> dict[str, Any]:
+        oi = {
+            "UNETLoader": {
+                # Bare install: `folder_paths.get_filename_list("diffusion_models")`
+                # is empty and the node ships no built-in option.
+                "input": {"required": {"unet_name": [[]], "weight_dtype": [["default", "fp8_e4m3fn"]]}},
+                "input_order": {"required": ["unet_name", "weight_dtype"]},
+                "output": ["MODEL"],
+                "output_name": ["MODEL"],
+                "python_module": "nodes",
+            },
+            "VAELoader": {
+                # One built-in option (`pixel_space`) — the loader that was
+                # already caught, kept here as the contrast case.
+                "input": {"required": {"vae_name": [["pixel_space"]]}},
+                "input_order": {"required": ["vae_name"]},
+                "output": ["VAE"],
+                "output_name": ["VAE"],
+                "python_module": "nodes",
+            },
+            "SaveImage": {
+                "input": {"required": {"images": "IMAGE"}},
+                "output": [],
+                "output_name": [],
+                "output_node": True,
+                "python_module": "nodes",
+            },
+        }
+        oi.update(extra)
+        return oi
+
+    def _graph(self, **extra) -> Graph:
+        return Graph.from_object_info(self._object_info(**extra))
+
+    def test_empty_combo_flags_the_missing_model(self):
+        """The regression: a value against a zero-option loader is an error, not
+        silence."""
+        g = self._graph()
+        result = g.validate_workflow(
+            {
+                "1": {
+                    "class_type": "UNETLoader",
+                    "inputs": {"unet_name": "flux1-dev.safetensors", "weight_dtype": "default"},
+                },
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        assert result["valid"] is False
+        errs = [e for e in result["errors"] if e["code"] == "no_options_available"]
+        assert len(errs) == 1
+        assert errs[0]["field"] == "unet_name"
+        assert errs[0]["node_id"] == "1"
+        assert "flux1-dev.safetensors" in errs[0]["message"]
+        assert errs[0]["valid_options"] == []
+        assert "UNETLoader" in errs[0]["hint"]
+
+    def test_populated_and_empty_loaders_are_both_reported(self):
+        """The ticket's count bug: with one loader populated and one empty, only
+        the populated one used to be reported. Both are now."""
+        g = self._graph()
+        result = g.validate_workflow(
+            {
+                "1": {
+                    "class_type": "UNETLoader",
+                    "inputs": {"unet_name": "flux1-dev.safetensors", "weight_dtype": "default"},
+                },
+                "2": {"class_type": "VAELoader", "inputs": {"vae_name": "ae.safetensors"}},
+                "3": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        codes = {(e["field"], e["code"]) for e in result["errors"]}
+        assert ("unet_name", "no_options_available") in codes
+        assert ("vae_name", "unknown_enum_value") in codes
+
+    def test_same_loader_with_one_option_installed_flags_membership(self):
+        """The ticket's counter-experiment, at the unit level: drop one file into
+        the folder and the SAME missing model is caught by the membership check.
+        Proves the mechanism was the empty list, not the loader."""
+        oi = self._object_info()
+        oi["UNETLoader"]["input"]["required"]["unet_name"] = [["some-other-model.safetensors"]]
+        g = Graph.from_object_info(oi)
+        result = g.validate_workflow(
+            {
+                "1": {
+                    "class_type": "UNETLoader",
+                    "inputs": {"unet_name": "flux1-dev.safetensors", "weight_dtype": "default"},
+                },
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        errs = [e for e in result["errors"] if e["field"] == "unet_name"]
+        assert len(errs) == 1
+        assert errs[0]["code"] == "unknown_enum_value"
+
+    def test_installed_value_on_populated_loader_still_passes(self):
+        """No false positive on the field that IS populated."""
+        g = self._graph()
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "VAELoader", "inputs": {"vae_name": "pixel_space"}},
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        assert result["valid"] is True, result["errors"]
+
+    def test_dict_form_empty_options_is_flagged(self):
+        """The partner-node dialect (``["COMBO", {"options": [...]}]``) declares
+        its choices in the options dict — an empty list there is the same
+        statement as an empty list-form combo."""
+        g = self._graph(
+            PartnerNode={
+                "input": {"required": {"model_name": ["COMBO", {"options": []}]}},
+                "output": ["MODEL"],
+                "output_name": ["MODEL"],
+                "python_module": "nodes",
+            }
+        )
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "PartnerNode", "inputs": {"model_name": "seedream-5"}},
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        errs = [e for e in result["errors"] if e["code"] == "no_options_available"]
+        assert [e["field"] for e in errs] == ["model_name"]
+
+    def test_remote_combo_stays_unconstrained(self):
+        """A combo whose options the frontend fetches at runtime ships NO
+        ``options`` key (``prune_dict`` drops it). That is "unknown", not "zero
+        installed" — validating against it would false-positive on every
+        remote-backed field, so it stays silent."""
+        g = self._graph(
+            RemoteNode={
+                "input": {"required": {"model": ["COMBO", {"remote": {"route": "/api/models"}}]}},
+                "output": ["MODEL"],
+                "output_name": ["MODEL"],
+                "python_module": "nodes",
+            }
+        )
+        port = next(p for p in g.node("RemoteNode").inputs if p.name == "model")
+        assert port.enum_declared is False
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "RemoteNode", "inputs": {"model": "whatever-the-route-returns"}},
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        assert result["valid"] is True, result["errors"]
+
+    def test_empty_combo_is_still_a_widget_not_a_link(self):
+        """``enum_declared`` is deliberately separate from ``is_enum`` so the
+        empty case cannot move a port between widget and link wiring."""
+        g = self._graph(
+            PartnerNode={
+                "input": {"required": {"model_name": ["COMBO", {"options": []}]}},
+                "output": ["MODEL"],
+                "output_name": ["MODEL"],
+                "python_module": "nodes",
+            }
+        )
+        list_form = next(p for p in g.node("UNETLoader").inputs if p.name == "unet_name")
+        dict_form = next(p for p in g.node("PartnerNode").inputs if p.name == "model_name")
+        assert (list_form.is_link, list_form.enum_declared, list_form.enum_values) == (False, True, [])
+        assert (dict_form.is_link, dict_form.enum_declared, dict_form.enum_values) == (False, True, [])
+
+    def test_absent_input_is_not_reported_as_unavailable(self):
+        """The check only fires on a value the workflow actually supplies — an
+        input that is missing entirely stays the existing required_input_missing
+        error, so the two never double-report the same field."""
+        g = self._graph()
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "UNETLoader", "inputs": {"weight_dtype": "default"}},
+                "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0]}},
+            }
+        )
+        by_field = {(e["field"], e["code"]) for e in result["errors"]}
+        assert ("unet_name", "required_input_missing") in by_field
+        assert ("unet_name", "no_options_available") not in by_field
+
+
 class TestValidateDynamicCombo:
     """Validate expands a ``COMFY_DYNAMICCOMBO_V3`` selector's chosen option and
     checks the dotted sub-inputs the server will actually require (BE-3777).


### PR DESCRIPTION
## ELI-5

`comfy validate` checks a dropdown value (a model name, an image name) against the list of options the server reports for that field. If the list was **empty**, the old code read that as "this field has no rules" and skipped the check entirely — so on a fresh install with zero models, the loaders that ship no built-in options (`UNETLoader`, `CLIPLoader`) said nothing at all, while a loader that happens to ship one built-in (`VAELoader`) correctly reported its missing model. Detection got *worse* the emptier the install, and the two silently-skipped loaders are the biggest downloads — exactly what a user needs told before starting a run. An empty option list now says "0 options installed for this field" instead of saying nothing.

## What changed

- `Port.validate_catalog` — a `COMBO` with a **declared but empty** option list and a supplied value now emits a new `no_options_available` finding instead of falling through the truthiness guard at the old `engine.py:98`.
- `_validate_catalog_value` promotes it to a hard error (same tier as `unknown_enum_value`, for the same reason: the server rejects it), with `field`, `node_id`, an install hint, and `valid_options: []` for parity with the enum error. The slot-editing path (`apply_slots` / `set-slot`) still surfaces it as a soft warning, unchanged in shape.
- New `Port.enum_declared` flag, set by `_parse_input_spec`, separates *"the server declared this field's choices and shipped none"* from *"this field's choices aren't in object_info at all"*.

## Why a new flag rather than just dropping the `and self.enum_values` guard

Because the two empty cases are not the same statement, and only one of them is safe to validate:

| object_info spec | meaning | new behavior |
| -- | -- | -- |
| `[[]]` (list-form, empty) | `folder_paths.get_filename_list(...)` returned nothing — no files installed | flagged |
| `["COMBO", {"options": []}]` | declared, explicitly empty | flagged |
| `["COMBO", {"remote": {...}}]` | options fetched by the frontend at runtime; `prune_dict` drops the absent `options` key (`comfy_api/latest/_io.py`) | **silent** (unconstrained, as today) |

`enum_declared` is deliberately *not* folded into `is_enum`, because `is_enum` also decides link-vs-widget wiring (`_is_link`) — an empty option list must not move a port between those. `is_enum` and `enum_values` come out of the parser byte-identical to before; the only new information is the flag. There is a test pinning that (`test_empty_combo_is_still_a_widget_not_a_link`).

## Evidence the server really does reject these (negative-claim falsification)

The diff makes `validate` deny something it used to pass, so the premise was checked against the product rather than only against my own tests:

- **ComfyUI `execution.py:1035-1067`** (local checkout at `c68789b0`): for both combo dialects — `isinstance(input_type, list)` and `input_type == io.Combo.io_type` with `combo_options = extra_info.get("options", [])` — the check is `val not in combo_options`. Against an empty list that is true for **every** value, producing `value_not_in_list`. So the run genuinely fails; the old silence just deferred the failure to submit time.
- **Counter-experiment (the one the ticket asked for), at the unit level:** `test_same_loader_with_one_option_installed_flags_membership` gives the same loader one installed option and the same missing model is then caught by the existing membership path — proving the mechanism was the empty list, not the loader. I did **not** run this against a live ComfyUI server with a file dropped into `models/unet/`; the evidence above is source-level plus unit-level.

## Known trade-off (pre-existing, not introduced here)

The server skips its built-in combo check for inputs covered by a node's own `VALIDATE_INPUTS` (`execution.py:1007`) — `LoadImage.image` is the core example, which accepts any annotated path that exists on disk. Such a value can pass on the server while `validate` flags it. That is the same over-strictness `unknown_enum_value` and the min/max errors already accept and document in this file, and `object_info` does not expose whether a node defines `VALIDATE_INPUTS`, so it cannot be narrowed from here. The empty case inherits it rather than adding it.

## Judgment calls

- **Distinct code, not `unknown_enum_value` with an empty `valid_options`** — the ticket offered both. The distinct code lets a caller say "no models installed for this loader" instead of "value not in 0 options", and `valid_options: []` is still present so a consumer keyed on the enum shape keeps working.
- **Error, not warning.** It matches `unknown_enum_value`, and the server's own verdict: the prompt will be rejected. It does mean `comfy validate` / `comfy run` preflight now exits non-zero on a fresh install for workflows that previously passed with silent, unrunnable inputs — which is the point of the parent ticket.
- Validation item codes are not registered in `error_codes.py` (that file is the envelope-level `error.code` contract), so `no_options_available` needed no registration — consistent with `unknown_enum_value`.

## Testing

`ruff check .`, `ruff format --check .` clean; full `pytest` green (4126 passed, 37 skipped). Eight new tests in `TestValidateEmptyCombo` cover: the empty loader being flagged, both loaders reported together (the ticket's 2-of-4 count bug), the counter-experiment, no false positive on a populated field, the dict-form empty case, remote combos staying silent, widget-vs-link invariance, and no double-report against `required_input_missing`.
