### PR TITLE
fix(run): stamp watcher_pid on --wait submit records so externally-killed runs get reaped (BE-6641)

### DIFF
--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -13,7 +13,6 @@ command is purely the worker that the foreground ``run`` detaches.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -78,15 +77,9 @@ def watch_job(
         # practice; exit quietly.
         return
 
-    state.watcher_pid = os.getpid()
-    # Recorded together with the pid so the reaper can tell *this* watcher from
-    # whatever inherits its pid later (see `_is_watcher_alive` in jobs.py).
-    try:
-        import psutil
-
-        state.watcher_pid_create_time = psutil.Process().create_time()
-    except Exception:  # noqa: BLE001 — best effort; None just means liveness-only
-        state.watcher_pid_create_time = None
+    # Pid + create_time recorded together so the reaper can tell *this* watcher
+    # from whatever inherits its pid later (see `_is_watcher_alive` in jobs.py).
+    jobs_state.stamp_watcher_identity(state)
     jobs_state.write(state)
 
     cloud_client = None

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -337,21 +337,46 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
         # Reap stale watchers: if the job is non-terminal and the watcher
         # PID is recorded but dead, mark the job as errored so it doesn't
         # sit as "running" forever.
+        #
+        # The verdict is re-derived from a re-read INSIDE the record's own
+        # lock, because everything above is a snapshot and this scan races
+        # live writers: `run --wait` now stamps its foreground pid too, so the
+        # window between the liveness probe and this write is one an ordinary
+        # `comfy run --wait` finishing normally can land its terminal
+        # `completed` write in — and `jobs ls --watch` re-runs the whole scan
+        # every refresh tick. Writing the snapshot back unconditionally would
+        # overwrite that verdict, and the outputs recorded with it, with a
+        # generic `watcher_crashed`.
         if (
             not state.is_terminal
             and state.watcher_pid is not None
             and state.watcher_pid > 0
             and not _is_watcher_alive(state)
         ):
-            state.status = "error"
-            state.error = {
-                "code": "watcher_crashed",
-                "message": f"Background watcher (pid {state.watcher_pid}) is no longer running.",
-                "hint": "re-submit the workflow, or check `comfy jobs status <id>` against the server",
-            }
-            state.watcher_pid = None
-            state.watcher_pid_create_time = None
-            jobs_state.write(state)
+            # Keyed on the filename, not `state.prompt_id`: the stem is what
+            # was read (and is already filter-validated above), so a record
+            # whose stored id disagrees with its file can't send the lock and
+            # the re-read to a different record than the one being reaped.
+            with jobs_state.locked(path.stem) as fresh:
+                if fresh is not None:
+                    if (
+                        not fresh.is_terminal
+                        and fresh.watcher_pid is not None
+                        and fresh.watcher_pid > 0
+                        and not _is_watcher_alive(fresh)
+                    ):
+                        fresh.status = "error"
+                        fresh.error = {
+                            "code": "watcher_crashed",
+                            "message": f"Background watcher (pid {fresh.watcher_pid}) is no longer running.",
+                            "hint": "re-submit the workflow, or check `comfy jobs status <id>` against the server",
+                        }
+                        fresh.watcher_pid = None
+                        fresh.watcher_pid_create_time = None
+                        jobs_state.write(fresh)
+                    # Report what is actually on disk either way — whether we
+                    # reaped it or the writer we raced beat us to a verdict.
+                    state = fresh
         # Scope to the resolved --where target. Done *after* the stale-watcher
         # reap above so cleanup stays where-agnostic no matter which view the
         # caller asked for.

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -627,11 +627,6 @@ def execute(
         )
         raise typer.Exit(code=130)
     except WebSocketTimeoutException:
-        if renderer.is_pretty():
-            pprint(
-                f"[bold red]Error: WebSocket timed out after {timeout}s waiting for server response.[/bold red]\n"
-                "[yellow]For long-running workflows, increase the timeout: comfy run --workflow <file> --timeout 300[/yellow]"
-            )
         # The job may genuinely still be running server-side, so the
         # submit-time "running" record is left non-terminal — but the watcher
         # stamp MUST be cleared: this process is about to exit, and a
@@ -639,9 +634,17 @@ def execute(
         # stale-watcher reap finalizes, so the next `jobs ls` after a
         # `--wait --timeout 60` on a long-running job would flip a healthy
         # job's record to `error`/`watcher_crashed` — a regression worse than
-        # the external-kill gap the stamp closes. The None guard is required:
-        # `execution.connect()` raises this same exception, and it runs before
-        # `wait_state` exists.
+        # the external-kill gap the stamp closes. `clear_watcher_identity`
+        # re-reads under the record's lock and leaves an already-terminal
+        # record alone, so a `comfy jobs cancel` that landed while we were
+        # blocked here isn't walked back to `running`. The None guard is
+        # required: `execution.connect()` raises this same exception, and it
+        # runs before `wait_state` exists.
+        #
+        # Done BEFORE the pretty-mode render below: that render is blocking
+        # (and can itself die on a closed stdout), and every millisecond
+        # between "we know we're leaving" and "the stamp is gone" is a window
+        # in which an external SIGKILL strands the stale pid.
         #
         # Consequence of the no-watcher limit documented at the submit-time
         # write above: nothing is left watching the prompt after this returns,
@@ -650,9 +653,12 @@ def execute(
         # `comfy jobs status <prompt_id>`, which infers the death from a
         # server that is down (or came back with no record of the prompt).
         if wait_state is not None:
-            wait_state.watcher_pid = None
-            wait_state.watcher_pid_create_time = None
-            _write_state(wait_state)
+            jobs_state.clear_watcher_identity(wait_state)
+        if renderer.is_pretty():
+            pprint(
+                f"[bold red]Error: WebSocket timed out after {timeout}s waiting for server response.[/bold red]\n"
+                "[yellow]For long-running workflows, increase the timeout: comfy run --workflow <file> --timeout 300[/yellow]"
+            )
         details = {"timeout": timeout}
         prompt_id = _submitted_prompt_id(execution)
         if prompt_id is not None:
@@ -1106,132 +1112,150 @@ def execute_cloud(
     state_file = jobs_state.write(state)
     _journal_run(workflow_name, submit.prompt_id, "cloud")
 
+    # Guard every exit from here on. `Client._request` only converts
+    # `urllib.error.HTTPError`, so a DNS failure, a connection reset, a TLS
+    # error or a non-JSON body from `wait_for_completion` escapes as a bare
+    # `URLError`/`OSError`/`ValueError` and matches none of the handlers
+    # below; `extract_outputs` and the rendering after them are likewise
+    # unguarded. Such an escape kills this process with the record still
+    # non-terminal AND stamped, which is exactly what the next `jobs ls`
+    # reaps to `error`/`watcher_crashed` — asserting a crash verdict about a
+    # CLOUD job that is very likely still running server-side and that
+    # `comfy jobs status <id> --where cloud` could otherwise reconcile
+    # against the API. Dropping the stamp on the way out leaves what an
+    # un-stamped `--wait` left before: a non-terminal record nobody is
+    # watching. Every handled exit below writes a terminal record first, and
+    # `clear_watcher_identity` re-reads under the lock and no-ops on those.
     try:
+        try:
 
-        def _probe():
-            st = client.get_job_status(submit.prompt_id)
-            if not st:
-                return None
-            return (st.get("status"), st.get("progress"), st.get("queue_position"))
+            def _probe():
+                st = client.get_job_status(submit.prompt_id)
+                if not st:
+                    return None
+                return (st.get("status"), st.get("progress"), st.get("queue_position"))
 
-        record = client.wait_for_completion(submit.prompt_id, timeout=float(timeout), progress_probe=_probe)
-    except TimeoutError as e:
-        state.status = "error"
-        state.error = {"code": "cloud_timeout", "message": str(e)}
-        jobs_state.write(state)
-        renderer.error(
-            code="cloud_timeout",
-            message=str(e),
-            hint=f"the cloud job went silent for {timeout}s; raise --timeout or watch via `comfy jobs watch {submit.prompt_id} --where cloud`",
-            details={"prompt_id": submit.prompt_id},
-        )
-        raise typer.Exit(code=1) from e
-    except Unauthenticated as e:
-        state.status = "error"
-        state.error = {"code": "cloud_unauthorized", "message": str(e)}
-        jobs_state.write(state)
-        renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy cloud login")
-        raise typer.Exit(code=1) from e
-    except HTTPError as e:
-        state.status = "error"
-        state.error = {"code": "cloud_http_error", "message": str(e)}
-        jobs_state.write(state)
-        renderer.error(
-            code="cloud_http_error",
-            message=f"Cloud server error while polling (HTTP {e.status}): {e.message}",
-            details={"status": e.status, "prompt_id": submit.prompt_id},
-        )
-        raise typer.Exit(code=1) from e
-    except KeyboardInterrupt:
-        state.status = "cancelled"
-        jobs_state.write(state)
-        renderer.error(code="cancelled", message="Cancelled by user", exit_code=130)
-        raise typer.Exit(code=130)
+            record = client.wait_for_completion(submit.prompt_id, timeout=float(timeout), progress_probe=_probe)
+        except TimeoutError as e:
+            state.status = "error"
+            state.error = {"code": "cloud_timeout", "message": str(e)}
+            jobs_state.write(state)
+            renderer.error(
+                code="cloud_timeout",
+                message=str(e),
+                hint=f"the cloud job went silent for {timeout}s; raise --timeout or watch via `comfy jobs watch {submit.prompt_id} --where cloud`",
+                details={"prompt_id": submit.prompt_id},
+            )
+            raise typer.Exit(code=1) from e
+        except Unauthenticated as e:
+            state.status = "error"
+            state.error = {"code": "cloud_unauthorized", "message": str(e)}
+            jobs_state.write(state)
+            renderer.error(code="cloud_unauthorized", message=str(e), hint="run: comfy cloud login")
+            raise typer.Exit(code=1) from e
+        except HTTPError as e:
+            state.status = "error"
+            state.error = {"code": "cloud_http_error", "message": str(e)}
+            jobs_state.write(state)
+            renderer.error(
+                code="cloud_http_error",
+                message=f"Cloud server error while polling (HTTP {e.status}): {e.message}",
+                details={"status": e.status, "prompt_id": submit.prompt_id},
+            )
+            raise typer.Exit(code=1) from e
+        except KeyboardInterrupt:
+            state.status = "cancelled"
+            jobs_state.write(state)
+            renderer.error(code="cancelled", message="Cancelled by user", exit_code=130)
+            raise typer.Exit(code=130)
 
-    # Determine the terminal status from the record.
-    node_outputs = client.extract_outputs(record)
-    output_urls = [o["url"] for o in node_outputs]
-    exec_status = record.get("status") or record.get("execution_status") or {}
-    if isinstance(exec_status, dict):
-        status_str = exec_status.get("status_str", "")
-    else:
-        status_str = str(exec_status).lower()
+        # Determine the terminal status from the record.
+        node_outputs = client.extract_outputs(record)
+        output_urls = [o["url"] for o in node_outputs]
+        exec_status = record.get("status") or record.get("execution_status") or {}
+        if isinstance(exec_status, dict):
+            status_str = exec_status.get("status_str", "")
+        else:
+            status_str = str(exec_status).lower()
 
-    if status_str in ("error", "failed"):
-        verdict = execution_errors.classify(record.get("error_message") or status_str)
-        state.status = "error"
-        state.error = {
-            "code": verdict["code"],
-            "message": verdict["message"],
-            "details": verdict["details"],
-        }
-        state_file = jobs_state.write(state)
-        renderer.error(
-            code=verdict["code"],
-            message=verdict["message"],
-            hint=verdict["hint"],
-            details={"prompt_id": submit.prompt_id, "status": status_str, **verdict["details"]},
-        )
-        raise typer.Exit(code=1)
-
-    # Success path.
-    state.status = "completed"
-    state.outputs = output_urls
-    # Stash the full node-keyed history record for downstream consumers
-    # (grouped outputs, item-named downloads).
-    state.record = record
-    state_file = jobs_state.write(state)
-
-    end = time.time()
-
-    # Silent-partial-execution guard: the cloud prunes branches that fail
-    # server-side validation and still reports `completed`. Diff the output
-    # nodes we submitted against the ones that actually returned outputs so a
-    # vanished branch surfaces instead of passing as a clean success.
-    warnings: list[dict] = []
-    submitted_outputs = _count_output_nodes(parsed_workflow, cloud_object_info)
-    returned_outputs = _returned_output_node_count(record)
-    if submitted_outputs is not None and returned_outputs < submitted_outputs:
-        warnings.append(
-            {
-                "code": "partial_execution",
-                "message": (
-                    f"submitted {submitted_outputs} output node(s) but the cloud returned outputs "
-                    f"for only {returned_outputs}; {submitted_outputs - returned_outputs} branch(es) "
-                    "were pruned server-side (likely failed validation) and produced nothing"
-                ),
-                "submitted_output_nodes": submitted_outputs,
-                "returned_output_nodes": returned_outputs,
+        if status_str in ("error", "failed"):
+            verdict = execution_errors.classify(record.get("error_message") or status_str)
+            state.status = "error"
+            state.error = {
+                "code": verdict["code"],
+                "message": verdict["message"],
+                "details": verdict["details"],
             }
+            state_file = jobs_state.write(state)
+            renderer.error(
+                code=verdict["code"],
+                message=verdict["message"],
+                hint=verdict["hint"],
+                details={"prompt_id": submit.prompt_id, "status": status_str, **verdict["details"]},
+            )
+            raise typer.Exit(code=1)
+
+        # Success path.
+        state.status = "completed"
+        state.outputs = output_urls
+        # Stash the full node-keyed history record for downstream consumers
+        # (grouped outputs, item-named downloads).
+        state.record = record
+        state_file = jobs_state.write(state)
+
+        end = time.time()
+
+        # Silent-partial-execution guard: the cloud prunes branches that fail
+        # server-side validation and still reports `completed`. Diff the output
+        # nodes we submitted against the ones that actually returned outputs so a
+        # vanished branch surfaces instead of passing as a clean success.
+        warnings: list[dict] = []
+        submitted_outputs = _count_output_nodes(parsed_workflow, cloud_object_info)
+        returned_outputs = _returned_output_node_count(record)
+        if submitted_outputs is not None and returned_outputs < submitted_outputs:
+            warnings.append(
+                {
+                    "code": "partial_execution",
+                    "message": (
+                        f"submitted {submitted_outputs} output node(s) but the cloud returned outputs "
+                        f"for only {returned_outputs}; {submitted_outputs - returned_outputs} branch(es) "
+                        "were pruned server-side (likely failed validation) and produced nothing"
+                    ),
+                    "submitted_output_nodes": submitted_outputs,
+                    "returned_output_nodes": returned_outputs,
+                }
+            )
+
+        if renderer.is_pretty():
+            if output_urls:
+                pprint("[bold green]\nOutputs:[/bold green]")
+                for u in output_urls:
+                    pprint(sanitize_markup(u))
+            for w in warnings:
+                pprint(f"[yellow]⚠ {sanitize_markup(w['message'])}[/yellow]")
+            pprint(f"[bold green]\nCloud workflow completed ({timedelta(seconds=end - start)})[/bold green]")
+
+        # Grouped views of the same artifacts: by producing node always, and by
+        # blueprint foreach item when compose stashed an item_map at submit.
+        outputs_by_node, outputs_by_item = _group_outputs(node_outputs, state.item_map)
+
+        renderer.emit(
+            {
+                "workflow": workflow_name,
+                "status": state.status,
+                "prompt_id": submit.prompt_id,
+                "client_id": client_id,
+                "outputs": output_urls,
+                "outputs_by_node": outputs_by_node,
+                "outputs_by_item": outputs_by_item,
+                "warnings": warnings,
+                "elapsed_seconds": end - start,
+                "base_url": target.base_url,
+                "state_file": str(state_file) if state_file else None,
+            },
+            command="run",
+            where="cloud",
         )
-
-    if renderer.is_pretty():
-        if output_urls:
-            pprint("[bold green]\nOutputs:[/bold green]")
-            for u in output_urls:
-                pprint(sanitize_markup(u))
-        for w in warnings:
-            pprint(f"[yellow]⚠ {sanitize_markup(w['message'])}[/yellow]")
-        pprint(f"[bold green]\nCloud workflow completed ({timedelta(seconds=end - start)})[/bold green]")
-
-    # Grouped views of the same artifacts: by producing node always, and by
-    # blueprint foreach item when compose stashed an item_map at submit.
-    outputs_by_node, outputs_by_item = _group_outputs(node_outputs, state.item_map)
-
-    renderer.emit(
-        {
-            "workflow": workflow_name,
-            "status": state.status,
-            "prompt_id": submit.prompt_id,
-            "client_id": client_id,
-            "outputs": output_urls,
-            "outputs_by_node": outputs_by_node,
-            "outputs_by_item": outputs_by_item,
-            "warnings": warnings,
-            "elapsed_seconds": end - start,
-            "base_url": target.base_url,
-            "state_file": str(state_file) if state_file else None,
-        },
-        command="run",
-        where="cloud",
-    )
+    except BaseException:
+        jobs_state.clear_watcher_identity(state)
+        raise

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -472,28 +472,24 @@ def execute(
             # "running" rather than "queued": this foreground process is
             # actively watching it, not leaving it detached in the queue.
             #
-            # DOCUMENTED LIMIT — `--wait` spawns no background watcher, by
-            # design; this process *is* the watcher. Every ordinary outcome is
-            # still recorded, because the handlers below run: a node failure and
-            # a cancel via `_mark_watch_exit`/`_mark_cancelled`, and a server
-            # that dies mid-run via the `server_died` write in the
-            # WebSocketException/OSError handler. What is NOT covered is this
-            # process being killed from OUTSIDE (a caller-imposed timeout
-            # SIGKILLing the process group, the terminal going away): no handler
-            # runs, the record stays at the submit-time `running`, and since no
-            # `watcher_pid` is recorded, `jobs ls`'s stale-watcher reap — which
-            # only fires on a recorded *and* dead pid — won't finalize it
-            # either. `comfy jobs status` still names the job and its
-            # last-known status, so attribution is degraded rather than lost;
-            # callers that expect to outlive their patience should submit
-            # WITHOUT `--wait`, whose detached watcher gets its own session and
-            # survives the parent. Spawning one here too was considered and
-            # rejected: it would put a second, independent writer on the state
-            # file this branch already finalizes, add a second server
-            # connection per foreground run, and leave a background process
-            # behind after a synchronous command returns. See
-            # docs/json-output.md, "Known limit: `--wait` has no background
-            # watcher".
+            # `--wait` spawns no background watcher, by design; this process
+            # *is* the watcher, and it stamps its own pid + create_time on the
+            # submit-time record below to say so. Every ordinary outcome is
+            # recorded by the handlers below: a node failure and a cancel via
+            # `_mark_watch_exit`/`_mark_cancelled`, and a server that dies
+            # mid-run via the `server_died` write in the
+            # WebSocketException/OSError handler. This process being killed
+            # from OUTSIDE (a caller-imposed timeout SIGKILLing the process
+            # group, the terminal going away) runs no handler, but the stamp
+            # covers it: the record is left non-terminal with a recorded,
+            # now-dead pid, which is exactly what `jobs ls`'s stale-watcher
+            # reap finalizes as `watcher_crashed`. Spawning a real watcher
+            # here too was considered and rejected: it would put a second,
+            # independent writer on the state file this branch already
+            # finalizes, add a second server connection per foreground run,
+            # and leave a background process behind after a synchronous
+            # command returns. See docs/json-output.md, "Known limit:
+            # `--wait` has no background watcher".
             wait_state = jobs_state.new(
                 prompt_id=execution.prompt_id,
                 client_id=execution.client_id,
@@ -504,15 +500,17 @@ def execute(
             )
             wait_state.item_map = (compose_meta or {}).get("items")
             wait_state.status = "running"
+            jobs_state.stamp_watcher_identity(wait_state)
             _write_state(wait_state)
 
             # `watch_execution` reports a terminal server event by rendering
             # the error and raising `typer.Exit` (1 for `execution_error`, 130
             # for `execution_interrupted`) — the ordinary failure path, not an
             # exception the handlers below see. Finalize the submit-time
-            # record here, or a failed job is stranded as a phantom `running`
-            # forever: `jobs ls` only reaps non-terminal records whose
-            # `watcher_pid` is dead, and `--wait` never sets one.
+            # record here: the stale-watcher reap would eventually flip a
+            # `running` record with our now-dead pid to a generic
+            # `watcher_crashed`, but this process knows the real verdict and
+            # must record it while it still can.
             try:
                 execution.watch_execution()
             except typer.Exit as exit_exc:
@@ -635,13 +633,26 @@ def execute(
                 "[yellow]For long-running workflows, increase the timeout: comfy run --workflow <file> --timeout 300[/yellow]"
             )
         # The job may genuinely still be running server-side, so the
-        # submit-time "running" record is left as-is — not marked terminal.
+        # submit-time "running" record is left non-terminal — but the watcher
+        # stamp MUST be cleared: this process is about to exit, and a
+        # recorded-but-dead pid on a non-terminal record is precisely what the
+        # stale-watcher reap finalizes, so the next `jobs ls` after a
+        # `--wait --timeout 60` on a long-running job would flip a healthy
+        # job's record to `error`/`watcher_crashed` — a regression worse than
+        # the external-kill gap the stamp closes. The None guard is required:
+        # `execution.connect()` raises this same exception, and it runs before
+        # `wait_state` exists.
+        #
         # Consequence of the no-watcher limit documented at the submit-time
         # write above: nothing is left watching the prompt after this returns,
         # so if the server dies later no `server_died` is ever written. The
         # record stays `running` until the caller asks
         # `comfy jobs status <prompt_id>`, which infers the death from a
         # server that is down (or came back with no record of the prompt).
+        if wait_state is not None:
+            wait_state.watcher_pid = None
+            wait_state.watcher_pid_create_time = None
+            _write_state(wait_state)
         details = {"timeout": timeout}
         prompt_id = _submitted_prompt_id(execution)
         if prompt_id is not None:
@@ -1075,9 +1086,14 @@ def execute_cloud(
         _tail_state_file(submit.prompt_id)
         return
 
-    # --wait: poll the cloud API directly from the foreground process.
-    # No watcher subprocess needed — simpler, no liveness/crash concerns,
-    # and the state file is written exactly once when the job finishes.
+    # --wait: poll the cloud API directly from the foreground process. No
+    # watcher subprocess is spawned — this process is the watcher, so it
+    # stamps its own pid + create_time on the submit-time record. Every
+    # in-process exit below (timeout, auth failure, HTTP error, Ctrl-C,
+    # failure, success) writes a terminal state the reap ignores; only an
+    # external kill leaves the record non-terminal, and its now-dead pid is
+    # what lets `jobs ls`'s stale-watcher reap finalize it as
+    # `watcher_crashed` instead of stranding it `running` forever.
     state = jobs_state.new(
         prompt_id=submit.prompt_id,
         client_id=client_id,
@@ -1086,6 +1102,7 @@ def execute_cloud(
         base_url=target.base_url,
     )
     state.item_map = (compose_meta or {}).get("items")
+    jobs_state.stamp_watcher_identity(state)
     state_file = jobs_state.write(state)
     _journal_run(workflow_name, submit.prompt_id, "cloud")
 

--- a/comfy_cli/jobs_state.py
+++ b/comfy_cli/jobs_state.py
@@ -40,6 +40,7 @@ won't change further; agents can stop polling.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -151,6 +152,24 @@ def read(prompt_id: str) -> JobState | None:
     except TypeError:
         # Required fields missing (e.g. truncated/legacy file) — treat as absent.
         return None
+
+
+def stamp_watcher_identity(state: JobState) -> None:
+    """Record the calling process as this record's watcher: pid + create_time
+    (both, or pid reuse defeats ``_is_watcher_alive``'s identity check).
+
+    Used by the detached watcher subprocess and by foreground ``--wait`` runs
+    alike — whichever process is actively finalizing the record stamps itself,
+    so the stale-watcher reap in ``jobs ls`` can finalize the record if that
+    process dies without running its handlers (killed from outside).
+    """
+    state.watcher_pid = os.getpid()
+    try:
+        import psutil
+
+        state.watcher_pid_create_time = psutil.Process().create_time()
+    except Exception:  # noqa: BLE001 — best effort; None just means liveness-only
+        state.watcher_pid_create_time = None
 
 
 def new(

--- a/comfy_cli/jobs_state.py
+++ b/comfy_cli/jobs_state.py
@@ -42,6 +42,8 @@ from __future__ import annotations
 import json
 import os
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -170,6 +172,67 @@ def stamp_watcher_identity(state: JobState) -> None:
         state.watcher_pid_create_time = psutil.Process().create_time()
     except Exception:  # noqa: BLE001 — best effort; None just means liveness-only
         state.watcher_pid_create_time = None
+
+
+@contextmanager
+def locked(prompt_id: str) -> Iterator[JobState | None]:
+    """Hold ``prompt_id``'s per-file lock and yield the record as it is on disk
+    *right now* (``None`` if there is no readable record).
+
+    Every writer of a job record — this module's ``write``, the watcher, the
+    foreground run, the reap in ``jobs ls`` — takes this same lock, so a
+    read-modify-write performed inside this block cannot interleave with
+    another process's write. ``write`` re-takes the lock, which is reentrant
+    within a thread, so calling it from inside the block is fine.
+
+    Yields ``None`` (without failing) when the id isn't one we can even name a
+    file for: callers are all best-effort bookkeeping paths that must not take
+    a command down over a state file.
+    """
+    try:
+        path = state_path(prompt_id)
+    except (ValueError, OSError, AttributeError, TypeError):
+        yield None
+        return
+    with locking.file_lock(path.with_suffix(".lock")):
+        yield read(prompt_id)
+
+
+def clear_watcher_identity(state: JobState) -> bool:
+    """Un-stamp this process as ``state``'s watcher and persist that, for a
+    process that is about to exit while deliberately leaving the record
+    NON-terminal (e.g. ``run --wait`` timing out on a job that is still running
+    server-side). Returns True if the on-disk record was rewritten.
+
+    Without this the record keeps a pid that is about to be dead, which is
+    exactly what the stale-watcher reap in ``jobs ls`` finalizes — it would
+    flip a healthy job to ``error``/``watcher_crashed``.
+
+    The read-modify-write runs under the record's lock against a *re-read*, not
+    against the caller's in-memory snapshot, which may be many minutes stale:
+    a concurrent ``comfy jobs cancel`` (or a watcher) can have made the record
+    terminal in the meantime, and blindly writing back the snapshot would walk
+    that verdict backwards to a non-terminal ``running`` that is then neither
+    terminal nor reapable — a permanent phantom. A record that is already
+    terminal, or that some other process has since stamped, is left untouched.
+    """
+    if not isinstance(state.prompt_id, str) or not state.prompt_id.strip():
+        return False
+    rewrote = False
+    try:
+        with locked(state.prompt_id) as on_disk:
+            if on_disk is not None and not on_disk.is_terminal and on_disk.watcher_pid == os.getpid():
+                on_disk.watcher_pid = None
+                on_disk.watcher_pid_create_time = None
+                rewrote = write(on_disk) is not None
+    except (OSError, ValueError):
+        # Same tolerance every other state-file write gets: bookkeeping must
+        # never fail an otherwise-handled exit path.
+        return False
+    # Keep the caller's snapshot in step so a later write can't re-stamp us.
+    state.watcher_pid = None
+    state.watcher_pid_create_time = None
+    return rewrote
 
 
 def new(

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -319,21 +319,27 @@ server all run through the foreground handlers, which write `error.code`
 (the classified execution verdict or `execution_error`; `cancelled`;
 `server_died`) before exiting.
 
-The gap is a `--wait` process that is **killed from outside** — a caller-imposed
-timeout (`SIGKILL`/`SIGTERM` on the process group), a terminal going away, the
-OS reaping the CLI alongside the server. No handler runs, so the state file is
-left at its submit-time `running`, and because `--wait` records no
-`watcher_pid`, `jobs ls`'s stale-watcher reap — which only fires on a recorded
-*and* dead pid — will not finalize it either. If the server then dies, nothing
-writes `server_died`.
+A `--wait` process that is **killed from outside** — a caller-imposed timeout
+(`SIGKILL`/`SIGTERM` on the process group), a terminal going away, the OS
+reaping the CLI alongside the server — runs no handler, so the state file is
+left at its submit-time `running`. To cover that, `--wait` (local and cloud)
+stamps its own `watcher_pid` (+ start time) on the submit-time record: the next
+`jobs ls` finds a non-terminal record whose recorded pid is dead, and its
+stale-watcher reap finalizes the job as `error` with `error_code:
+"watcher_crashed"` — the same treatment a crashed background watcher gets — and
+`jobs ls --orphaned` lists it. One exception keeps a live job safe: when
+`--wait` gives up on its *own* `--timeout` (`ws_timeout`), the job may genuinely
+still be running server-side, so the record stays `running` and the pid stamp is
+cleared — the reap never touches it, and `comfy jobs status <prompt_id>` can
+still consult the server.
 
-Attribution is degraded there, not lost: `comfy jobs status <prompt_id>` still
-names the job, its last-known status, and its workflow via `server_not_running`
-/ `prompt_not_found`. **For runs that may outlive the caller's patience, submit
-without `--wait`** — the async path spawns a watcher that survives the parent
-(its own session/process group), and it is the watcher that writes `server_died`
-when the server disappears mid-job. `comfy jobs ls` then reports both the status
-and the `error_code`.
+What the reap cannot tell you is *why* the process died, or what happened to the
+job afterwards — `watcher_crashed` records the watcher's death, not the job's
+outcome. **For runs that may outlive the caller's patience, submit without
+`--wait`** — the async path spawns a watcher that survives the parent (its own
+session/process group), and it is the watcher that writes `server_died` when the
+server disappears mid-job. `comfy jobs ls` then reports both the status and the
+`error_code`.
 
 A watcher is deliberately *not* spawned on `--wait`: it would put a second,
 independent writer on the state file the foreground already finalizes, add a

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -327,11 +327,21 @@ stamps its own `watcher_pid` (+ start time) on the submit-time record: the next
 `jobs ls` finds a non-terminal record whose recorded pid is dead, and its
 stale-watcher reap finalizes the job as `error` with `error_code:
 "watcher_crashed"` — the same treatment a crashed background watcher gets — and
-`jobs ls --orphaned` lists it. One exception keeps a live job safe: when
-`--wait` gives up on its *own* `--timeout` (`ws_timeout`), the job may genuinely
-still be running server-side, so the record stays `running` and the pid stamp is
-cleared — the reap never touches it, and `comfy jobs status <prompt_id>` can
-still consult the server.
+`jobs ls --orphaned` lists it. The stamp is dropped again on the exits where
+the job may genuinely still be alive on the server, so the reap can't claim a
+crash the CLI hasn't established: when local `--wait` gives up on its *own*
+`--timeout` (`ws_timeout`), and when cloud `--wait` dies on a network error
+that escapes its handlers (a DNS failure or connection reset while polling, as
+opposed to the handled `cloud_timeout` / `cloud_unauthorized` /
+`cloud_http_error` exits, which record a terminal verdict of their own). In
+both cases the record is left non-terminal with no pid, the reap never touches
+it, and `comfy jobs status <prompt_id>` can still consult the server for the
+real outcome.
+
+The reap itself never overwrites a verdict that landed first: it re-reads each
+record under that record's lock before rewriting it, so a `--wait` run
+finishing normally in the same instant keeps its `completed` status and its
+outputs.
 
 What the reap cannot tell you is *why* the process died, or what happened to the
 job afterwards — `watcher_crashed` records the watcher's death, not the job's

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -734,6 +734,38 @@ class TestWaitStateFile:
         assert "wait-slow" not in {r.prompt_id for r in orphans}
         assert jobs_state.read("wait-slow").status == "running"
 
+    def test_timeout_does_not_walk_back_a_concurrent_terminal_verdict(self, workflow_file, monkeypatch):
+        """`wait_state` is a snapshot taken at submit and never re-read, and a
+        `--wait` that times out is precisely the case where the prompt sat
+        queued long enough for someone to run `comfy jobs cancel` on it. The
+        stamp-clearing write must therefore re-read under the lock: writing the
+        stale snapshot back would walk a persisted terminal `cancelled` to a
+        non-terminal `running` with no pid — a record that is neither terminal
+        nor reapable, i.e. a permanent phantom."""
+        from comfy_cli import jobs_state
+
+        self._capture_errors(monkeypatch)
+        mock_exec = self._mock_exec("wait-raced")
+
+        def _cancel_then_timeout():
+            # Stand-in for a concurrent `comfy jobs cancel`: a terminal record
+            # lands on disk while this process is still blocked in the watch.
+            racer = jobs_state.read("wait-raced")
+            racer.status = "cancelled"
+            racer.error = {"code": "cancelled", "message": "Cancelled by user", "details": {}}
+            jobs_state.write(racer)
+            raise WebSocketTimeoutException("timed out")
+
+        mock_exec.watch_execution.side_effect = _cancel_then_timeout
+
+        with pytest.raises(typer.Exit):
+            self._run(workflow_file, mock_exec)
+
+        state = jobs_state.read("wait-raced")
+        assert state is not None
+        assert state.status == "cancelled", "the timeout handler overwrote a terminal verdict"
+        assert state.error["code"] == "cancelled"
+
     def test_timeout_before_submit_writes_no_state(self, workflow_file, monkeypatch):
         """`connect()` can raise WebSocketTimeoutException before `queue()`
         ever returns a prompt_id — `wait_state` is still None there, so the
@@ -1040,6 +1072,56 @@ class TestCloudWaitWatcherStamp:
         row = next(r for r in rows if r.prompt_id == "cloud-wait-slow")
         assert row.status == "error"
         assert row.error_code == "cloud_timeout", "the reap must not overwrite a terminal record's cause"
+
+    def test_unhandled_network_error_clears_stamp(self, workflow_file, fake_target):
+        """`Client._request` only converts `urllib.error.HTTPError`, so a DNS
+        failure / connection reset / TLS error escapes `wait_for_completion` as
+        a bare `URLError` matching none of the handlers. That kills this
+        process with the record non-terminal; the stamp must come off on the
+        way out or the next `jobs ls` reaps a cloud job that is still running
+        server-side into `error`/`watcher_crashed`, destroying the one thing
+        that made it reconcilable against the API."""
+        import urllib.error
+
+        from comfy_cli import jobs_state
+        from comfy_cli.command import jobs as jobs_mod
+
+        mock_client = self._mock_client("cloud-wait-urlerror")
+        mock_client.wait_for_completion.side_effect = urllib.error.URLError("dns went away")
+
+        with pytest.raises(urllib.error.URLError):
+            self._run_cloud(workflow_file, fake_target, mock_client)
+
+        state = jobs_state.read("cloud-wait-urlerror")
+        assert state is not None
+        # Still the submit-time `queued` — an unhandled escape must not invent
+        # a terminal verdict about a job the cloud may well still be running.
+        assert not state.is_terminal, "an unhandled escape must not invent a terminal verdict"
+        assert state.watcher_pid is None
+        assert state.watcher_pid_create_time is None
+
+        rows = jobs_mod._gather_local_state_files(limit=100)
+        row = next(r for r in rows if r.prompt_id == "cloud-wait-urlerror")
+        assert row.status == state.status
+        assert row.error_code is None
+
+    def test_unhandled_error_after_poll_clears_stamp(self, workflow_file, fake_target):
+        """Same guarantee past the polling loop: `extract_outputs` and the
+        rendering after it run before/after the terminal write with no handler
+        of their own."""
+        from comfy_cli import jobs_state
+
+        mock_client = self._mock_client("cloud-wait-extract-boom")
+        mock_client.wait_for_completion.return_value = {"status": {"status_str": "success"}, "outputs": {}}
+        mock_client.extract_outputs.side_effect = TypeError("malformed record")
+
+        with pytest.raises(TypeError):
+            self._run_cloud(workflow_file, fake_target, mock_client)
+
+        state = jobs_state.read("cloud-wait-extract-boom")
+        assert state is not None
+        assert not state.is_terminal
+        assert state.watcher_pid is None
 
 
 class TestDetectPartnerNodes:

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -629,6 +629,32 @@ class TestWaitStateFile:
         assert final.completed_at is not None
         assert final.submitted_at == mid_run["state"].submitted_at
 
+    def test_submit_time_record_carries_watcher_identity(self, workflow_file):
+        """The foreground --wait process IS the watcher, and the submit-time
+        record says so (BE-6641): pid + create_time stamped exactly like the
+        detached watcher's, so a --wait process killed from outside leaves a
+        record the stale-watcher reap can finalize instead of a permanent
+        phantom `running`."""
+        import psutil
+
+        from comfy_cli import jobs_state
+
+        mock_exec = self._mock_exec("wait-stamped")
+        mid_run = {}
+
+        def _observe_mid_run():
+            mid_run["state"] = jobs_state.read("wait-stamped")
+
+        mock_exec.watch_execution.side_effect = _observe_mid_run
+
+        self._run(workflow_file, mock_exec)
+
+        state = mid_run["state"]
+        assert state is not None
+        assert state.watcher_pid == os.getpid()
+        assert state.watcher_pid_create_time is not None
+        assert abs(state.watcher_pid_create_time - psutil.Process().create_time()) <= 1.0
+
     def test_disconnect_mid_run_records_server_died(self, workflow_file, monkeypatch):
         from comfy_cli import jobs_state
 
@@ -684,11 +710,48 @@ class TestWaitStateFile:
         assert err["details"] == {"timeout": 30, "prompt_id": "wait-slow"}
 
         # A timed-out watch says nothing about the job — it may still be
-        # running server-side, so the record stays non-terminal.
+        # running server-side, so the record stays non-terminal. The watcher
+        # stamp must be CLEARED on this one exit: this process is gone after
+        # the raise, and a recorded-but-dead pid on a non-terminal record is
+        # exactly what the stale-watcher reap flips to `watcher_crashed` —
+        # which would mark a healthy long-running job as errored.
         state = jobs_state.read("wait-slow")
         assert state is not None
         assert state.status == "running"
         assert state.completed_at is None
+        assert state.watcher_pid is None
+        assert state.watcher_pid_create_time is None
+
+        # And the reap agrees: the record survives `jobs ls` untouched and is
+        # never surfaced as an orphan.
+        from comfy_cli.command import jobs as jobs_mod
+
+        rows = jobs_mod._gather_local_state_files(limit=100)
+        row = next(r for r in rows if r.prompt_id == "wait-slow")
+        assert row.status == "running"
+        assert row.error_code is None
+        orphans = jobs_mod._gather_local_state_files(limit=100, orphaned_only=True)
+        assert "wait-slow" not in {r.prompt_id for r in orphans}
+        assert jobs_state.read("wait-slow").status == "running"
+
+    def test_timeout_before_submit_writes_no_state(self, workflow_file, monkeypatch):
+        """`connect()` can raise WebSocketTimeoutException before `queue()`
+        ever returns a prompt_id — `wait_state` is still None there, so the
+        handler's stamp-clearing must not blow up, and no state file exists
+        to rewrite."""
+        from comfy_cli import jobs_state
+
+        errors = self._capture_errors(monkeypatch)
+        mock_exec = self._mock_exec(None)
+        mock_exec.connect.side_effect = WebSocketTimeoutException("connect timed out")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(workflow_file, mock_exec)
+        assert exc_info.value.exit_code == 1
+
+        err = next(e for e in errors if e["code"] == "ws_timeout")
+        assert err["details"] == {"timeout": 30}
+        assert list(jobs_state.state_dir().glob("*.json")) == []
 
     def test_token_cancel_records_cancelled_state(self, workflow_file, fresh_token):
         from comfy_cli import jobs_state
@@ -742,10 +805,10 @@ class TestWaitStateFile:
         """`watch_execution` signals a failed node by raising `typer.Exit(1)`
         after rendering the error — the ordinary failure path, not an
         exception the disconnect handlers see. The submit-time `running`
-        record must still be moved to a terminal status, or the job is
-        stranded as a phantom nothing ever reaps (`jobs ls` only reaps
-        non-terminal records with a dead watcher_pid, which --wait never
-        sets)."""
+        record must still be moved to a terminal status here: the stale-
+        watcher reap would eventually flip it to a generic `watcher_crashed`
+        once this process exits, but the real classified verdict is known
+        right now and must not be lost to that fallback."""
         from comfy_cli import jobs_state
 
         mock_exec = self._mock_exec("wait-exec-error")
@@ -871,6 +934,112 @@ class TestWaitStateFile:
 
         assert emitted and emitted[-1]["status"] == "completed"
         assert emitted[-1]["state_file"] is None
+
+
+class TestCloudWaitWatcherStamp:
+    """Cloud `--wait` polls from the foreground with no watcher subprocess, so
+    the submit-time record stamps THIS process as the watcher (BE-6641) — an
+    external kill then leaves a non-terminal record with a dead pid, which
+    `jobs ls`'s stale-watcher reap finalizes as `watcher_crashed`. Every
+    in-process exit writes a terminal record the reap ignores."""
+
+    @pytest.fixture
+    def fake_target(self):
+        from comfy_cli.target import Target
+
+        return Target(
+            kind="cloud",
+            base_url="https://cloud.example.com",
+            path_prefix="/api",
+            history_path="history_v2",
+            jobs_path="jobs",
+            api_key="test-api-key",
+        )
+
+    def _run_cloud(self, workflow_file, fake_target, mock_client):
+        from comfy_cli.command.run import execute_cloud
+
+        with (
+            patch("comfy_cli.target.resolve_target", return_value=fake_target),
+            # Empty cloud object_info: preflight and partner detection both
+            # fail open, keeping the test on the submit/poll path under test.
+            patch("comfy_cli.cql.engine._load_from_target", return_value={}),
+            patch("comfy_cli.comfy_client.Client", return_value=mock_client),
+        ):
+            execute_cloud(workflow_file, wait=True, timeout=30)
+
+    def _mock_client(self, prompt_id):
+        from comfy_cli.comfy_client import SubmitResult
+
+        mock_client = MagicMock()
+        mock_client.submit_prompt.return_value = SubmitResult(prompt_id=prompt_id, number=1, node_errors={})
+        mock_client.extract_outputs.return_value = []
+        return mock_client
+
+    def test_submit_time_record_carries_watcher_identity(self, workflow_file, fake_target):
+        import psutil
+
+        from comfy_cli import jobs_state
+
+        mock_client = self._mock_client("cloud-wait-stamped")
+        mid_run = {}
+
+        def _observe_then_succeed(*args, **kwargs):
+            mid_run["state"] = jobs_state.read("cloud-wait-stamped")
+            return {"status": {"status_str": "success"}, "outputs": {}}
+
+        mock_client.wait_for_completion.side_effect = _observe_then_succeed
+
+        self._run_cloud(workflow_file, fake_target, mock_client)
+
+        state = mid_run["state"]
+        assert state is not None
+        assert state.watcher_pid == os.getpid()
+        assert state.watcher_pid_create_time is not None
+        assert abs(state.watcher_pid_create_time - psutil.Process().create_time()) <= 1.0
+
+    def test_success_writes_terminal_record_reap_is_noop(self, workflow_file, fake_target):
+        from comfy_cli import jobs_state
+        from comfy_cli.command import jobs as jobs_mod
+
+        mock_client = self._mock_client("cloud-wait-done")
+        mock_client.wait_for_completion.return_value = {"status": {"status_str": "success"}, "outputs": {}}
+
+        self._run_cloud(workflow_file, fake_target, mock_client)
+
+        state = jobs_state.read("cloud-wait-done")
+        assert state is not None
+        assert state.status == "completed"
+
+        rows = jobs_mod._gather_local_state_files(limit=100)
+        row = next(r for r in rows if r.prompt_id == "cloud-wait-done")
+        assert row.status == "completed"
+        assert row.error_code is None
+        assert jobs_state.read("cloud-wait-done").status == "completed"
+
+    def test_cloud_timeout_writes_terminal_record_reap_is_noop(self, workflow_file, fake_target):
+        """The cloud-side `--timeout` exit is TERMINAL (`cloud_timeout`) by
+        long-standing design — unlike the local ws_timeout, nothing needs to
+        clear the stamp, because the reap never touches terminal records."""
+        from comfy_cli import jobs_state
+        from comfy_cli.command import jobs as jobs_mod
+
+        mock_client = self._mock_client("cloud-wait-slow")
+        mock_client.wait_for_completion.side_effect = TimeoutError("job went silent for 30s")
+
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run_cloud(workflow_file, fake_target, mock_client)
+        assert exc_info.value.exit_code == 1
+
+        state = jobs_state.read("cloud-wait-slow")
+        assert state is not None
+        assert state.status == "error"
+        assert state.error["code"] == "cloud_timeout"
+
+        rows = jobs_mod._gather_local_state_files(limit=100)
+        row = next(r for r in rows if r.prompt_id == "cloud-wait-slow")
+        assert row.status == "error"
+        assert row.error_code == "cloud_timeout", "the reap must not overwrite a terminal record's cause"
 
 
 class TestDetectPartnerNodes:

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -896,9 +896,14 @@ def test_reap_finalizes_nonterminal_record_with_dead_watcher_pid(monkeypatch):
     # A real process that is provably gone: spawn, capture its create_time
     # while alive, then terminate and reap it.
     p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
-    create_time = psutil.Process(p.pid).create_time()
-    p.terminate()
-    p.wait()
+    try:
+        create_time = psutil.Process(p.pid).create_time()
+    finally:
+        # In `finally` so a create_time() failure can't leave a 30s sleeper
+        # behind for the rest of the suite.
+        if p.poll() is None:
+            p.terminate()
+        p.wait(timeout=10)
 
     state_dir = jobs_state.state_dir()
     _write_state(
@@ -941,6 +946,47 @@ def test_reap_leaves_nonterminal_record_without_pid_alone(monkeypatch):
     orphans = jobs_mod._gather_local_state_files(limit=100, orphaned_only=True)
     assert "wait-timed-out" not in {r.prompt_id for r in orphans}
     assert jobs_state.read("wait-timed-out").status == "running"
+
+
+def test_reap_reread_yields_to_a_writer_that_finished_first(monkeypatch):
+    """The reap's read → liveness-probe → write is not atomic, and `--wait`
+    runs now stamp their foreground pid, so an ordinary `comfy run --wait`
+    finishing normally can land its terminal `completed` write (outputs and
+    all) inside that window — every `jobs ls --watch` refresh tick re-runs the
+    scan. The write must re-derive its verdict from a re-read under the lock,
+    or it clobbers that result with a generic `watcher_crashed`."""
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(state_dir, "raced-record", status="running", watcher_pid=999_999)
+
+    # No live process behind the pid, so the snapshot check says "reap it".
+    monkeypatch.setattr(jobs_mod, "_is_watcher_alive", lambda state: False)
+
+    real_locked = jobs_state.locked
+
+    def _locked_after_writer_wins(prompt_id):
+        # Stand-in for the racing `--wait` process: its terminal write lands
+        # between our liveness probe and our own write.
+        if prompt_id == "raced-record":
+            winner = jobs_state.read("raced-record")
+            winner.status = "completed"
+            winner.outputs = ["out.png"]
+            winner.watcher_pid = None
+            jobs_state.write(winner)
+        return real_locked(prompt_id)
+
+    monkeypatch.setattr(jobs_state, "locked", _locked_after_writer_wins)
+
+    rows = jobs_mod._gather_local_state_files(limit=100)
+    row = next(r for r in rows if r.prompt_id == "raced-record")
+    assert row.status == "completed", "the reap overwrote a verdict that landed first"
+    assert row.error_code is None
+    assert row.outputs == 1
+
+    final = jobs_state.read("raced-record")
+    assert final.status == "completed"
+    assert final.outputs == ["out.png"]
 
 
 def _command_flags(*path: str) -> list[str]:

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -884,6 +884,65 @@ def test_orphaned_flag_filters_to_watcher_crashed(monkeypatch):
     assert orphan_ids == {"orphan-crashed"}, f"--orphaned should select only watcher_crashed rows; got {orphan_ids}"
 
 
+def test_reap_finalizes_nonterminal_record_with_dead_watcher_pid(monkeypatch):
+    """A `running` record carrying a dead pid + that pid's REAL create_time —
+    what a `comfy run --wait` killed from outside now leaves behind (BE-6641)
+    — is flipped by the reap to `error`/`watcher_crashed`, surfaces under
+    `--orphaned`, and the pid pair is cleared in the rewritten file."""
+    import psutil
+
+    from comfy_cli import jobs_state
+
+    # A real process that is provably gone: spawn, capture its create_time
+    # while alive, then terminate and reap it.
+    p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    create_time = psutil.Process(p.pid).create_time()
+    p.terminate()
+    p.wait()
+
+    state_dir = jobs_state.state_dir()
+    _write_state(
+        state_dir,
+        "wait-killed",
+        status="running",
+        watcher_pid=p.pid,
+        watcher_pid_create_time=create_time,
+    )
+
+    rows = jobs_mod._gather_local_state_files(limit=100)
+    row = next(r for r in rows if r.prompt_id == "wait-killed")
+    assert row.status == "error"
+    assert row.error_code == "watcher_crashed"
+
+    orphans = jobs_mod._gather_local_state_files(limit=100, orphaned_only=True)
+    assert "wait-killed" in {r.prompt_id for r in orphans}
+
+    rewritten = jobs_state.read("wait-killed")
+    assert rewritten.status == "error"
+    assert rewritten.error["code"] == "watcher_crashed"
+    assert rewritten.watcher_pid is None
+    assert rewritten.watcher_pid_create_time is None
+
+
+def test_reap_leaves_nonterminal_record_without_pid_alone(monkeypatch):
+    """A `running` record with NO recorded pid — what a local `--wait` that
+    hit its own `--timeout` deliberately leaves (the job may still be running
+    server-side) — must never be reaped or listed as an orphan."""
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(state_dir, "wait-timed-out", status="running", watcher_pid=None)
+
+    rows = jobs_mod._gather_local_state_files(limit=100)
+    row = next(r for r in rows if r.prompt_id == "wait-timed-out")
+    assert row.status == "running"
+    assert row.error_code is None
+
+    orphans = jobs_mod._gather_local_state_files(limit=100, orphaned_only=True)
+    assert "wait-timed-out" not in {r.prompt_id for r in orphans}
+    assert jobs_state.read("wait-timed-out").status == "running"
+
+
 def _command_flags(*path: str) -> list[str]:
     """Flags exposed for a command path via the machine-readable help contract.
 


### PR DESCRIPTION
## ELI-5

`comfy run --wait` sits in the foreground watching a job. If that process is killed from the outside — a CI `timeout` command SIGKILLing it, the terminal window closing — no cleanup code runs, and the job's on-disk record says `running` forever. Worse, the existing janitor in `comfy jobs ls` (which cleans up after crashed background watchers) skipped these records, because `--wait` never wrote down *which process* was watching. This PR makes `--wait` write its own process id on the record at submit time, so the janitor now recognizes a killed `--wait` run the same way it recognizes a crashed background watcher: the next `comfy jobs ls` marks it `error` / `watcher_crashed`, and `jobs ls --orphaned` lists it for cleanup.

One case deliberately goes the other way: when `--wait` gives up on its **own** `--timeout`, the job may genuinely still be running on the server — so there the pid stamp is **cleared** before exiting. Without that clear, a `--wait --timeout 60` against a long-running job would leave a dead pid behind and the janitor would wrongly mark a *healthy* job as crashed — a regression worse than the gap being closed.

## What changed

- **`comfy_cli/jobs_state.py`** — new `stamp_watcher_identity(state)`: records the calling process's pid + psutil `create_time` (both, or pid reuse defeats `_is_watcher_alive`'s identity check). Tolerant `except` mirrors the previous inline code; `None` create_time falls back to liveness-only in the reap.
- **`comfy_cli/command/job_watcher.py`** — the detached watcher's inline pid+create_time stamping (previously lines 81–89) now calls the shared helper. Behavior identical.
- **Local `--wait`** (`run/__init__.py::execute`) — the submit-time `running` record is stamped before the write. The `WebSocketTimeoutException` handler — the ONE exit that deliberately leaves the record non-terminal — clears the pid pair and rewrites the file before erroring out. The clear is guarded on `wait_state is not None` because `execution.connect()` raises the same exception before `wait_state` exists.
- **Cloud `--wait`** (`execute_cloud`) — the submit-time record is stamped the same way. No clearing needed anywhere on this path: every in-process exit (`cloud_timeout`, `Unauthenticated`, `HTTPError`, Ctrl-C, prompt-rejected, failure, success) already writes a terminal state, which the reap ignores; only an external kill leaves the record non-terminal, and reaping that is the point. The reap is deliberately where-agnostic (`jobs.py::_gather_local_state_files`), so it covers cloud records with zero reap changes.
- **Docs/comments** — the "Known limit: `--wait` has no background watcher" section in `docs/json-output.md` and the two comment blocks in `run/__init__.py` that said "`--wait` never sets a watcher_pid" now describe the stamped behavior. Still no watcher subprocess on `--wait` — the second-writer/second-connection rationale for that is unchanged.

## Exit-path audit (why only ws_timeout clears)

All other exits from the local wait branch mark the record terminal, and the reap only touches non-terminal records: `typer.Exit` from `watch_execution` → `_mark_watch_exit`; post-watch cancel token and `KeyboardInterrupt` → `_mark_cancelled`; success → `completed`; WS/Conn/OSError with the cancel token set → `_mark_cancelled`; with a prompt_id → `server_died`. The WS/Conn/OSError fallthrough without a prompt_id can only leave no on-disk record (a non-string prompt_id means `jobs_state.write` refused the submit-time write too). An *uncaught* exception (or a best-effort terminal write that fails) leaves `running` + dead pid → reaped as `watcher_crashed`, which is accurate — the foreground watcher did die — and strictly better than today's forever-`running`; no clearing was added for those, deliberately.

## Testing

All new tests are in `tests/comfy_cli/command/test_run.py` and `tests/comfy_cli/jobs/test_jobs.py`, both directions:

- **Stamp (local + cloud):** mid-run, the submit-time record carries `watcher_pid == os.getpid()` and a `create_time` within 1.0s of `psutil.Process().create_time()`.
- **Killed → reaped:** a `running` record carrying a provably-dead pid + its real create_time (spawned child, create_time captured while alive, then terminated and reaped) is flipped by `_gather_local_state_files` to `error`/`watcher_crashed`, appears under `orphaned_only=True`, and the pid pair is cleared in the rewritten file.
- **Timed-out-but-alive → NOT reaped:** `watch_execution` raising `WebSocketTimeoutException` leaves the record `running` with `watcher_pid is None`, and a subsequent `_gather_local_state_files` leaves it `running` and excludes it from `--orphaned`.
- **Timeout-before-submit:** `connect()` raising `WebSocketTimeoutException` (wait_state still None) doesn't crash the handler and writes no state file.
- **Cloud terminal exits:** mocked `wait_for_completion` success and `TimeoutError` both yield terminal records on which the reap is a no-op (the `cloud_timeout` cause is not overwritten).
- **Watcher regression:** `tests/comfy_cli/command/test_jobs_pid_alive.py` passes unchanged after the helper extraction.

`ruff check` + `ruff format --check` green at CI's pinned ruff version. Full suite green: `pytest -q` — **4343 passed, 37 skipped** (16m01s), plus the targeted suites (`test_run.py`, `test_jobs.py`, `test_jobs_pid_alive.py` — 303 tests) run separately.

### End-to-end SIGKILL check (not just the unit halves)

The unit tests prove the stamp and the reap independently — mocked execution can't be `kill -9`'d. So the two halves were also joined manually against a real killed process: a Python process ran exactly the submit-time sequence from the `--wait` branch (`jobs_state.new` → `status = "running"` → `stamp_watcher_identity` → `write`) into an isolated state dir, then was `kill -9`'d. The on-disk record was left `"status": "running"` with `watcher_pid: 33147` / a real `watcher_pid_create_time`, as expected. Running the reap afterwards:

```
jobs ls            -> killed-wait-job error watcher_crashed
jobs ls --orphaned -> [('killed-wait-job', 'error', 'watcher_crashed')]
rewritten file     -> error {'code': 'watcher_crashed', ...} watcher_pid: None None
```

That is acceptance criterion 1 verified against a genuine external kill, with zero changes to the reap.

## Judgment calls

- The reap message still says "Background watcher (pid N) is no longer running" even though the dead process is now sometimes a foreground `--wait`. The ticket allowed rewording only if it caused no test churn — two existing test assertions pin the current wording, so it stays.
- Terminal `--wait` records now carry the (by-then-dead) pid pair on disk, same as terminal records written by the detached watcher always have. The reap's non-terminal gate means this is inert; no consumer reads `watcher_pid` outside the reap (audited `_is_watcher_alive` + `_gather_local_state_files`).


## Self-review notes

- **Call-site completeness.** All four `jobs_state.new(...)` sites were audited: local `--wait` (stamped here), local async and cloud async (the detached watcher stamps itself via the same helper), and cloud `--wait` (stamped here). No record-creating path is left unstamped, and no consumer other than the reap reads `watcher_pid` (`git grep watcher_pid` across `comfy_cli/` — only `jobs.py`'s `_is_watcher_alive` + `_gather_local_state_files`), so `jobs cancel` / `jobs watch` / `jobs status` are unaffected.
- **Terminal records keep an inert dead pid.** Both `--wait` paths leave the pid pair on the record after a terminal write, exactly as the detached watcher always has; the reap's non-terminal gate makes it inert.
- **Best-effort write.** If the `ws_timeout` stamp-clearing write fails (unwritable state dir), `_write_state` swallows it and the record keeps the dead pid, so a later `jobs ls` would reap it. That is the pre-existing best-effort contract of every state write on this path, not new behavior introduced here.
- **Negative-claim falsification (per the review protocol):** not triggered — this change adds no "not supported"/deny/dead-end path and denies no capability. Its user-facing effect is the opposite: records that were previously stranded and invisible to `jobs ls --orphaned` are now finalized and listed. The one place behavior is deliberately *withheld* (the `ws_timeout` clear) preserves today's non-reap behavior for a job that may still be alive, and the empirical check above confirms the reap still fires everywhere else.


---

## Review resolution (commit `62b1278`)

Eight cursor-review findings + one CodeRabbit finding. Four fixed, four answered on-thread, one test cleanup. All nine threads resolved with replies.

The findings that held up were one family: **now that every `--wait` run stamps a pid, three write paths that were previously harmless can overwrite a verdict that landed first.**

- **`jobs_state`** — new `locked(prompt_id)` (yields the on-disk record while holding that record's lock; `write` is reentrant inside it) and `clear_watcher_identity(state)`, which un-stamps via a locked read-modify-write and no-ops on a record that has since gone terminal or been re-stamped.
- **Local `ws_timeout`** — clears the stamp through that helper instead of writing back the submit-time snapshot. `wait_state` is a snapshot taken at submit and never re-read, and a timeout is *precisely* the case where the prompt sat queued long enough for a `comfy jobs cancel` to land — the old blind write walked that terminal `cancelled` back to a non-terminal `running` with no pid, i.e. a record neither terminal nor reapable. The clear also now runs **before** the pretty-mode render rather than after, shrinking the window an external kill can strand.
- **Cloud `--wait`** — every exit past the submit write is guarded. `Client._request` (`comfy_client.py:268`) only converts `urllib.error.HTTPError`, so a DNS failure / connection reset / TLS error from `wait_for_completion` escapes as a bare `URLError` matching no handler, and `extract_outputs` + the rendering after it are unguarded too. The record was left non-terminal **and** stamped, so the next `jobs ls` reaped a cloud job still running server-side into `error`/`watcher_crashed`. It now drops the stamp on the way out and stays reconcilable against the API.

  **This revises the "Exit-path audit" section above**, which concluded no clearing was needed on the cloud path. That reasoning holds for local (a dead foreground watcher is the whole story) but not for cloud, where the job outlives the process — `watcher_crashed` there asserts something the CLI has not established.
- **The reap** (`jobs.py::_gather_local_state_files`) — re-derives its verdict from a re-read *inside* the record's lock. Its read → liveness-probe → write was non-atomic, and `--wait` runs stamping a foreground pid put an ordinary `comfy run --wait` finishing normally inside that window; the reap clobbered its `completed` status and its outputs with a generic `watcher_crashed`, on every `jobs ls --watch` refresh tick. Keyed on the filename rather than the stored id, so a record whose id disagrees with its file can't send the lock elsewhere.
- **CodeRabbit** — the spawned child in the reap test is terminated in a `finally`, so a `create_time()` failure can't leak a 30s sleeper into the rest of the suite.

**Answered, not changed** (full reasoning on each thread): the `_write_state` best-effort tolerance on both the success and clearing paths (a state dir that can't take a few hundred bytes has already broken `jobs ls`/`jobs status`/the submit write; a retry buys nothing against ENOSPC); a SIGTERM handler (an external kill leaving a stamped record *is* the mechanism, not a bug — and a process-wide signal handler is a CLI-semantics decision, not a bugfix); skipping the stamp when `create_time` is `None` (`psutil` is a hard dep and the call introspects our own process, so the branch is effectively unreachable — and a pid-only stamp is strictly better than none, not worse); and the shared/NFS-home cross-host reap (pre-existing for the detached watcher, and a schema + reap redesign for a configuration ComfyUI doesn't target).

### Verification

- Each of the four new tests was run with its fix reverted and confirmed to fail: `test_timeout_does_not_walk_back_a_concurrent_terminal_verdict`, `test_unhandled_network_error_clears_stamp`, `test_unhandled_error_after_poll_clears_stamp`, `test_reap_reread_yields_to_a_writer_that_finished_first`.
- Full suite green: `pytest -q` — **4348 passed, 36 skipped** (9m26s).
- `ruff check` + `ruff format --check` clean on all touched files.
