### PR TITLE
fix(jobs): read the fields /api/jobs/<id> actually serves — restore error text for failed cloud jobs (BE-6645)

### DIFF
--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -448,8 +448,16 @@ def _poll_cloud_once(state: jobs_state.JobState, *, client: Any = None) -> bool:
         # `error_message` string. `classify` parses either shape, so hand it
         # whichever the deployment actually sent — without this the watcher
         # classifies `None` and writes the generic "ComfyUI reported an
-        # execution error." into every failed cloud job's state file.
-        verdict = execution_errors.classify(record.get("error_message") or record.get("execution_error"))
+        # execution error." into every failed cloud job's state file. The
+        # structured object wins when both are present: a deployment that also
+        # fills `error_message` with a short generic string would otherwise
+        # discard `node_id`/`exception_type`/`traceback_tail`, and the state
+        # file keeps no other copy of them. (`classify`'s details are built
+        # field-by-field, so the secret-bearing `current_inputs` never reaches
+        # the state file — see `execution_errors.redact_record`.)
+        structured = record.get("execution_error")
+        raw_cause = structured if isinstance(structured, dict) else (record.get("error_message") or structured)
+        verdict = execution_errors.classify(raw_cause)
         state.error = {
             "code": verdict["code"],
             "message": verdict["message"],

--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -382,6 +382,24 @@ _CLOUD_STATUS_MAP = {
 }
 
 
+def _cloud_record_meta(record: dict) -> dict[str, Any]:
+    """The metadata fields a cloud terminal verdict attaches to ``details``.
+
+    ``/api/jobs/<id>`` (``JobDetailResponse``) serves the timestamps as Unix
+    millisecond ints; the deprecated ``/api/job/<id>/status`` served ready-made
+    ``created_at``/``updated_at`` strings, and is the only dialect that ever
+    served ``assigned_inference``. Read both, old names first, so the state
+    file keeps the string shape it has always carried.
+    """
+    from comfy_cli.command.jobs import _ms_to_iso
+
+    return {
+        "assigned_inference": record.get("assigned_inference"),
+        "created_at": record.get("created_at") or _ms_to_iso(record.get("create_time")),
+        "updated_at": record.get("updated_at") or _ms_to_iso(record.get("update_time")),
+    }
+
+
 def _poll_cloud_once(state: jobs_state.JobState, *, client: Any = None) -> bool:
     """Update ``state`` in-place from Comfy Cloud. Return True if terminal."""
     try:
@@ -424,22 +442,26 @@ def _poll_cloud_once(state: jobs_state.JobState, *, client: Any = None) -> bool:
                 pass
         return True
     if state.status == "error":
-        verdict = execution_errors.classify(record.get("error_message"))
+        # Same endpoint move as `jobs._cloud_status_snapshot`: `/api/jobs/<id>`
+        # serves the cause as a structured `execution_error` object, while the
+        # deprecated `/api/job/<id>/status` served a JSON-encoded
+        # `error_message` string. `classify` parses either shape, so hand it
+        # whichever the deployment actually sent — without this the watcher
+        # classifies `None` and writes the generic "ComfyUI reported an
+        # execution error." into every failed cloud job's state file.
+        verdict = execution_errors.classify(record.get("error_message") or record.get("execution_error"))
         state.error = {
             "code": verdict["code"],
             "message": verdict["message"],
             "hint": verdict["hint"],
-            "details": {
-                **verdict["details"],
-                **{k: record.get(k) for k in ("assigned_inference", "created_at", "updated_at")},
-            },
+            "details": {**verdict["details"], **_cloud_record_meta(record)},
         }
         return True
     if state.status == "cancelled":
         state.error = {
             "code": "cancelled",
             "message": record.get("error_message") or "Cloud job was cancelled.",
-            "details": {k: record.get(k) for k in ("assigned_inference", "created_at", "updated_at")},
+            "details": _cloud_record_meta(record),
         }
         return True
     return False

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -184,8 +184,21 @@ def _emit_terminal(renderer, payload: dict, *, command: str, where: str | None =
         raw = payload.get("error_message") or payload.get("details")
     message = raw if isinstance(raw, str) else None
     hint = None
+    # This whole payload becomes `renderer.error(details=...)`, and a cloud
+    # snapshot's structured record carries the full server traceback — the very
+    # blob the trimming below exists to keep out of an envelope. Cap it before
+    # the status branches so the `cancelled` path is covered too; the full
+    # record stays reachable via `comfy --json jobs status <prompt_id>`.
+    structured = payload.get("execution_error")
+    if isinstance(structured, dict):
+        structured = execution_errors.trim_record(structured)
+        payload["execution_error"] = structured
     if status == "error":
-        verdict = execution_errors.classify(raw)
+        # Classify the structured record itself when the cloud snapshot
+        # carries one: re-parsing the flattened one-liner would JSON-sniff an
+        # `exception_message` that is itself JSON (API nodes commonly raise
+        # with raw JSON bodies) and decode it back into a fields-less dict.
+        verdict = execution_errors.classify(structured if isinstance(structured, dict) else raw)
         code, message, hint = verdict["code"], verdict["message"], verdict["hint"]
         # The raw server text repeats the full traceback; keep the envelope to
         # the one-line cause + structured tail and leave the full record to
@@ -2094,27 +2107,44 @@ def _execution_error_line(err: Any) -> str | None:
     ``traceback``, ``current_inputs``) — unlike the deprecated
     ``/api/job/<id>/status``, which served a single JSON-encoded
     ``error_message`` string. Flatten it back to the one-line shape the pretty
-    `error` row and `_emit_terminal`'s `execution_errors.classify` fallback
-    both consume. Returns ``None`` when the object carries nothing nameable, so
-    a present-but-empty record never fabricates an error line.
+    `error` row and the snapshot's top-level ``error_message`` both consume
+    (``_emit_terminal`` classifies the structured record directly, so it never
+    round-trips through this line). Returns ``None`` when the record carries
+    nothing nameable, so a present-but-empty record never fabricates an error
+    line.
+
+    Parsing is delegated to ``execution_errors.parse_error_message`` so this
+    path and the watcher's ``classify`` path agree on *what the record says*
+    whatever shape it arrives in — dict, JSON-encoded string or plain text.
+    Only the rendering differs: the line below keeps ``exception_type``, which
+    ``classify``'s envelope message drops in favour of the node prefix, and the
+    pretty `error` row is the one place that type is surfaced to a human.
     """
-    if not isinstance(err, dict):
-        return None
-    exception_message = str(err.get("exception_message") or "").strip()
-    exception_type = str(err.get("exception_type") or "").strip()
-    node_id = err.get("node_id")
-    node_type = str(err.get("node_type") or "").strip()
+    parsed = execution_errors.parse_error_message(err)
+
+    def _one_line(value: Any) -> str:
+        # `split()` on arbitrary whitespace, not `strip()`: an
+        # `exception_message` with internal newlines (common for multi-line
+        # server errors) would otherwise blow up a helper documented as
+        # rendering "one human line" into a multi-row Rich cell.
+        return " ".join(str(value or "").split())
+
+    exception_message = _one_line(parsed.get("exception_message"))
+    exception_type = _one_line(parsed.get("exception_type"))
+    node_id = _one_line(parsed.get("node_id"))
+    node_type = _one_line(parsed.get("node_type"))
 
     # Joining the present parts (rather than formatting both unconditionally)
     # is what keeps a record missing one field from rendering `ValueError: `
     # with a dangling separator.
     head = ": ".join(part for part in (exception_type, exception_message) if part)
-    # `is None`, not falsiness: node `0` is a real node id and must survive.
-    node_id = "" if node_id is None else str(node_id).strip()
     where = " ".join(part for part in (f"node {node_id}" if node_id else "", node_type) if part)
-    if head and where:
-        return f"{head} ({where})"
-    return head or (f"({where})" if where else None)
+    if not where:
+        return head or None
+    # A record with node fields but no exception text used to render the bare
+    # parenthetical `(node 5 KSampler)` — a cause-less error row. Borrow
+    # `classify`'s stand-in cause so the line always states one.
+    return f"{head or 'ComfyUI reported an execution error.'} ({where})"
 
 
 def _ms_to_iso(value: Any) -> str | None:
@@ -2178,13 +2208,30 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     # `/api/jobs/<id>` (JobDetailResponse) serves the failure cause as a
     # structured `execution_error` object and the timestamps as Unix-ms ints —
     # the deprecated `/api/job/<id>/status` served `error_message` /
-    # `created_at` / `updated_at` instead. Read the new names, keeping the old
-    # ones as the first choice so a deployment still on the old dialect (whose
-    # `error_message` is the JSON-encoded record `classify` parses in full)
-    # keeps working unchanged.
-    execution_error = status.get("execution_error")
-    execution_error = execution_error if isinstance(execution_error, dict) else None
-    error_message = status.get("error_message") or _execution_error_line(execution_error)
+    # `created_at` / `updated_at` instead. Read both dialects: the timestamps
+    # keep the old names as first choice (they carry the same information in a
+    # ready-made shape), while the failure cause prefers the structured record
+    # — see below.
+    raw_execution_error = status.get("execution_error")
+    # `current_inputs` — the failing node's widget values — can carry API keys,
+    # and this record is emitted verbatim by `jobs status`. Redact before it
+    # enters the payload at all, not at each rendering site.
+    execution_error = (
+        execution_errors.redact_record(raw_execution_error) if isinstance(raw_execution_error, dict) else None
+    )
+    # Only a *failed* job gets a cause synthesized from the record: a stale
+    # `execution_error` left on a retried-then-succeeded job would otherwise
+    # fabricate an `error` row on a green one. `canceled` is spelled out
+    # alongside `_ERROR_STATUSES` because the state map above deliberately
+    # leaves cloud's one-l spelling unmapped (BE-6612).
+    failed = state in _ERROR_STATUSES or state == "canceled"
+    # The structured record wins over `error_message` when the server sent
+    # one: a deployment that fills `error_message` with a short generic string
+    # ("job failed") alongside a detailed object would otherwise discard the
+    # only copy of the real cause. Non-dict shapes (the deprecated dialect's
+    # JSON-encoded string) still parse — `_execution_error_line` routes
+    # everything through `execution_errors.parse_error_message`.
+    error_message = (_execution_error_line(raw_execution_error) if failed else None) or status.get("error_message")
 
     return {
         "prompt_id": prompt_id,

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -26,7 +26,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from dataclasses import dataclass, field, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
@@ -2086,6 +2086,55 @@ def _cloud_client():
         raise typer.Exit(code=1) from e
 
 
+def _execution_error_line(err: Any) -> str | None:
+    """Render a ``JobDetailResponse.execution_error`` object as one human line.
+
+    ``/api/jobs/<id>`` serves a failed job's cause as a structured object
+    (``node_id``, ``node_type``, ``exception_message``, ``exception_type``,
+    ``traceback``, ``current_inputs``) — unlike the deprecated
+    ``/api/job/<id>/status``, which served a single JSON-encoded
+    ``error_message`` string. Flatten it back to the one-line shape the pretty
+    `error` row and `_emit_terminal`'s `execution_errors.classify` fallback
+    both consume. Returns ``None`` when the object carries nothing nameable, so
+    a present-but-empty record never fabricates an error line.
+    """
+    if not isinstance(err, dict):
+        return None
+    exception_message = str(err.get("exception_message") or "").strip()
+    exception_type = str(err.get("exception_type") or "").strip()
+    node_id = err.get("node_id")
+    node_type = str(err.get("node_type") or "").strip()
+
+    # Joining the present parts (rather than formatting both unconditionally)
+    # is what keeps a record missing one field from rendering `ValueError: `
+    # with a dangling separator.
+    head = ": ".join(part for part in (exception_type, exception_message) if part)
+    # `is None`, not falsiness: node `0` is a real node id and must survive.
+    node_id = "" if node_id is None else str(node_id).strip()
+    where = " ".join(part for part in (f"node {node_id}" if node_id else "", node_type) if part)
+    if head and where:
+        return f"{head} ({where})"
+    return head or (f"({where})" if where else None)
+
+
+def _ms_to_iso(value: Any) -> str | None:
+    """Convert a Unix-millisecond timestamp to an ISO-8601 UTC string.
+
+    ``JobDetailResponse`` serves ``create_time``/``update_time`` as integer
+    milliseconds, where the deprecated status endpoint served ready-made
+    ``created_at``/``updated_at`` strings. Callers (the pretty table rows, the
+    JSON fields) expect the string shape, so normalize here. Anything that
+    isn't a finite, representable number returns ``None`` rather than raising —
+    a malformed timestamp must not take down a `jobs status` call.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return datetime.fromtimestamp(float(value) / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
 def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     """Compose a cloud snapshot from /api/jobs/<id> + /api/history_v2/<id>."""
     from comfy_cli import jobs_state
@@ -2126,16 +2175,33 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
             item_map = job.item_map if job is not None else None
             outputs_by_node, outputs_by_item = _group_outputs(node_outputs, item_map)
 
+    # `/api/jobs/<id>` (JobDetailResponse) serves the failure cause as a
+    # structured `execution_error` object and the timestamps as Unix-ms ints —
+    # the deprecated `/api/job/<id>/status` served `error_message` /
+    # `created_at` / `updated_at` instead. Read the new names, keeping the old
+    # ones as the first choice so a deployment still on the old dialect (whose
+    # `error_message` is the JSON-encoded record `classify` parses in full)
+    # keeps working unchanged.
+    execution_error = status.get("execution_error")
+    execution_error = execution_error if isinstance(execution_error, dict) else None
+    error_message = status.get("error_message") or _execution_error_line(execution_error)
+
     return {
         "prompt_id": prompt_id,
         "status": state,
         "outputs": outputs,
         "outputs_by_node": outputs_by_node,
         "outputs_by_item": outputs_by_item,
+        # Not served by the plural jobs-detail endpoint at all — kept so an
+        # older deployment still populates it; never synthesized.
         "assigned_inference": status.get("assigned_inference"),
-        "error_message": status.get("error_message"),
-        "created_at": status.get("created_at"),
-        "updated_at": status.get("updated_at"),
+        "error_message": error_message,
+        # The full structured record rides along for `--json` consumers; the
+        # flattened one-liner above is what the pretty row and the envelope
+        # classification read.
+        "execution_error": execution_error,
+        "created_at": status.get("created_at") or _ms_to_iso(status.get("create_time")),
+        "updated_at": status.get("updated_at") or _ms_to_iso(status.get("update_time")),
         "base_url": client.target.base_url,
     }
 

--- a/comfy_cli/execution_errors.py
+++ b/comfy_cli/execution_errors.py
@@ -30,6 +30,43 @@ _TRANSIENT_AUTH_MARKER = "please login first to use this node"
 # How many trailing traceback frames survive into envelope details.
 _TRACEBACK_TAIL_FRAMES = 2
 
+# Fields of a server ``execution_error`` record that must never reach an error
+# envelope: ``current_inputs`` is the failing node's widget values, which
+# routinely carry API keys and other user secrets. JSON mode engages
+# automatically for non-TTY output, so an unredacted record lands verbatim in
+# CI logs and agent transcripts.
+_SECRET_RECORD_KEYS = frozenset({"current_inputs"})
+
+
+def redact_record(record: Any) -> Any:
+    """Drop the ``execution_error`` fields that may carry user secrets.
+
+    Non-dict input is returned unchanged — callers pass whatever the server
+    sent, and only the object dialect has fields to redact.
+    """
+    if not isinstance(record, dict):
+        return record
+    return {k: v for k, v in record.items() if k not in _SECRET_RECORD_KEYS}
+
+
+def trim_record(record: Any) -> Any:
+    """:func:`redact_record` plus the traceback capped at its tail frames.
+
+    What an *envelope* may carry: the same two-frame budget
+    :func:`classify` applies to ``details["traceback_tail"]``. The full server
+    traceback stays reachable via ``comfy --json jobs status <prompt_id>``,
+    which is the documented place for it.
+    """
+    if not isinstance(record, dict):
+        return record
+    out = redact_record(record)
+    tb = out.get("traceback")
+    if isinstance(tb, str):
+        tb = [tb]
+    if isinstance(tb, (list, tuple)) and len(tb) > _TRACEBACK_TAIL_FRAMES:
+        out["traceback"] = [str(frame) for frame in tb[-_TRACEBACK_TAIL_FRAMES:]]
+    return out
+
 
 def parse_error_message(raw: Any) -> dict[str, Any]:
     """Normalize a job-failure payload into flat fields.
@@ -65,6 +102,13 @@ def parse_error_message(raw: Any) -> dict[str, Any]:
     }
     tb = data.get("traceback") or []
     if isinstance(tb, str):
+        tb = [tb]
+    elif not isinstance(tb, (list, tuple)):
+        # A server that serves `traceback` as a scalar or an object must not
+        # take the caller down: `tb[-2:]` raises TypeError on a non-sequence,
+        # and `job_watcher._poll_cloud_once` guards only the HTTP fetch — the
+        # detached watcher would die mid-poll and strand the state file in a
+        # non-terminal status forever.
         tb = [tb]
     if tb:
         out["traceback_tail"] = [str(frame) for frame in tb[-_TRACEBACK_TAIL_FRAMES:]]

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -28,6 +28,11 @@
       "description": "Cloud status/watch terminal: artifact URLs grouped by blueprint foreach item (via the compose item_map on the job state file). Empty object when no item_map exists.",
       "additionalProperties": {"type": "array", "items": {"type": "string"}}
     },
+    "execution_error": {
+      "type": ["object", "null"],
+      "description": "Cloud `jobs status`/`jobs watch`: the failed job's structured cause, passed through verbatim from `/api/jobs/<id>` (`JobDetailResponse.execution_error` — `node_id`, `node_type`, `exception_message`, `exception_type`, `traceback`, `current_inputs`). Null on every job the server reports no execution error for. The top-level `error_message` is the same record flattened to one human line; this key is what a `--json` consumer reads to get the fields back without re-parsing that line.",
+      "additionalProperties": true
+    },
     "scope": {
       "type": "string",
       "enum": ["local", "cloud", "all"],

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -30,7 +30,7 @@
     },
     "execution_error": {
       "type": ["object", "null"],
-      "description": "Cloud `jobs status`/`jobs watch`: the failed job's structured cause, passed through verbatim from `/api/jobs/<id>` (`JobDetailResponse.execution_error` — `node_id`, `node_type`, `exception_message`, `exception_type`, `traceback`, `current_inputs`). Null on every job the server reports no execution error for. The top-level `error_message` is the same record flattened to one human line; this key is what a `--json` consumer reads to get the fields back without re-parsing that line.",
+      "description": "Cloud `jobs status`/`jobs watch`: the failed job's structured cause from `/api/jobs/<id>` (`JobDetailResponse.execution_error` — `node_id`, `node_type`, `exception_message`, `exception_type`, `traceback`). Null on every job the server reports no execution error for. `current_inputs` is always redacted — the failing node's widget values routinely carry API keys — and on the `jobs watch` terminal envelope `traceback` is capped at its last two frames, the same budget `error.details.traceback_tail` uses; `jobs status` carries it in full. The top-level `error_message` is the same record flattened to one human line; this key is what a `--json` consumer reads to get the fields back without re-parsing that line.",
       "additionalProperties": true
     },
     "scope": {

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2056,8 +2056,14 @@ def test_cloud_status_snapshot_reads_execution_error_and_ms_timestamps(monkeypat
     assert snap["error_message"] == (
         "torch.cuda.OutOfMemoryError: Allocation on device 0 would exceed allowed memory (node 5 KSampler)"
     )
-    # The full record rides along untouched for `--json` consumers.
-    assert snap["execution_error"] == _FAILED_DETAIL["execution_error"]
+    # The record rides along for `--json` consumers — minus `current_inputs`,
+    # whose widget values can carry API keys.
+    assert snap["execution_error"] == {
+        k: v for k, v in _FAILED_DETAIL["execution_error"].items() if k != "current_inputs"
+    }
+    assert "current_inputs" not in snap["execution_error"]
+    # `jobs status` is the documented home of the full traceback.
+    assert snap["execution_error"]["traceback"] == _FAILED_DETAIL["execution_error"]["traceback"]
     assert snap["created_at"] == "2025-01-01T00:00:00+00:00"
     assert snap["updated_at"] == "2025-01-01T00:01:00.500000+00:00"
     # Not served by this endpoint — never fabricated.
@@ -2131,6 +2137,124 @@ def test_jobs_watch_cloud_failed_job_reports_the_real_cause(monkeypatch, capsys)
     assert "Allocation on device 0 would exceed allowed memory" in env["error"]["message"]
     assert "ended in status" not in env["error"]["message"]
     assert env["error"]["details"]["execution_error"]["node_type"] == "KSampler"
+    # The whole payload becomes `renderer.error(details=...)`, so the nested
+    # record must be as trimmed as the top-level one: no widget values, and a
+    # traceback capped at the same two-frame budget as `traceback_tail`.
+    record = env["error"]["details"]["execution_error"]
+    assert "current_inputs" not in record
+    assert len(record["traceback"]) <= 2
+
+
+def test_jobs_watch_cloud_terminal_envelope_trims_a_long_traceback(monkeypatch, capsys):
+    """A server traceback longer than the tail budget is capped in the watch
+    envelope — JSON mode auto-engages off a TTY, so an unbounded blob would
+    land in CI and agent logs."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    frames = [f"  File f{i}.py, line {i}" for i in range(12)]
+    detail = {
+        **_FAILED_DETAIL,
+        "execution_error": {**_FAILED_DETAIL["execution_error"], "traceback": frames},
+    }
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(detail))
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    with pytest.raises(typer.Exit):
+        jobs_mod._cloud_watch("pid-failed", poll_interval=0.01, max_wait=5)
+
+    env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+    assert env["error"]["details"]["execution_error"]["traceback"] == frames[-2:]
+    # ...and the classified tail agrees with it, so the envelope carries the
+    # same two frames twice over rather than the full blob once.
+    assert env["error"]["details"]["error_message"] == env["error"]["message"]
+
+
+def test_jobs_watch_cloud_prefers_the_structured_record_over_a_json_message(monkeypatch, capsys):
+    """An `exception_message` that is itself JSON (API nodes raise with raw
+    JSON bodies) must not be re-decoded into a fields-less dict: classify the
+    structured record, not the flattened one-liner."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    detail = {
+        "status": "failed",
+        "execution_error": {
+            "node_id": "9",
+            "node_type": "ApiNode",
+            "exception_message": '{"detail": "upstream refused the request"}',
+        },
+    }
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(detail))
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    with pytest.raises(typer.Exit):
+        jobs_mod._cloud_watch("pid-json-msg", poll_interval=0.01, max_wait=5)
+
+    env = json.loads([ln for ln in capsys.readouterr().out.splitlines() if ln.strip()][-1])
+    assert env["error"]["message"] == 'ApiNode (node 9): {"detail": "upstream refused the request"}'
+    assert env["error"]["details"]["execution_error"]["node_type"] == "ApiNode"
+
+
+def test_cloud_status_snapshot_prefers_structured_over_generic_error_message(monkeypatch):
+    """A deployment serving both a terse `error_message` and a detailed
+    `execution_error` must surface the detailed one."""
+    detail = {**_FAILED_DETAIL, "error_message": "job failed"}
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(detail))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-both")
+    assert snap["error_message"].startswith("torch.cuda.OutOfMemoryError: Allocation on device 0")
+
+
+def test_cloud_status_snapshot_parses_a_string_execution_error(monkeypatch):
+    """A non-dict `execution_error` (the deprecated dialect's JSON-encoded
+    record) must still produce a cause rather than being discarded to None."""
+    payload = {
+        "status": "failed",
+        "execution_error": json.dumps({"exception_message": "boom", "node_id": 3, "node_type": "VAEDecode"}),
+    }
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(payload))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-str-err")
+    assert snap["error_message"] == "boom (node 3 VAEDecode)"
+    # The published key stays object-or-null, so a string shape lands as null.
+    assert snap["execution_error"] is None
+
+
+def test_cloud_status_snapshot_ignores_a_stale_error_on_a_succeeded_job(monkeypatch):
+    """A non-failed job never has a cause synthesized for it — a stale record
+    on a retried-then-succeeded job would fabricate an `error` row."""
+    payload = {"status": "success", "execution_error": _FAILED_DETAIL["execution_error"]}
+
+    class _SucceededClient(_FakeCloudClient):
+        # The shared fake refuses `get_history` to guard the error paths; a
+        # completed job legitimately fetches it (and has no outputs here).
+        def get_history(self, prompt_id):
+            return None
+
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _SucceededClient(payload))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-ok")
+    assert snap["status"] == "completed"
+    assert snap["error_message"] is None
+
+
+def test_poll_cloud_once_survives_a_malformed_traceback():
+    """A `traceback` served as an object slices to a TypeError that only
+    `_poll_cloud_once`'s *fetch* is guarded against — it would kill the
+    detached watcher and strand the state file mid-flight."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    client = _FakeCloudClient(
+        {"status": "failed", "execution_error": {"exception_message": "boom", "traceback": {"frame": 1}}}
+    )
+    state = jobs_state.new(prompt_id="pid", client_id="c", workflow="w", where="cloud")
+    assert job_watcher._poll_cloud_once(state, client=client) is True
+    assert state.status == "error"
+    assert state.error["message"] == "boom"
 
 
 def test_cloud_status_pretty_renders_the_execution_error_row(monkeypatch, capsys):
