### PR TITLE
fix(node): normalize the cm-cli exit code from `comfy node install --exit-on-fail` (BE-6634)

### DIFF
--- a/comfy_cli/command/custom_nodes/cm_cli_util.py
+++ b/comfy_cli/command/custom_nodes/cm_cli_util.py
@@ -170,13 +170,15 @@ def normalize_cm_cli_exit_code(returncode: int) -> int:
     fabricated 247 and any multiple of 256 as 0 — a failure reporting success.
     Normalize to the shell's 128+N signal convention, and never return 0.
 
-    2 is remapped because Click already uses it for its own usage errors; leaving it
-    through would make "you invoked comfy wrong" indistinguishable from "cm-cli
-    exited 2". Callers should keep the raw status in their error ``details``.
+    A low byte of 2 is remapped because Click already uses 2 for its own usage
+    errors; leaving it through (whether as a literal 2 or a wide status like 258
+    that ``sys.exit`` truncates back to 2) would make "you invoked comfy wrong"
+    indistinguishable from "cm-cli exited 2". Callers should keep the raw status
+    in their error ``details``.
     """
     if returncode < 0:
         return min(128 + abs(returncode), 255)
-    if returncode == 2 or returncode % 256 == 0:
+    if returncode % 256 in (0, 2):
         return 1
     return returncode
 

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -13,7 +13,11 @@ from rich.console import Console
 
 from comfy_cli import constants, logging, tracking, ui, utils
 from comfy_cli.command.custom_nodes.bisect_custom_nodes import bisect_app
-from comfy_cli.command.custom_nodes.cm_cli_util import execute_cm_cli, find_cm_cli
+from comfy_cli.command.custom_nodes.cm_cli_util import (
+    execute_cm_cli,
+    find_cm_cli,
+    normalize_cm_cli_exit_code,
+)
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.constants import NODE_ZIP_FILENAME
 from comfy_cli.file_utils import (
@@ -675,7 +679,15 @@ def install(
         )
     except subprocess.CalledProcessError as e:
         if exit_on_fail:
-            raise typer.Exit(code=e.returncode)
+            code = normalize_cm_cli_exit_code(e.returncode)
+            get_renderer().error(
+                code="node_install_failed",
+                message=f"`cm-cli install` failed with exit code {e.returncode}.",
+                hint="see the cm-cli output above for the failing pack; re-run `comfy node install --exit-on-fail ...` to retry",
+                details={"cm_cli_returncode": e.returncode},
+                exit_code=code,
+            )
+            raise typer.Exit(code=code) from e
 
 
 @app.command(help="Reinstall custom nodes")

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -702,14 +702,20 @@ def install(
                 f"dependency installation after `cm-cli install` failed with exit code {raw} "
                 "(the packs installed; their dependencies did not)."
             )
-            hint = "see the pip/uv output above for the failing dependency; re-run `comfy node install --fast-deps --exit-on-fail ...` to retry"
+            hint = (
+                "see the pip/uv output above for the failing dependency; "
+                "re-run `comfy node install --fast-deps --exit-on-fail ...` to retry"
+            )
             details = {"returncode": raw, "failed_stage": "dependency-install"}
         else:
             if raw < 0:
                 message = f"`cm-cli install` was killed by signal {-raw}."
             else:
                 message = f"`cm-cli install` failed with exit code {raw}."
-            hint = "see the cm-cli output above for the failing pack; re-run `comfy node install --exit-on-fail ...` to retry"
+            hint = (
+                "see the cm-cli output above for the failing pack; "
+                "re-run `comfy node install --exit-on-fail ...` to retry"
+            )
             details = {"cm_cli_returncode": raw, "failed_stage": "cm-cli"}
         renderer.error(
             code="node_install_failed",

--- a/comfy_cli/command/custom_nodes/command.py
+++ b/comfy_cli/command/custom_nodes/command.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import pathlib
 import platform
@@ -667,27 +668,58 @@ def install(
     else:
         cmd = ["install"] + nodes
 
+    renderer = get_renderer()
+    # execute_cm_cli streams cm-cli's raw output to sys.stdout; in JSON/NDJSON
+    # mode stdout is reserved for the single envelope, so route the stream to
+    # stderr (mirrors pack_scan._read_pyproject and outdated._core_latest).
+    stream_ctx = contextlib.nullcontext() if renderer.is_pretty() else contextlib.redirect_stdout(sys.stderr)
     try:
-        execute_cm_cli(
-            cmd,
-            channel=channel,
-            fast_deps=fast_deps,
-            no_deps=no_deps,
-            uv_compile=effective_uv_compile,
-            mode=mode,
-            raise_on_error=exit_on_fail,
-        )
-    except subprocess.CalledProcessError as e:
-        if exit_on_fail:
-            code = normalize_cm_cli_exit_code(e.returncode)
-            get_renderer().error(
-                code="node_install_failed",
-                message=f"`cm-cli install` failed with exit code {e.returncode}.",
-                hint="see the cm-cli output above for the failing pack; re-run `comfy node install --exit-on-fail ...` to retry",
-                details={"cm_cli_returncode": e.returncode},
-                exit_code=code,
+        with stream_ctx:
+            execute_cm_cli(
+                cmd,
+                channel=channel,
+                fast_deps=fast_deps,
+                no_deps=no_deps,
+                uv_compile=effective_uv_compile,
+                mode=mode,
+                raise_on_error=exit_on_fail,
             )
-            raise typer.Exit(code=code) from e
+    except subprocess.CalledProcessError as e:
+        if not exit_on_fail:
+            # execute_cm_cli re-raises unexpected exit codes even with raise_on_error
+            # off; keep surfacing those instead of swallowing them here (mirrors the
+            # `comfy update all` handler in cmdline.py).
+            raise
+        raw = e.returncode
+        code = normalize_cm_cli_exit_code(raw)
+        failed_argv = e.cmd if isinstance(e.cmd, list | tuple) else [e.cmd]
+        ran_cm_cli = any(str(part).replace("-", "_") == "cm_cli" for part in failed_argv)
+        if fast_deps and not ran_cm_cli:
+            # With --fast-deps, execute_cm_cli runs DependencyCompiler after cm-cli
+            # succeeds; a pip/uv failure there is not a cm-cli failure — the packs
+            # themselves installed.
+            message = (
+                f"dependency installation after `cm-cli install` failed with exit code {raw} "
+                "(the packs installed; their dependencies did not)."
+            )
+            hint = "see the pip/uv output above for the failing dependency; re-run `comfy node install --fast-deps --exit-on-fail ...` to retry"
+            details = {"returncode": raw, "failed_stage": "dependency-install"}
+        else:
+            if raw < 0:
+                message = f"`cm-cli install` was killed by signal {-raw}."
+            else:
+                message = f"`cm-cli install` failed with exit code {raw}."
+            hint = "see the cm-cli output above for the failing pack; re-run `comfy node install --exit-on-fail ...` to retry"
+            details = {"cm_cli_returncode": raw, "failed_stage": "cm-cli"}
+        renderer.error(
+            code="node_install_failed",
+            message=message,
+            hint=hint,
+            details=details,
+            exit_code=code,
+            command="node install",
+        )
+        raise typer.Exit(code=code) from e
 
 
 @app.command(help="Reinstall custom nodes")

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -808,6 +808,15 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "`comfy feedback` was run in JSON/non-interactive mode without an inline message.",
         'comfy feedback "your feedback here"',
     ),
+    # --- custom node install (`comfy node install`) ---------------------------
+    ErrorCode(
+        "node_install_failed",
+        "`comfy node install --exit-on-fail` ran `cm-cli install` and it exited non-zero. "
+        "`details.cm_cli_returncode` carries cm-cli's raw status (the process exit code is "
+        "normalized — signals become 128+N, and 2 becomes 1 so it can't be confused with a "
+        "CLI usage error).",
+        "read the cm-cli output above for the failing pack, then re-run `comfy node install --exit-on-fail`",
+    ),
     # --- custom node dependency report (`comfy node deps`) --------------------
     ErrorCode(
         "installed_versions_unavailable",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -811,11 +811,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
     # --- custom node install (`comfy node install`) ---------------------------
     ErrorCode(
         "node_install_failed",
-        "`comfy node install --exit-on-fail` ran `cm-cli install` and it exited non-zero. "
-        "`details.cm_cli_returncode` carries cm-cli's raw status (the process exit code is "
-        "normalized — signals become 128+N, and 2 becomes 1 so it can't be confused with a "
-        "CLI usage error).",
-        "read the cm-cli output above for the failing pack, then re-run `comfy node install --exit-on-fail`",
+        "`comfy node install --exit-on-fail` failed: `cm-cli install` exited non-zero "
+        '(`details.failed_stage` == "cm-cli", raw status in `details.cm_cli_returncode`) or, '
+        "with --fast-deps, the follow-up dependency install failed after the packs installed "
+        '(`details.failed_stage` == "dependency-install", raw status in `details.returncode`). '
+        "The process exit code is normalized — signals become 128+N, and any status whose low "
+        "byte is 0 or 2 becomes 1 so it can't read as success or a CLI usage error.",
+        "read the output above for the failing pack or dependency, then re-run `comfy node install --exit-on-fail`",
     ),
     # --- custom node dependency report (`comfy node deps`) --------------------
     ErrorCode(

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -1,13 +1,36 @@
+import json
 import re
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
+from comfy_cli import cmdline
 from comfy_cli.command.custom_nodes.command import app
 from comfy_cli.file_utils import DownloadException
 
 runner = CliRunner()
+
+
+def _split_stream_runner() -> CliRunner:
+    """A runner that keeps stdout and stderr separate, so tests can assert the
+    JSON-mode contract that stdout carries ONLY the envelope."""
+    try:
+        return CliRunner(mix_stderr=False)  # click < 8.2
+    except TypeError:
+        return CliRunner()  # click >= 8.2 always separates
+
+
+@pytest.fixture
+def _reset_renderer():
+    """Invoking the root app installs a process-wide JSON renderer; drop it so
+    later tests that invoke the sub-app get the default pretty renderer back."""
+    yield
+    from comfy_cli.output.renderer import reset_renderer_for_testing
+
+    reset_renderer_for_testing()
 
 
 def strip_ansi(text):
@@ -172,6 +195,74 @@ def test_install_exit_on_fail_code_2_does_not_masquerade_as_usage_error():
         mock_execute.side_effect = subprocess.CalledProcessError(2, "cm-cli")
         result = runner.invoke(app, ["install", "bad-node", "--exit-on-fail"])
         assert result.exit_code == 1
+
+
+def test_install_exit_on_fail_wide_status_with_low_byte_2_is_remapped():
+    """A wide status like 258 truncates to 2 in `sys.exit` — the exact Click
+    usage-error collision the remap exists to prevent — so the normalization
+    keys on the low byte, not the literal value 2."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(258, "cm-cli")
+        result = runner.invoke(app, ["install", "bad-node", "--exit-on-fail"])
+        assert result.exit_code == 1
+
+
+def test_install_without_exit_on_fail_surfaces_unexpected_exit_codes():
+    """execute_cm_cli itself swallows cm-cli exits 1/2 when raise_on_error is
+    off; anything else (e.g. a signal death) it re-raises, and install must not
+    turn that into a silent exit 0 (mirrors the `comfy update all` handler)."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(-9, "cm-cli")
+        result = runner.invoke(app, ["install", "bad-node"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, subprocess.CalledProcessError)
+
+
+def test_install_exit_on_fail_json_stdout_carries_only_the_envelope(_reset_renderer):
+    """execute_cm_cli streams cm-cli's raw output to sys.stdout; in JSON mode
+    install routes that stream to stderr so stdout stays a single parseable
+    envelope, labeled with the actual subcommand."""
+
+    def _stream_then_fail(args, **kwargs):
+        sys.stdout.write("raw cm-cli progress line\n")
+        raise subprocess.CalledProcessError(7, ["python", "-m", "cm_cli", "install"])
+
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli", side_effect=_stream_then_fail):
+        result = _split_stream_runner().invoke(cmdline.app, ["--json", "node", "install", "bad-node", "--exit-on-fail"])
+
+    assert result.exit_code == 7
+    envelope = json.loads(result.stdout.strip())
+    assert envelope["ok"] is False
+    assert envelope["command"] == "node install"
+    assert envelope["error"]["code"] == "node_install_failed"
+    assert envelope["error"]["details"] == {"cm_cli_returncode": 7, "failed_stage": "cm-cli"}
+
+
+def test_install_exit_on_fail_signal_death_is_reported_as_a_signal(_reset_renderer):
+    """No process exits with -9 — cm-cli was killed by signal 9. The message
+    says so instead of leaking Popen's negative-signal encoding."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(-9, ["python", "-m", "cm_cli", "install"])
+        result = runner.invoke(cmdline.app, ["--json", "node", "install", "bad-node", "--exit-on-fail"])
+
+    assert result.exit_code == 137
+    envelope = json.loads(result.stdout.strip().splitlines()[-1])
+    assert "killed by signal 9" in envelope["error"]["message"]
+    assert envelope["error"]["details"]["cm_cli_returncode"] == -9
+
+
+def test_install_fast_deps_dep_failure_is_not_blamed_on_cm_cli(_reset_renderer):
+    """With --fast-deps, execute_cm_cli runs the dependency compiler after
+    cm-cli succeeds; a pip/uv failure there is a dependency failure — the packs
+    themselves installed — and must not be attributed to cm-cli."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(1, ["uv", "pip", "install", "-r", "requirements.txt"])
+        result = runner.invoke(cmdline.app, ["--json", "node", "install", "bad-node", "--fast-deps", "--exit-on-fail"])
+
+    assert result.exit_code == 1
+    envelope = json.loads(result.stdout.strip().splitlines()[-1])
+    assert "dependency installation" in envelope["error"]["message"]
+    assert envelope["error"]["details"] == {"returncode": 1, "failed_stage": "dependency-install"}
 
 
 def test_save_snapshot_no_output():

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -225,6 +225,9 @@ def test_install_exit_on_fail_json_stdout_carries_only_the_envelope(_reset_rende
 
     def _stream_then_fail(args, **kwargs):
         sys.stdout.write("raw cm-cli progress line\n")
+        # click's CliRunner only flushes stdout at invoke exit, so the redirected
+        # stderr wrapper would otherwise hold this line in its buffer forever.
+        sys.stdout.flush()
         raise subprocess.CalledProcessError(7, ["python", "-m", "cm_cli", "install"])
 
     with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli", side_effect=_stream_then_fail):
@@ -232,6 +235,7 @@ def test_install_exit_on_fail_json_stdout_carries_only_the_envelope(_reset_rende
 
     assert result.exit_code == 7
     envelope = json.loads(result.stdout.strip())
+    assert "raw cm-cli progress line\n" in result.stderr
     assert envelope["ok"] is False
     assert envelope["command"] == "node install"
     assert envelope["error"]["code"] == "node_install_failed"

--- a/tests/comfy_cli/command/nodes/test_node_install.py
+++ b/tests/comfy_cli/command/nodes/test_node_install.py
@@ -145,6 +145,35 @@ def test_install_exit_on_fail_reraises_and_propagates_code():
         assert args[0][0] == "install" and "--exit-on-fail" in args[0] and "bad-node" in args[0]
 
 
+def test_install_exit_on_fail_signal_death_becomes_shell_convention_code():
+    """`Popen.wait()` returns -9 when the OOM killer reaps cm-cli mid dependency
+    build. Exiting with that raw value would truncate to a fabricated 247, so map
+    it to the shell's 128+N convention."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(-9, "cm-cli")
+        result = runner.invoke(app, ["install", "bad-node", "--exit-on-fail"])
+        assert result.exit_code == 137
+
+
+def test_install_exit_on_fail_code_that_would_truncate_to_zero_stays_nonzero():
+    """Windows can return codes above 255; a multiple of 256 would otherwise
+    truncate to 0 and report a failed install as a success."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(256, "cm-cli")
+        result = runner.invoke(app, ["install", "bad-node", "--exit-on-fail"])
+        assert result.exit_code == 1
+
+
+def test_install_exit_on_fail_code_2_does_not_masquerade_as_usage_error():
+    """Click reserves exit code 2 for its own usage errors, so a cm-cli exit 2 is
+    remapped rather than letting a wrapper confuse "you invoked comfy wrong" with
+    "cm-cli exited 2"."""
+    with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
+        mock_execute.side_effect = subprocess.CalledProcessError(2, "cm-cli")
+        result = runner.invoke(app, ["install", "bad-node", "--exit-on-fail"])
+        assert result.exit_code == 1
+
+
 def test_save_snapshot_no_output():
     with patch("comfy_cli.command.custom_nodes.command.execute_cm_cli") as mock_execute:
         result = runner.invoke(app, ["save-snapshot"])


### PR DESCRIPTION
## ELI-5

When `comfy node install --exit-on-fail` fails, the number it hands back to the shell could lie. If the underlying `cm-cli` process was killed by a signal (say, the OOM killer during a heavy dependency build), Python reports that as a negative number, and the shell mangles it into a meaningless one (`-9` became `247`). Worse, some large failure codes wrapped around to `0` — a failed install that *reported success* to the CI script the flag exists for. Now the code is normalized the standard way (`137` for an OOM kill, never `0`), and the raw status is still available in the JSON error details.

## What changed

- `comfy node install --exit-on-fail` now routes cm-cli's status through `normalize_cm_cli_exit_code` (the helper #676 added for `comfy update all --exit-on-fail`) instead of forwarding it raw to `typer.Exit`:
  - signal deaths (`-N`) map to the shell's `128+N` convention (`-9` → `137`, not a fabricated `247`)
  - non-zero multiples of 256 map to `1` instead of truncating to `0` (a failure must never report success)
  - `2` maps to `1` so a real cm-cli failure can't masquerade as Click's reserved usage-error code
- The failure now also emits the structured `node_install_failed` error (registered in `error_codes.py`), so JSON mode gets a proper envelope with `details.cm_cli_returncode` carrying the raw status — matching what `comfy update all --exit-on-fail` already does.
- Tests: three new cases (`-9` → 137, `256` → 1, `2` → 1) alongside the existing code-7 propagation test, which is unchanged by normalization and still passes.

Out of scope, per the spike (BE-6606): `reinstall`/`fix` have no `--exit-on-fail` flag and are untouched; the no-flag default behavior of `execute_cm_cli` is unchanged.

## Testing

- `pytest tests/comfy_cli/command/nodes/test_node_install.py tests/comfy_cli/output/test_error_code_registry.py tests/comfy_cli/command/test_update_exit_on_fail.py` — 61 passed
- Full suite: 4339 passed, 37 skipped
- `ruff check` + `ruff format --check` clean on CI's pinned ruff 0.15.15 (the uv.lock ruff 0.12.7 flags pre-existing UP038 hits repo-wide, unrelated to this change)

## Judgment calls

- PR #676 merged this morning, so the helper is imported rather than duplicated (the ticket's preferred branch).
- The `node_install_failed` registry entry's wording mirrors the neighboring `update_custom_nodes_failed` entry from #676 for consistency; the call-site hint uses the ticket's verbatim text (the registry hint is the documented fallback).