### PR TITLE
feat(models): prune old background-download records (BE-6653)

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -755,9 +755,12 @@ def _submit_background_download(
 
     # Every submit adds two files here and nothing else ever removes them, so the
     # sweep rides along with the one command that grows the directory. Belt and
-    # braces: `prune` is already best-effort per file, and this covers the
-    # directory scan it starts with — a submit must never fail over bookkeeping.
-    with contextlib.suppress(OSError):
+    # braces: `prune` already swallows an OSError on every unlink *and* on the
+    # directory scan, so nothing should escape — but the state file is already
+    # written and the worker not yet spawned, so anything that did escape would
+    # strand a `starting` record with no download behind it. A submit must never
+    # fail over bookkeeping, so nothing at all is allowed out of here.
+    with contextlib.suppress(Exception):
         download_state.prune(workspace)
 
     try:
@@ -820,7 +823,14 @@ def _download_worker(
     cancel_marker = download_state.cancel_marker_for(path)
 
     def cancelled() -> bool:
-        return cancel_marker.exists()
+        # The sentinel is the explicit stop request. A vanished state file is the
+        # implicit one: `prune` deletes a record together with its sentinel, so
+        # without this a worker that outlived a failed `download-cancel` kill and
+        # woke up after the sweep would no longer see the cancel and would resume
+        # writing to `dest`. Nothing is tracking this transfer any more, and
+        # nothing could cancel it again — stop. State writes are atomic
+        # (`os.replace`), so the file never transiently disappears.
+        return cancel_marker.exists() or not path.exists()
 
     # `download-cancel` may have landed while we were still starting up — it
     # can't signal a process that has no pid on file yet, so the sentinel is how
@@ -878,8 +888,12 @@ def _download_worker(
             with contextlib.suppress(OSError):
                 pathlib.Path(state.dest).unlink(missing_ok=True)
         state.completed_bytes = 0
-        with contextlib.suppress(OSError):
-            download_state.write_path(path, state)
+        # Only persist a record that is still on disk: `write_path` would
+        # otherwise recreate — with a fresh `updated_at` — one `prune` just
+        # collected, and the sweep would have to age it out all over again.
+        if path.exists():
+            with contextlib.suppress(OSError):
+                download_state.write_path(path, state)
         raise typer.Exit(code=0) from None
     except BaseException as e:  # noqa: BLE001 — any failure must reach the state file
         state.status = "failed"
@@ -990,7 +1004,7 @@ def downloads(
         bool,
         typer.Option(
             "--prune",
-            help="Remove terminal download records older than 7 days (always keeps the 50 most recent).",
+            help="Remove finished download records older than 7 days (always keeps the 50 most recent).",
         ),
     ] = False,
 ):
@@ -998,14 +1012,25 @@ def downloads(
     renderer = get_renderer()
 
     pruned = 0
+    prune_failed = False
     if prune:
         # Before the rows are built, so the listing shows exactly the survivors.
-        with contextlib.suppress(OSError):
+        try:
             pruned = download_state.prune(get_workspace())
+        except Exception as e:  # noqa: BLE001 — `prune` is documented not to raise
+            # Reaching here means the sweep died somewhere its own per-file and
+            # per-scan handling doesn't cover, possibly *after* deleting records.
+            # The user asked for a destructive operation, so say it didn't finish
+            # rather than reporting a clean `pruned: 0`/`changed: false` no-op.
+            prune_failed = True
+            print(f"[bold yellow]Could not finish pruning download records: {escape(str(e))}[/bold yellow]")
         if pruned:
             print(f"Pruned {pruned} old download record(s).")
 
-    rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(get_workspace())]
+    # `_reconciled` persists status corrections, so a plain listing can mutate
+    # on-disk state too; keep its flags to fold into `changed` below.
+    reconciled = [_reconciled(s) for s in download_state.list_all(get_workspace())]
+    rows = [download_state.status_payload(fresh) for fresh, _ in reconciled]
     if not rows:
         print("No background downloads found.")
     else:
@@ -1014,9 +1039,12 @@ def downloads(
     payload = {"total": len(rows), "downloads": rows}
     if prune:
         payload["pruned"] = pruned
-    # A plain listing changes nothing and keeps emitting no `changed` at all —
-    # only the pruning form has a mutation to report.
-    renderer.emit(payload, command="model downloads", changed=(pruned > 0) if prune else None)
+    # A plain listing keeps emitting no `changed` at all — only the pruning form
+    # has a mutation to report. When it does report one it covers every write
+    # this call made: deletions, the reconciliation write-backs above, and a
+    # sweep that failed partway and may have deleted before it did.
+    changed = pruned > 0 or prune_failed or any(did for _, did in reconciled)
+    renderer.emit(payload, command="model downloads", changed=changed if prune else None)
 
 
 @app.command("download-cancel")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -753,6 +753,13 @@ def _submit_background_download(
         )
         raise typer.Exit(code=1) from e
 
+    # Every submit adds two files here and nothing else ever removes them, so the
+    # sweep rides along with the one command that grows the directory. Belt and
+    # braces: `prune` is already best-effort per file, and this covers the
+    # directory scan it starts with — a submit must never fail over bookkeeping.
+    with contextlib.suppress(OSError):
+        download_state.prune(workspace)
+
     try:
         pid = _spawn_download_worker(state_file, log_file)
     except OSError as e:
@@ -977,15 +984,39 @@ def download_status(
 
 @app.command("downloads")
 @tracking.track_command("model")
-def downloads(_ctx: typer.Context):
+def downloads(
+    _ctx: typer.Context,
+    prune: Annotated[
+        bool,
+        typer.Option(
+            "--prune",
+            help="Remove terminal download records older than 7 days (always keeps the 50 most recent).",
+        ),
+    ] = False,
+):
     """List every background download this workspace knows about, newest first."""
     renderer = get_renderer()
+
+    pruned = 0
+    if prune:
+        # Before the rows are built, so the listing shows exactly the survivors.
+        with contextlib.suppress(OSError):
+            pruned = download_state.prune(get_workspace())
+        if pruned:
+            print(f"Pruned {pruned} old download record(s).")
+
     rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(get_workspace())]
     if not rows:
         print("No background downloads found.")
     else:
         _render_download_rows(rows)
-    renderer.emit({"total": len(rows), "downloads": rows}, command="model downloads")
+
+    payload = {"total": len(rows), "downloads": rows}
+    if prune:
+        payload["pruned"] = pruned
+    # A plain listing changes nothing and keeps emitting no `changed` at all —
+    # only the pruning form has a mutation to report.
+    renderer.emit(payload, command="model downloads", changed=(pruned > 0) if prune else None)
 
 
 @app.command("download-cancel")

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -44,13 +44,18 @@ should be able to read — or tamper with — these records.
 Cancellation is signalled out-of-band by an empty ``<id>.cancel`` sentinel next
 to the state file. A sentinel can't be clobbered by a state write that raced it,
 so a worker that comes up (or ticks) after ``download-cancel`` always observes
-the request; see :func:`request_cancel`.
+the request; see :func:`request_cancel`. A worker treats its own state file
+disappearing as a cancellation too — that is what keeps :func:`prune` from
+collecting a record out from under a worker that outlived a failed kill and
+leaving it writing bytes nothing can track or stop.
 
 Terminal statuses (``completed``, ``failed``, ``cancelled``) mean the file won't
-change further; agents can stop polling. Such records are also the only ones
-:func:`prune` may delete — it keeps the :data:`PRUNE_KEEP` most recent records
-whatever their age, so the directory stays bounded without losing the recent
-history ``comfy model downloads`` renders.
+change further; agents can stop polling. Such records are what :func:`prune`
+normally collects; a record still claiming an *active* status is only collected
+after the far longer :data:`PRUNE_ACTIVE_MAX_AGE_S` (no live worker goes that
+long without a write). Either way prune keeps the :data:`PRUNE_KEEP` most recent
+records whatever their age, so the directory stays bounded without losing the
+recent history ``comfy model downloads`` renders.
 """
 
 from __future__ import annotations
@@ -86,6 +91,17 @@ PROGRESS_THROTTLE_S = 1.0
 # long-lived workspace.
 PRUNE_MAX_AGE_S = 7 * 24 * 3600.0
 PRUNE_KEEP = 50
+
+# A record still claiming `starting`/`downloading` gets its own, much longer
+# window. Without one the directory is not actually bounded: prune reads the
+# on-disk status as-is (see `prune`), so records left `downloading` by SIGKILLed
+# workers are only collected once some *poll* verb reconciles them to a terminal
+# status — and a submit-only workflow (fire `--background`, watch the
+# destination file, never poll) never runs one. A worker rewrites its state file
+# at least every PROGRESS_THROTTLE_S while it makes progress, so an active
+# record this stale has no live writer; the worker also treats its record
+# disappearing as a cancellation, so collecting one can't leave bytes streaming.
+PRUNE_ACTIVE_MAX_AGE_S = 30 * 24 * 3600.0
 
 # The state dir can hold presigned urls; keep it owner-only.
 STATE_DIR_MODE = 0o700
@@ -306,7 +322,12 @@ _FIELD_VALIDATORS: dict[str, Any] = {
 def read_path(path: Path) -> DownloadState | None:
     try:
         data = json.loads(Path(path).read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
+        # ValueError covers both json.JSONDecodeError and the UnicodeDecodeError
+        # a state file with invalid UTF-8 raises out of `read_text`. Callers rely
+        # on an unreadable record reading as *absent* rather than raising — the
+        # opportunistic sweep on the submit path must never fail a download over
+        # one corrupt file it happened to glob.
         return None
     if not isinstance(data, dict):
         return None
@@ -323,70 +344,151 @@ def read_path(path: Path) -> DownloadState | None:
         return None
 
 
+def _iter_records(workspace: Path) -> list[tuple[Path, DownloadState]]:
+    """Every readable state file paired with the path it was read from, newest first.
+
+    The path is what callers that *delete* need: a record's ``id`` field is
+    untrusted content read back off disk and does not necessarily agree with the
+    filename it was found under.
+    """
+    base = Path(workspace) / STATE_DIRNAME
+    try:
+        if not base.is_dir():
+            return []
+        paths = sorted(base.glob("*.json"))
+    except OSError:
+        return []
+    records = [(p, s) for p, s in ((p, read_path(p)) for p in paths) if s is not None]
+    records.sort(key=lambda item: (item[1].started_at or "", item[1].id), reverse=True)
+    return records
+
+
 def list_all(workspace: Path) -> list[DownloadState]:
     """Every readable state file, newest ``started_at`` first."""
+    return [state for _, state in _iter_records(workspace)]
+
+
+def _remove_record(state_file: Path) -> bool:
+    """Delete one record plus its ``.log``/``.cancel`` sidecars. True if it went.
+
+    Both the record and its sidecars are addressed relative to ``state_file``,
+    never rebuilt from the record's own ``id`` field: a corrupt or hand-copied
+    ``<a>.json`` carrying ``"id": "<b>"`` would otherwise unlink ``<b>``'s state,
+    log and cancel sentinel — potentially an in-flight download's — while
+    ``<a>.json`` survived every subsequent sweep. This is also exactly how the
+    worker derives its own sentinel (see :func:`cancel_marker_for`).
+
+    The state file goes first and the sidecars only follow if it actually went.
+    A record that could not be deleted (read-only mount, EPERM, a Windows
+    sharing violation) keeps showing up in ``comfy model downloads``, so it must
+    keep its ``<id>.log`` — the only diagnostic for why that download failed —
+    and its cancel sentinel with it.
+    """
+    try:
+        state_file.unlink(missing_ok=True)
+    except OSError:
+        return False
+    for sidecar in (state_file.with_suffix(".log"), state_file.with_suffix(".cancel")):
+        with contextlib.suppress(OSError):
+            sidecar.unlink(missing_ok=True)
+    return True
+
+
+def _mtime_before(path: Path, cutoff: datetime) -> bool:
+    """True when ``path``'s mtime is at or before ``cutoff`` (False if unknowable)."""
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, timezone.utc) <= cutoff
+    except (OSError, OverflowError, ValueError):
+        return False
+
+
+def _sweep_junk(workspace: Path, cutoff: datetime, readable: set[Path]) -> int:
+    """Collect what :func:`_iter_records` cannot see, and would leak forever.
+
+    Three kinds: state files too corrupt for :func:`read_path` to parse, ``.tmp``
+    files a :func:`write_path` killed between write and ``os.replace`` leaked,
+    and ``.log``/``.cancel`` sidecars whose record is already gone. None of these
+    has a record timestamp to age off, so mtime stands in — and nothing is
+    touched inside the same window live files use, so a write racing the sweep is
+    never in scope. ``readable`` is the set of state files that *did* parse, so
+    they are not re-read here. Returns the number of *records* (state files)
+    removed; sidecars and tmp files are not records and are not counted.
+    """
     base = Path(workspace) / STATE_DIRNAME
-    if not base.is_dir():
-        return []
-    states = [s for s in (read_path(p) for p in sorted(base.glob("*.json"))) if s is not None]
-    states.sort(key=lambda s: (s.started_at or "", s.id), reverse=True)
-    return states
+    try:
+        entries = sorted(base.iterdir())
+    except OSError:
+        return 0
+    record_stems = {p.stem for p in entries if p.suffix == ".json"}
+    removed = 0
+    for path in entries:
+        suffix = path.suffix
+        if suffix == ".json":
+            if path in readable:
+                continue  # a readable record; the age sweep above owns it
+        elif suffix in (".log", ".cancel"):
+            if path.stem in record_stems:
+                continue  # still paired with a record
+        elif suffix != ".tmp":
+            continue
+        if not _mtime_before(path, cutoff):
+            continue
+        if suffix == ".json":
+            if _remove_record(path):
+                removed += 1
+        else:
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+    return removed
 
 
-def prune(workspace: Path, *, max_age_s: float = PRUNE_MAX_AGE_S, keep: int = PRUNE_KEEP) -> int:
-    """Delete terminal records older than ``max_age_s``, keeping the ``keep`` most recent.
+def prune(
+    workspace: Path,
+    *,
+    max_age_s: float = PRUNE_MAX_AGE_S,
+    active_max_age_s: float = PRUNE_ACTIVE_MAX_AGE_S,
+    keep: int = PRUNE_KEEP,
+) -> int:
+    """Delete records older than ``max_age_s``, keeping the ``keep`` most recent.
 
     Age is measured from ``updated_at`` (the terminal transition time — every
     :func:`write_path` refreshes it), falling back to ``started_at`` when
-    unparsable; a record with neither parsable is junk and prunes. Records in
-    :data:`ACTIVE_STATUSES` are never touched, regardless of age — the on-disk
-    status is read as-is rather than :func:`reconcile`d, so a record whose worker
-    died while ``downloading`` is left alone until the next
-    ``downloads``/``download-status`` reconciles it to a terminal status, and a
-    later sweep collects it. That keeps prune off psutil, which is what lets it
-    be called opportunistically from the submit path.
+    unparsable; a record with neither parsable is junk and prunes. A record in
+    :data:`ACTIVE_STATUSES` is held to the far longer ``active_max_age_s``
+    instead: the on-disk status is read as-is rather than :func:`reconcile`d, so
+    a record whose worker died while ``downloading`` is normally left for the
+    next ``downloads``/``download-status`` to reconcile to a terminal status and
+    a later sweep to collect — but a workflow that only ever submits never runs
+    one, and those records must not accumulate forever either. Reading the
+    status as-is is what keeps prune off psutil, which is what lets it be called
+    opportunistically from the submit path.
 
     The keep floor counts ALL records, active and terminal alike, so it matches
     what ``comfy model downloads`` renders. Each pruned record's ``<id>.log`` and
-    ``<id>.cancel`` go with it. Best effort per file: an :class:`OSError` on one
-    unlink never aborts the sweep or propagates. Returns the number of records
-    removed.
+    ``<id>.cancel`` go with it; unparsable records, leaked ``.tmp`` files and
+    orphaned sidecars past the same window go too (see :func:`_sweep_junk`).
+    Best effort per file: an :class:`OSError` on one unlink — or on the directory
+    scan itself — never aborts the sweep or propagates. Returns the number of
+    records removed.
     """
     workspace = Path(workspace)
     keep = max(0, keep)
-    states = list_all(workspace)
-    if len(states) <= keep:
-        return 0
+    records = _iter_records(workspace)
 
-    cutoff = datetime.now(timezone.utc) - timedelta(seconds=max_age_s)
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=max_age_s)
+    active_cutoff = now - timedelta(seconds=active_max_age_s)
     removed = 0
-    for state in states[keep:]:
-        if state.status not in TERMINAL_STATUSES:
-            continue
+    for path, state in records[keep:]:
+        # An unrecognised status is neither active nor renderable history — it
+        # ages out on the normal window rather than pinning a file forever.
+        limit = active_cutoff if state.status in ACTIVE_STATUSES else cutoff
         stamp = _parse_iso(state.updated_at) or _parse_iso(state.started_at)
-        if stamp is not None and stamp > cutoff:
+        if stamp is not None and stamp > limit:
             continue
-        try:
-            # Route through the path helpers so the id re-validates: it comes
-            # out of a file this process did not necessarily write.
-            targets = (
-                state_path(workspace, state.id),
-                log_path(workspace, state.id),
-                cancel_path(workspace, state.id),
-            )
-        except ValueError:
-            continue
-        state_file, *side_files = targets
-        gone = False
-        with contextlib.suppress(OSError):
-            state_file.unlink(missing_ok=True)
-            gone = True
-        for path in side_files:
-            with contextlib.suppress(OSError):
-                path.unlink(missing_ok=True)
-        if gone:
+        if _remove_record(path):
             removed += 1
-    return removed
+    return removed + _sweep_junk(workspace, cutoff, {path for path, _ in records})
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -47,7 +47,10 @@ so a worker that comes up (or ticks) after ``download-cancel`` always observes
 the request; see :func:`request_cancel`.
 
 Terminal statuses (``completed``, ``failed``, ``cancelled``) mean the file won't
-change further; agents can stop polling.
+change further; agents can stop polling. Such records are also the only ones
+:func:`prune` may delete — it keeps the :data:`PRUNE_KEEP` most recent records
+whatever their age, so the directory stays bounded without losing the recent
+history ``comfy model downloads`` renders.
 """
 
 from __future__ import annotations
@@ -61,7 +64,7 @@ import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +78,14 @@ ACTIVE_STATUSES = frozenset({"starting", "downloading"})
 # The worker rewrites the state file at most this often while bytes stream in.
 # Terminal transitions always write, regardless of the throttle.
 PROGRESS_THROTTLE_S = 1.0
+
+# Nothing else ever removes a record, so the state directory grows by two files
+# per submit forever. `prune` bounds it: terminal records older than
+# PRUNE_MAX_AGE_S are removable, but the PRUNE_KEEP most recent are kept
+# regardless of age so `comfy model downloads` still renders recent history in a
+# long-lived workspace.
+PRUNE_MAX_AGE_S = 7 * 24 * 3600.0
+PRUNE_KEEP = 50
 
 # The state dir can hold presigned urls; keep it owner-only.
 STATE_DIR_MODE = 0o700
@@ -320,6 +331,62 @@ def list_all(workspace: Path) -> list[DownloadState]:
     states = [s for s in (read_path(p) for p in sorted(base.glob("*.json"))) if s is not None]
     states.sort(key=lambda s: (s.started_at or "", s.id), reverse=True)
     return states
+
+
+def prune(workspace: Path, *, max_age_s: float = PRUNE_MAX_AGE_S, keep: int = PRUNE_KEEP) -> int:
+    """Delete terminal records older than ``max_age_s``, keeping the ``keep`` most recent.
+
+    Age is measured from ``updated_at`` (the terminal transition time — every
+    :func:`write_path` refreshes it), falling back to ``started_at`` when
+    unparsable; a record with neither parsable is junk and prunes. Records in
+    :data:`ACTIVE_STATUSES` are never touched, regardless of age — the on-disk
+    status is read as-is rather than :func:`reconcile`d, so a record whose worker
+    died while ``downloading`` is left alone until the next
+    ``downloads``/``download-status`` reconciles it to a terminal status, and a
+    later sweep collects it. That keeps prune off psutil, which is what lets it
+    be called opportunistically from the submit path.
+
+    The keep floor counts ALL records, active and terminal alike, so it matches
+    what ``comfy model downloads`` renders. Each pruned record's ``<id>.log`` and
+    ``<id>.cancel`` go with it. Best effort per file: an :class:`OSError` on one
+    unlink never aborts the sweep or propagates. Returns the number of records
+    removed.
+    """
+    workspace = Path(workspace)
+    keep = max(0, keep)
+    states = list_all(workspace)
+    if len(states) <= keep:
+        return 0
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=max_age_s)
+    removed = 0
+    for state in states[keep:]:
+        if state.status not in TERMINAL_STATUSES:
+            continue
+        stamp = _parse_iso(state.updated_at) or _parse_iso(state.started_at)
+        if stamp is not None and stamp > cutoff:
+            continue
+        try:
+            # Route through the path helpers so the id re-validates: it comes
+            # out of a file this process did not necessarily write.
+            targets = (
+                state_path(workspace, state.id),
+                log_path(workspace, state.id),
+                cancel_path(workspace, state.id),
+            )
+        except ValueError:
+            continue
+        state_file, *side_files = targets
+        gone = False
+        with contextlib.suppress(OSError):
+            state_file.unlink(missing_ok=True)
+            gone = True
+        for path in side_files:
+            with contextlib.suppress(OSError):
+                path.unlink(missing_ok=True)
+        if gone:
+            removed += 1
+    return removed
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/schemas/downloads.json
+++ b/comfy_cli/schemas/downloads.json
@@ -14,7 +14,7 @@
     },
     "pruned": {
       "type": "integer",
-      "description": "Number of old terminal records deleted by this call. Present only when `--prune` was passed."
+      "description": "Number of old records deleted by this call. Present only when `--prune` was passed."
     }
   }
 }