@@ -2153,7 +2277,6 @@ def test_cloud_status_pretty_renders_the_execution_error_row(monkeypatch, capsys
     ("err", "expected"),
     [
         ({}, None),
-        ("a string, not an object", None),
         (None, None),
         ({"exception_message": "boom"}, "boom"),
         ({"exception_message": "boom", "exception_type": "ValueError"}, "ValueError: boom"),
@@ -2162,7 +2285,16 @@ def test_cloud_status_pretty_renders_the_execution_error_row(monkeypatch, capsys
         # Node 0 is a real node id — it must not be dropped as falsy.
         ({"exception_message": "boom", "node_id": 0}, "boom (node 0)"),
         ({"exception_message": "boom", "node_type": "KSampler"}, "boom (KSampler)"),
-        ({"node_id": 5, "node_type": "KSampler"}, "(node 5 KSampler)"),
+        # Node fields but no cause: state one rather than emitting the bare
+        # parenthetical `(node 5 KSampler)` as the whole error line.
+        ({"node_id": 5, "node_type": "KSampler"}, "ComfyUI reported an execution error. (node 5 KSampler)"),
+        # Internal newlines collapse — this helper renders *one* line, and the
+        # pretty `error` cell is a single Rich row.
+        ({"exception_message": "boom\n  at frame\n  at frame2"}, "boom at frame at frame2"),
+        # Non-dict shapes route through `execution_errors.parse_error_message`
+        # rather than being discarded, so the watcher and this path agree.
+        ("a string, not an object", "a string, not an object"),
+        ('{"exception_message": "boom", "node_type": "KSampler"}', "boom (KSampler)"),
     ],
 )
 def test_execution_error_line_partial_records(err, expected):

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2022,6 +2022,203 @@ def test_jobs_watch_cloud_terminal_envelope_carries_grouped_outputs(monkeypatch,
     assert env["data"]["outputs_by_item"] == {"s1": ["https://cloud.example/view/a.png"]}
 
 
+# ---------------------------------------------------------------------------
+# `/api/jobs/<id>` (JobDetailResponse) field names — execution_error + *_time
+# ---------------------------------------------------------------------------
+
+
+# A failed job exactly as the plural jobs-detail endpoint serves it: the cause
+# is a structured `execution_error` object (never a top-level `error_message`)
+# and the timestamps are Unix-millisecond ints (never `created_at` strings).
+_FAILED_DETAIL = {
+    "status": "failed",
+    "execution_error": {
+        "node_id": "5",
+        "node_type": "KSampler",
+        "exception_message": "Allocation on device 0 would exceed allowed memory",
+        "exception_type": "torch.cuda.OutOfMemoryError",
+        "traceback": ["  File a.py, line 1", "  File b.py, line 2"],
+        "current_inputs": {"seed": [42]},
+    },
+    "create_time": 1_735_689_600_000,
+    "update_time": 1_735_689_660_500,
+}
+
+
+def test_cloud_status_snapshot_reads_execution_error_and_ms_timestamps(monkeypatch):
+    """The fields `/api/jobs/<id>` actually serves must land on the snapshot:
+    a compact `error_message` line, the structured record, ISO timestamps."""
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(_FAILED_DETAIL))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-failed")
+    assert snap is not None
+    assert snap["status"] == "error"
+    assert snap["error_message"] == (
+        "torch.cuda.OutOfMemoryError: Allocation on device 0 would exceed allowed memory (node 5 KSampler)"
+    )
+    # The full record rides along untouched for `--json` consumers.
+    assert snap["execution_error"] == _FAILED_DETAIL["execution_error"]
+    assert snap["created_at"] == "2025-01-01T00:00:00+00:00"
+    assert snap["updated_at"] == "2025-01-01T00:01:00.500000+00:00"
+    # Not served by this endpoint — never fabricated.
+    assert snap["assigned_inference"] is None
+
+
+def test_cloud_status_snapshot_payload_validates_against_schema(monkeypatch):
+    """The emitted payload — `execution_error` included — must satisfy the
+    published `jobs status` contract."""
+    import jsonschema
+
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(_FAILED_DETAIL))
+    snap = jobs_mod._cloud_status_snapshot("pid-failed")
+
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    # `host`/`port` are stamped by the renderer, not the snapshot.
+    jsonschema.Draft202012Validator(schema).validate({**snap, "host": "cloud.example", "port": 443})
+
+
+def test_cloud_status_snapshot_keeps_old_shape_fallback(monkeypatch):
+    """A deployment still serving the deprecated dialect (top-level
+    `error_message`, ready-made `created_at`) populates the same fields."""
+    payload = {
+        "status": "failed",
+        "error_message": "RIP to the server",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:01:00Z",
+        "assigned_inference": "inf-7",
+    }
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(payload))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-old")
+    assert snap is not None
+    assert snap["error_message"] == "RIP to the server"
+    assert snap["execution_error"] is None
+    assert snap["created_at"] == "2025-01-01T00:00:00Z"
+    assert snap["updated_at"] == "2025-01-01T00:01:00Z"
+    assert snap["assigned_inference"] == "inf-7"
+
+
+def test_cloud_status_snapshot_tolerates_unusable_timestamps(monkeypatch):
+    """A malformed `create_time` degrades to None — it must not raise out of
+    `jobs status`."""
+    payload = {"status": "running", "create_time": "not-a-number", "update_time": None}
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(payload))
+
+    snap = jobs_mod._cloud_status_snapshot("pid-bad-ts")
+    assert snap is not None
+    assert snap["created_at"] is None
+    assert snap["updated_at"] is None
+
+
+def test_jobs_watch_cloud_failed_job_reports_the_real_cause(monkeypatch, capsys):
+    """`jobs watch --where cloud` on a failed job exits 1 with ok:false and the
+    server's own exception text — not the generic "ended in status 'error'"."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(_FAILED_DETAIL))
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    with pytest.raises(typer.Exit) as exc:
+        jobs_mod._cloud_watch("pid-failed", poll_interval=0.01, max_wait=5)
+    assert exc.value.exit_code == 1
+
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    env = json.loads(lines[-1])
+    assert env["type"] == "envelope" and env["ok"] is False
+    assert "Allocation on device 0 would exceed allowed memory" in env["error"]["message"]
+    assert "ended in status" not in env["error"]["message"]
+    assert env["error"]["details"]["execution_error"]["node_type"] == "KSampler"
+
+
+def test_cloud_status_pretty_renders_the_execution_error_row(monkeypatch, capsys):
+    """The pretty `jobs status` table shows an `error` row for a failed cloud
+    job — the row that has been blank since the endpoint moved."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient(_FAILED_DETAIL))
+
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="jobs status"))
+    jobs_mod._cloud_status("pid-failed")
+    out = capsys.readouterr().out
+    assert "error" in out
+    assert "OutOfMemoryError" in out
+
+
+@pytest.mark.parametrize(
+    ("err", "expected"),
+    [
+        ({}, None),
+        ("a string, not an object", None),
+        (None, None),
+        ({"exception_message": "boom"}, "boom"),
+        ({"exception_message": "boom", "exception_type": "ValueError"}, "ValueError: boom"),
+        ({"exception_type": "ValueError"}, "ValueError"),
+        ({"exception_message": "boom", "node_id": 5}, "boom (node 5)"),
+        # Node 0 is a real node id — it must not be dropped as falsy.
+        ({"exception_message": "boom", "node_id": 0}, "boom (node 0)"),
+        ({"exception_message": "boom", "node_type": "KSampler"}, "boom (KSampler)"),
+        ({"node_id": 5, "node_type": "KSampler"}, "(node 5 KSampler)"),
+    ],
+)
+def test_execution_error_line_partial_records(err, expected):
+    """The endpoint marks every `ExecutionError` field required, but the line
+    builder degrades field-by-field rather than emitting `None: None (node
+    None None)` if one ever goes missing."""
+    assert jobs_mod._execution_error_line(err) == expected
+
+
+def test_poll_cloud_once_classifies_the_structured_execution_error():
+    """The background watcher polls the same `/api/jobs/<id>`, so it must read
+    the same fields — otherwise every failed cloud job's state file records the
+    generic "ComfyUI reported an execution error." with null timestamps."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    client = _FakeCloudClient(_FAILED_DETAIL)
+    state = jobs_state.new(prompt_id="pid", client_id="c", workflow="w", where="cloud")
+    assert job_watcher._poll_cloud_once(state, client=client) is True
+
+    assert state.status == "error"
+    assert state.error is not None
+    # `classify` parses the object shape directly, so the verdict keeps the
+    # node prefix and the structured fields — not just a flattened line.
+    assert state.error["message"] == "KSampler (node 5): Allocation on device 0 would exceed allowed memory"
+    assert state.error["details"]["exception_type"] == "torch.cuda.OutOfMemoryError"
+    assert state.error["details"]["node_id"] == "5"
+    assert state.error["details"]["traceback_tail"] == ["  File a.py, line 1", "  File b.py, line 2"]
+    assert state.error["details"]["created_at"] == "2025-01-01T00:00:00+00:00"
+    assert state.error["details"]["updated_at"] == "2025-01-01T00:01:00.500000+00:00"
+
+
+def test_poll_cloud_once_cancelled_carries_iso_timestamps():
+    """The cancelled branch reads the same timestamps through the same helper."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    client = _FakeCloudClient({"status": "cancelled", "create_time": 1_735_689_600_000})
+    state = jobs_state.new(prompt_id="pid", client_id="c", workflow="w", where="cloud")
+    assert job_watcher._poll_cloud_once(state, client=client) is True
+
+    assert state.error["code"] == "cancelled"
+    assert state.error["message"] == "Cloud job was cancelled."
+    assert state.error["details"]["created_at"] == "2025-01-01T00:00:00+00:00"
+    assert state.error["details"]["updated_at"] is None
+
+
+def test_jobs_schema_documents_execution_error():
+    """schemas/jobs.json carries the additive structured-cause key."""
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    prop = schema["properties"]["execution_error"]
+    assert prop["type"] == ["object", "null"]
+    assert prop["additionalProperties"] is True
+
+
 def test_jobs_schema_documents_grouped_outputs():
     """schemas/jobs.json carries the additive grouped-output keys."""
     schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"

