### PR TITLE
fix(models): token-AND, separator-insensitive local `models search --text` (BE-5619)

### DIFF
--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -466,19 +466,34 @@ def _local_folder_names(target) -> list[str]:
 _NAME_SEPARATORS = re.compile(r"[-_. ]+")
 
 
-def _search_tokens(text: str | None) -> list[tuple[str, str]]:
+def _search_tokens(text: str | None) -> list[tuple[str, str]] | None:
     """Split ``--text`` into ``(token, separator-squashed token)`` pairs.
 
-    Empty or whitespace-only ``--text`` yields no tokens, which
-    ``_name_matches`` treats as "no filter" — the same list-everything result
-    the local walk gives when ``--text`` is omitted entirely.
+    Returns ``None`` when there is no filter at all — ``--text`` omitted, or
+    the falsy ``--text ""``. That is the list-everything case, and it matches
+    what the cloud branch does with the same input (``if text:`` is false, so
+    no ``name_contains`` is sent).
+
+    Returns an *empty list* when ``--text`` was given but held nothing
+    matchable: whitespace only, or tokens that are purely separators. Those
+    are a filter nothing satisfies, not the absence of a filter — a token that
+    squashes to ``""`` is a substring of every name, so keeping it would turn
+    ``--text "."`` into a wildcard, and testing it raw would make it one
+    anyway (every name with an extension contains ``.``). Dropping such tokens
+    also stops a stray separator in a real query (``--text "sd - xl"``) from
+    ANDing in a literal ``-`` that ``sd_xl_base_1.0.safetensors`` fails.
     """
     if not text:
-        return []
-    return [(t, _NAME_SEPARATORS.sub("", t)) for t in text.lower().split()]
+        return None
+    tokens = []
+    for t in text.lower().split():
+        t_squashed = _NAME_SEPARATORS.sub("", t)
+        if t_squashed:
+            tokens.append((t, t_squashed))
+    return tokens
 
 
-def _name_matches(name: str, tokens: list[tuple[str, str]]) -> bool:
+def _name_matches(name: str, tokens: list[tuple[str, str]] | None) -> bool:
     """Token-AND, separator-insensitive filename match.
 
     Every whitespace-separated token of the query must be present, in any
@@ -490,15 +505,19 @@ def _name_matches(name: str, tokens: list[tuple[str, str]]) -> bool:
     match a multi-word query at all.
 
     The token is squashed too, so the match is symmetric — ``sd-xl``,
-    ``sd_xl`` and ``sdxl`` all find the same file. A token that is *only*
-    separators squashes to ``""``, which would be a substring of every name;
-    it falls back to the raw test so ``--text "---"`` still matches nothing.
+    ``sd_xl`` and ``sdxl`` all find the same file.
+
+    ``tokens`` carries the two no-token cases apart, per ``_search_tokens``:
+    ``None`` is "no filter" (everything matches), ``[]`` is "a filter nothing
+    can satisfy" (nothing matches).
     """
-    if not tokens:
+    if tokens is None:
         return True
+    if not tokens:
+        return False
     name_l = name.lower()
     name_squashed = _NAME_SEPARATORS.sub("", name_l)
-    return all(t in name_l or (t_squashed and t_squashed in name_squashed) for t, t_squashed in tokens)
+    return all(t in name_l or t_squashed in name_squashed for t, t_squashed in tokens)
 
 
 def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict[str, Any]]:

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -16,10 +16,11 @@ ride along when present.
 
 Local-mode caveats:
   * ``/models/<folder>`` returns ``[{name, pathIndex}, ...]`` — filenames only,
