### PR TITLE
fix(jobs): speak cloud's actual /api/jobs status vocabulary (BE-6644)

### DIFF
--- a/comfy_cli/command/job_watcher.py
+++ b/comfy_cli/command/job_watcher.py
@@ -370,16 +370,10 @@ def _poll_local_once(state: jobs_state.JobState, *, host: str | None, port: int 
     return False, True
 
 
-_CLOUD_STATUS_MAP = {
-    "success": "completed",
-    "completed": "completed",
-    "failed": "error",
-    "error": "error",
-    "non_retryable_error": "error",
-    "lost": "error",
-    "cancelled": "cancelled",
-    "canceled": "cancelled",
-}
+# Cloud's /api/jobs status enum → the CLI's published vocabulary. Aliased to
+# the one shared map so the watcher, `jobs status`, and `jobs ls` can never
+# drift apart on what a raw cloud status means.
+_CLOUD_STATUS_MAP = jobs_state.CLOUD_STATUS_ALIASES
 
 
 def _poll_cloud_once(state: jobs_state.JobState, *, client: Any = None) -> bool:

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -2091,7 +2091,17 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     # only landed correctly by fall-through. Mapping here keeps the snapshot —
     # and everything downstream of it (`jobs status`, `jobs watch` state events,
     # `_TERMINAL_VERDICT`) — inside the vocabulary `schemas/jobs.json` declares.
-    state = jobs_state.CLOUD_STATUS_ALIASES.get(raw, raw or "pending")
+    #
+    # An unmapped status resolves to `unknown` rather than passing through raw:
+    # unlike the per-row `jobs[].status` (deliberately unconstrained, so a new
+    # server spelling widens the listing instead of breaking it), this top-level
+    # `status` is a closed enum, and a raw `allocated` / `uploading` / future
+    # addition emitted here is a payload a strict consumer must reject. `unknown`
+    # is in that enum for exactly this case, and — like the passthrough it
+    # replaces — is non-terminal, so nothing about when `_cloud_watch` stops
+    # changes. The server's own word is kept verbatim in `status_raw` so no
+    # diagnostic detail is lost to the canonicalization.
+    state = jobs_state.CLOUD_STATUS_ALIASES.get(raw, "unknown") if raw else "pending"
 
     outputs: list[str] = []
     outputs_by_node: dict[str, list[str]] = {}
@@ -2110,6 +2120,11 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     return {
         "prompt_id": prompt_id,
         "status": state,
+        # The server's own spelling, before canonicalization. Always present so
+        # an agent can tell `in_progress` from `executing` (and read a status
+        # this CLI has not learned yet) without the closed `status` enum having
+        # to widen for every server-side addition.
+        "status_raw": raw or None,
         "outputs": outputs,
         "outputs_by_node": outputs_by_node,
         "outputs_by_item": outputs_by_item,
@@ -2143,10 +2158,15 @@ def _cloud_status(prompt_id: str) -> None:
         tbl = Table(title=f"Cloud prompt {sanitize_markup(prompt_id[:8])}…", border_style="cyan", show_header=False)
         tbl.add_column(style="bold cyan")
         tbl.add_column()
-        # Every cell below comes straight off `/api/jobs/<id>` — including
-        # `status`, which falls through to the server's own vocabulary when it
-        # is not one of the aliases `_cloud_status_snapshot` knows.
-        tbl.add_row("status", sanitize_markup(snap["status"]))
+        # Every cell below comes straight off `/api/jobs/<id>`. `status` is the
+        # canonicalized one; when the server's spelling differs (an alias, or a
+        # status this CLI does not know and canonicalized to `unknown`), show it
+        # alongside so the pretty view never hides the server's actual word.
+        raw_status = snap.get("status_raw")
+        if raw_status and raw_status != snap["status"]:
+            tbl.add_row("status", f"{sanitize_markup(snap['status'])} [dim]({sanitize_markup(raw_status)})[/dim]")
+        else:
+            tbl.add_row("status", sanitize_markup(snap["status"]))
         if snap.get("assigned_inference"):
             tbl.add_row("inference", sanitize_markup(snap["assigned_inference"]))
         if snap.get("created_at"):
@@ -2216,9 +2236,13 @@ def _cloud_watch(prompt_id: str, *, poll_interval: float, max_wait: float) -> No
             break
 
         if time.time() >= deadline:
+            # The server's own spelling when we have it: "still unknown" names
+            # nothing, and a timeout on a status this CLI cannot map is exactly
+            # when the raw word is the whole diagnostic.
+            stuck_at = snap.get("status_raw") or snap["status"]
             renderer.error(
                 code="cloud_timeout",
-                message=f"prompt {prompt_id} still {snap['status']} after {max_wait}s",
+                message=f"prompt {prompt_id} still {stuck_at} after {max_wait}s",
                 hint="raise --max-wait or re-run with --where cloud",
                 details=snap,
             )

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 import typer
 from websocket import WebSocket, WebSocketException, WebSocketTimeoutException
 
-from comfy_cli import cancellation, execution_errors, tracking
+from comfy_cli import cancellation, execution_errors, jobs_state, tracking
 from comfy_cli.env_checker import check_comfy_server_running
 from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.http import ResponseTooLarge, authed_urlopen, plain_urlopen, read_capped
@@ -216,22 +216,12 @@ def _emit_terminal(renderer, payload: dict, *, command: str, where: str | None =
 # meaningful alongside. `completed` is terminal but deliberately absent.
 _ERROR_STATUSES = frozenset({"error", "cancelled"})
 
-# Cloud's raw job statuses → the row vocabulary above. Mirrors
-# ``job_watcher._CLOUD_STATUS_MAP`` (kept as a local copy rather than imported:
-# ``job_watcher`` imports this module, so the dependency only runs one way).
-# The failure spellings matter here — an unmapped `non_retryable_error` /
-# `lost` / `canceled` misses `_ERROR_STATUSES` and silently drops the state
-# file's `error_code` for exactly the jobs that failed.
-_CLOUD_ROW_STATUS_MAP = {
-    "success": "completed",
-    "completed": "completed",
-    "failed": "error",
-    "error": "error",
-    "non_retryable_error": "error",
-    "lost": "error",
-    "cancelled": "cancelled",
-    "canceled": "cancelled",
-}
+# Cloud's raw job statuses → the row vocabulary above. One shared map, owned by
+# ``jobs_state`` so ``job_watcher`` (which imports this module) can use the same
+# copy without an import cycle. The failure spellings matter here — an unmapped
+# `non_retryable_error` / `lost` / `canceled` misses `_ERROR_STATUSES` and
+# silently drops the state file's `error_code` for exactly the jobs that failed.
+_CLOUD_ROW_STATUS_MAP = jobs_state.CLOUD_STATUS_ALIASES
 
 
 @dataclass(frozen=True)
@@ -2096,21 +2086,12 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     if status is None:
         return None
     raw = (status.get("status") or "").lower()
-    # Deliberately NOT _CLOUD_ROW_STATUS_MAP: this map lacks cloud's two cancel
-    # spellings, so a cancelled cloud job snapshots as the raw `canceled` — not
-    # in the published `status` enum, not in `_cloud_watch`'s terminal set (so
-    # `jobs watch --where cloud` spins to `cloud_timeout`), and not in
-    # `_TERMINAL_VERDICT` (so `jobs status` reports it ok:true/exit 0 instead of
-    # the documented 130). Real bugs, but adding the aliases here changes an
-    # exit code on a path this PR does not otherwise touch — see BE-6612.
-    state = {
-        "success": "completed",
-        "completed": "completed",
-        "failed": "error",
-        "error": "error",
-        "non_retryable_error": "error",
-        "lost": "error",
-    }.get(raw, raw or "pending")
+    # The shared alias map: /api/jobs serves ingest's filter enum, whose
+    # `in_progress` is not in the published `status` enum and whose `cancelled`
+    # only landed correctly by fall-through. Mapping here keeps the snapshot —
+    # and everything downstream of it (`jobs status`, `jobs watch` state events,
+    # `_TERMINAL_VERDICT`) — inside the vocabulary `schemas/jobs.json` declares.
+    state = jobs_state.CLOUD_STATUS_ALIASES.get(raw, raw or "pending")
 
     outputs: list[str] = []
     outputs_by_node: dict[str, list[str]] = {}

--- a/comfy_cli/jobs_state.py
+++ b/comfy_cli/jobs_state.py
@@ -52,6 +52,32 @@ from comfy_cli.utils import get_os
 
 TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled"})
 
+# Cloud's /api/jobs status enum (ingest ``toFilterStatus``: pending,
+# in_progress, completed, failed, cancelled) -> the CLI's published jobs
+# vocabulary (``comfy_cli/schemas/jobs.json``). Legacy raw-jobstate spellings
+# from the deprecated /api/job/<id>/status endpoint are kept as cheap defense;
+# `canceled` has never been observed from ingest but is one typo-of-vocabulary
+# away.
+#
+# Lives here rather than in ``command/jobs.py`` so both ``command/jobs.py`` and
+# ``command/job_watcher.py`` can share one copy — ``job_watcher`` imports
+# ``command.jobs``, so a map owned by ``jobs`` could only be shared by importing
+# it the wrong way round.
+CLOUD_STATUS_ALIASES = {
+    "pending": "pending",
+    "in_progress": "running",
+    "completed": "completed",
+    "failed": "error",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
+    # legacy raw jobstate vocabulary (deprecated endpoint), kept defensively:
+    "success": "completed",
+    "error": "error",
+    "non_retryable_error": "error",
+    "lost": "error",
+    "executing": "running",
+}
+
 
 def state_dir() -> Path:
     """Return ``<config-root>/jobs`` and ensure it exists with safe mode."""

--- a/comfy_cli/jobs_state.py
+++ b/comfy_cli/jobs_state.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import json
 import re
+import types
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -63,20 +64,36 @@ TERMINAL_STATUSES = frozenset({"completed", "error", "cancelled"})
 # ``command/job_watcher.py`` can share one copy — ``job_watcher`` imports
 # ``command.jobs``, so a map owned by ``jobs`` could only be shared by importing
 # it the wrong way round.
-CLOUD_STATUS_ALIASES = {
-    "pending": "pending",
-    "in_progress": "running",
-    "completed": "completed",
-    "failed": "error",
-    "cancelled": "cancelled",
-    "canceled": "cancelled",
-    # legacy raw jobstate vocabulary (deprecated endpoint), kept defensively:
-    "success": "completed",
-    "error": "error",
-    "non_retryable_error": "error",
-    "lost": "error",
-    "executing": "running",
-}
+#
+# Read-only (like ``TERMINAL_STATUSES`` above) because the two consumers now
+# bind this object by identity rather than copying it: an in-place ``.update()``
+# / ``.pop()`` / ``monkeypatch.setitem`` used to be contained to one module and
+# would now rewrite terminal classification in the watcher and the exit code of
+# ``jobs watch`` process-wide.
+CLOUD_STATUS_ALIASES = types.MappingProxyType(
+    {
+        "pending": "pending",
+        "in_progress": "running",
+        "completed": "completed",
+        "failed": "error",
+        "cancelled": "cancelled",
+        "canceled": "cancelled",
+        # legacy raw jobstate vocabulary (deprecated endpoint), kept defensively:
+        "success": "completed",
+        "error": "error",
+        "non_retryable_error": "error",
+        # `retryable_error` is terminal-as-error here for the same reason
+        # ``output/glyphs.py`` already renders it ✗: the CLI is not told when
+        # (or whether) a retry happens, so the alternative is not "wait for the
+        # retry" but "sit on a status nothing recognizes" — `jobs watch` spins
+        # to `cloud_timeout`, `jobs ls` drops the state file's `error_code`, and
+        # the watcher's stall guard invents a terminal verdict after 300s
+        # anyway. Reporting the error the server reported is the honest one.
+        "retryable_error": "error",
+        "lost": "error",
+        "executing": "running",
+    }
+)
 
 
 def state_dir() -> Path:

--- a/comfy_cli/output/glyphs.py
+++ b/comfy_cli/output/glyphs.py
@@ -23,10 +23,20 @@ STATUS_STYLE: dict[str, tuple[str, str]] = {
 DEFAULT_STYLE: tuple[str, str] = ("·", "dim")
 
 
-# Cloud's raw status vocabulary (``executing``, ``success``, ``failed``,
-# ``non_retryable_error``, ``retryable_error``) doesn't match the small set
-# above. Canonicalize at the rendering boundary so users see one stable set
-# regardless of whether the prompt ran on a local server or Comfy Cloud.
+# Cloud's raw status vocabulary (``executing``, ``in_progress``, ``success``,
+# ``failed``, ``non_retryable_error``, ``retryable_error``, ``lost``) doesn't
+# match the small set above. Canonicalize at the rendering boundary so users see
+# one stable set regardless of whether the prompt ran on a local server or
+# Comfy Cloud.
+#
+# This has to agree with ``jobs_state.CLOUD_STATUS_ALIASES``, but deliberately
+# stays a separate literal rather than importing it: this module is the leaf of
+# the output package, and ``jobs_state`` pulls in ``comfy_cli.utils`` (psutil,
+# requests, rich) — too much to drag in to draw a check mark. The agreement is
+# pinned instead by
+# ``test_glyphs.test_cloud_aliases_agree_with_the_shared_status_map``, which
+# renders every key of the shared map through ``status_glyph`` and fails on any
+# drift in either direction.
 _CLOUD_ALIASES = {
     "executing": "running",
     # /api/jobs (ingest's filter enum) spells an executing job `in_progress`;
@@ -36,6 +46,8 @@ _CLOUD_ALIASES = {
     "failed": "error",
     "non_retryable_error": "error",
     "retryable_error": "error",
+    "lost": "error",
+    "canceled": "cancelled",
 }
 
 

--- a/comfy_cli/output/glyphs.py
+++ b/comfy_cli/output/glyphs.py
@@ -29,6 +29,9 @@ DEFAULT_STYLE: tuple[str, str] = ("·", "dim")
 # regardless of whether the prompt ran on a local server or Comfy Cloud.
 _CLOUD_ALIASES = {
     "executing": "running",
+    # /api/jobs (ingest's filter enum) spells an executing job `in_progress`;
+    # without this it renders as the unknown-status fallback dot.
+    "in_progress": "running",
     "success": "completed",
     "failed": "error",
     "non_retryable_error": "error",

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -15,6 +15,10 @@
       "description": "`cancelled` is one of `jobs_state.TERMINAL_STATUSES` and is copied verbatim out of a job's state file into a `jobs status` payload, so it belongs in this enum alongside the statuses the live `/queue` + `/history` snapshot produces.",
       "enum": ["running", "pending", "queued", "completed", "error", "cancelled", "unknown", "watching"]
     },
+    "status_raw": {
+      "type": ["string", "null"],
+      "description": "`jobs status`/`jobs watch --where cloud`: the server's own status spelling before canonicalization into the closed `status` enum above (e.g. `in_progress` -> `running`, `non_retryable_error` -> `error`). Null when the server reported no status. A cloud status this CLI does not know canonicalizes to `unknown` rather than passing through raw — this field is where that spelling survives, so the enum stays closed without losing what the server actually said."
+    },
     "queue_position": {"type": ["integer", "null"]},
     "workflow_size": {"type": ["integer", "null"]},
     "outputs": {"type": "array", "items": {"type": "string"}},

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -1886,6 +1886,7 @@ _CLOUD_STATUS_CASES = [
     ("canceled", "cancelled"),
     ("success", "completed"),
     ("non_retryable_error", "error"),
+    ("retryable_error", "error"),
     ("lost", "error"),
 ]
 
@@ -2031,6 +2032,101 @@ def test_poll_cloud_once_records_in_progress_as_running():
     assert state.status == "running"
     assert state.status in job_watcher._KNOWN_INFLIGHT_STATUSES
     assert state.status not in jobs_state.TERMINAL_STATUSES
+
+
+def test_retryable_error_is_classified_everywhere_the_other_failures_are():
+    """`retryable_error` is part of the raw cloud vocabulary `output/glyphs.py`
+    already renders ✗, but was the one failure spelling missing from the shared
+    map. Unmapped it reproduced the `in_progress` bug on all three surfaces: the
+    watcher never sees a terminal status (its stall guard then invents one after
+    300s), `jobs ls` rows miss `_ERROR_STATUSES` and drop the state file's
+    `error_code`, and `jobs watch` spins to `cloud_timeout`."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    assert jobs_state.CLOUD_STATUS_ALIASES["retryable_error"] == "error"
+
+    row = jobs_mod._cloud_job_to_row({"id": "pid-retry", "status": "retryable_error"})
+    assert row.status == "error"
+    assert row.status in jobs_mod._ERROR_STATUSES
+
+    client = _FakeCloudClient({"status": "retryable_error", "error_message": "boom"})
+    state = jobs_state.new(prompt_id="pid", client_id="c", workflow="w", where="cloud")
+    assert job_watcher._poll_cloud_once(state, client=client) is True
+    assert state.status == "error"
+    assert state.status in jobs_state.TERMINAL_STATUSES
+
+
+def test_shared_alias_map_is_read_only():
+    """The two consumers bind this map by identity (see the `is` assertions
+    above), so an in-place mutation that used to be contained to one module
+    would now rewrite terminal classification in the watcher and the exit code
+    of `jobs watch` process-wide. `TERMINAL_STATUSES` is a frozenset for the
+    same reason."""
+    from comfy_cli import jobs_state
+
+    with pytest.raises(TypeError):
+        jobs_state.CLOUD_STATUS_ALIASES["failed"] = "completed"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        jobs_state.CLOUD_STATUS_ALIASES.pop("failed")  # type: ignore[attr-defined]
+    assert jobs_state.CLOUD_STATUS_ALIASES["failed"] == "error"
+
+
+@pytest.mark.parametrize("raw_status", ["allocated", "uploading", "a_status_from_2027"])
+def test_cloud_status_snapshot_canonicalizes_an_unknown_status_and_keeps_the_raw(monkeypatch, raw_status):
+    """The top-level `status` is a closed enum (unlike the per-row
+    `jobs[].status`, which the schema deliberately leaves open), so a status the
+    CLI cannot map must not pass through raw and put the payload out of
+    contract. It resolves to the enum's `unknown`, and the server's own word
+    survives in `status_raw`."""
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient({"status": raw_status}))
+    snap = jobs_mod._cloud_status_snapshot("pid-alloc")
+    assert snap is not None
+    assert snap["status"] == "unknown"
+    assert snap["status_raw"] == raw_status
+
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    assert snap["status"] in schema["properties"]["status"]["enum"]
+    # Non-terminal, exactly like the raw passthrough it replaces — canonicalizing
+    # must not change when `_cloud_watch` decides a job is done.
+    assert snap["status"] not in {"completed", "error", "cancelled"}
+
+
+@pytest.mark.parametrize(("raw_status", "expected"), _CLOUD_STATUS_CASES)
+def test_cloud_status_snapshot_always_reports_the_servers_own_spelling(monkeypatch, raw_status, expected):
+    """`status_raw` is present on every cloud snapshot, not just unmapped ones,
+    so an agent can tell `in_progress` from `executing` after both canonicalize
+    to `running`."""
+
+    class _Client(_FakeCloudClient):
+        def get_history(self, prompt_id):
+            return None
+
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _Client({"status": raw_status}))
+    snap = jobs_mod._cloud_status_snapshot("pid-raw")
+    assert snap is not None
+    assert snap["status"] == expected
+    assert snap["status_raw"] == raw_status
+
+
+def test_cloud_watch_timeout_names_the_raw_status_it_is_stuck_on(monkeypatch, capsys):
+    """A timeout on a status the CLI cannot map is exactly when the server's own
+    word is the whole diagnostic — "still unknown" would name nothing."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _FakeCloudClient({"status": "allocated"}))
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    with pytest.raises(typer.Exit):
+        jobs_mod._cloud_watch("pid-stuck", poll_interval=0.0, max_wait=0.0)
+
+    lines = [json.loads(ln) for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    err = next(ln for ln in lines if ln.get("error", {}).get("code") == "cloud_timeout")
+    assert "allocated" in err["error"]["message"]
+    assert err["error"]["details"]["status"] == "unknown"
 
 
 _CLOUD_RECORD = {

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -1872,6 +1872,167 @@ def test_poll_cloud_once_treats_fatal_statuses_as_terminal(raw_status):
     assert state.error["message"] == "RIP to the server"
 
 
+# The status enum `GET /api/jobs/<id>` and `/api/jobs` actually serve (ingest's
+# `toFilterStatus`), plus the legacy raw-jobstate spellings the shared alias map
+# keeps defensively. `in_progress` is the one that used to pass through unmapped.
+_CLOUD_STATUS_CASES = [
+    # cloud's served filter enum
+    ("pending", "pending"),
+    ("in_progress", "running"),
+    ("completed", "completed"),
+    ("failed", "error"),
+    ("cancelled", "cancelled"),
+    # defensive aliases
+    ("canceled", "cancelled"),
+    ("success", "completed"),
+    ("non_retryable_error", "error"),
+    ("lost", "error"),
+]
+
+
+@pytest.mark.parametrize(("raw_status", "expected"), _CLOUD_STATUS_CASES)
+def test_cloud_status_snapshot_speaks_the_published_vocabulary(monkeypatch, raw_status, expected):
+    """Every status cloud actually serves maps into `schemas/jobs.json`'s enum."""
+
+    class _Client(_FakeCloudClient):
+        def get_history(self, prompt_id):
+            return None  # `completed` reaches the history fetch; nothing to group.
+
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _Client({"status": raw_status}))
+    snap = jobs_mod._cloud_status_snapshot("pid-vocab")
+    assert snap is not None
+    assert snap["status"] == expected
+
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    assert snap["status"] in schema["properties"]["status"]["enum"]
+
+
+def test_every_cloud_alias_target_is_in_the_published_status_enum():
+    """Guards the invariant the parametrized cases above only sample: whatever
+    an alias maps *to* must be a status `schemas/jobs.json` declares, so a
+    future entry cannot reintroduce an out-of-vocabulary passthrough."""
+    from comfy_cli import jobs_state
+
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    allowed = set(json.loads(schema_path.read_text())["properties"]["status"]["enum"])
+    assert set(jobs_state.CLOUD_STATUS_ALIASES.values()) <= allowed
+    # Everything ingest's `toFilterStatus` can serve is covered — an unmapped
+    # one falls through raw, which is how `in_progress` escaped in the first place.
+    assert {"pending", "in_progress", "completed", "failed", "cancelled"} <= set(jobs_state.CLOUD_STATUS_ALIASES)
+
+
+def test_cloud_status_snapshot_uses_the_one_shared_alias_map():
+    """`jobs status`, `jobs ls`, and the watcher must not re-diverge — they all
+    point at `jobs_state.CLOUD_STATUS_ALIASES`, not private copies."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    assert jobs_mod._CLOUD_ROW_STATUS_MAP is jobs_state.CLOUD_STATUS_ALIASES
+    assert job_watcher._CLOUD_STATUS_MAP is jobs_state.CLOUD_STATUS_ALIASES
+
+
+def test_cloud_job_to_row_maps_in_progress_to_running():
+    """`jobs ls --where cloud` rows carry the documented `running`, not the raw
+    `in_progress` JobRow's docstring never listed."""
+    row = jobs_mod._cloud_job_to_row({"id": "pid-row", "status": "in_progress"})
+    assert row.status == "running"
+    assert row.where == "cloud"
+
+
+def test_jobs_status_cloud_in_progress_envelope_is_schema_conformant(monkeypatch, capsys):
+    """End-to-end through `jobs status --where cloud` on an executing job: the
+    envelope reports `running`, and the payload validates against the published
+    schema.
+
+    The union schema's `required: ["host", "port"]` is the one violation
+    tolerated: cloud payloads carry `base_url` instead and never had host/port,
+    a pre-existing gap that predates (and is out of scope for) the status
+    vocabulary this test is about. Every OTHER schema error still fails —
+    filtering the known errors rather than dropping `required` wholesale keeps
+    a future required field from silently going unchecked here.
+    """
+    import jsonschema
+
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    class _RunningClient(_FakeCloudClient):
+        def get_history(self, prompt_id):  # pragma: no cover — in-flight never fetches
+            raise AssertionError("history must not be fetched for an in-flight job")
+
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: _RunningClient({"status": "in_progress"}))
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs status"))
+    jobs_mod._cloud_status("pid-inflight")
+    lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    env = json.loads(lines[-1])
+    assert env["type"] == "envelope" and env["ok"] is True
+    data = env["data"]
+    assert data["status"] == "running"
+
+    schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    errors = [
+        e
+        for e in jsonschema.Draft202012Validator(schema).iter_errors(data)
+        if not (e.validator == "required" and e.validator_value == ["host", "port"])
+    ]
+    assert errors == [], [e.message for e in errors]
+
+
+@pytest.mark.parametrize("raw_cancel", ["cancelled", "canceled"])
+def test_cloud_watch_in_progress_then_cancelled_exits_130(monkeypatch, capsys, raw_cancel):
+    """A cloud job that goes in_progress -> cancelled streams `running` then
+    `cancelled` state events, breaks out of the poll loop (no `cloud_timeout`),
+    and settles the documented cancelled verdict: ok:false, code `cancelled`,
+    exit 130."""
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    class _CancelClient(_FakeCloudClient):
+        def __init__(self):
+            super().__init__({})
+            self._statuses = iter(["in_progress", raw_cancel, raw_cancel])
+
+        def get_job_status(self, prompt_id):
+            return {"status": next(self._statuses)}
+
+    client = _CancelClient()
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_cloud_client", lambda: client)
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    with pytest.raises(typer.Exit) as exc:
+        jobs_mod._cloud_watch("pid-cancel", poll_interval=0.0, max_wait=5)
+    assert exc.value.exit_code == 130
+
+    lines = [json.loads(ln) for ln in capsys.readouterr().out.splitlines() if ln.strip()]
+    states = [ln["status"] for ln in lines if ln.get("type") == "state"]
+    assert states == ["running", "cancelled"]
+    env = lines[-1]
+    assert env["type"] == "envelope"
+    assert env["ok"] is False
+    assert env["error"]["code"] == "cancelled"
+    # A `cloud_timeout` here would mean the terminal status was never recognized.
+    assert not any(ln.get("error", {}).get("code") == "cloud_timeout" for ln in lines if ln.get("error"))
+
+
+def test_poll_cloud_once_records_in_progress_as_running():
+    """The async watcher writes `running` into the job state file — a raw
+    `in_progress` there would be a non-terminal status nothing recognizes."""
+    from comfy_cli import jobs_state
+    from comfy_cli.command import job_watcher
+
+    client = _FakeCloudClient({"status": "in_progress"})
+    state = jobs_state.new(prompt_id="pid", client_id="c", workflow="w", where="cloud")
+    assert job_watcher._poll_cloud_once(state, client=client) is False
+    assert state.status == "running"
+    assert state.status in job_watcher._KNOWN_INFLIGHT_STATUSES
+    assert state.status not in jobs_state.TERMINAL_STATUSES
+
+
 _CLOUD_RECORD = {
     "status": {"completed": True, "status_str": "success"},
     "outputs": {

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -1944,14 +1944,8 @@ def test_cloud_job_to_row_maps_in_progress_to_running():
 def test_jobs_status_cloud_in_progress_envelope_is_schema_conformant(monkeypatch, capsys):
     """End-to-end through `jobs status --where cloud` on an executing job: the
     envelope reports `running`, and the payload validates against the published
-    schema.
-
-    The union schema's `required: ["host", "port"]` is the one violation
-    tolerated: cloud payloads carry `base_url` instead and never had host/port,
-    a pre-existing gap that predates (and is out of scope for) the status
-    vocabulary this test is about. Every OTHER schema error still fails —
-    filtering the known errors rather than dropping `required` wholesale keeps
-    a future required field from silently going unchecked here.
+    schema with no exemptions — #696 made `host`/`port` required only for
+    payloads without a cloud `base_url`, so the cloud payload conforms outright.
     """
     import jsonschema
 
@@ -1975,11 +1969,7 @@ def test_jobs_status_cloud_in_progress_envelope_is_schema_conformant(monkeypatch
 
     schema_path = Path(__file__).parents[3] / "comfy_cli" / "schemas" / "jobs.json"
     schema = json.loads(schema_path.read_text())
-    errors = [
-        e
-        for e in jsonschema.Draft202012Validator(schema).iter_errors(data)
-        if not (e.validator == "required" and e.validator_value == ["host", "port"])
-    ]
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(data))
     assert errors == [], [e.message for e in errors]
 
 

--- a/tests/comfy_cli/output/test_glyphs.py
+++ b/tests/comfy_cli/output/test_glyphs.py
@@ -26,6 +26,31 @@ def test_cloud_in_progress_renders_as_running():
     assert "·" not in out
 
 
+def test_cloud_aliases_agree_with_the_shared_status_map():
+    """This module keeps its own alias literal on purpose — it is the leaf of
+    the output package and importing ``jobs_state`` here would drag psutil /
+    requests / rich in to draw a check mark. That copy is only safe if
+    something fails when the two drift, which is this test: every raw status
+    ``jobs_state.CLOUD_STATUS_ALIASES`` knows must render exactly as its
+    canonical form does.
+
+    Both directions have already drifted once — `lost` and `canceled` were in
+    the shared map but not here (rendering as the dim `·` unknown dot instead
+    of `✗`/`⊘`), and `retryable_error` was here but not there.
+    """
+    from comfy_cli import jobs_state
+
+    for raw, canonical in jobs_state.CLOUD_STATUS_ALIASES.items():
+        assert status_glyph(raw) == status_glyph(canonical), f"{raw!r} does not render as {canonical!r}"
+
+    # ...and nothing this module aliases may be unknown to the shared map: an
+    # entry only here would canonicalize one way on the pretty surface and
+    # another in the payload.
+    from comfy_cli.output.glyphs import _CLOUD_ALIASES
+
+    assert set(_CLOUD_ALIASES) <= set(jobs_state.CLOUD_STATUS_ALIASES)
+
+
 def test_cloud_failed_renders_as_error():
     assert "✗" in status_glyph("failed")
     assert "error" in status_glyph("failed")

--- a/tests/comfy_cli/output/test_glyphs.py
+++ b/tests/comfy_cli/output/test_glyphs.py
@@ -17,6 +17,15 @@ def test_cloud_executing_renders_as_running():
     assert "running" in status_glyph("executing")  # canonical label
 
 
+def test_cloud_in_progress_renders_as_running():
+    """`/api/jobs` spells an executing job `in_progress`; without the alias it
+    renders as the unknown-status fallback dot."""
+    out = status_glyph("in_progress")
+    assert "◐" in out
+    assert "running" in out
+    assert "·" not in out
+
+
 def test_cloud_failed_renders_as_error():
     assert "✗" in status_glyph("failed")
     assert "error" in status_glyph("failed")


### PR DESCRIPTION
## ELI-5

Comfy Cloud calls a job that is currently running `in_progress`. The CLI's dictionary of "what cloud words mean" never had that word in it, so the word leaked straight out to you: `comfy jobs status --where cloud` on a running job printed `status: "in_progress"`, which is not one of the statuses the CLI's own published schema says it can print. Now there is one dictionary, in one place, that all three copies share — and it knows `in_progress` means `running`.

## What changed

`GET /api/jobs/<id>` and `/api/jobs` serve ingest's filter enum — `pending`, `in_progress`, `completed`, `failed`, `cancelled` (`services/ingest/server/implementation/job.go` `toFilterStatus`). The CLI had **three separate copies** of a cloud→CLI status map, all still speaking the deprecated raw-jobstate dialect (`success`/`non_retryable_error`/`lost`). Consequences of the missing `in_progress` entry, all of which this fixes:

- `comfy --json jobs status --where cloud` emitted a `status` outside the `comfy_cli/schemas/jobs.json` enum.
- `comfy jobs watch --where cloud` streamed `in_progress` as an NDJSON `state` event.
- `_cloud_job_to_row` put it on a `JobRow` whose documented vocabulary is `running`, so `jobs ls --where cloud` rendered it too.
- The detached watcher wrote it into the job state file — where it is **not** in `_KNOWN_INFLIGHT_STATUSES`, so the 300s stall guard declared `unknown_status_stall` and gave up on a perfectly healthy long-running cloud job. That is the one behavior fix here beyond the string change, and it is strictly in the safe direction (more statuses recognized as in-flight, none removed).
- `glyphs.status_glyph` rendered the unknown-status fallback dot instead of the `running` spinner glyph.

`cancelled` was landing correctly only by `.get(raw, raw)` fall-through in each copy.

The fix: one `jobs_state.CLOUD_STATUS_ALIASES` map, with all three copies now pointing at it. It lives in `jobs_state` rather than `command/jobs.py` because `command/job_watcher.py` imports `command/jobs.py` — a map owned by `jobs` could only be shared by importing it the wrong way round. `output/glyphs.py` keeps its own display-alias table (different concern — it also handles local-only spellings) and just gains the `in_progress` entry.

## User-visible change

Running cloud jobs now report `status: "running"` (schema-conformant) instead of the accidental raw `in_progress` — on `jobs status`, `jobs watch`, `jobs ls --where cloud`, and in job state files. **No exit codes change.** A cancelled cloud job already terminated `jobs watch` with 130 and settled `jobs wait` at 130 on `main` (`cancelled` fell through into `_cloud_watch`'s terminal set, `jobs_state.TERMINAL_STATUSES`, and `_TERMINAL_VERDICT`); this PR just makes that path explicit rather than accidental. `jobs status` remains a pure observer (plain `renderer.emit`, exit 0 for every status).

`_ERROR_STATUSES` gating from #677 is untouched: `in_progress`→`running` is not an error status, so `error_code` attribution on `jobs ls` rows behaves exactly as before.

## Tests

New coverage in `tests/comfy_cli/jobs/test_jobs.py` and `tests/comfy_cli/output/test_glyphs.py`:

- The snapshot parametrized over the **actual served enum** (`pending`, `in_progress`, `completed`, `failed`, `cancelled`) plus the defensive aliases (`canceled`, `success`, `non_retryable_error`, `lost`), each asserted to land inside the published `status` enum.
- An invariant test that **every** value in `CLOUD_STATUS_ALIASES` is in the schema enum and every served status is a key — so a future entry cannot reintroduce an out-of-vocabulary passthrough.
- An identity test that `jobs._CLOUD_ROW_STATUS_MAP` and `job_watcher._CLOUD_STATUS_MAP` really are the one shared object, so the three copies cannot silently re-diverge.
- `jobs status --where cloud` end-to-end on a mocked `in_progress` job: envelope reports `running` and the payload validates against `comfy_cli/schemas/jobs.json`.
- `_cloud_watch` on `in_progress` → `cancelled` (and the single-l `canceled` spelling): `state` events `running` then `cancelled`, loop breaks with no `cloud_timeout`, envelope `ok:false`, code `cancelled`, exit 130 — locking in the existing behavior rather than changing it.
- `_poll_cloud_once` on `in_progress`: state file records `running`, non-terminal, and inside `_KNOWN_INFLIGHT_STATUSES`.
- `glyphs.status_glyph("in_progress")` renders the `running` glyph, not the fallback dot.

Verified red→green: with the test files in place and the source change reverted, 9 of these fail.

## Verification run

- `ruff check` / `ruff format --check` clean on every touched file. (The repo-wide run reports 17 `UP038` errors + 1 unformatted file — **identical on `origin/main` with no diff applied**; that is a newer local ruff than CI's pin, not something this PR introduces.)
- `pytest` green over every test module that imports `jobs_state`, `job_watcher`, `command.jobs`, or `glyphs`: `tests/comfy_cli/jobs`, `tests/comfy_cli/output`, `test_jobs_state.py`, `command/test_run.py`, `command/test_observer_session_safety.py`, `command/test_jobs_pid_alive.py`, `command/test_pretty_print_sanitize.py`, `command/test_command_init.py` — **578 passed**.
- **Judgment call / not done:** the whole-repo `pytest` was started but reached only ~8% in 11 minutes (≈2h projected) while holding the machine-wide suite lock, so it was stopped in favor of the targeted set above. Full-suite coverage is left to CI. The change is three module-level rebindings plus one dict entry, and every module that reads those symbols is in the set that was run.

## Provenance

- Coordination: PR #677 (`_CLOUD_ROW_STATUS_MAP`) **has merged**, so its map was absorbed into the shared one per the plan rather than landed alongside it.
- Supersedes BE-6612 (named in commit ee847d1). The concern that deferred this work out of #677 — "adding the cancel aliases changes an exit code" — does not apply: `cancelled` already reached the terminal sets by fall-through, so no exit code moves. The now-deleted `# Deliberately NOT _CLOUD_ROW_STATUS_MAP` comment block recorded that concern and goes away with it.
- The shared map is a plain `dict`, matching the spec, rather than a `MappingProxyType`. Aliasing it by reference into two modules is safe because nothing in the tree mutates any of the three names (verified by grep); a frozen mapping would be belt-and-braces but is scope the ticket did not ask for.
- `run --wait`'s cloud path also calls `get_job_status`, and was checked and deliberately **not** changed: it passes the raw status to `wait_for_completion` purely as an opaque change-detection signal for the silence deadline, and derives its terminal verdict from `/history_v2`'s `status_str` — a different vocabulary entirely.
- No change to `comfy_cli/schemas/jobs.json` — conforming to it is the point.