--- a/tests/comfy_cli/test_execution_errors.py
+++ b/tests/comfy_cli/test_execution_errors.py
@@ -113,3 +113,38 @@ def test_classify_handles_empty_input():
 def test_verdict_codes_are_registered():
     for raw in (None, _cloud_error_message("Unauthorized: Please login first to use this node.")):
         assert error_codes.is_registered(execution_errors.classify(raw)["code"])
+
+
+def test_parse_survives_a_non_sequence_traceback():
+    """A server that serves `traceback` as an object/scalar must not raise:
+    `tb[-2:]` on a non-sequence is a TypeError, and the detached cloud watcher
+    calls this outside any guard (`job_watcher._poll_cloud_once`)."""
+    for tb in ({"frame": 1}, 7, object()):
+        parsed = execution_errors.parse_error_message({"exception_message": "boom", "traceback": tb})
+        assert parsed["exception_message"] == "boom"
+        assert len(parsed["traceback_tail"]) == 1
+
+
+def test_redact_record_drops_current_inputs():
+    """`current_inputs` is the failing node's widget values — API keys live
+    there, and the record is emitted into CI/agent logs verbatim."""
+    record = {"exception_message": "boom", "current_inputs": {"api_key": ["sk-secret"]}, "node_id": "5"}
+    redacted = execution_errors.redact_record(record)
+    assert "current_inputs" not in redacted
+    assert redacted == {"exception_message": "boom", "node_id": "5"}
+    # The caller's dict is left alone.
+    assert "current_inputs" in record
+    # Non-dict shapes pass straight through.
+    assert execution_errors.redact_record("plain text") == "plain text"
+    assert execution_errors.redact_record(None) is None
+
+
+def test_trim_record_caps_the_traceback_at_the_tail_budget():
+    """Same two-frame budget `details["traceback_tail"]` uses."""
+    trimmed = execution_errors.trim_record({"traceback": _TRACEBACK, "current_inputs": {"seed": [1]}})
+    assert trimmed["traceback"] == _TRACEBACK[-2:]
+    assert "current_inputs" not in trimmed
+    # A traceback already within budget is untouched, in any shape.
+    assert execution_errors.trim_record({"traceback": ["one"]})["traceback"] == ["one"]
+    assert execution_errors.trim_record({"traceback": "one frame"})["traceback"] == "one frame"
+    assert execution_errors.trim_record({"traceback": {"frame": 1}})["traceback"] == {"frame": 1}