--- a/comfy_cli/schemas/downloads.json
+++ b/comfy_cli/schemas/downloads.json
@@ -11,6 +11,10 @@
     "downloads": {
       "type": "array",
       "items": { "$ref": "download_status.json#/$defs/row" }
+    },
+    "pruned": {
+      "type": "integer",
+      "description": "Number of old terminal records deleted by this call. Present only when `--prune` was passed."
     }
   }
 }

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -129,6 +130,12 @@ class TestStatePersistence:
 # ---------------------------------------------------------------------------
 
 
+def _backdate(path: Path, days_ago: float) -> None:
+    """Push ``path``'s mtime into the past — the only age the junk sweep has."""
+    when = time.time() - days_ago * 86400
+    os.utime(path, (when, when))
+
+
 def _persist_aged(
     workspace,
     *,
@@ -172,14 +179,73 @@ class TestPrune:
         assert download_state.list_all(workspace) == []
 
     @pytest.mark.parametrize("status", ["starting", "downloading"])
-    def test_active_records_are_never_pruned_however_old(self, workspace, status):
+    def test_active_records_survive_the_terminal_window(self, workspace, status):
         """An in-flight record has no business being deleted, and prune reads the
         on-disk status rather than reconciling — a worker that died mid-transfer
         is collected on a later sweep, once a poll verb has marked it failed."""
-        state = _persist_aged(workspace, status=status, days_ago=30)
+        state = _persist_aged(workspace, status=status, days_ago=20)
 
         assert download_state.prune(workspace, keep=0) == 0
         assert download_state.state_path(workspace, state.id).exists()
+
+    @pytest.mark.parametrize("status", ["starting", "downloading"])
+    def test_a_long_dead_active_record_is_eventually_collected(self, workspace, status):
+        """Otherwise the directory is not bounded at all: a workflow that only
+        ever submits never runs the poll verb that would reconcile these to a
+        terminal status, so they would accumulate forever. A worker writes at
+        least every PROGRESS_THROTTLE_S, so nothing live is this stale."""
+        state = _persist_aged(workspace, status=status, days_ago=40)
+
+        assert download_state.prune(workspace, keep=0) == 1
+        assert not download_state.state_path(workspace, state.id).exists()
+
+    def test_an_unrecognised_status_ages_out_on_the_normal_window(self, workspace):
+        """Neither terminal nor active: junk, and it must not pin a file forever."""
+        state = _persist_aged(workspace, status="wat", days_ago=8)
+
+        assert download_state.prune(workspace, keep=0) == 1
+        assert not download_state.state_path(workspace, state.id).exists()
+
+    def test_deletion_targets_come_from_the_filename_not_the_id_field(self, workspace):
+        """A record's `id` is untrusted content read back off disk. Rebuilding
+        the unlink targets from it lets a corrupt or hand-copied `<a>.json`
+        carrying `"id": "<b>"` delete *b*'s state and cancel sentinel — possibly
+        an in-flight download's — while surviving every sweep itself."""
+        victim = _state(status="downloading")
+        download_state.write(workspace, victim)
+        victim_cancel = download_state.cancel_path(workspace, victim.id)
+        victim_cancel.touch()
+
+        impostor = _persist_aged(workspace, status="completed", days_ago=8)
+        impostor_path = download_state.state_path(workspace, impostor.id)
+        data = json.loads(impostor_path.read_text())
+        data["id"] = victim.id
+        impostor_path.write_text(json.dumps(data))
+
+        assert download_state.prune(workspace, keep=0) == 1
+
+        assert not impostor_path.exists(), "the file actually enumerated is the one that goes"
+        assert download_state.state_path(workspace, victim.id).exists()
+        assert victim_cancel.exists()
+
+    def test_sidecars_survive_a_state_file_that_could_not_be_removed(self, workspace, monkeypatch):
+        """A record still listed by `comfy model downloads` must keep its
+        `<id>.log` — the only diagnostic for why that download failed."""
+        state = _persist_aged(workspace, status="failed", days_ago=8)
+        log = download_state.log_path(workspace, state.id)
+        log.write_text("traceback\n")
+        real_unlink = Path.unlink
+
+        def selective(self, missing_ok=False):
+            if self.suffix == ".json":
+                raise OSError("read-only file system")
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", selective)
+
+        assert download_state.prune(workspace, keep=0) == 0
+        assert download_state.state_path(workspace, state.id).exists()
+        assert log.read_text() == "traceback\n"
 
     def test_keep_floor_wins_over_age(self, workspace):
         # started_at descending, so "newest" is unambiguous.
@@ -226,6 +292,70 @@ class TestPrune:
 
         assert download_state.prune(workspace, keep=len(states)) == 0
         assert len(download_state.list_all(workspace)) == len(states)
+
+
+class TestPruneCollectsJunk:
+    """`list_all` can only see what parses, so exactly the debris most likely to
+    accumulate — unreadable records, tmp files a killed writer leaked, sidecars
+    whose record is gone — is what a record-only sweep would leak forever. None
+    of it has a record timestamp, so mtime stands in for one.
+    """
+
+    def _junk(self, workspace, name: str, *, body: bytes = b"junk", days_ago: float) -> Path:
+        path = download_state.state_dir(workspace) / name
+        path.write_bytes(body)
+        _backdate(path, days_ago)
+        return path
+
+    @pytest.mark.parametrize("body", [b"{not json", b"\xff\xfe not utf-8"], ids=["bad-json", "bad-utf8"])
+    def test_an_old_unreadable_record_is_collected_with_its_sidecars(self, workspace, body):
+        path = self._junk(workspace, "deadbeefcafe.json", body=body, days_ago=8)
+        log = self._junk(workspace, "deadbeefcafe.log", days_ago=8)
+
+        assert download_state.prune(workspace, keep=0) == 1
+        assert not path.exists()
+        assert not log.exists()
+
+    def test_a_fresh_unreadable_record_is_left_alone(self, workspace):
+        """It could be a file something is still mid-way through creating."""
+        path = self._junk(workspace, "deadbeefcafe.json", body=b"{not json", days_ago=0)
+
+        assert download_state.prune(workspace, keep=0) == 0
+        assert path.exists()
+
+    def test_an_old_leaked_tmp_file_is_collected_but_a_fresh_one_is_not(self, workspace):
+        stale = self._junk(workspace, "deadbeefcafe.1234.ab12cd34.tmp", days_ago=8)
+        live = self._junk(workspace, "cafedeadbeef.1234.ef56ab78.tmp", days_ago=0)
+
+        # tmp files are not records, so they never count toward the return value.
+        assert download_state.prune(workspace, keep=0) == 0
+        assert not stale.exists()
+        assert live.exists()
+
+    def test_orphaned_sidecars_are_collected_but_paired_ones_are_kept(self, workspace):
+        kept = _state(status="downloading")
+        download_state.write(workspace, kept)
+        paired_log = download_state.log_path(workspace, kept.id)
+        paired_log.write_text("still in flight\n")
+        _backdate(paired_log, 8)
+
+        orphan_log = self._junk(workspace, "deadbeefcafe.log", days_ago=8)
+        orphan_cancel = self._junk(workspace, "deadbeefcafe.cancel", body=b"", days_ago=8)
+
+        assert download_state.prune(workspace, keep=0) == 0
+        assert not orphan_log.exists()
+        assert not orphan_cancel.exists()
+        assert paired_log.exists()
+
+    def test_an_unreadable_record_never_fails_the_sweep_or_the_listing(self, workspace):
+        """`read_text` raises UnicodeDecodeError — a ValueError, not an OSError —
+        on invalid UTF-8, and the submit path's sweep must survive it."""
+        good = _persist_aged(workspace, status="completed", days_ago=1)
+        self._junk(workspace, "deadbeefcafe.json", body=b"\xff\xfe", days_ago=0)
+
+        assert download_state.read_path(download_state.state_dir(workspace) / "deadbeefcafe.json") is None
+        assert [s.id for s in download_state.list_all(workspace)] == [good.id]
+        assert download_state.prune(workspace, keep=0) == 0
 
 
 class TestPruneOnSubmit:
@@ -310,6 +440,37 @@ class TestDownloadsPruneFlag:
         env = json_renderer()
         assert env["data"] == {"total": 0, "downloads": [], "pruned": 0}
         assert env["changed"] is False
+
+    def test_a_reconciliation_write_back_counts_as_changed(self, workspace, json_renderer, tmp_path):
+        """Nothing was deleted, but the listing still rewrote a record on disk —
+        reporting `changed: false` would tell an agent this call was a no-op."""
+        state = _state(dest=str(tmp_path / "missing.bin"), status="downloading", pid=424242, total_bytes=10)
+        download_state.write(workspace, state)
+
+        models.downloads(None, prune=True)
+        env = json_renderer()
+
+        assert env["data"]["pruned"] == 0
+        assert env["changed"] is True
+        assert download_state.read(workspace, state.id).status == "failed"
+
+    def test_a_failed_sweep_is_reported_rather_than_read_as_a_no_op(self, workspace, json_renderer, monkeypatch):
+        """`prune` swallows OSError per file and on the directory scan, so an
+        escape is unexpected — and may have deleted records before it happened.
+        The user asked for a destructive operation; `pruned: 0, changed: false`
+        would be a lie about it."""
+
+        def boom(*args, **kwargs):
+            raise OSError("state dir is unreadable")
+
+        monkeypatch.setattr(download_state, "prune", boom)
+
+        models.downloads(None, prune=True)
+        env = json_renderer()
+
+        assert env["ok"] is True
+        assert env["data"]["pruned"] == 0
+        assert env["changed"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1331,6 +1492,33 @@ class TestCancellationReachesTheWorker:
         final = download_state.read(workspace, state.id)
         assert (final.status, final.completed_bytes) == ("cancelled", 0)
         assert not dest.exists(), "the partial file must not survive the cancel"
+
+    def test_worker_stops_when_its_record_is_pruned_out_from_under_it(self, workspace, monkeypatch, tmp_path):
+        """`download-cancel` writes a terminal `cancelled` record and warns that
+        the worker may still be running when the kill fails; such a worker writes
+        nothing, so the record ages out and `prune` takes it — sentinel included.
+        Without treating a vanished record as a cancellation, a worker that woke
+        after that sweep would no longer see the cancel and would resume writing
+        to `dest`, untracked and uncancellable.
+        """
+        dest = tmp_path / "m.safetensors"
+        state = _state(dest=str(dest), status="starting", downloader="aria2", pid=None)
+        path = download_state.write(workspace, state)
+
+        def transfer(url, filepath, headers, downloader, progress_callback):
+            filepath.write_bytes(b"partial")
+            path.unlink()  # the sweep collects the record mid-transfer
+            progress_callback(7, 4096)
+
+        monkeypatch.setattr(models, "download_file", transfer)
+        monkeypatch.setattr(download_state, "PROGRESS_THROTTLE_S", 0.0)
+
+        with pytest.raises(typer.Exit) as exc:
+            models._download_worker(state_file=str(path))
+
+        assert exc.value.exit_code == 0
+        assert not dest.exists(), "the abandoned partial must not survive"
+        assert not path.exists(), "a pruned record must not be resurrected by the write-back"
 
     def test_worker_cancel_on_httpx_leaves_the_destination_alone(self, workspace, monkeypatch, tmp_path):
         """`DownloadCancelled` unwinds out of the httpx transfer *before* the

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -120,6 +121,195 @@ class TestStatePersistence:
 
     def test_list_all_on_missing_dir(self, tmp_path):
         assert download_state.list_all(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# 1.5 pruning: nothing else ever removes a record, so the state dir would grow
+#     without bound in a long-lived workspace.
+# ---------------------------------------------------------------------------
+
+
+def _persist_aged(
+    workspace,
+    *,
+    status: str = "completed",
+    days_ago: float = 8.0,
+    started_days_ago: float | None = None,
+) -> download_state.DownloadState:
+    """Persist one record whose timestamps are backdated on disk.
+
+    A plain ``write`` always stamps ``updated_at`` with *now*, so the ages this
+    module's prune window keys off have to be rewritten into the JSON directly.
+    """
+    state = _state(dest=str(Path(workspace) / "m.safetensors"), status=status)
+    path = download_state.write(workspace, state)
+
+    now = datetime.now(timezone.utc)
+    state.updated_at = (now - timedelta(days=days_ago)).isoformat(timespec="seconds")
+    started = days_ago if started_days_ago is None else started_days_ago
+    state.started_at = (now - timedelta(days=started)).isoformat(timespec="seconds")
+
+    data = json.loads(path.read_text())
+    data["updated_at"] = state.updated_at
+    data["started_at"] = state.started_at
+    path.write_text(json.dumps(data))
+    return state
+
+
+class TestPrune:
+    def test_removes_an_old_terminal_record_and_its_sidecars(self, workspace):
+        state = _persist_aged(workspace, status="completed", days_ago=8)
+        log = download_state.log_path(workspace, state.id)
+        cancel = download_state.cancel_path(workspace, state.id)
+        log.write_text("worker output\n")
+        cancel.touch()
+
+        assert download_state.prune(workspace, keep=0) == 1
+
+        assert not download_state.state_path(workspace, state.id).exists()
+        assert not log.exists()
+        assert not cancel.exists()
+        assert download_state.list_all(workspace) == []
+
+    @pytest.mark.parametrize("status", ["starting", "downloading"])
+    def test_active_records_are_never_pruned_however_old(self, workspace, status):
+        """An in-flight record has no business being deleted, and prune reads the
+        on-disk status rather than reconciling — a worker that died mid-transfer
+        is collected on a later sweep, once a poll verb has marked it failed."""
+        state = _persist_aged(workspace, status=status, days_ago=30)
+
+        assert download_state.prune(workspace, keep=0) == 0
+        assert download_state.state_path(workspace, state.id).exists()
+
+    def test_keep_floor_wins_over_age(self, workspace):
+        # started_at descending, so "newest" is unambiguous.
+        states = [_persist_aged(workspace, days_ago=30 + i, started_days_ago=30 + i) for i in range(5)]
+
+        assert download_state.prune(workspace, keep=3) == 2
+
+        survivors = {s.id for s in download_state.list_all(workspace)}
+        assert survivors == {s.id for s in states[:3]}
+
+    def test_a_young_terminal_record_survives_the_default_window(self, workspace):
+        state = _persist_aged(workspace, status="completed", days_ago=1)
+
+        assert download_state.prune(workspace, keep=0) == 0
+        assert download_state.state_path(workspace, state.id).exists()
+
+    def test_unparsable_timestamps_are_treated_as_old(self, workspace):
+        """A terminal record that carries no usable age is junk once it is past
+        the keep floor — there is nothing left that could make it recent."""
+        state = _persist_aged(workspace, status="failed")
+        path = download_state.state_path(workspace, state.id)
+        data = json.loads(path.read_text())
+        data["updated_at"] = data["started_at"] = ""
+        path.write_text(json.dumps(data))
+
+        assert download_state.prune(workspace, keep=0) == 1
+        assert not path.exists()
+
+    def test_an_unlink_failure_is_not_fatal(self, workspace, monkeypatch):
+        state = _persist_aged(workspace, days_ago=30)
+
+        def boom(self, missing_ok=False):
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(Path, "unlink", boom)
+
+        # Best effort: the sweep neither raises nor claims a record it failed to
+        # remove.
+        assert download_state.prune(workspace, keep=0) == 0
+        assert download_state.state_path(workspace, state.id).exists()
+
+    def test_prune_leaves_a_workspace_under_the_floor_alone(self, workspace):
+        states = [_persist_aged(workspace, days_ago=30 + i, started_days_ago=30 + i) for i in range(3)]
+
+        assert download_state.prune(workspace, keep=len(states)) == 0
+        assert len(download_state.list_all(workspace)) == len(states)
+
+
+class TestPruneOnSubmit:
+    """`--background` is the one command that grows the state dir, so it sweeps."""
+
+    def _submit(self, workspace, monkeypatch):
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+        )
+
+    def test_submit_prunes_records_past_the_keep_floor(self, workspace, monkeypatch, json_renderer):
+        # One more than the floor, so exactly the oldest falls outside it once
+        # the submit's own record is written.
+        seeded = [
+            _persist_aged(workspace, days_ago=30 + i, started_days_ago=30 + i)
+            for i in range(download_state.PRUNE_KEEP + 1)
+        ]
+
+        self._submit(workspace, monkeypatch)
+        env = json_renderer()
+        assert env["ok"] is True
+
+        survivors = {s.id for s in download_state.list_all(workspace)}
+        assert seeded[-1].id not in survivors  # the oldest went
+        assert seeded[0].id in survivors  # recent history is untouched
+        assert len(survivors) == download_state.PRUNE_KEEP
+
+    def test_a_pruning_failure_never_fails_the_submit(self, workspace, monkeypatch, json_renderer):
+        def boom(*args, **kwargs):
+            raise OSError("state dir is unreadable")
+
+        monkeypatch.setattr(download_state, "prune", boom)
+        self._submit(workspace, monkeypatch)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["status"] == "starting"
+
+
+class TestDownloadsPruneFlag:
+    def _seed(self, workspace) -> list[download_state.DownloadState]:
+        """One over the keep floor plus a fresh record — so exactly the two
+        oldest are prunable, and everything else is recent history to retain."""
+        old = [
+            _persist_aged(workspace, days_ago=30 + i, started_days_ago=30 + i)
+            for i in range(download_state.PRUNE_KEEP + 1)
+        ]
+        fresh = _persist_aged(workspace, days_ago=1, started_days_ago=1)
+        return [fresh, *old]
+
+    def test_prune_flag_removes_and_reports(self, workspace, json_renderer):
+        records = self._seed(workspace)
+
+        models.downloads(None, prune=True)
+        env = json_renderer()
+
+        assert env["command"] == "model downloads"
+        assert env["changed"] is True
+        assert env["data"]["pruned"] == 2
+        assert env["data"]["total"] == download_state.PRUNE_KEEP
+        listed = {row["id"] for row in env["data"]["downloads"]}
+        assert listed == {r.id for r in records[:-2]}
+
+    def test_without_the_flag_nothing_is_removed(self, workspace, json_renderer):
+        records = self._seed(workspace)
+
+        models.downloads(None)
+        env = json_renderer()
+
+        assert env["data"]["total"] == len(records)
+        # The envelope shape agents already parse is unchanged without the flag.
+        assert "pruned" not in env["data"]
+        assert "changed" not in env
+
+    def test_prune_flag_on_an_empty_workspace(self, workspace, json_renderer):
+        models.downloads(None, prune=True)
+        env = json_renderer()
+        assert env["data"] == {"total": 0, "downloads": [], "pruned": 0}
+        assert env["changed"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

Every time you start a background model download, the CLI drops two little bookkeeping files in `<workspace>/.comfy-downloads` — and until now nothing ever threw them away. Start a few hundred downloads over a year and the folder just keeps growing. This teaches the CLI to take out the trash: records that finished (completed / failed / cancelled) more than a week ago get deleted, but the 50 most recent are always kept so `comfy model downloads` still shows you your recent history. The sweep happens automatically whenever you submit a new background download, and you can also run it yourself with `comfy model downloads --prune`.

## What changed

- `download_state.prune(workspace, *, max_age_s=PRUNE_MAX_AGE_S, keep=PRUNE_KEEP)` — deletes terminal records older than 7 days plus their `<id>.log` / `<id>.cancel` sidecars, and returns how many records went. New module constants `PRUNE_MAX_AGE_S = 7 * 24 * 3600.0` and `PRUNE_KEEP = 50`.
- `_submit_background_download` calls it opportunistically right after writing the new record — the one command that grows the directory is the one that sweeps it.
- `comfy model downloads --prune` runs the sweep before building the rows, prints `Pruned N old download record(s).` when N > 0, and adds `"pruned": N` to the envelope. No standalone `downloads-prune` command; the flag is the verb.
- `comfy_cli/schemas/downloads.json` documents the optional `pruned` field.

## Design notes

- **Keep floor counts every record, active or terminal.** It is derived from `list_all`, which is exactly the list `comfy model downloads` renders, so "the 50 most recent" means the same thing in both places.
- **Age comes from `updated_at`** (the terminal-transition time — every `write_path` refreshes it), falling back to `started_at`. A terminal record with neither timestamp parsable is junk once it is past the keep floor, so it prunes.
- **Active records are never touched, at any age, and `prune` deliberately does not `reconcile()`.** Reconciling would pull `psutil` into a best-effort path that runs on every submit. A record whose worker was SIGKILLed sits at `downloading` on disk until the next `downloads` / `download-status` reconciles it to `failed`, and a later sweep collects it — one sweep later, no records leaked.
- **Nothing about pruning can fail a submit.** Each unlink is individually wrapped in `contextlib.suppress(OSError)`, ids are re-validated through `state_path` / `log_path` / `cancel_path` (a record whose id does not validate is skipped rather than guessed at), and the submit call site adds a second `suppress(OSError)` over the directory scan itself.
- **Deletion is real data loss, by design.** After a record is pruned, `comfy model download-status <old-id>` returns `download_not_found` for that id. That is the point of the ticket, and the 7-day window plus the 50-record floor is what bounds the exposure — an id that a caller could plausibly still be polling is both recent and inside the floor.

## Judgment calls

- **`"pruned"` and `"changed"` appear only when `--prune` is passed.** A plain `comfy model downloads` emits the exact same envelope it does today (no `pruned` key, and no `changed` key at all — `emit` omits `changed` when it is `None`). Adding the fields unconditionally would have changed the shape agents already parse for a read-only listing that mutates nothing. There is a regression test asserting the plain form is unchanged.
- **`prune` addresses files through the id path helpers, as specified.** That relies on the `<id>.json` filename matching the record's internal `id`, which `write()` is the only thing that establishes. A hand-corrupted file whose internal id names a *different* record would misdirect one delete; that file is already unreachable via `download-status`, and driving the paths off the directory listing instead would have meant duplicating `list_all`'s sort and losing the "same list `downloads` renders" guarantee, so I kept the specified design.
- **`keep` is clamped to `>= 0`** so a caller passing a negative floor cannot turn `states[keep:]` into a slice from the end.

## Testing

- `TestPrune` (7 cases): sidecars go with the record; `starting`/`downloading` survive 30 days; the keep floor beats age; a 1-day-old terminal record survives the default window; unparsable timestamps prune; a monkeypatched `Path.unlink` raising `OSError` neither raises nor inflates the count; a workspace under the floor is untouched.
- `TestPruneOnSubmit`: a submit into a workspace holding `PRUNE_KEEP + 1` ancient records drops the oldest and keeps the rest; a `prune` that raises `OSError` still leaves the submit succeeding.
- `TestDownloadsPruneFlag`: `--prune` reports `pruned` + `changed`, the listing shows exactly the survivors (50 rows — the acceptance criterion), and without the flag nothing is removed and the envelope shape is unchanged.
- `ruff check` + `ruff format --diff` clean on the version CI pins (0.15.15).
- Full `pytest` suite green (4349 passed, 37 skipped). One reviewer-relevant caveat: the full run was made just before a final one-line change to how `changed` is passed to `emit`; after that change I re-ran the two affected packages (`tests/comfy_cli/command/test_model_download_background.py` + `tests/comfy_cli/output`, 332 tests) rather than the whole 11-minute suite again.