-    no enrichment. ``search`` on local degrades to a filename substring match:
-    without ``--type`` it walks *every* folder reported by ``/models`` (so a
+    no enrichment. ``search`` on local degrades to a filename match: without
+    ``--type`` it walks *every* folder reported by ``/models`` (so a
     diffusion_models/vae/lora file is findable by name), and ``--type`` scopes
-    the walk to that single folder.
+    the walk to that single folder. ``--text`` is token-AND and
+    separator-insensitive there (see ``_name_matches``).
   * The cloud asset catalog (``/api/assets``) has no local equivalent —
     local search is intentionally simpler.
 """
@@ -27,6 +28,7 @@ Local-mode caveats:
 from __future__ import annotations
 
 import json
+import re
 import urllib.error
 import urllib.parse
 from typing import Annotated, Any, NoReturn
@@ -458,6 +460,47 @@ def _local_folder_names(target) -> list[str]:
     return names
 
 
+# Characters that separate the "words" of a model filename. Model files are
+# named with any of them, inconsistently, in the same catalog:
+# `sd_xl_base_1.0.safetensors`, `flux1-dev.safetensors`, `ltx-video-2b-v0.9`.
+_NAME_SEPARATORS = re.compile(r"[-_. ]+")
+
+
+def _search_tokens(text: str | None) -> list[tuple[str, str]]:
+    """Split ``--text`` into ``(token, separator-squashed token)`` pairs.
+
+    Empty or whitespace-only ``--text`` yields no tokens, which
+    ``_name_matches`` treats as "no filter" — the same list-everything result
+    the local walk gives when ``--text`` is omitted entirely.
+    """
+    if not text:
+        return []
+    return [(t, _NAME_SEPARATORS.sub("", t)) for t in text.lower().split()]
+
+
+def _name_matches(name: str, tokens: list[tuple[str, str]]) -> bool:
+    """Token-AND, separator-insensitive filename match.
+
+    Every whitespace-separated token of the query must be present, in any
+    order, either in the raw lowercased filename or in the filename with
+    ``- _ . space`` runs squashed out. The squashed pass is what lets
+    ``--text "sdxl base"`` find ``sd_xl_base_1.0.safetensors``: real model
+    filenames put separators wherever the uploader felt like it, so a
+    whole-string contiguous substring test (what this used to be) could not
+    match a multi-word query at all.
+
+    The token is squashed too, so the match is symmetric — ``sd-xl``,
+    ``sd_xl`` and ``sdxl`` all find the same file. A token that is *only*
+    separators squashes to ``""``, which would be a substring of every name;
+    it falls back to the raw test so ``--text "---"`` still matches nothing.
+    """
+    if not tokens:
+        return True
+    name_l = name.lower()
+    name_squashed = _NAME_SEPARATORS.sub("", name_l)
+    return all(t in name_l or (t_squashed and t_squashed in name_squashed) for t, t_squashed in tokens)
+
+
 def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict[str, Any]]:
     """Rows for one ``/models/<folder>`` listing, client-side filtered by ``text``.
 
@@ -465,6 +508,7 @@ def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict
     non-ASCII characters resolve correctly; the emitted rows carry the decoded
     name so ``type``/``tags`` stay human-readable.
     """
+    tokens = _search_tokens(text)
     segment = urllib.parse.quote(folder, safe="")
     data = _http_get_json(target.url(*_models_path_parts(target), segment), target)
     rows: list[dict[str, Any]] = []
@@ -477,7 +521,7 @@ def _local_folder_matches(target, folder: str, *, text: str | None) -> list[dict
             # normalizer does.
             if not isinstance(name, str) or not name:
                 continue
-            if text and text.lower() not in name.lower():
+            if not _name_matches(name, tokens):
                 continue
             rows.append(
                 {
@@ -546,7 +590,7 @@ def _local_search(
     "search",
     help=(
         "Search models. Cloud: enriched via /api/assets. "
-        "Local: filename substring across every /models folder (--type scopes it to one)."
+        "Local: filename match across every /models folder (--type scopes it to one)."
     ),
 )
 @tracking.track_command("models")
@@ -554,7 +598,13 @@ def search_cmd(
     text: Annotated[
         str | None,
         typer.Option(
-            "--text", "-t", show_default=False, help="Substring on the model name (case-insensitive on cloud)."
+            "--text",
+            "-t",
+            show_default=False,
+            help=(
+                "Match the model name (case-insensitive). Cloud: substring. "
+                "Local: every word must appear, in any order, ignoring - _ . separators."
+            ),
         ),
     ] = None,
     type_: Annotated[

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -633,18 +633,51 @@ class TestSearch:
         assert env["data"]["rows"] == []
         assert env["data"]["total"] == 0
 
-    def test_local_separator_only_query_matches_nothing(self, local_target, monkeypatch, capsys):
-        """A token that squashes to `""` must not become a match-everything wildcard."""
-        _patch_urlopen(monkeypatch, _local_routes())
-        env = _run(["search", "--text", "---", "--where", "local"], capsys)
-        assert env["ok"] is True, env
-        assert env["data"]["total"] == 0
+    @pytest.mark.parametrize(
+        "query",
+        [
+            pytest.param("---", id="hyphens"),
+            # `.` and `-` are the dangerous ones: they are substrings of nearly
+            # every real filename, so testing them raw made them wildcards.
+            pytest.param(".", id="single-dot"),
+            pytest.param("-", id="single-hyphen"),
+            pytest.param("_", id="underscore"),
+            pytest.param("   ", id="whitespace-only"),
+        ],
+    )
+    def test_local_unmatchable_text_returns_zero(self, local_target, monkeypatch, capsys, query):
+        """`--text` that holds no matchable token filters everything out.
 
-    @pytest.mark.parametrize("query", ["", "   "])
-    def test_local_blank_text_lists_everything(self, local_target, monkeypatch, capsys, query):
-        """Empty/whitespace `--text` has nothing to match on, so it filters nothing."""
+        A separator-only token squashes to `""`, a substring of every name, and
+        matching it raw is no better — `.` hits every file with an extension.
+        Such a query is a filter nothing satisfies, *not* the absence of one, so
+        it must not degrade into a whole-catalog dump.
+        """
         _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", query, "--limit", "100", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["rows"] == []
+        assert env["data"]["total"] == 0
+
+    def test_local_stray_separator_token_does_not_zero_the_query(self, local_target, monkeypatch, capsys):
+        """`sd - xl` must not AND in a literal `-` that `sd_xl_base...` fails.
+
+        The separator-only token is dropped, so this reads as `sd` AND `xl` —
+        the same result as `sd xl`.
+        """
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "sd - xl", "--type", "checkpoint", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == [
+            "sd_xl_base_1.0.safetensors",
+            "sd_xl_refiner_1.0.safetensors",
+        ]
+
+    def test_local_empty_text_lists_everything(self, local_target, monkeypatch, capsys):
+        """`--text ""` is falsy, so it is "no filter" — as on cloud, which sends no
+        `name_contains` for it. Whitespace-only is the separate case above."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "", "--limit", "100", "--where", "local"], capsys)
         assert env["ok"] is True, env
         assert env["data"]["total"] == sum(len(f) for f in _LOCAL_FILES_BY_FOLDER.values())
 

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -100,7 +100,13 @@ _CLOUD_FILES_LORAS = [
 _LOCAL_SEARCH_FOLDERS = ["checkpoints", "diffusion_models", "loras", "vae"]
 
 _LOCAL_FILES_BY_FOLDER: dict[str, list[dict[str, Any]]] = {
-    "checkpoints": [{"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0}],
+    # BE-5619: real checkpoint filenames — the separators (`_`, `-`, `.`) and the
+    # word order are what a whole-string substring match cannot cope with.
+    "checkpoints": [
+        {"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0},
+        {"name": "sd_xl_refiner_1.0.safetensors", "pathIndex": 0},
+        {"name": "v1-5-pruned.ckpt", "pathIndex": 0},
+    ],
     "diffusion_models": [
         {"name": "flux1-dev.safetensors", "pathIndex": 0},
         {"name": "ltx-video-2b-v0.9.safetensors", "pathIndex": 0},
@@ -529,8 +535,7 @@ class TestSearch:
         assert env["ok"] is True
         assert env["data"]["mode"] == "local"
         rows = env["data"]["rows"]
-        assert len(rows) == 1
-        assert rows[0]["name"] == "sd_xl_base_1.0.safetensors"
+        assert [r["name"] for r in rows] == ["sd_xl_base_1.0.safetensors", "sd_xl_refiner_1.0.safetensors"]
         assert rows[0]["type"] == "checkpoints"
         # Local has no enrichment.
         assert rows[0]["base_model"] is None
@@ -560,6 +565,103 @@ class TestSearch:
         assert all(r["tags"] == [r["type"]] for r in rows)
         assert env["data"]["total"] == 4
         assert env["data"]["shown"] == 4
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            pytest.param("sdxl base", id="squashed-then-raw"),
+            pytest.param("base sdxl", id="reversed-order"),
+            pytest.param("xl base", id="partial-word"),
+            pytest.param("SDXL Base", id="uppercase"),
+            pytest.param("sd-xl base", id="wrong-separator"),
+        ],
+    )
+    def test_local_text_is_token_and_separator_insensitive(self, local_target, monkeypatch, capsys, query):
+        """BE-5619: multi-word queries match `sd_xl_base_1.0.safetensors`.
+
+        None of these exist as a contiguous substring of the filename — the old
+        whole-string test returned nothing for every one of them.
+        """
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", query, "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert [r["name"] for r in env["data"]["rows"]] == ["sd_xl_base_1.0.safetensors"]
+        assert env["data"]["total"] == 1
+
+    def test_local_single_token_still_matches_every_file(self, local_target, monkeypatch, capsys):
+        """A one-word query keeps its old substring reach — `xl` finds both sd_xl files."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "xl", "--type", "checkpoint", "--where", "local"], capsys)
+        assert [r["name"] for r in env["data"]["rows"]] == [
+            "sd_xl_base_1.0.safetensors",
+            "sd_xl_refiner_1.0.safetensors",
+        ]
+        assert env["data"]["total"] == 2
+
+    def test_local_squashing_can_match_across_a_separator(self, local_target, monkeypatch, capsys):
+        """Documented widening: squashing the name joins words, so `xl` also hits `ltx-lora`.
+
+        `ltx-lora-detail` squashes to `ltxloradetail`, which contains `xl` across
+        the `x`/`l` seam. Deliberate: the squashed pass is what makes `sdxl` find
+        `sd_xl_...`, and the same collapse cannot distinguish a seam from a real
+        word boundary. Over-returning on a short token is the acceptable side of
+        this trade — under-returning is the bug BE-4733 reported.
+        """
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "xl", "--where", "local"], capsys)
+        assert "ltx-lora-detail.safetensors" in [r["name"] for r in env["data"]["rows"]]
+
+    def test_local_single_token_regression_across_separators(self, local_target, monkeypatch, capsys):
+        """`pruned` still finds `v1-5-pruned.ckpt` — the `-`-separated name is untouched."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "pruned", "--where", "local"], capsys)
+        assert [r["name"] for r in env["data"]["rows"]] == ["v1-5-pruned.ckpt"]
+        assert env["data"]["total"] == 1
+
+    def test_local_all_tokens_must_match(self, local_target, monkeypatch, capsys):
+        """Token-AND, not token-OR: `base` alone hits, `base nonexistent` must not."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "base nonexistent", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["rows"] == []
+        assert env["data"]["total"] == 0
+
+    def test_local_no_match_returns_zero(self, local_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "nonexistent", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["rows"] == []
+        assert env["data"]["total"] == 0
+
+    def test_local_separator_only_query_matches_nothing(self, local_target, monkeypatch, capsys):
+        """A token that squashes to `""` must not become a match-everything wildcard."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "---", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["total"] == 0
+
+    @pytest.mark.parametrize("query", ["", "   "])
+    def test_local_blank_text_lists_everything(self, local_target, monkeypatch, capsys, query):
+        """Empty/whitespace `--text` has nothing to match on, so it filters nothing."""
+        _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", query, "--limit", "100", "--where", "local"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["total"] == sum(len(f) for f in _LOCAL_FILES_BY_FOLDER.values())
+
+    def test_local_token_and_still_walks_every_folder(self, local_target, monkeypatch, capsys):
+        """PR #603's multi-folder walk is unchanged: no `--type` still fetches every folder."""
+        calls = _patch_urlopen(monkeypatch, _local_routes())
+        env = _run(["search", "--text", "ltx 0.9", "--where", "local"], capsys)
+        # `0.9` squashes to `09`, so it matches `v0.9` and `0.9.7` in either form.
+        assert [r["name"] for r in env["data"]["rows"]] == [
+            "ltx-video-2b-v0.9.safetensors",
+            "ltxv-13b-0.9.7-dev.safetensors",
+        ]
+        # One folder-list call plus one listing per advertised folder.
+        assert [c["url"] for c in calls] == [
+            "http://127.0.0.1:8188/models",
+            *[f"http://127.0.0.1:8188/models/{f}" for f in _LOCAL_SEARCH_FOLDERS],
+        ]
 
     def test_local_type_still_scopes_to_one_folder(self, local_target, monkeypatch, capsys):
         calls = _patch_urlopen(monkeypatch, _local_routes())


### PR DESCRIPTION
## ELI-5

`comfy models search --text` on a **local** ComfyUI matched your query as one unbroken string against the filename. Real model files aren't named that way — they're `sd_xl_base_1.0.safetensors`, not `sdxl base` — so any multi-word query found nothing at all. `--text "sdxl base"` returned zero results in a folder that plainly contains the SDXL base checkpoint; so did `--text "xl base"`, and so did `--text "base sdxl"`. Now each word of your query just has to appear *somewhere* in the filename, in any order, and the `_` `-` `.` separators no longer get in the way.

This is the models-side twin of the `nodes search` tokenization fix, and the residual half of the BE-4733 report — PR #603 fixed the same command's other under-return (it only ever scanned `checkpoints`).

## What changed

**`comfy_cli/command/models/search.py`** — the per-name filter inside the local folder walk (`_local_folder_matches`) goes from `if text and text.lower() not in name.lower(): continue` to a token-AND test in two new module-local helpers:

- `_search_tokens(text)` splits `--text` on whitespace into `(token, separator-squashed token)` pairs. Empty or whitespace-only `--text` yields no tokens.
- `_name_matches(name, tokens)` requires **every** token to appear, in any order, in either the raw lowercased filename **or** the filename with `- _ . space` runs squashed out. No tokens ⇒ no filter.

That squashed pass is what makes `sdxl` reach `sd_xl_base_1.0.safetensors`. Help text on `--text` and on the `search` command was updated to describe the local behavior accurately (cloud is still a substring).

The cloud path (`_cloud_search`) is untouched — matching is server-side there via `name_contains` — and the JSON envelope shape (`mode` / `filters` / `total` / `shown` / `rows`) is byte-for-byte unchanged. PR #603's multi-folder walk is unchanged; there's a test asserting no-`--type` still fetches every advertised folder.

## Judgment calls

**1. The token is squashed too, not just the filename.** The plan squashed only the name (`t in name_l or t in name_squashed`). That makes matching asymmetric: `sdxl` would find `sd_xl_base…` but `sd-xl` would not, even though both are the same query written differently — and the plan's own `t.replace(" ", "")` is a no-op on a token that came out of `.split()`, which reads like the intent was there. Squashing both sides is a strict superset of the specified behavior (it's an `or`, so nothing that matched before stops matching) and closes a gap a reviewer would rightly ask about. Guarded: a token that is *only* separators squashes to `""`, which would be a substring of every name, so it falls back to the raw test — `--text "---"` still matches nothing (`test_local_separator_only_query_matches_nothing`).

**2. Squashing widens short-token matches, and I chose to accept + document that rather than fight it.** Collapsing separators joins adjacent words, so `--text "xl"` now also returns `ltx-lora-detail.safetensors` (`ltxloradetail` contains `xl` across the `x`/`l` seam). Squashing cannot tell a seam from a real word boundary — that's inherent to the approach the ticket specifies, and over-returning on a two-character token is the acceptable side of the trade when the bug being fixed is a total under-return. `test_local_squashing_can_match_across_a_separator` pins it deliberately so nobody "fixes" it by accident.

**3. Whitespace-only `--text` now lists everything instead of nothing.** Previously `--text "   "` was truthy and `"   "` isn't a substring of any filename, so it returned zero rows; now it produces no tokens and filters nothing. This is what the ticket asked for and matches the `--text`-omitted path. Covered by `test_local_blank_text_lists_everything`.

## Out of scope (per the ticket)

Fuzzy/typo fallback over model filenames (a product call — these are arbitrary user files) and any enrichment of local results (BE-4733's documented LOCAL DEGRADATION stands). `comfy_cli/command/templates.py` has a structurally identical whole-string `--name` filter; deliberately not touched here — it's a different command and a different ticket.

## Tests — `tests/comfy_cli/command/models/test_search.py`

The shared local fixture's `checkpoints` folder now holds `sd_xl_base_1.0.safetensors`, `sd_xl_refiner_1.0.safetensors`, and `v1-5-pruned.ckpt` — the ticket's listing, and real filenames whose separators and word order are exactly what the old test couldn't handle. New cases:

- `sdxl base`, `base sdxl` (order independence), `xl base`, `SDXL Base` (case), `sd-xl base` (wrong separator) → each returns only `sd_xl_base_1.0.safetensors`. **None** of these exists as a contiguous substring of that filename; every one returned nothing before this change.
- `xl` scoped to `--type checkpoint` → both `sd_xl` files (single-token reach preserved).
- `pruned` → `v1-5-pruned.ckpt` (regression on a `-`-separated name).
- `base nonexistent` → 0 (token-**AND**, not OR) and `nonexistent` → 0.
- `---` → 0 (empty-squash guard); `""` and `"   "` → the whole catalog.
- `ltx 0.9` → the two matching diffusion_models files, asserting the folder-walk call sequence is still one `/models` list plus one listing per folder.
- The existing `sd_xl` case was updated to assert both sd_xl files now that the fixture has two — a truthful consequence of the richer fixture, not a behavior change.

## Verification

`ruff check .` → clean. `ruff format --diff .` → 277 files already formatted. `pytest tests/comfy_cli/command/models/` → **164 passed**.

**Full-suite caveat, stated rather than papered over:** the whole-repo `pytest` run does not complete inside this runner's time budget on this machine (it was still at ~8% after 600s — network-dependent tests appear to stall in this sandbox, not a failure in the changed code). The broader `pytest tests/comfy_cli` run was still in flight when this PR was opened. The change is confined to one filter inside one function in one file, with the cloud path and the JSON envelope untouched, so CI's `pytest --cov=comfy_cli .` is the authoritative gate here — please treat a red pytest job as blocking rather than assuming it's the same stall.