### PR DESCRIPTION
## ELI-5

When a job fails on Comfy Cloud, `comfy jobs status` and `comfy jobs watch` used to tell you *why* — "OutOfMemoryError in your KSampler". Since the CLI moved to the newer `GET /api/jobs/<id>` endpoint (#495), it kept asking that endpoint for field names it does not serve, so every failed cloud job came back with an empty error and a shrug: `job <id> ended in status 'error'`. The create/update timestamps went blank the same way. This reads the field names the endpoint actually serves, so the real cause is back.

## What changed

**1. `_cloud_status_snapshot` (`comfy_cli/command/jobs.py`)** — `/api/jobs/<id>` (`JobDetailResponse`) serves a failed job's cause as a structured `execution_error` object (`node_id`, `node_type`, `exception_message`, `exception_type`, `traceback`, `current_inputs`) and its timestamps as Unix-millisecond ints (`create_time` / `update_time`). The deprecated `/api/job/<id>/status` served a JSON-encoded `error_message` string plus ready-made `created_at` / `updated_at` strings, and those are the names the snapshot was still reading. Now:

- `error_message` = the deprecated top-level string **if the deployment still sends one**, else the structured record flattened to one human line — `torch.cuda.OutOfMemoryError: Allocation on device 0 would exceed allowed memory (node 5 KSampler)`. That single populated field is what restores `_emit_terminal` → `execution_errors.classify`, which has been classifying `None` since the endpoint move; `_emit_terminal` itself is untouched.
- `execution_error` = the full structured object, carried through verbatim so `--json` consumers get the fields without re-parsing the line (it also rides into the error envelope's `details`, since `_emit_terminal` passes the whole payload).
- `created_at` / `updated_at` = the old string fields if present, else `create_time` / `update_time` converted to ISO-8601 UTC — so the pretty rows and the JSON fields keep the string shape they have always had.
- `assigned_inference` is **not** served by the plural endpoint and is deliberately left as a plain `.get()` (stays `None`; the pretty row is already conditional). Not fabricated.

**2. `comfy_cli/schemas/jobs.json`** — `execution_error` added as an optional `["object", "null"]` with `additionalProperties: true`. The schema is the published contract for `jobs status` output, and the payload now emits this key.

**3. `_poll_cloud_once` (`comfy_cli/command/job_watcher.py`) — see the judgment call below.**

## Judgment call — the watcher is the same bug at the sibling call site

The ticket scoped the fix to `_cloud_status_snapshot`. The background watcher polls the **same** `client.get_job_status` and reads the **same** old field names, so every failed cloud job's state file has been recording the generic `ComfyUI reported an execution error.` with null timestamps — and that state file is what `comfy jobs ls` reads for its `error_code` column. I fixed it here rather than leaving a known-identical regression one function away; if you'd rather have it split out, say so and I'll pull it into its own PR.

Chesterton's-fence note, since this widens an existing condition: `classify(record.get("error_message"))` was written 2026-06-21 (64c9883), **before** #495 (a0a0a73, 2026-07-07) moved the endpoint out from under it. `record.get("error_message") or record.get("execution_error")` cannot disagree with the old read when `error_message` is present — it only fires where the old read produced `None` — and `execution_errors.classify` already accepts an already-decoded dict (that is the local-WebSocket shape), so the object goes in structured rather than flattened. Timestamps in both the error and cancelled branches now go through the same `_ms_to_iso` helper via `_cloud_record_meta`.

Two smaller calls worth naming:

- **The line format differs slightly between the two paths, on purpose.** The snapshot's `error_message` is the ticket's compact form (`<type>: <message> (node <id> <type>)`); the watcher hands `classify` the object directly, so its state file gets `classify`'s own prefixing (`KSampler (node 5): <message>`). Feeding `classify` the structure keeps `details.node_id` / `exception_type` / `traceback_tail` intact, which is strictly better where the shape allows it.
- **`_execution_error_line` degrades field by field.** Every `ExecutionError` field is required by the spec, but a record missing one renders what it has rather than `None: None (node None None)`, and returns `None` for an empty object so a present-but-empty record never fabricates an error line. `node_id` is tested against `is None`, not falsiness, so node `0` survives.

## Tests

All in `tests/comfy_cli/jobs/test_jobs.py`:

- Snapshot of a failed cloud job served the new way (full `execution_error` + ms timestamps): compact `error_message` line, structured record passed through, ISO-8601 timestamps, `assigned_inference` still `None`.
- That same payload validated against `comfy_cli/schemas/jobs.json` with `jsonschema`.
- Old-shape fallback: a deployment serving top-level `error_message` / `created_at` / `assigned_inference` populates the identical snapshot fields.
- `jobs watch --where cloud` on the failed job: exits 1, envelope `ok:false`, message carries the server's own exception text (asserted *not* to be `ended in status`), and `details.execution_error` keeps the structured record.
- Pretty `jobs status` renders the `error` row through the existing 600-char truncate + markup-escape path.
- `_execution_error_line` parametrized over partial/missing/non-dict records, including node `0`.
- Malformed `create_time` degrades to `None` instead of raising out of `jobs status`.
- Watcher: `_poll_cloud_once` classifies the structured cause (message, `exception_type`, `node_id`, `traceback_tail`, ISO timestamps) and the cancelled branch carries the same ISO timestamps.

## Verification

`ruff check .` and `ruff format --diff .` clean repo-wide on the CI-pinned ruff 0.15.15 (277 files). Tests: `tests/comfy_cli/jobs/test_jobs.py` **181 passed**, plus every other module that imports `command.jobs` / `job_watcher` and the schema/envelope suites — `test_local_address.py`, `test_host_port.py`, `test_command_init.py`, `test_pretty_print_sanitize.py`, `test_observer_session_safety.py`, `test_jobs_pid_alive.py`, `tests/comfy_cli/output/`, `test_run.py` — **505 passed**. The whole-repo `pytest` run was queued behind a concurrent full-suite run on the same machine and had not finished when this PR went up; CI's run is the gate on it. Nothing outside the jobs/watcher paths is touched.

This change only *restores* error text — it adds no capability-denying path, so there is no negative claim to falsify.
