### PR TITLE
fix(models): claim destinations from foreground downloads too, with a deterministic tie-break (BE-6652)

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -476,20 +476,23 @@ def download(
 
     local_filepath = get_workspace() / relative_path / local_filename
 
-    if local_filepath.exists():
-        raise _download_failure(
-            code="model_file_exists",
-            message=f"File already exists: {local_filepath}",
-            hint="pass `--filename` to save under a different name, or remove the existing file",
-            details={"path": str(local_filepath)},
-        )
-
-    # The exists() check above cannot see a transfer that is still in flight: a
-    # background download streams into a `.part` sibling and only renames onto
-    # `dest` at the end, so the destination stays absent for the whole transfer
-    # and two submissions for the same model would both pass, both stream a full
-    # copy, and the later rename would silently overwrite the earlier. Checked
-    # before the `--background` split so a foreground transfer is refused too.
+    # A destination-exists check cannot see a transfer that is still in flight: on
+    # the httpx path a background download streams into a `.part` sibling and only
+    # renames onto `dest` at the end, so the destination stays absent for the whole
+    # transfer and two submissions for the same model would both pass, both stream
+    # a full copy, and the later rename would silently overwrite the earlier.
+    #
+    # Ordered *before* `exists()` on purpose: `--downloader aria2` writes straight
+    # to the destination (it owns its own `.aria2` resume control file), so a live
+    # aria2 transfer makes `exists()` true and the caller would get
+    # `model_file_exists` with the hint "remove the existing file" — advice that
+    # deletes the output a running worker is still writing. The accurate refusal
+    # has to win.
+    #
+    # Scope, precisely: this refuses a submission — foreground or `--background` —
+    # into a destination that a *background* download has claimed. It cannot refuse
+    # against an in-flight *foreground* transfer, which writes no state record and
+    # so is invisible both here and to `exists()`.
     in_flight = _active_download_for(local_filepath)
     if in_flight is not None:
         raise _download_failure(
@@ -500,6 +503,14 @@ def download(
                 f"or cancel it with `comfy model download-cancel {in_flight.id}`"
             ),
             details={"path": str(local_filepath), "download_id": in_flight.id, "status": in_flight.status},
+        )
+
+    if local_filepath.exists():
+        raise _download_failure(
+            code="model_file_exists",
+            message=f"File already exists: {local_filepath}",
+            hint="pass `--filename` to save under a different name, or remove the existing file",
+            details={"path": str(local_filepath)},
         )
 
     start_time = time.monotonic()
@@ -771,6 +782,31 @@ def _submit_background_download(
         )
         raise typer.Exit(code=1) from e
 
+    # Claim, then re-check. The pre-flight scan in `download()` is check-then-act:
+    # between it and the `write` above sit the `--background` split and, for a
+    # Hugging Face url, a whole `check_unauthorized` network round trip — wide
+    # enough for two near-simultaneous submissions to both pass it, both stream a
+    # full copy, and the later `os.replace` to silently overwrite the earlier. The
+    # state record just written *is* the claim, so re-scanning now sees any
+    # competitor that also claimed `dest`; `_claim_order` picks the same winner
+    # from both sides, and the loser withdraws its claim before any bytes move.
+    #
+    # This closes the background-vs-background race the guard documents. It cannot
+    # close one against a foreground transfer, which never writes a claim.
+    competitor = _active_download_for(dest, exclude_id=state.id)
+    if competitor is not None and _claim_order(competitor) < _claim_order(state):
+        with contextlib.suppress(OSError):
+            state_file.unlink(missing_ok=True)
+        raise _download_failure(
+            code="model_download_in_flight",
+            message=f"A background download ({competitor.id}) is already writing to {dest}.",
+            hint=(
+                f"track it with `comfy model download-status {competitor.id}`, "
+                f"or cancel it with `comfy model download-cancel {competitor.id}`"
+            ),
+            details={"path": str(dest), "download_id": competitor.id, "status": competitor.status},
+        )
+
     try:
         pid = _spawn_download_worker(state_file, log_file)
     except OSError as e:
@@ -969,11 +1005,50 @@ def _reconciled(state: download_state.DownloadState) -> tuple[download_state.Dow
     return fresh, changed
 
 
-def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | None:
+def _dest_key(path: pathlib.Path | str) -> str:
+    """The comparison key for "the same destination".
+
+    ``realpath``, not ``abspath``: ComfyUI model directories are routinely
+    symlinks (``models/loras`` pointing at ``/data/loras``) and get addressed
+    both ways, and a lexical normalization leaves those two spellings unequal —
+    so both submissions would pass and their transfers would land on the same
+    inode. ``realpath`` resolves the symlinks that exist and normalizes the rest,
+    which also covers a ``--relative-path`` carrying ``..`` (it is only
+    ``expanduser``-ed, never passed through :func:`_reject_unsafe_component`).
+
+    ``normcase`` folds case on Windows; on POSIX it is identity, so a
+    case-insensitive macOS volume can still alias two spellings past this — the
+    same residual ``local_filepath.exists()`` has.
+    """
+    return os.path.normcase(os.path.realpath(path))
+
+
+def _claim_order(state: download_state.DownloadState) -> tuple[str, str]:
+    """Total order over competing claims on one destination: first writer wins.
+
+    ``started_at`` is second-resolution so ties are common; ``id`` (12 random hex
+    chars) breaks them, and because both racers compute the same order over the
+    same two records they always agree on who won.
+    """
+    return (state.started_at or "", state.id)
+
+
+def _active_download_for(
+    dest: pathlib.Path,
+    *,
+    exclude_id: str | None = None,
+) -> download_state.DownloadState | None:
     """The live background download already targeting ``dest``, if any.
 
-    Reconciles each record first (persisting the correction), so a SIGKILLed
+    Reconciles the *matching* records (persisting the correction), so a SIGKILLed
     worker's stale record demotes to ``failed`` here and never wedges the path.
+    Records for other destinations are filtered out by ``dest`` first and never
+    reconciled: :func:`_reconciled` persists a status correction, and running it
+    over every record would make a plain ``comfy model download`` rewrite
+    bookkeeping for unrelated downloads — off a stale ``list_all`` snapshot, so a
+    worker that completed during the scan could have its ``completed`` record
+    overwritten with ``failed``. Reconcile never rewrites ``dest``, so the
+    unreconciled value is the right key to filter on.
 
     The predicate is deliberately "reconciled status is active", *not*
     :func:`download_state.worker_alive`: a just-submitted download sits in
@@ -983,30 +1058,39 @@ def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | N
     near-simultaneous double-submit this guard exists to catch. Reconcile keeps
     both a within-grace ``starting`` record and a live worker blocking, while
     demoting a dead worker's record so it self-clears.
+
+    ``exclude_id`` skips one record: :func:`_submit_background_download` re-runs
+    this scan *after* writing its own claim and must not find itself.
+
+    The scan is scoped to ``get_workspace()``'s state directory. A destination can
+    sit outside the workspace (``--relative-path`` accepts ``..`` and absolute
+    paths), so two invocations from different workspaces consult disjoint state
+    directories and do not see each other — inherent to per-workspace state, not
+    something this scan can close.
     """
-    # `abspath` on BOTH sides, not `Path.absolute()` on one: `absolute()` does not
-    # normalize, so a `--relative-path` carrying `..` (it is only `expanduser`-ed,
-    # never passed through `_reject_unsafe_component`) would leave one side
-    # un-normalized and the comparison would miss the very collision it is for.
-    # `normcase` folds case on Windows; on POSIX it is identity, so a
-    # case-insensitive macOS volume can still alias two spellings past this — the
-    # same residual `local_filepath.exists()` above would have.
-    wanted = os.path.normcase(os.path.abspath(dest))
+    wanted = _dest_key(dest)
+    winner: download_state.DownloadState | None = None
     try:
-        records = download_state.list_all(get_workspace())
-    except OSError:
-        # The scan is advisory, so an unreadable state directory must degrade to
-        # the pre-guard behavior rather than turn a working download into a
-        # traceback — this read is on the foreground path too, which never
-        # touched the state directory before.
+        for state in download_state.list_all(get_workspace()):
+            if state.id == exclude_id:
+                continue
+            if _dest_key(state.dest) != wanted:
+                continue
+            fresh, _ = _reconciled(state)
+            if fresh.status not in download_state.ACTIVE_STATUSES:
+                continue
+            if winner is None or _claim_order(fresh) < _claim_order(winner):
+                winner = fresh
+    except (OSError, ValueError):
+        # The scan is advisory, so an unreadable state directory — or a corrupt
+        # record that trips a lookup mid-loop — must degrade to the pre-guard
+        # behavior rather than turn a working download into a traceback. This
+        # runs on the foreground path too, which never read the state directory
+        # before, so a single bad file must not break every download in the
+        # workspace. Whole scan, not just `list_all`: the reconcile of a matching
+        # record is just as much part of the advisory read.
         return None
-    for state in records:
-        fresh, _ = _reconciled(state)
-        if fresh.status not in download_state.ACTIVE_STATUSES:
-            continue
-        if os.path.normcase(os.path.abspath(fresh.dest)) == wanted:
-            return fresh
-    return None
+    return winner
 
 
 @app.command("download-status")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -99,7 +99,13 @@ def _download_failure(
         details=details,
         command="model download",
     )
-    return typer.Exit(code=1)
+    failure = typer.Exit(code=1)
+    # `typer.Exit` carries an exit code and nothing else, so `str(exc)` is empty.
+    # The foreground claim record wants the same text the user just saw in its
+    # `error` field; stash it here rather than have every raise site thread the
+    # message out by hand.
+    failure.comfy_error_message = message
+    return failure
 
 
 def _scrub_url(url: str) -> str:
@@ -490,20 +496,21 @@ def download(
     # has to win.
     #
     # Scope, precisely: this refuses a submission — foreground or `--background` —
-    # into a destination that a *background* download has claimed. It cannot refuse
-    # against an in-flight *foreground* transfer, which writes no state record and
-    # so is invisible both here and to `exists()`.
+    # into a destination that any live download has claimed, of either kind. It is
+    # kept as a *pre-flight* check even though both submit paths now re-scan after
+    # writing their own claim, because it is what lets the common sequential case
+    # ("I already have this downloading") refuse early, before filename resolution
+    # and an HF round trip, and without leaving a record behind. The post-write
+    # re-scan is the authoritative gate; this one is the cheap one.
+    #
+    # Residual, unchanged and unclosable here: the scan only reads *this*
+    # workspace's state directory, so two invocations from different workspaces
+    # aimed at the same file (via `--relative-path ../..` or an absolute path)
+    # consult disjoint directories and cannot see each other. See
+    # `_active_download_for`.
     in_flight = _active_download_for(local_filepath)
     if in_flight is not None:
-        raise _download_failure(
-            code="model_download_in_flight",
-            message=f"A background download ({in_flight.id}) is already writing to {local_filepath}.",
-            hint=(
-                f"track it with `comfy model download-status {in_flight.id}`, "
-                f"or cancel it with `comfy model download-cancel {in_flight.id}`"
-            ),
-            details={"path": str(local_filepath), "download_id": in_flight.id, "status": in_flight.status},
-        )
+        raise _in_flight_failure(in_flight, local_filepath)
 
     if local_filepath.exists():
         raise _download_failure(
@@ -543,113 +550,155 @@ def download(
         )
         return
 
-    if needs_hf_auth:
-        try:
-            import huggingface_hub
-        except ImportError:
-            print("huggingface_hub not found. Installing...")
-            import subprocess
+    # A foreground transfer claims its destination too, for the same reason the
+    # `--background` one does: until it did, it wrote no record and so was
+    # invisible to every other invocation — a second foreground run, or a
+    # `--background` submit started during one, passed both the scan above and
+    # `exists()` and the two transfers landed on the same file. Claim first, then
+    # re-scan (`_enforce_claim`), then move bytes; the record is what makes this
+    # run visible to whoever comes next, and it shows up in `comfy model
+    # downloads` like any other.
+    claim = _claim_foreground(url=url, dest=local_filepath, downloader=resolved_downloader)
+    if claim is not None:
+        _enforce_claim(claim, local_filepath)
 
-            from comfy_cli.resolve_python import resolve_workspace_python
-
+    try:
+        if needs_hf_auth:
             try:
-                # NB: this installs into the *workspace* interpreter (pinned by
-                # tests/comfy_cli/test_models_python_resolution.py), which is not
-                # necessarily the one running this process — so the import below
-                # can still fail for e.g. a pipx-installed CLI. That predates this
-                # change and is tracked separately; what's new here is that the
-                # failure now ends in an envelope instead of a traceback.
-                python = resolve_workspace_python(str(get_workspace()))
-                subprocess.check_call([python, "-m", "pip", "install", "huggingface_hub"])
                 import huggingface_hub
+            except ImportError:
+                print("huggingface_hub not found. Installing...")
+                import subprocess
+
+                from comfy_cli.resolve_python import resolve_workspace_python
+
+                try:
+                    # NB: this installs into the *workspace* interpreter (pinned by
+                    # tests/comfy_cli/test_models_python_resolution.py), which is not
+                    # necessarily the one running this process — so the import below
+                    # can still fail for e.g. a pipx-installed CLI. That predates this
+                    # change and is tracked separately; what's new here is that the
+                    # failure now ends in an envelope instead of a traceback.
+                    python = resolve_workspace_python(str(get_workspace()))
+                    subprocess.check_call([python, "-m", "pip", "install", "huggingface_hub"])
+                    import huggingface_hub
+                except Exception as e:
+                    raise _download_failure(
+                        code="download_failed",
+                        message=(
+                            f"`huggingface_hub` is required for Hugging Face downloads and could not be installed: {e}"
+                        ),
+                        hint="install it manually (`pip install huggingface_hub`) and retry",
+                        details={"url": _scrub_url(url)},
+                    ) from None
+
+            print(f"Downloading model {escape(str(model_id))} from Hugging Face...")
+            try:
+                output_path = huggingface_hub.hf_hub_download(
+                    repo_id=repo_id,
+                    filename=hf_filename,
+                    subfolder=hf_folder_name,
+                    revision=hf_branch_name,
+                    token=hf_api_token,
+                    local_dir=get_workspace() / relative_path,
+                    cache_dir=get_workspace() / relative_path,
+                )
             except Exception as e:
                 raise _download_failure(
                     code="download_failed",
-                    message=f"`huggingface_hub` is required for Hugging Face downloads and could not be installed: {e}",
-                    hint="install it manually (`pip install huggingface_hub`) and retry",
-                    details={"url": _scrub_url(url)},
+                    message=f"Hugging Face download failed: {e}",
+                    hint="check the repo/revision exists and the token has access to it",
+                    details={"url": _scrub_url(url), "repo_id": repo_id},
                 ) from None
 
-        print(f"Downloading model {escape(str(model_id))} from Hugging Face...")
-        try:
-            output_path = huggingface_hub.hf_hub_download(
-                repo_id=repo_id,
-                filename=hf_filename,
-                subfolder=hf_folder_name,
-                revision=hf_branch_name,
-                token=hf_api_token,
-                local_dir=get_workspace() / relative_path,
-                cache_dir=get_workspace() / relative_path,
-            )
-        except Exception as e:
-            raise _download_failure(
-                code="download_failed",
-                message=f"Hugging Face download failed: {e}",
-                hint="check the repo/revision exists and the token has access to it",
-                details={"url": _scrub_url(url), "repo_id": repo_id},
-            ) from None
+            # `hf_hub_download` names the file after the *repo* path (`hf_filename`)
+            # and nests it under `hf_folder_name`, so the resolved `local_filename` was
+            # silently ignored on this branch only — the public-HF path below goes
+            # through download_file(local_filepath) and honours it. That split made the
+            # `local_filepath.exists()` guard above check a path this branch never
+            # writes, and made its `model_file_exists` hint ("pass `--filename`")
+            # impossible to act on. Gate the move on the *resolved* name rather than on
+            # `--filename`: `local_filename` can equally come from the prompt above
+            # (whose default is only a suggestion), so keying on `filename is not None`
+            # left the same split open via the prompt door.
+            if pathlib.Path(output_path) != local_filepath:
+                try:
+                    local_filepath.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.move(str(output_path), str(local_filepath))
+                    output_path = str(local_filepath)
+                except OSError as e:
+                    raise _download_failure(
+                        code="download_failed",
+                        message=f"Downloaded the model but could not save it as {local_filepath}: {e}",
+                        hint="check the destination directory is writable, or omit `--filename`",
+                        details={"url": _scrub_url(url), "path": str(local_filepath)},
+                    ) from None
 
-        # `hf_hub_download` names the file after the *repo* path (`hf_filename`)
-        # and nests it under `hf_folder_name`, so the resolved `local_filename` was
-        # silently ignored on this branch only — the public-HF path below goes
-        # through download_file(local_filepath) and honours it. That split made the
-        # `local_filepath.exists()` guard above check a path this branch never
-        # writes, and made its `model_file_exists` hint ("pass `--filename`")
-        # impossible to act on. Gate the move on the *resolved* name rather than on
-        # `--filename`: `local_filename` can equally come from the prompt above
-        # (whose default is only a suggestion), so keying on `filename is not None`
-        # left the same split open via the prompt door.
-        if pathlib.Path(output_path) != local_filepath:
+            print(f"Model downloaded successfully to: {escape(str(output_path))}")
+        else:
+            print(f"Start downloading URL: {escape(_scrub_url(url))} into {escape(str(local_filepath))}")
             try:
-                local_filepath.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(output_path), str(local_filepath))
-                output_path = str(local_filepath)
-            except OSError as e:
+                download_file(url, local_filepath, headers, downloader=resolved_downloader)
+            except DownloadException as e:
+                # `message` is rendered through `Text` (see `_download_failure`), which
+                # never parses markup, and `error_panel` sanitizes it (ANSI/control-byte
+                # strip) before it reaches the terminal — so a server-chosen message (the
+                # 401 branch of guess_status_code_reason echoes one, and aria2 relays its
+                # own) can't clear the screen or repaint earlier output.
                 raise _download_failure(
                     code="download_failed",
-                    message=f"Downloaded the model but could not save it as {local_filepath}: {e}",
-                    hint="check the destination directory is writable, or omit `--filename`",
+                    message=str(e),
                     details={"url": _scrub_url(url), "path": str(local_filepath)},
                 ) from None
-
-        print(f"Model downloaded successfully to: {escape(str(output_path))}")
+            except OSError as e:
+                # download_file() converts network failures to DownloadException, but a
+                # local filesystem failure (unwritable dir, disk full) still escapes as
+                # OSError — which would end the command with a traceback and no envelope.
+                raise _download_failure(
+                    code="download_failed",
+                    message=f"Could not write the downloaded file to {local_filepath}: {e}",
+                    hint="check the destination directory exists, is writable, and has free space",
+                    details={"url": _scrub_url(url), "path": str(local_filepath)},
+                ) from None
+            except Exception as e:
+                # Backstop for the invariant this command promises: a `--json` caller must
+                # never get a bare traceback with no envelope. The downloader can still
+                # raise something neither branch above names — e.g. a malformed
+                # `Content-Length` from a broken proxy used to surface as ValueError out of
+                # `int(...)` (now guarded in file_utils, but the class of failure remains).
+                raise _download_failure(
+                    code="download_failed",
+                    message=f"Download failed unexpectedly ({type(e).__name__}): {e}",
+                    hint="retry; if it persists, re-run without `--json` for the full traceback",
+                    details={"url": _scrub_url(url), "path": str(local_filepath)},
+                ) from None
+    except BaseException as e:
+        # `BaseException`, not `Exception`: every failure above raises `typer.Exit`,
+        # which derives from `click.exceptions.Exit` — a `BaseException` — so an
+        # `Exception` handler would let the ordinary error paths past and leave the
+        # record pinned at `downloading` until something reconciled it. This also
+        # catches the KeyboardInterrupt the error code's hint tells users to send.
+        if claim is not None:
+            claim.status = "failed"
+            # `_download_failure` stashes the message it rendered; a `typer.Exit`
+            # stringifies to "" otherwise.
+            claim.error = getattr(e, "comfy_error_message", None) or str(e) or type(e).__name__
+        raise
     else:
-        print(f"Start downloading URL: {escape(_scrub_url(url))} into {escape(str(local_filepath))}")
-        try:
-            download_file(url, local_filepath, headers, downloader=resolved_downloader)
-        except DownloadException as e:
-            # `message` is rendered through `Text` (see `_download_failure`), which
-            # never parses markup, and `error_panel` sanitizes it (ANSI/control-byte
-            # strip) before it reaches the terminal — so a server-chosen message (the
-            # 401 branch of guess_status_code_reason echoes one, and aria2 relays its
-            # own) can't clear the screen or repaint earlier output.
-            raise _download_failure(
-                code="download_failed",
-                message=str(e),
-                details={"url": _scrub_url(url), "path": str(local_filepath)},
-            ) from None
-        except OSError as e:
-            # download_file() converts network failures to DownloadException, but a
-            # local filesystem failure (unwritable dir, disk full) still escapes as
-            # OSError — which would end the command with a traceback and no envelope.
-            raise _download_failure(
-                code="download_failed",
-                message=f"Could not write the downloaded file to {local_filepath}: {e}",
-                hint="check the destination directory exists, is writable, and has free space",
-                details={"url": _scrub_url(url), "path": str(local_filepath)},
-            ) from None
-        except Exception as e:
-            # Backstop for the invariant this command promises: a `--json` caller must
-            # never get a bare traceback with no envelope. The downloader can still
-            # raise something neither branch above names — e.g. a malformed
-            # `Content-Length` from a broken proxy used to surface as ValueError out of
-            # `int(...)` (now guarded in file_utils, but the class of failure remains).
-            raise _download_failure(
-                code="download_failed",
-                message=f"Download failed unexpectedly ({type(e).__name__}): {e}",
-                hint="retry; if it persists, re-run without `--json` for the full traceback",
-                details={"url": _scrub_url(url), "path": str(local_filepath)},
-            ) from None
+        if claim is not None:
+            claim.status = "completed"
+            # Best-effort, and only on the success path where the file is final:
+            # one stat makes `download-status`/`downloads` report a real size and
+            # 100% for this record instead of a bare `completed` with no bytes.
+            with contextlib.suppress(OSError):
+                claim.completed_bytes = os.stat(local_filepath).st_size
+                claim.total_bytes = claim.completed_bytes
+    finally:
+        # Reached on both paths, but never on SIGKILL — which is exactly the case
+        # `download_state.reconcile` already handles: a record whose pid and
+        # pid_create_time no longer match a live process demotes to `failed`, so a
+        # hard-killed foreground run self-clears just like a dead worker.
+        _release_foreground(claim)
 
     elapsed = time.monotonic() - start_time
     print(f"Done in {_format_elapsed(elapsed)}")
@@ -788,34 +837,19 @@ def _submit_background_download(
     # enough for two near-simultaneous submissions to both pass it, both stream a
     # full copy, and the later `os.replace` to silently overwrite the earlier. The
     # state record just written *is* the claim, so re-scanning now sees any
-    # competitor that also claimed `dest`; `_claim_order` picks the same winner
-    # from both sides, and the loser withdraws its claim before any bytes move.
+    # competitor that also claimed `dest`. The foreground path does the same thing
+    # with the same helper, so the two now claim against each other as well.
     #
-    # This *narrows* the background-vs-background race; it does not close it. A
-    # re-scan cannot see a claim that has not been written yet, and nothing orders
-    # a competitor's `write` before our scan — so a competitor whose record lands
-    # after we look is still missed and both submissions proceed (reproduced at 12
-    # simultaneous submits; 4 and 8 came out clean). What changed is the width of
-    # the window: from `[pre-flight scan -> write]`, which spans the `--background`
-    # split and an HF round trip, down to `[write -> re-scan]`. Closing it needs an
-    # atomic claim — an `O_EXCL` sibling or an `flock` — which is a design call
-    # this guard does not make.
-    #
-    # It does nothing at all against a foreground transfer, which never writes a
-    # claim.
-    competitor = _active_download_for(dest, exclude_id=state.id)
-    if competitor is not None and _claim_order(competitor) < _claim_order(state):
-        with contextlib.suppress(OSError):
-            state_file.unlink(missing_ok=True)
-        raise _download_failure(
-            code="model_download_in_flight",
-            message=f"A background download ({competitor.id}) is already writing to {dest}.",
-            hint=(
-                f"track it with `comfy model download-status {competitor.id}`, "
-                f"or cancel it with `comfy model download-cancel {competitor.id}`"
-            ),
-            details={"path": str(dest), "download_id": competitor.id, "status": competitor.status},
-        )
+    # This *narrows* the race; it does not close it. A re-scan cannot see a claim
+    # that has not been written yet, and nothing orders a competitor's `write`
+    # before our scan — so a competitor whose record lands after we look is still
+    # missed and both submissions proceed (reproduced at 12 simultaneous submits;
+    # 4 and 8 came out clean). What changed is the width of the window: from
+    # `[pre-flight scan -> write]`, which spans the `--background` split and an HF
+    # round trip, down to `[write -> re-scan]`. Closing it needs an atomic claim —
+    # an `O_EXCL` sibling or an `flock` — which is a design call this guard does
+    # not make.
+    _enforce_claim(state, dest)
 
     try:
         pid = _spawn_download_worker(state_file, log_file)
@@ -1053,7 +1087,13 @@ def _active_download_for(
     *,
     exclude_id: str | None = None,
 ) -> download_state.DownloadState | None:
-    """The live background download already targeting ``dest``, if any.
+    """The live download already targeting ``dest``, if any — of either kind.
+
+    Foreground runs write records too (see :func:`_claim_foreground`), so this
+    scan now covers foreground-vs-foreground and foreground-vs-background as well
+    as the background-vs-background case it was written for. It does not
+    distinguish them: a claim is a claim, and the caller words its refusal from
+    the winner's ``kind``.
 
     Reconciles the *matching* records (persisting the correction), so a SIGKILLed
     worker's stale record demotes to ``failed`` here and never wedges the path.
@@ -1077,11 +1117,16 @@ def _active_download_for(
     ``exclude_id`` skips one record: :func:`_submit_background_download` re-runs
     this scan *after* writing its own claim and must not find itself.
 
-    The scan is scoped to ``get_workspace()``'s state directory. A destination can
-    sit outside the workspace (``--relative-path`` accepts ``..`` and absolute
-    paths), so two invocations from different workspaces consult disjoint state
-    directories and do not see each other — inherent to per-workspace state, not
-    something this scan can close.
+    The scan is scoped to ``get_workspace()``'s state directory, and that is the
+    one residual no claim written here can close. A destination can sit outside
+    the workspace (``--relative-path`` is only ``expanduser``-ed, so it accepts
+    ``..`` and absolute paths), so two invocations run against *different*
+    workspaces but aimed at the same file consult disjoint
+    ``<workspace>/.comfy-downloads`` directories and are invisible to each other
+    — both claim, both win, both write. Closing it needs a claim that lives next
+    to the destination rather than next to the workspace (an ``O_EXCL`` sidecar),
+    or a refusal of workspace-escaping ``--relative-path``; both are design calls
+    with their own tradeoffs and neither is made here.
     """
     wanted = _dest_key(dest)
     winner: download_state.DownloadState | None = None
@@ -1108,19 +1153,127 @@ def _active_download_for(
     return winner
 
 
+def _in_flight_failure(competitor: download_state.DownloadState, dest: pathlib.Path) -> typer.Exit:
+    """The ``model_download_in_flight`` refusal, worded for the claim we hit.
+
+    Both halves vary by ``kind``. A background download really can be cancelled
+    with ``download-cancel``; a live *foreground* one cannot — that command now
+    refuses it, because the recorded pid is a user CLI process sharing the
+    terminal's foreground process group — so pointing at it would be advice that
+    fails. Ctrl-C in the owning terminal is the honest instruction.
+    """
+    kind = "foreground" if competitor.is_foreground else "background"
+    stop = (
+        "interrupt it with Ctrl-C in the terminal running it"
+        if competitor.is_foreground
+        else f"cancel it with `comfy model download-cancel {competitor.id}`"
+    )
+    return _download_failure(
+        code="model_download_in_flight",
+        message=f"A {kind} download ({competitor.id}) is already writing to {dest}.",
+        hint=f"track it with `comfy model download-status {competitor.id}`, or {stop}",
+        details={
+            "path": str(dest),
+            "download_id": competitor.id,
+            "status": competitor.status,
+            "kind": competitor.kind,
+        },
+    )
+
+
+def _enforce_claim(state: download_state.DownloadState, dest: pathlib.Path) -> None:
+    """Re-scan for a competing claim on ``dest`` and withdraw ours if we lost.
+
+    The second half of claim-then-check, shared by both submit paths. The caller
+    has already *written* ``state`` — that record is the claim — so this scan sees
+    any competitor that also claimed ``dest``, which the pre-flight scan in
+    :func:`download` structurally cannot: it runs before the claim exists, with
+    the ``--background`` split and (for a Hugging Face url) a whole
+    ``check_unauthorized`` round trip between it and the write.
+
+    Both racers run this over the same two records and rank them with the same
+    :func:`_claim_order`, so they agree on the winner instead of both backing off
+    — mutual refusal would wedge the destination and neither download would
+    happen. The loser deletes its own record before raising, so it leaves no
+    phantom claim behind.
+
+    Raises the ``typer.Exit`` the caller should propagate; returns None when we
+    won (or when there was no competitor at all).
+    """
+    competitor = _active_download_for(dest, exclude_id=state.id)
+    if competitor is None or _claim_order(state) < _claim_order(competitor):
+        return
+
+    download_state.delete(get_workspace(), state.id)
+    raise _in_flight_failure(competitor, dest)
+
+
+def _claim_foreground(url: str, dest: pathlib.Path, downloader: str) -> download_state.DownloadState | None:
+    """Claim ``dest`` for a transfer about to run in *this* process.
+
+    Before this existed the foreground path wrote no record at all, so it was
+    invisible to every other invocation: a second foreground run — or a
+    ``--background`` submit started during one — sailed past the destination scan
+    and past ``exists()`` (the httpx downloader streams into a ``.part`` sibling,
+    so nothing is at ``dest`` until the very end), and the two transfers
+    interleaved into one file. With ``--downloader aria2`` they interleave
+    literally, since aria2 writes straight to the destination.
+
+    ``pid``/``pid_create_time`` are this CLI process's own, which is what makes
+    the record self-clearing: a run that is SIGKILLed never reaches its ``finally``
+    to write a terminal status, and :func:`download_state.reconcile` then demotes
+    the record exactly as it does for a dead worker. Recording
+    ``pid_create_time`` is not optional for that to work — without it
+    :func:`download_state.is_worker_process` falls back to matching the *worker's*
+    argv marker, which a foreground CLI process does not carry.
+
+    Returns None when the claim could not be persisted. That is a deliberate
+    degradation to the pre-claim behavior rather than a failure: the state
+    directory is bookkeeping, and an unwritable workspace must not turn a
+    download that used to work into an error. (The ``--background`` path *does*
+    fail there, because a detached worker has nowhere else to report from.)
+    """
+    # Absolute, as `_submit_background_download` also takes care to be. `dest` is
+    # built from `workspace_manager.workspace_path`, which is not guaranteed
+    # absolute, and this string is read back by *other* processes: `_dest_key`
+    # resolves it with `realpath`, which anchors a relative path to the reader's
+    # cwd, so a relative `dest` would key differently for a reader started
+    # elsewhere and the two would not recognize each other's claim.
+    # `download_cancel` reads it as a plain path too.
+    dest = pathlib.Path(dest).absolute()
+    state = download_state.new(url=url, dest=str(dest), downloader=downloader)
+    state.kind = "foreground"
+    state.status = "downloading"
+    state.pid = os.getpid()
+    state.pid_create_time = download_state.process_create_time(state.pid)
+    try:
+        download_state.write(get_workspace(), state)
+    except (OSError, ValueError):
+        return None
+    return state
+
+
+def _release_foreground(state: download_state.DownloadState | None) -> None:
+    """Persist a foreground claim's terminal status. Never raises."""
+    if state is None:
+        return
+    with contextlib.suppress(OSError, ValueError):
+        download_state.write(get_workspace(), state)
+
+
 @app.command("download-status")
 @tracking.track_command("model")
 def download_status(
     _ctx: typer.Context,
     download_id: Annotated[str, typer.Argument(help="The download id returned by `download --background`.")],
 ):
-    """Report the progress of one background download."""
+    """Report the progress of one download, background or foreground."""
     renderer = get_renderer()
     state = download_state.read(get_workspace(), download_id)
     if state is None:
         renderer.error(
             code="download_not_found",
-            message=f"No background download with id {download_id!r}.",
+            message=f"No download with id {download_id!r}.",
             hint="list the known downloads with `comfy model downloads`",
             details={"id": download_id},
         )
@@ -1135,11 +1288,17 @@ def download_status(
 @app.command("downloads")
 @tracking.track_command("model")
 def downloads(_ctx: typer.Context):
-    """List every background download this workspace knows about, newest first."""
+    """List every download this workspace knows about, newest first.
+
+    Covers both kinds: a plain `comfy model download` claims its destination the
+    same way a `--background` one does, so it appears here too (`kind` tells them
+    apart). That is what makes a second run refuse instead of racing into the
+    same file.
+    """
     renderer = get_renderer()
     rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(get_workspace())]
     if not rows:
-        print("No background downloads found.")
+        print("No downloads found.")
     else:
         _render_download_rows(rows)
     renderer.emit({"total": len(rows), "downloads": rows}, command="model downloads")
@@ -1151,14 +1310,21 @@ def download_cancel(
     _ctx: typer.Context,
     download_id: Annotated[str, typer.Argument(help="The download id returned by `download --background`.")],
 ):
-    """Kill a background download's worker and remove its partial file."""
+    """Kill a background download's worker and remove its partial file.
+
+    Background only, for a live download: a foreground record's pid is a user CLI
+    process sharing its terminal's foreground process group, so the `killpg` this
+    sends would take out the surrounding shell job. A live foreground download is
+    refused with `model_download_foreground_cancel` and the instruction to Ctrl-C
+    it in its own terminal; a *dead* one still sweeps here as usual.
+    """
     renderer = get_renderer()
     workspace = get_workspace()
     state = download_state.read(workspace, download_id)
     if state is None:
         renderer.error(
             code="download_not_found",
-            message=f"No background download with id {download_id!r}.",
+            message=f"No download with id {download_id!r}.",
             hint="list the known downloads with `comfy model downloads`",
             details={"id": download_id},
         )
@@ -1203,6 +1369,30 @@ def download_cancel(
             print(f"Download {download_id} is already {state.status}; nothing to cancel.")
         renderer.emit(payload, command="model download-cancel", changed=bool(reclaimed))
         return
+
+    # Refuse a *live* foreground download before anything is signalled — sentinel
+    # included. Everything below this point assumes the recorded pid belongs to a
+    # detached worker, which `_spawn_download_worker` gives its own session: that
+    # is what makes `kill_worker`'s `os.killpg(os.getpgid(pid), ...)` safe, since
+    # the worker is its own process-group leader and the group contains only it
+    # and its children. A foreground record's pid is the *user's CLI process*,
+    # which shares the terminal's foreground process group — so the same killpg
+    # would take out the surrounding shell job (the pipeline, an enclosing
+    # script), not just the transfer. There is no narrower signal to send from
+    # here, so the honest answer is to tell the user where to press Ctrl-C.
+    #
+    # A *dead* foreground record still goes down the normal path below: the
+    # partial file it left behind is exactly what the user is trying to reclaim,
+    # and `stop_worker`/`kill_worker` are inert for a pid that no longer matches
+    # its recorded start time.
+    if state.is_foreground and download_state.worker_alive(state):
+        renderer.error(
+            code="model_download_foreground_cancel",
+            message=f"Download {download_id} is running in the foreground of another terminal (pid {state.pid}).",
+            hint="interrupt it with Ctrl-C in the terminal running it",
+            details={"id": download_id, "pid": state.pid, "kind": state.kind, "dest": state.dest},
+        )
+        raise typer.Exit(code=1)
 
     # Sentinel first, then the signal. The sentinel is what a worker that is
     # still starting up (no pid on file yet) — or one that outlives SIGTERM —

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -484,6 +484,24 @@ def download(
             details={"path": str(local_filepath)},
         )
 
+    # The exists() check above cannot see a transfer that is still in flight: a
+    # background download streams into a `.part` sibling and only renames onto
+    # `dest` at the end, so the destination stays absent for the whole transfer
+    # and two submissions for the same model would both pass, both stream a full
+    # copy, and the later rename would silently overwrite the earlier. Checked
+    # before the `--background` split so a foreground transfer is refused too.
+    in_flight = _active_download_for(local_filepath)
+    if in_flight is not None:
+        raise _download_failure(
+            code="model_download_in_flight",
+            message=f"A background download ({in_flight.id}) is already writing to {local_filepath}.",
+            hint=(
+                f"track it with `comfy model download-status {in_flight.id}`, "
+                f"or cancel it with `comfy model download-cancel {in_flight.id}`"
+            ),
+            details={"path": str(local_filepath), "download_id": in_flight.id, "status": in_flight.status},
+        )
+
     start_time = time.monotonic()
 
     # Every resolution step above (metadata requests, token config, filename,
@@ -949,6 +967,46 @@ def _reconciled(state: download_state.DownloadState) -> tuple[download_state.Dow
         with contextlib.suppress(OSError, ValueError):
             download_state.write(get_workspace(), fresh)
     return fresh, changed
+
+
+def _active_download_for(dest: pathlib.Path) -> download_state.DownloadState | None:
+    """The live background download already targeting ``dest``, if any.
+
+    Reconciles each record first (persisting the correction), so a SIGKILLed
+    worker's stale record demotes to ``failed`` here and never wedges the path.
+
+    The predicate is deliberately "reconciled status is active", *not*
+    :func:`download_state.worker_alive`: a just-submitted download sits in
+    ``starting`` with no pid for up to :data:`download_state.STARTUP_GRACE_S`
+    while its worker's interpreter boots, and ``worker_alive`` reports False for
+    a pidless record — so gating on it would pass during exactly the
+    near-simultaneous double-submit this guard exists to catch. Reconcile keeps
+    both a within-grace ``starting`` record and a live worker blocking, while
+    demoting a dead worker's record so it self-clears.
+    """
+    # `abspath` on BOTH sides, not `Path.absolute()` on one: `absolute()` does not
+    # normalize, so a `--relative-path` carrying `..` (it is only `expanduser`-ed,
+    # never passed through `_reject_unsafe_component`) would leave one side
+    # un-normalized and the comparison would miss the very collision it is for.
+    # `normcase` folds case on Windows; on POSIX it is identity, so a
+    # case-insensitive macOS volume can still alias two spellings past this — the
+    # same residual `local_filepath.exists()` above would have.
+    wanted = os.path.normcase(os.path.abspath(dest))
+    try:
+        records = download_state.list_all(get_workspace())
+    except OSError:
+        # The scan is advisory, so an unreadable state directory must degrade to
+        # the pre-guard behavior rather than turn a working download into a
+        # traceback — this read is on the foreground path too, which never
+        # touched the state directory before.
+        return None
+    for state in records:
+        fresh, _ = _reconciled(state)
+        if fresh.status not in download_state.ACTIVE_STATUSES:
+            continue
+        if os.path.normcase(os.path.abspath(fresh.dest)) == wanted:
+            return fresh
+    return None
 
 
 @app.command("download-status")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from typing import Annotated
 from urllib.parse import parse_qs, unquote, urlparse, urlsplit, urlunsplit
 
@@ -626,6 +627,13 @@ def download(
                     local_filepath.parent.mkdir(parents=True, exist_ok=True)
                     shutil.move(str(output_path), str(local_filepath))
                     output_path = str(local_filepath)
+                # Covers `shutil.Error` too — it derives from `OSError` (Lib/shutil.py:
+                # `class Error(OSError)`), so the multi-file/partial-move failures
+                # `shutil.move` raises under that name land here and end in an
+                # envelope, not a bare traceback. Pinned by
+                # `test_hf_move_failure_emits_an_envelope_not_a_traceback`, because
+                # this branch has no `except Exception` backstop the way the
+                # direct-download one below does.
                 except OSError as e:
                     raise _download_failure(
                         code="download_failed",
@@ -638,7 +646,17 @@ def download(
         else:
             print(f"Start downloading URL: {escape(_scrub_url(url))} into {escape(str(local_filepath))}")
             try:
-                download_file(url, local_filepath, headers, downloader=resolved_downloader)
+                download_file(
+                    url,
+                    local_filepath,
+                    headers,
+                    downloader=resolved_downloader,
+                    # Feeds the claim record its byte counts — above all the
+                    # total, which is what lets `reconcile` tell a killed-but-
+                    # finished run from a killed-mid-flight one. See
+                    # `_foreground_progress`.
+                    progress_callback=_foreground_progress(claim) if claim is not None else None,
+                )
             except DownloadException as e:
                 # `message` is rendered through `Text` (see `_download_failure`), which
                 # never parses markup, and `error_panel` sanitizes it (ANSI/control-byte
@@ -698,7 +716,7 @@ def download(
         # `download_state.reconcile` already handles: a record whose pid and
         # pid_create_time no longer match a live process demotes to `failed`, so a
         # hard-killed foreground run self-clears just like a dead worker.
-        _release_foreground(claim)
+        _persist_foreground(claim)
 
     elapsed = time.monotonic() - start_time
     print(f"Done in {_format_elapsed(elapsed)}")
@@ -1204,7 +1222,17 @@ def _enforce_claim(state: download_state.DownloadState, dest: pathlib.Path) -> N
     if competitor is None or _claim_order(state) < _claim_order(competitor):
         return
 
-    download_state.delete(get_workspace(), state.id)
+    if not download_state.delete(get_workspace(), state.id):
+        # The unlink failed (a read-only state directory, a permission change
+        # under us). Withdrawing the claim is the whole point of this branch, so
+        # falling back to a terminal status is the next best thing: a `failed`
+        # record is inert to `_active_download_for` and to `download-cancel`,
+        # where the `downloading` one we just wrote would read as a live claim and
+        # refuse every later submission to this destination until something
+        # reconciled it away.
+        state.status = "failed"
+        state.error = f"withdrew this claim; {competitor.id} won {dest}"
+        _persist_foreground(state)
     raise _in_flight_failure(competitor, dest)
 
 
@@ -1227,11 +1255,12 @@ def _claim_foreground(url: str, dest: pathlib.Path, downloader: str) -> download
     :func:`download_state.is_worker_process` falls back to matching the *worker's*
     argv marker, which a foreground CLI process does not carry.
 
-    Returns None when the claim could not be persisted. That is a deliberate
-    degradation to the pre-claim behavior rather than a failure: the state
-    directory is bookkeeping, and an unwritable workspace must not turn a
-    download that used to work into an error. (The ``--background`` path *does*
-    fail there, because a detached worker has nowhere else to report from.)
+    Returns None when the claim could not be persisted, *or* when this process's
+    start time could not be read. Both are deliberate degradations to the
+    pre-claim behavior rather than failures: the state directory is bookkeeping,
+    and an unwritable workspace must not turn a download that used to work into
+    an error. (The ``--background`` path *does* fail there, because a detached
+    worker has nowhere else to report from.)
     """
     # Absolute, as `_submit_background_download` also takes care to be. `dest` is
     # built from `workspace_manager.workspace_path`, which is not guaranteed
@@ -1241,11 +1270,29 @@ def _claim_foreground(url: str, dest: pathlib.Path, downloader: str) -> download
     # elsewhere and the two would not recognize each other's claim.
     # `download_cancel` reads it as a plain path too.
     dest = pathlib.Path(dest).absolute()
-    state = download_state.new(url=url, dest=str(dest), downloader=downloader)
+    # `_scrub_url`, not `url`: a foreground record is written for its *claim*, and
+    # nothing ever reads this field back from one (only the detached worker needs
+    # the real url, and it gets its own record). A resolved download url routinely
+    # carries a credential — CivitAI links append `?token=`, presigned S3/SAS links
+    # carry the signature in the query — so persisting it verbatim would drop a
+    # secret into `<workspace>/.comfy-downloads/`, a directory inside the ComfyUI
+    # checkout that nothing gitignores, for no reader's benefit.
+    state = download_state.new(url=_scrub_url(url), dest=str(dest), downloader=downloader)
     state.kind = "foreground"
     state.status = "downloading"
     state.pid = os.getpid()
     state.pid_create_time = download_state.process_create_time(state.pid)
+    if state.pid_create_time is None:
+        # Without the start time this claim is unfalsifiable. `worker_alive` falls
+        # back to bare pid liveness when `pid_create_time` is None, so once this
+        # process exits and the OS recycles its number the record reads *live*
+        # forever: `reconcile` never demotes it, every later download to this
+        # destination is refused as `model_download_in_flight`, and
+        # `download-cancel` refuses it as foreground — leaving hand-deletion of
+        # the JSON as the only way out. A claim that cannot retract itself on
+        # death is worse than no claim, so degrade to the pre-claim behavior
+        # exactly as an unwritable state directory does.
+        return None
     try:
         download_state.write(get_workspace(), state)
     except (OSError, ValueError):
@@ -1253,12 +1300,54 @@ def _claim_foreground(url: str, dest: pathlib.Path, downloader: str) -> download
     return state
 
 
-def _release_foreground(state: download_state.DownloadState | None) -> None:
-    """Persist a foreground claim's terminal status. Never raises."""
+def _persist_foreground(state: download_state.DownloadState | None) -> None:
+    """Write a foreground claim to disk. Never raises.
+
+    Used for both the progress writes and the terminal one: the state directory
+    is bookkeeping, and a download that is otherwise fine must not die because a
+    record could not be updated.
+    """
     if state is None:
         return
     with contextlib.suppress(OSError, ValueError):
         download_state.write(get_workspace(), state)
+
+
+def _foreground_progress(state: download_state.DownloadState) -> Callable[[int, int | None], None]:
+    """A ``progress_callback`` that keeps a foreground claim's counters current.
+
+    Chiefly for ``total_bytes``, which is what lets a foreground record survive a
+    SIGKILL honestly. :func:`download_state.reconcile` resolves a dead ``downloading``
+    record to ``completed`` only when ``total_bytes`` is known and the file on disk
+    reached it; with no callback the field stayed None for the whole transfer, so a
+    run killed in the window between the rename and the ``finally`` below left a
+    *complete* model at ``dest`` under a record that read ``failed`` forever — and
+    ``download-cancel`` then deleted that finished file as an aria2 partial.
+
+    It also makes the record's progress real. ``comfy model downloads`` and
+    ``download-status`` now list foreground downloads, and without this they would
+    report 0 bytes and no percent for the entire transfer.
+
+    Writes are throttled to :data:`download_state.PROGRESS_THROTTLE_S`, as the
+    worker's are, with one exception: a newly-learned total is written
+    immediately. It arrives once, before the first chunk, and it is the field
+    that matters if this process is killed a moment later.
+    """
+    last_write = 0.0
+
+    def on_progress(completed: int, total: int | None) -> None:
+        nonlocal last_write
+        state.completed_bytes = completed
+        learned_total = total is not None and state.total_bytes != total
+        if total is not None:
+            state.total_bytes = total
+        now = time.monotonic()
+        if not learned_total and now - last_write < download_state.PROGRESS_THROTTLE_S:
+            return
+        last_write = now
+        _persist_foreground(state)
+
+    return on_progress
 
 
 @app.command("download-status")

--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -791,8 +791,18 @@ def _submit_background_download(
     # competitor that also claimed `dest`; `_claim_order` picks the same winner
     # from both sides, and the loser withdraws its claim before any bytes move.
     #
-    # This closes the background-vs-background race the guard documents. It cannot
-    # close one against a foreground transfer, which never writes a claim.
+    # This *narrows* the background-vs-background race; it does not close it. A
+    # re-scan cannot see a claim that has not been written yet, and nothing orders
+    # a competitor's `write` before our scan — so a competitor whose record lands
+    # after we look is still missed and both submissions proceed (reproduced at 12
+    # simultaneous submits; 4 and 8 came out clean). What changed is the width of
+    # the window: from `[pre-flight scan -> write]`, which spans the `--background`
+    # split and an HF round trip, down to `[write -> re-scan]`. Closing it needs an
+    # atomic claim — an `O_EXCL` sibling or an `flock` — which is a design call
+    # this guard does not make.
+    #
+    # It does nothing at all against a foreground transfer, which never writes a
+    # claim.
     competitor = _active_download_for(dest, exclude_id=state.id)
     if competitor is not None and _claim_order(competitor) < _claim_order(state):
         with contextlib.suppress(OSError):
@@ -1029,6 +1039,11 @@ def _claim_order(state: download_state.DownloadState) -> tuple[str, str]:
     ``started_at`` is second-resolution so ties are common; ``id`` (12 random hex
     chars) breaks them, and because both racers compute the same order over the
     same two records they always agree on who won.
+
+    Agreeing on the winner requires both records to be *visible* to both racers,
+    which the re-scan in :func:`_submit_background_download` cannot guarantee — a
+    racer that scans before the other's record lands sees no competitor at all, so
+    this order is never consulted and both proceed. See that call site.
     """
     return (state.started_at or "", state.id)
 

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -24,9 +24,21 @@ State-file contract (``download-state/1``)::
       "started_at": "<iso8601>",
       "updated_at": "<iso8601>",
       "downloader": "httpx" | "aria2",
+      "kind": "background" | "foreground",
       "needs_civitai_auth": <bool>,
       "needs_hf_auth": <bool>
     }
+
+``kind`` distinguishes a detached worker from a plain ``comfy model download``
+running in the caller's own terminal. Both write records — a foreground transfer
+that claimed no destination was invisible to every other invocation, so two of
+them raced into the same file — but they are not interchangeable: a background
+worker gets its own session (:func:`kill_worker` may ``killpg`` it), whereas a
+foreground record's pid is the *user's CLI process*, sharing the terminal's
+foreground process group. Signalling that group would kill the user's shell job,
+so ``download-cancel`` refuses a live foreground record instead. The field is
+additive within ``download-state/1``: readers drop unknown keys, and a record
+written before it existed reads back as ``"background"``, which is what it was.
 
 ``pid`` is only ever written by the worker itself, together with
 ``pid_create_time`` — the pair identifies the process, so a recycled pid can
@@ -169,8 +181,19 @@ class DownloadState:
     started_at: str = ""
     updated_at: str = ""
     downloader: str = "httpx"
+    kind: str = "background"
     needs_civitai_auth: bool = False
     needs_hf_auth: bool = False
+
+    @property
+    def is_foreground(self) -> bool:
+        """True when this record's pid is a user CLI process, not a detached worker.
+
+        The distinction is only ever load-bearing in the *refusing* direction
+        (``download-cancel`` must not signal a foreground pid's process group),
+        so an unrecognized value reads as ``background`` — see :data:`_TOLERANT_FIELDS`.
+        """
+        return self.kind == "foreground"
 
     @property
     def is_terminal(self) -> bool:
@@ -284,9 +307,30 @@ _FIELD_VALIDATORS: dict[str, Any] = {
     "started_at": lambda v: isinstance(v, str),
     "updated_at": lambda v: isinstance(v, str),
     "downloader": lambda v: isinstance(v, str),
+    "kind": lambda v: v in ("background", "foreground"),
     "needs_civitai_auth": lambda v: isinstance(v, bool),
     "needs_hf_auth": lambda v: isinstance(v, bool),
 }
+
+# Fields whose validator failure drops *the field* (falling back to the dataclass
+# default) rather than the whole record.
+#
+# `kind` is in here because rejecting the record is the more dangerous outcome by
+# far. A record reads as absent to every caller, including the destination-claim
+# scan — so one unrecognized `kind` on a *live* download would make its claim
+# invisible and let a second writer into the same file, which is the exact
+# corruption the claim exists to prevent. Dropping one advisory field is the
+# smaller loss.
+#
+# The fallback is the dataclass default, `"background"`, which is exactly right
+# for the case that actually occurs — a record written before this field existed,
+# which *was* a background worker. It is the less conservative choice for the
+# case that does not occur today: a *live foreground* record whose `kind` got
+# rewritten to something unrecognized would read as cancellable, and
+# `download-cancel` would then `killpg` the user's shell job. Nothing writes a
+# third value, so that population is empty; a future version that adds one must
+# revisit this line rather than assume tolerance covers it.
+_TOLERANT_FIELDS = frozenset({"kind"})
 
 
 def read_path(path: Path) -> DownloadState | None:
@@ -298,15 +342,39 @@ def read_path(path: Path) -> DownloadState | None:
         return None
     known = set(DownloadState.__dataclass_fields__)
     filtered = {k: v for k, v in data.items() if k in known}
-    for key, value in filtered.items():
+    for key, value in list(filtered.items()):
         validator = _FIELD_VALIDATORS.get(key)
         if validator is not None and not validator(value):
+            if key in _TOLERANT_FIELDS:
+                del filtered[key]
+                continue
             return None
     try:
         return DownloadState(**filtered)
     except TypeError:
         # Truncated/legacy file missing a required field — treat as absent.
         return None
+
+
+def delete(workspace: Path, download_id: str) -> bool:
+    """Remove one state file. Returns False if it could not be removed.
+
+    Used to *withdraw a claim*: both the background and the foreground submit
+    paths write their record and then re-scan for a competitor, and the racer
+    that loses that comparison has to take its record back off disk before it
+    exits. Leaving it behind would be worse than never having written it — an
+    abandoned ``downloading`` record with a pid that is about to disappear reads
+    as a live claim until something reconciles it, so it would refuse every later
+    submission to that destination for no reason.
+
+    Absent is success: the caller's goal is "this claim is gone", and a record
+    that was never written (or already swept) satisfies it.
+    """
+    try:
+        state_path(workspace, download_id).unlink(missing_ok=True)
+        return True
+    except (OSError, ValueError):
+        return False
 
 
 def list_all(workspace: Path) -> list[DownloadState]:
@@ -482,10 +550,19 @@ def percent(state: DownloadState) -> float | None:
 
 
 def status_payload(state: DownloadState) -> dict[str, Any]:
-    """The ``download-status`` / ``downloads`` envelope row for one download."""
+    """The ``download-status`` / ``downloads`` envelope row for one download.
+
+    ``kind`` is reported because these rows are now the only place a foreground
+    download is visible, and the two kinds are not interchangeable to a consumer:
+    ``download-cancel`` refuses a live ``foreground`` row (its pid is a user CLI
+    process sharing a terminal's process group, so signalling it would kill the
+    surrounding shell job). Without the field the only way to learn that is to
+    try the cancel and read the refusal.
+    """
     return {
         "id": state.id,
         "status": state.status,
+        "kind": state.kind,
         "completed_bytes": state.completed_bytes,
         "total_bytes": state.total_bytes,
         "percent": percent(state),

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -39,6 +39,9 @@ foreground process group. Signalling that group would kill the user's shell job,
 so ``download-cancel`` refuses a live foreground record instead. The field is
 additive within ``download-state/1``: readers drop unknown keys, and a record
 written before it existed reads back as ``"background"``, which is what it was.
+A record carrying an *unrecognized* ``kind`` is a different case — see
+``_TOLERANT_FALLBACKS`` — and reads back as ``"foreground"``, the side that
+refuses to be signalled.
 
 ``pid`` is only ever written by the worker itself, together with
 ``pid_create_time`` — the pair identifies the process, so a recycled pid can
@@ -191,7 +194,9 @@ class DownloadState:
 
         The distinction is only ever load-bearing in the *refusing* direction
         (``download-cancel`` must not signal a foreground pid's process group),
-        so an unrecognized value reads as ``background`` — see :data:`_TOLERANT_FIELDS`.
+        so an unrecognized value reads as ``foreground`` — the non-cancellable
+        side. See :data:`_TOLERANT_FALLBACKS`. Only a record with no ``kind`` at
+        all reads as ``background``, because that is what it provably was.
         """
         return self.kind == "foreground"
 
@@ -312,25 +317,31 @@ _FIELD_VALIDATORS: dict[str, Any] = {
     "needs_hf_auth": lambda v: isinstance(v, bool),
 }
 
-# Fields whose validator failure drops *the field* (falling back to the dataclass
-# default) rather than the whole record.
+# Fields whose validator failure replaces *the field* with the value below
+# rather than rejecting the whole record.
 #
 # `kind` is in here because rejecting the record is the more dangerous outcome by
-# far. A record reads as absent to every caller, including the destination-claim
-# scan — so one unrecognized `kind` on a *live* download would make its claim
-# invisible and let a second writer into the same file, which is the exact
-# corruption the claim exists to prevent. Dropping one advisory field is the
-# smaller loss.
+# far. A rejected record reads as absent to every caller, including the
+# destination-claim scan — so one unrecognized `kind` on a *live* download would
+# make its claim invisible and let a second writer into the same file, which is
+# the exact corruption the claim exists to prevent. Keeping the record and
+# distrusting one field is the smaller loss.
 #
-# The fallback is the dataclass default, `"background"`, which is exactly right
-# for the case that actually occurs — a record written before this field existed,
-# which *was* a background worker. It is the less conservative choice for the
-# case that does not occur today: a *live foreground* record whose `kind` got
-# rewritten to something unrecognized would read as cancellable, and
-# `download-cancel` would then `killpg` the user's shell job. Nothing writes a
-# third value, so that population is empty; a future version that adds one must
-# revisit this line rather than assume tolerance covers it.
-_TOLERANT_FIELDS = frozenset({"kind"})
+# The substitute is `"foreground"`, *not* the dataclass default. `kind` is the
+# one field that gates a destructive action, so tolerance here has to fail
+# closed: `download-cancel` refuses a live `foreground` record and sends the user
+# to Ctrl-C, whereas a `background` one reaches `kill_worker` ->
+# `os.killpg(os.getpgid(pid), ...)`. Guessing "background" for a value we could
+# not parse would aim that killpg at a pid we have no reason to believe is a
+# detached worker — and if it is in fact a foreground record whose `kind` was
+# corrupted, at the user's own shell job. Refusing to cancel a record we cannot
+# read is recoverable (the process is Ctrl-C-able, and the record reconciles once
+# it exits); signalling the wrong process group is not.
+#
+# A record with no `kind` key at all is a different case and is *not* routed
+# here: it falls through to the dataclass default, `"background"`, because every
+# record written before this field existed really was a detached worker.
+_TOLERANT_FALLBACKS: dict[str, Any] = {"kind": "foreground"}
 
 
 def read_path(path: Path) -> DownloadState | None:
@@ -345,8 +356,8 @@ def read_path(path: Path) -> DownloadState | None:
     for key, value in list(filtered.items()):
         validator = _FIELD_VALIDATORS.get(key)
         if validator is not None and not validator(value):
-            if key in _TOLERANT_FIELDS:
-                del filtered[key]
+            if key in _TOLERANT_FALLBACKS:
+                filtered[key] = _TOLERANT_FALLBACKS[key]
                 continue
             return None
     try:

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -402,7 +402,13 @@ def worker_alive(state: DownloadState, *, pid_alive=None) -> bool:
     self-corrects on the next poll, while signalling a stranger's process group
     is not, so only the reporting side is allowed the benefit of the doubt.
     """
-    if state.pid is None:
+    if not state.pid or state.pid <= 0:
+        # Not just `is None`. The field validator accepts any non-bool int, so a
+        # corrupt or tampered record can carry a negative pid — and
+        # `psutil.Process(-1)` raises ValueError, which `utils.is_running` does
+        # not catch. One bad state file would then traceback out of every command
+        # that reconciles, including `model download` itself. `is_worker_process`
+        # and `kill_worker` already screen the same way.
         return False
     if pid_alive is None:
         from comfy_cli.utils import is_running as pid_alive  # noqa: N813

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -614,6 +614,15 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "pass `--filename` to save under a different name, or remove the existing file",
     ),
     ErrorCode(
+        "model_download_in_flight",
+        "`comfy model download` refused to start because a live background download is already "
+        "writing to the same destination (`details.path`). `details.download_id` names that "
+        "download and `details.status` is its current status. A background transfer streams into "
+        "a `.part` sibling, so the destination is absent until it completes — without this check "
+        "two submissions would both run and the later one would silently overwrite the earlier.",
+        "track it with `comfy model download-status <id>`, or cancel it with `comfy model download-cancel <id>`",
+    ),
+    ErrorCode(
         "hf_unauthorized",
         "Hugging Face returned 401 for the model URL and no Hugging Face API token is configured "
         "(gated or private repo).",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -615,12 +615,27 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "model_download_in_flight",
-        "`comfy model download` refused to start because a live background download is already "
-        "writing to the same destination (`details.path`). `details.download_id` names that "
-        "download and `details.status` is its current status. A background transfer streams into "
-        "a `.part` sibling, so the destination is absent until it completes — without this check "
-        "two submissions would both run and the later one would silently overwrite the earlier.",
-        "track it with `comfy model download-status <id>`, or cancel it with `comfy model download-cancel <id>`",
+        "`comfy model download` refused to start because a live download is already writing to "
+        "the same destination (`details.path`). `details.download_id` names that download, "
+        "`details.status` is its current status, and `details.kind` is `background` (a detached "
+        "worker) or `foreground` (a `comfy model download` running in another terminal). The httpx "
+        "downloader streams into a `.part` sibling, so the destination stays absent until the "
+        "transfer completes — without this check two submissions would both run and the later one "
+        "would silently overwrite the earlier; under `--downloader aria2`, which writes straight to "
+        "the destination, they would interleave into the same file.",
+        "track it with `comfy model download-status <id>`; a background download can be stopped "
+        "with `comfy model download-cancel <id>`, a foreground one with Ctrl-C in its own terminal",
+    ),
+    ErrorCode(
+        "model_download_foreground_cancel",
+        "`comfy model download-cancel` refused to cancel a download that is running in the "
+        "foreground of another terminal (`details.id`, `details.pid`). A background download runs in "
+        "its own session, so cancelling it signals only the worker's process group; a foreground "
+        "download's recorded pid is the user's own CLI process, which shares the terminal's "
+        "foreground process group — signalling that group would kill the surrounding shell job "
+        "rather than just the transfer. Once the foreground process is gone its record reconciles "
+        "to `failed` and `download-cancel` will sweep the partial file as usual.",
+        "interrupt it with Ctrl-C in the terminal running it",
     ),
     ErrorCode(
         "hf_unauthorized",
@@ -647,7 +662,9 @@ REGISTRY: tuple[ErrorCode, ...] = (
     # --- background model downloads (`model download --background`) ----------
     ErrorCode(
         "download_not_found",
-        "No background download state file matches the given download id.",
+        "No download state file matches the given download id. Both `--background` submissions and plain "
+        "foreground `comfy model download` runs write one, so an id that resolves to neither was never "
+        "written, or its record has already been pruned.",
         "list the known downloads with `comfy model downloads`",
     ),
     ErrorCode(

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -234,6 +234,14 @@ def _poll_aria2_download(download, progress_callback: ProgressCallback | None = 
     removed before the exception propagates: with aria2 the bytes move inside the
     aria2c process, not this one, so simply walking away would leave it happily
     finishing a download the user just cancelled.
+
+    A :class:`KeyboardInterrupt` gets the same treatment, and needs it more.
+    Ctrl-C is what `comfy model download` tells a user to press to stop a
+    foreground transfer — and it lands here, in the poll loop's sleep, not in a
+    progress callback, so `DownloadCancelled` never fires. Without this the
+    interrupted CLI would tear down its destination *claim* on the way out while
+    the aria2c daemon carried on writing to that same destination: the exact
+    unguarded interleaving the claim exists to prevent.
     """
     import time
 
@@ -280,7 +288,7 @@ def _poll_aria2_download(download, progress_callback: ProgressCallback | None = 
                     raise DownloadException("aria2 download was removed before completion")
 
                 time.sleep(0.5)
-        except DownloadCancelled:
+        except (DownloadCancelled, KeyboardInterrupt):
             _remove_aria2_download(download)
             raise
 

--- a/comfy_cli/schemas/download_status.json
+++ b/comfy_cli/schemas/download_status.json
@@ -2,18 +2,33 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/download_status.json",
   "title": "comfy model download-status <id> --json data payload",
-  "description": "Reconciled progress for one background download. The reported status is the state file corrected against reality: completed_bytes prefers a live stat() of dest, and an 'downloading' record whose worker pid is gone resolves to 'completed' (size reached the known total) or 'failed' (it did not).",
+  "description": "Reconciled progress for one download, background or foreground (see 'kind'). The reported status is the state file corrected against reality: completed_bytes prefers a live stat() of dest, and an 'downloading' record whose pid is gone resolves to 'completed' (size reached the known total) or 'failed' (it did not).",
   "type": "object",
   "$defs": {
     "row": {
       "type": "object",
-      "required": ["id", "status", "completed_bytes", "total_bytes", "percent", "elapsed_seconds", "dest", "error"],
+      "required": [
+        "id",
+        "status",
+        "kind",
+        "completed_bytes",
+        "total_bytes",
+        "percent",
+        "elapsed_seconds",
+        "dest",
+        "error"
+      ],
       "additionalProperties": true,
       "properties": {
         "id": { "type": "string" },
         "status": {
           "type": "string",
           "enum": ["starting", "downloading", "completed", "failed", "cancelled"]
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["background", "foreground"],
+          "description": "'background' is a detached worker, cancellable with `comfy model download-cancel <id>`. 'foreground' is a `comfy model download` running in a user's own terminal; download-cancel refuses a live one (its pid shares that terminal's process group) — interrupt it with Ctrl-C there instead. A record written before this field existed reads back as 'background', which is what it was."
         },
         "completed_bytes": { "type": "integer" },
         "total_bytes": {

--- a/tests/comfy_cli/command/models/test_model_download_json.py
+++ b/tests/comfy_cli/command/models/test_model_download_json.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 import sys
 from typing import Any
 from unittest.mock import Mock, patch
@@ -521,3 +522,48 @@ def test_hf_download_honours_prompted_filename(tmp_path):
     assert result.exit_code == 0, result.output
     assert (tmp_path / "models" / "checkpoints" / "typed.safetensors").read_bytes() == b"weights"
     assert not hf_written.exists()
+
+
+def test_hf_move_failure_emits_an_envelope_not_a_traceback(tmp_path):
+    """`shutil.move` raises `shutil.Error` for a partial/multi-file move failure.
+
+    It derives from `OSError` (Lib/shutil.py: `class Error(OSError)`), so the
+    branch's `except OSError` does catch it — but this is the branch with no
+    `except Exception` backstop, so the one invariant this whole file pins (a
+    `--json` caller always gets an envelope) rests entirely on that class
+    relationship continuing to hold. Pin it.
+    """
+    hf_written = tmp_path / "models" / "checkpoints" / "repo-name.safetensors"
+    hf_written.parent.mkdir(parents=True)
+    hf_written.write_bytes(b"weights")
+
+    fake_hub = Mock()
+    fake_hub.hf_hub_download.return_value = str(hf_written)
+
+    cfg = Mock()
+    cfg.get_or_override.return_value = "hf_token"
+    cfg.get.return_value = None
+
+    fake_shutil = Mock()
+    fake_shutil.Error = shutil.Error
+    fake_shutil.move.side_effect = shutil.Error("Destination path already exists")
+
+    with patch.dict(sys.modules, {"huggingface_hub": fake_hub}):
+        result = _invoke(
+            [
+                "--url",
+                "https://huggingface.co/org/repo/resolve/main/repo-name.safetensors",
+                "--relative-path",
+                "models/checkpoints",
+                "--filename",
+                "mine.safetensors",
+            ],
+            config_manager=cfg,
+            check_huggingface_url={"return_value": (True, "org/repo", "repo-name.safetensors", None, "main")},
+            check_unauthorized={"return_value": True},
+            get_workspace={"return_value": tmp_path},
+            shutil={"new": fake_shutil},
+        )
+
+    env = _assert_error_envelope(result, "download_failed")
+    assert "could not save it as" in env["error"]["message"]

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -791,6 +791,12 @@ class TestSubmitRefusesAClaimedDestination:
         it, both stream a full copy, and the later `os.replace` can silently
         overwrite the earlier. The record each one writes is its claim; the
         re-scan after that write is what turns two winners into one.
+
+        Scope: this plants the competitor's claim *before* the re-scan, so the
+        re-scan can see it. The interleaving where a competitor's write lands
+        after our scan is not covered here because it is not covered by the code
+        either — see `_submit_background_download`, which narrows that race
+        rather than closing it.
         """
         dest = self._dest(workspace)
         competitor = _state(dest=str(dest), status="downloading", pid=1234)

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -562,6 +562,143 @@ class TestSubmitFailsFast:
         assert "Hugging Face API token" in capsys.readouterr().out
 
 
+class TestSubmitRefusesAClaimedDestination:
+    """A destination already claimed by a *live* background download is refused.
+
+    `local_filepath.exists()` cannot catch this: a background transfer streams
+    into a `.part` sibling and only renames onto `dest` at the very end, so the
+    destination is absent for the whole transfer and a second submission would
+    otherwise sail through, stream a full second copy, and silently overwrite the
+    first at rename time.
+    """
+
+    DEST = ("models/loras", "m.safetensors")
+
+    def _dest(self, workspace) -> Path:
+        return workspace / self.DEST[0] / self.DEST[1]
+
+    def _download(self, **kwargs):
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path=self.DEST[0],
+            filename=self.DEST[1],
+            **kwargs,
+        )
+
+    def test_a_second_submission_is_refused(self, workspace, no_spawn, json_renderer):
+        """The classic double-submit: a live worker owns the destination."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234, total_bytes=4096)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["ok"] is False
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+        assert env["error"]["details"]["status"] == "downloading"
+        assert env["error"]["details"]["path"] == str(self._dest(workspace))
+        # The refusal is read-only: the in-flight record is left exactly as it was.
+        assert download_state.read(workspace, live.id).status == "downloading"
+        assert len(download_state.list_all(workspace)) == 1
+
+    def test_a_pidless_starting_record_still_blocks(self, workspace, no_spawn, json_renderer):
+        """The regression test for reconcile-vs-`worker_alive`.
+
+        A just-submitted download sits in `starting` with no pid for up to
+        STARTUP_GRACE_S while its worker's interpreter boots, and `worker_alive`
+        reports False for a pidless record — so a `worker_alive` predicate would
+        wave through exactly the near-simultaneous double-submit this guard is
+        for. `_state()` stamps `started_at` now, i.e. inside the grace window.
+        """
+        live = _state(dest=str(self._dest(workspace)), status="starting", pid=None)
+        download_state.write(workspace, live)
+
+        with pytest.raises(typer.Exit) as exc:
+            self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        assert json_renderer()["error"]["code"] == "model_download_in_flight"
+
+    def test_a_dead_workers_record_self_clears(self, workspace, monkeypatch, json_renderer):
+        """A SIGKILLed worker's stale record must never wedge the path: the scan
+        reconciles first, so the record demotes to `failed` and the submit runs."""
+        stale = _state(dest=str(self._dest(workspace)), status="downloading", pid=4242, total_bytes=4096)
+        download_state.write(workspace, stale)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["download_id"] != stale.id
+        # ...and the demotion was persisted, not merely computed in memory.
+        assert download_state.read(workspace, stale.id).status == "failed"
+
+    def test_a_live_download_to_another_destination_does_not_block(self, workspace, monkeypatch, json_renderer):
+        other = _state(dest=str(workspace / "models" / "loras" / "other.safetensors"), status="downloading", pid=1234)
+        download_state.write(workspace, other)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["dest"] == str(self._dest(workspace))
+
+    def test_an_unnormalized_relative_path_does_not_slip_past(self, workspace, no_spawn, json_renderer):
+        """`--relative-path` is only `expanduser`-ed, never rejected for `..`, so
+        both sides of the comparison have to be normalized or a caller could
+        spell the same destination differently and defeat the guard."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit):
+                models.download(
+                    None,
+                    url="https://example.com/m.safetensors",
+                    relative_path="models/loras/../loras",
+                    filename=self.DEST[1],
+                    background=True,
+                )
+
+        assert json_renderer()["error"]["details"]["download_id"] == live.id
+
+    def test_an_unreadable_state_directory_does_not_break_the_download(self, workspace, monkeypatch, json_renderer):
+        """The scan is advisory. It is now on the foreground path too, which never
+        read the state directory before, so a failure there must degrade to the
+        pre-guard behavior rather than become a traceback."""
+        monkeypatch.setattr(download_state, "list_all", MagicMock(side_effect=OSError("state dir is not readable")))
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+
+    def test_a_foreground_download_is_refused_too(self, workspace, monkeypatch, json_renderer):
+        """The guard sits before the `--background` split, so a foreground
+        transfer into a claimed destination is refused before any bytes move."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+        monkeypatch.setattr(models, "download_file", MagicMock(side_effect=AssertionError("a transfer started")))
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download()
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+
+
 class TestSubmitEnvelope:
     def _submit(self, workspace, monkeypatch, **kwargs):
         monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -357,6 +357,32 @@ class TestProgressCallback:
         assert (40, 100) in seen
         assert seen[-1] == (100, 100)
 
+    def test_ctrl_c_stops_the_daemon_side_aria2_transfer(self):
+        """Ctrl-C has to reach *aria2c*, not just this process.
+
+        With aria2 the bytes move inside the daemon, and the foreground
+        `download_file` call passes a progress callback that never raises
+        `DownloadCancelled` — so an interrupt lands here, in the poll loop, and
+        nothing else would ever tell aria2c to stop. Walking away would leave the
+        daemon writing to a destination whose *claim* the interrupted CLI has just
+        withdrawn: the unguarded double-writer the claim exists to prevent, via
+        the very keystroke `model_download_foreground_cancel` tells users to press.
+        """
+        from comfy_cli.file_utils import _poll_aria2_download
+
+        download = MagicMock()
+        download.total_length = 100
+        download.completed_length = 10
+        download.is_complete = False
+        download.has_failed = False
+        download.is_removed = False
+
+        with patch("time.sleep", side_effect=KeyboardInterrupt):
+            with pytest.raises(KeyboardInterrupt):
+                _poll_aria2_download(download)
+
+        download.remove.assert_called_once_with(force=True, files=True)
+
 
 class TestWorkerThrottle:
     def test_progress_writes_are_throttled_but_terminal_always_lands(self, workspace, monkeypatch, tmp_path):
@@ -1110,6 +1136,30 @@ class TestForegroundClaimsItsDestination:
             assert json_renderer()["error"]["details"]["download_id"] == rival.id
             assert download_state.read(workspace, "mmmmmmmmmmmm") is None
 
+    def test_a_claim_we_cannot_unlink_is_made_inert_instead(self, workspace, monkeypatch, json_renderer):
+        """Withdrawing the claim is the point of losing; the unlink is only how.
+
+        If the unlink fails, leaving our `downloading` record behind is worse than
+        never having written it: it reads as a live claim to `_active_download_for`
+        and would refuse every later submission to this destination until something
+        reconciled it away. A terminal status is inert to the same readers, so fall
+        back to that.
+        """
+        rival = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        rival.started_at = "2000-01-01T00:00:00+00:00"
+        self._race(monkeypatch, rival)
+        monkeypatch.setattr(download_state, "delete", lambda workspace, download_id: False)
+        monkeypatch.setattr(models, "download_file", MagicMock(side_effect=AssertionError("a transfer started")))
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit):
+                self._download()
+
+        assert json_renderer()["error"]["details"]["download_id"] == rival.id
+        ours = [s for s in download_state.list_all(workspace) if s.id != rival.id]
+        assert [s.status for s in ours] == ["failed"]
+        assert download_state.read(workspace, rival.id).status == "downloading"
+
     def test_an_unwritable_state_directory_still_downloads(self, workspace, monkeypatch, capsys):
         """The claim is bookkeeping. An unwritable workspace must degrade to the
         old behavior — no claim, transfer still runs — not turn a download that
@@ -1121,6 +1171,102 @@ class TestForegroundClaimsItsDestination:
         self._download()
 
         assert len(calls) == 1
+
+    def test_an_unverifiable_pid_claims_nothing(self, workspace, monkeypatch, capsys):
+        """No `pid_create_time` means the claim could never retract itself.
+
+        `worker_alive` falls back to bare pid liveness when the start time is
+        missing, so once this process exits and the OS recycles its number the
+        record reads *live* forever: `reconcile` never demotes it, every later
+        download to that destination is refused, and `download-cancel` refuses it
+        as foreground. A permanently wedged destination is worse than the race the
+        claim narrows, so the claim is simply not written — the same degradation
+        an unwritable state directory gets.
+        """
+        monkeypatch.setattr(download_state, "process_create_time", lambda pid: None)
+        calls = self._transfer(monkeypatch)
+
+        self._download()
+
+        assert len(calls) == 1
+        assert download_state.list_all(workspace) == []
+
+    def test_the_claim_does_not_persist_the_url_query(self, workspace, monkeypatch, capsys):
+        """A resolved download url carries credentials — a presigned S3/SAS
+        signature, or CivitAI's `?token=`. Nothing reads a *foreground* record's
+        url back (only the detached worker needs the real one), so persisting it
+        verbatim would write a secret into `<workspace>/.comfy-downloads/`, which
+        nothing gitignores, for no reader at all."""
+        signed = "https://example.com/m.safetensors?X-Amz-Signature=hunter2"
+        seen: list = []
+        monkeypatch.setattr(models, "download_file", lambda *a, **k: seen.append(a[0]))
+
+        models.download(None, url=signed, relative_path=self.DEST[0], filename=self.DEST[1])
+
+        # The transfer itself still gets the real url...
+        assert seen == [signed]
+        # ...but the record on disk does not.
+        (record,) = download_state.list_all(workspace)
+        assert record.url == "https://example.com/m.safetensors"
+        assert "hunter2" not in json.dumps(record.to_dict())
+
+    def test_progress_is_persisted_so_a_killed_run_reconciles_honestly(self, workspace, monkeypatch, capsys):
+        """The record has to learn `total_bytes` *during* the transfer.
+
+        `reconcile` resolves a dead `downloading` record to `completed` only when
+        the total is known and the file reached it. With no progress callback the
+        field stayed None for the whole foreground transfer, so a run SIGKILLed in
+        the window between the rename and its `finally` left a *complete* model
+        under a record reading `failed` forever — and `download-cancel` then
+        deleted that finished file as an aria2 partial.
+        """
+        snapshot: list = []
+
+        def land_the_file(url, path, headers, downloader=None, progress_callback=None):
+            # The size arrives before the first chunk, as it does off Content-Length.
+            progress_callback(0, 4096)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"x" * 4096)
+            # A SIGKILL landing *here* runs no Python cleanup: no terminal status,
+            # no `finally`. Whatever is on disk at this instant is all a later
+            # reader ever sees, so that is what this asserts on.
+            snapshot.extend(download_state.list_all(workspace))
+
+        monkeypatch.setattr(models, "download_file", land_the_file)
+
+        self._download()
+
+        (record,) = snapshot
+        assert record.status == "downloading"
+        assert record.total_bytes == 4096
+
+        # And that is enough for the next reader to call it what it is: the file
+        # reached the known total, so this is a finished download, not a corpse.
+        fresh = download_state.reconcile(record, pid_alive=lambda pid: False)
+        assert fresh.status == "completed"
+
+    def test_progress_writes_are_throttled(self, workspace, monkeypatch, capsys):
+        """Once the total is known the record must not be rewritten per chunk — a
+        multi-GB transfer would otherwise be thousands of state writes."""
+        writes: list = []
+        real_write = download_state.write
+
+        def counting_write(ws, state):
+            writes.append(state.completed_bytes)
+            return real_write(ws, state)
+
+        monkeypatch.setattr(download_state, "write", counting_write)
+
+        def chunked(url, path, headers, downloader=None, progress_callback=None):
+            for completed in range(0, 500):
+                progress_callback(completed, 4096)
+
+        monkeypatch.setattr(models, "download_file", chunked)
+
+        self._download()
+
+        # The claim, the newly-learned total, and the terminal write — not 500.
+        assert len(writes) <= 4
 
 
 class TestSubmitEnvelope:
@@ -1246,8 +1392,11 @@ class TestSubmitEnvelope:
         )
 
         assert len(calls) == 1
-        # The foreground call site does not pass a progress callback.
-        assert "progress_callback" not in calls[0][1]
+        # The foreground call site *does* pass a progress callback now — it used
+        # not to, because there was no record to feed. There is one now, and
+        # `total_bytes` on it is what tells `reconcile` a run killed just after
+        # the rename finished rather than died mid-transfer.
+        assert callable(calls[0][1]["progress_callback"])
         # It *does* now leave a record — a foreground transfer that claims nothing
         # is invisible to every other invocation, which is how two of them ended up
         # writing the same file. The record is a foreground one and it is terminal,
@@ -1999,15 +2148,21 @@ class TestCorruptStateFiles:
         assert state.is_foreground is False
 
     @pytest.mark.parametrize("value", ["worker", "", None, 3])
-    def test_an_unrecognized_kind_drops_the_field_not_the_record(self, workspace, tmp_path, value):
-        """`kind` is the one *tolerant* field: a bad value drops the field rather
-        than the whole record.
+    def test_an_unrecognized_kind_reads_as_the_non_cancellable_one(self, workspace, tmp_path, value):
+        """`kind` is the one *tolerant* field: a bad value replaces the field
+        rather than rejecting the whole record — and it fails *closed*.
 
         Rejecting the record is the far more dangerous outcome. A record that
         reads as absent is invisible to the destination-claim scan too, so one
         unrecognized `kind` on a *live* download would un-claim its destination
         and let a second writer into the same file — the exact corruption the
         claim exists to prevent.
+
+        But the substitute cannot be the `background` default, because `kind` is
+        what gates a destructive action: `background` reaches `kill_worker`'s
+        `os.killpg`. A value we could not parse is no evidence that the pid is a
+        detached worker, so it reads as `foreground` — refused by
+        `download-cancel`, which is the recoverable way to be wrong.
         """
         path = tmp_path / "odd-kind.json"
         payload = _state().to_dict()
@@ -2016,7 +2171,8 @@ class TestCorruptStateFiles:
 
         state = download_state.read_path(path)
         assert state is not None
-        assert state.kind == "background"
+        assert state.kind == "foreground"
+        assert state.is_foreground is True
 
     @pytest.mark.parametrize("kind", ["background", "foreground"])
     def test_the_status_row_reports_the_kind(self, kind):

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -854,6 +854,275 @@ class TestSubmitRefusesAClaimedDestination:
         assert env["data"]["download_id"] != latecomer.id
 
 
+class TestForegroundClaimsItsDestination:
+    """A foreground `comfy model download` writes a claim record too.
+
+    Before it did, the foreground path was a blind spot: it wrote no state at all,
+    so a second foreground run — or a `--background` submit started during one —
+    passed both the destination scan (which only saw background records) and
+    `exists()` (the httpx downloader streams into a `.part` sibling, so nothing is
+    at `dest` until the rename), and the two transfers landed on the same file.
+    With `--downloader aria2`, which writes straight to the destination, they
+    interleave into it byte by byte.
+    """
+
+    DEST = ("models/loras", "m.safetensors")
+
+    def _dest(self, workspace) -> Path:
+        return workspace / self.DEST[0] / self.DEST[1]
+
+    def _download(self, **kwargs):
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path=self.DEST[0],
+            filename=self.DEST[1],
+            **kwargs,
+        )
+
+    def _transfer(self, monkeypatch, fn=None):
+        """Patch the byte transfer; returns the list of calls it recorded."""
+        calls: list = []
+
+        def download_file(*args, **kwargs):
+            calls.append((args, kwargs))
+            if fn is not None:
+                return fn(*args, **kwargs)
+            return None
+
+        monkeypatch.setattr(models, "download_file", download_file)
+        return calls
+
+    # -- the hole this closes -------------------------------------------------
+
+    def test_a_second_foreground_run_is_refused(self, workspace, monkeypatch, json_renderer):
+        """Ticket case 1: a live *foreground* record now blocks the next run."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234, kind="foreground")
+        download_state.write(workspace, live)
+        monkeypatch.setattr(models, "download_file", MagicMock(side_effect=AssertionError("a transfer started")))
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download()
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+        assert env["error"]["details"]["kind"] == "foreground"
+        # The refusal names Ctrl-C, not `download-cancel` — which would itself
+        # refuse a live foreground record, so pointing at it would be dead advice.
+        assert "Ctrl-C" in env["error"]["hint"]
+        assert "download-cancel" not in env["error"]["hint"]
+
+    def test_a_background_submit_during_a_foreground_run_is_refused(self, workspace, no_spawn, json_renderer):
+        """The cross-kind direction: `--background` must see the foreground claim."""
+        live = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234, kind="foreground")
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        assert json_renderer()["error"]["details"]["download_id"] == live.id
+
+    def test_the_record_is_written_before_any_bytes_move(self, workspace, monkeypatch, capsys):
+        """Ticket case 6. Order is the whole point: `--downloader aria2` writes
+        straight to the destination, so a claim published *after* the transfer
+        starts leaves the window it exists to close wide open."""
+        seen: list = []
+
+        def download_file(*args, **kwargs):
+            seen.append([(s.kind, s.status) for s in download_state.list_all(workspace)])
+
+        monkeypatch.setattr(models, "download_file", download_file)
+
+        self._download(downloader="aria2")
+
+        assert seen == [[("foreground", "downloading")]]
+
+    # -- terminal bookkeeping -------------------------------------------------
+
+    def test_success_marks_the_record_completed(self, workspace, monkeypatch, capsys):
+        """Ticket case 7a."""
+
+        def land_the_file(url, dest, headers, **kwargs):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"x" * 17)
+
+        self._transfer(monkeypatch, land_the_file)
+
+        self._download()
+
+        (record,) = download_state.list_all(workspace)
+        assert record.kind == "foreground"
+        assert record.status == "completed"
+        # The size comes off the finished file, so `download-status` reports 100%
+        # rather than a bare `completed` with no bytes.
+        assert record.completed_bytes == 17
+        assert download_state.percent(record) == 100.0
+
+    def test_a_failed_transfer_marks_the_record_failed(self, workspace, monkeypatch, json_renderer):
+        """Ticket case 7b: the failure text is persisted, not just rendered."""
+        self._transfer(monkeypatch, MagicMock(side_effect=DownloadException("connection reset by peer")))
+
+        with pytest.raises(typer.Exit):
+            self._download()
+
+        assert json_renderer()["error"]["code"] == "download_failed"
+        (record,) = download_state.list_all(workspace)
+        assert record.status == "failed"
+        assert "connection reset by peer" in record.error
+
+    def test_a_keyboard_interrupt_marks_the_record_failed(self, workspace, monkeypatch, capsys):
+        """Ctrl-C is a `BaseException`, and it is precisely what the foreground
+        cancel hint tells users to send — so an `except Exception` here would
+        leave the record pinned at `downloading` after the documented way out."""
+        self._transfer(monkeypatch, MagicMock(side_effect=KeyboardInterrupt))
+
+        with pytest.raises(KeyboardInterrupt):
+            self._download()
+
+        (record,) = download_state.list_all(workspace)
+        assert record.status == "failed"
+
+    def test_a_completed_record_does_not_block_the_next_download(self, workspace, monkeypatch, capsys):
+        """The records accumulate, so they must be inert once terminal."""
+        self._transfer(monkeypatch)
+        self._download()
+        self._download()
+
+        assert [s.status for s in download_state.list_all(workspace)] == ["completed", "completed"]
+
+    def test_a_dead_foreground_record_self_clears(self, workspace, monkeypatch, capsys):
+        """Ticket case 5, the mirror of `test_a_dead_workers_record_self_clears`.
+
+        A SIGKILLed foreground run never reaches its `finally`, so its record is
+        left claiming `downloading` forever. Nothing else would ever clear it —
+        reconcile has to, off the pid it recorded.
+        """
+        stale = _state(
+            dest=str(self._dest(workspace)), status="downloading", pid=4242, kind="foreground", total_bytes=4096
+        )
+        download_state.write(workspace, stale)
+        self._transfer(monkeypatch)
+
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            self._download()
+
+        assert download_state.read(workspace, stale.id).status == "failed"
+        assert len(download_state.list_all(workspace)) == 2
+
+    # -- claim-then-check, foreground side ------------------------------------
+
+    def _race(self, monkeypatch, rival):
+        """Plant `rival`'s claim in the window between our write and the re-scan."""
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                planted.append(real_write(ws, rival))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+
+    def test_an_earlier_rival_takes_the_destination(self, workspace, monkeypatch, json_renderer):
+        """Ticket case 2: we lose, and we take our own claim back off disk."""
+        rival = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        rival.started_at = "2000-01-01T00:00:00+00:00"
+        self._race(monkeypatch, rival)
+        monkeypatch.setattr(models, "download_file", MagicMock(side_effect=AssertionError("a transfer started")))
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download()
+
+        assert exc.value.exit_code == 1
+        assert json_renderer()["error"]["details"]["download_id"] == rival.id
+        # Our record is gone and the rival's is untouched. A withdrawn claim left
+        # behind would refuse every later submission to this destination.
+        assert [s.id for s in download_state.list_all(workspace)] == [rival.id]
+        assert download_state.read(workspace, rival.id).status == "downloading"
+
+    def test_a_later_rival_does_not_take_the_destination(self, workspace, monkeypatch, capsys):
+        """Ticket case 3: we win and the transfer proceeds."""
+        rival = _state(dest=str(self._dest(workspace)), status="starting", pid=None)
+        rival.started_at = "2999-01-01T00:00:00+00:00"
+        self._race(monkeypatch, rival)
+        calls = self._transfer(monkeypatch)
+
+        self._download()
+
+        assert len(calls) == 1
+
+    @pytest.mark.parametrize(
+        ("rival_id", "we_win"),
+        [("zzzzzzzzzzzz", True), ("000000000000", False)],
+        ids=["our-id-sorts-first", "rival-id-sorts-first"],
+    )
+    def test_identical_timestamps_produce_exactly_one_winner(
+        self, workspace, monkeypatch, json_renderer, capsys, rival_id, we_win
+    ):
+        """Ticket case 4, the mutual-refusal regression.
+
+        `started_at` is second-resolution, so two racers colliding inside the same
+        second is the *common* tie, not an exotic one. Without the `id` term in
+        `_claim_order` each would see the other as an equally-ranked live claim,
+        both would back off, and the destination would be wedged for the user with
+        no download running at all — a worse outcome than the race itself. The
+        order is total, so the tie resolves the same way from both sides: exactly
+        one proceeds, and it is the lower id.
+        """
+        rival = _state(dest=str(self._dest(workspace)), status="downloading", pid=1234)
+        rival.id = rival_id
+        monkeypatch.setattr(download_state, "new_id", lambda: "mmmmmmmmmmmm")
+
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                # Same second, differing id — the tie the `id` term breaks.
+                rival.started_at = state.started_at
+                planted.append(real_write(ws, rival))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+        calls = self._transfer(monkeypatch)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            if we_win:
+                self._download()
+            else:
+                with pytest.raises(typer.Exit) as exc:
+                    self._download()
+
+        if we_win:
+            assert len(calls) == 1
+            assert download_state.read(workspace, "mmmmmmmmmmmm").status == "completed"
+        else:
+            assert calls == []
+            assert exc.value.exit_code == 1
+            assert json_renderer()["error"]["details"]["download_id"] == rival.id
+            assert download_state.read(workspace, "mmmmmmmmmmmm") is None
+
+    def test_an_unwritable_state_directory_still_downloads(self, workspace, monkeypatch, capsys):
+        """The claim is bookkeeping. An unwritable workspace must degrade to the
+        old behavior — no claim, transfer still runs — not turn a download that
+        used to work into an error. (`--background` *does* fail there, because a
+        detached worker has nowhere else to report from.)"""
+        monkeypatch.setattr(download_state, "write", MagicMock(side_effect=OSError("read-only file system")))
+        calls = self._transfer(monkeypatch)
+
+        self._download()
+
+        assert len(calls) == 1
+
+
 class TestSubmitEnvelope:
     def _submit(self, workspace, monkeypatch, **kwargs):
         monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
@@ -979,7 +1248,12 @@ class TestSubmitEnvelope:
         assert len(calls) == 1
         # The foreground call site does not pass a progress callback.
         assert "progress_callback" not in calls[0][1]
-        assert download_state.list_all(workspace) == []
+        # It *does* now leave a record — a foreground transfer that claims nothing
+        # is invisible to every other invocation, which is how two of them ended up
+        # writing the same file. The record is a foreground one and it is terminal,
+        # so it blocks nothing once this run is over.
+        records = download_state.list_all(workspace)
+        assert [(r.kind, r.status) for r in records] == [("foreground", "completed")]
 
 
 class TestSpawnFlags:
@@ -1059,6 +1333,7 @@ class TestPollVerbs:
         assert env["data"] == {
             "id": state.id,
             "status": "downloading",
+            "kind": "background",
             "completed_bytes": 50,
             "total_bytes": 200,
             "percent": 25.0,
@@ -1129,6 +1404,7 @@ class TestPollVerbs:
         assert set(env["data"]["downloads"][0]) == {
             "id",
             "status",
+            "kind",
             "completed_bytes",
             "total_bytes",
             "percent",
@@ -1173,6 +1449,90 @@ class TestPollVerbs:
         assert env["data"]["status"] == "cancelled"
         assert env["data"]["completed_bytes"] == 0
         assert download_state.read(workspace, state.id).status == "cancelled"
+
+    def test_cancel_refuses_a_live_foreground_download(self, workspace, json_renderer, tmp_path):
+        """Ticket case 8, and the hazard this whole guard exists for.
+
+        `kill_worker` does `os.killpg(os.getpgid(pid), ...)`. That is safe for a
+        background worker because `_spawn_download_worker` gives it its own
+        session, so the group holds only it and its children. A *foreground*
+        record's pid is the user's own CLI process, sharing the terminal's
+        foreground process group — the same killpg would SIGTERM the surrounding
+        shell job. So nothing may be signalled, and no sentinel written either.
+        """
+        state = _state(
+            dest=str(tmp_path / "m.safetensors"),
+            status="downloading",
+            kind="foreground",
+            pid=os.getpid(),
+            pid_create_time=download_state.process_create_time(os.getpid()),
+        )
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "kill_worker") as kill:
+            with patch("os.killpg") as killpg:
+                with pytest.raises(typer.Exit) as exc:
+                    models.download_cancel(None, download_id=state.id)
+
+        assert exc.value.exit_code == 1
+        kill.assert_not_called()
+        killpg.assert_not_called()
+        assert not download_state.cancel_path(workspace, state.id).exists()
+
+        env = json_renderer()
+        assert env["ok"] is False
+        assert env["error"]["code"] == "model_download_foreground_cancel"
+        assert env["error"]["details"]["kind"] == "foreground"
+        assert env["error"]["details"]["pid"] == os.getpid()
+        assert "Ctrl-C" in env["error"]["hint"]
+        # The refusal changed nothing.
+        assert download_state.read(workspace, state.id).status == "downloading"
+
+    def test_cancel_of_a_dead_foreground_record_still_sweeps(self, workspace, json_renderer, tmp_path):
+        """The other half: once the foreground process is gone there is no group
+        left to signal, and its partial file is exactly what the user is trying to
+        reclaim — so a dead foreground record takes the normal path.
+
+        Under `--downloader aria2`, which writes straight to the destination, that
+        partial *is* the destination — the interleaving hazard that made the
+        foreground claim necessary in the first place.
+        """
+        dest = tmp_path / "m.safetensors"
+        dest.write_bytes(b"x" * 10)
+        state = _state(
+            dest=str(dest),
+            status="downloading",
+            kind="foreground",
+            downloader="aria2",
+            pid=5150,
+            pid_create_time=1.0,
+            total_bytes=100,
+        )
+        download_state.write(workspace, state)
+
+        with patch.object(download_state, "is_worker_process", return_value=False):
+            with patch("comfy_cli.utils.is_running", return_value=False):
+                models.download_cancel(None, download_id=state.id)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["status"] == "cancelled"
+        assert not dest.exists()
+
+    def test_cancel_still_signals_a_live_background_worker(self, workspace, json_renderer, tmp_path):
+        """The guard must key on `kind`, not merely on liveness — an unconditional
+        refusal would take `download-cancel` away from the workers it is for."""
+        state = _state(dest=str(tmp_path / "m.safetensors"), status="downloading", pid=5150, pid_create_time=1.0)
+        download_state.write(workspace, state)
+        assert state.kind == "background"
+
+        alive = [True, True, False]
+        with patch.object(download_state, "is_worker_process", side_effect=lambda *a: alive.pop(0) if alive else False):
+            with patch.object(download_state, "kill_worker", return_value=True) as kill:
+                models.download_cancel(None, download_id=state.id)
+
+        kill.assert_called_once_with(5150, 1.0)
+        assert json_renderer()["data"]["status"] == "cancelled"
 
     def test_cancel_writes_the_sentinel_before_signalling(self, workspace, json_renderer, tmp_path):
         """A worker still in interpreter startup has no pid to signal; the
@@ -1293,7 +1653,7 @@ class TestHumanRendering:
 
     def test_empty_downloads_renders_a_message(self, workspace, capsys):
         models.downloads(None)
-        assert "No background downloads" in capsys.readouterr().out
+        assert "No downloads found" in capsys.readouterr().out
 
     def test_unknown_total_renders_without_crashing(self, workspace, capsys, tmp_path):
         state = _state(dest=str(tmp_path / "m"), status="starting", total_bytes=None)
@@ -1624,6 +1984,50 @@ class TestCorruptStateFiles:
         path.write_text(json.dumps(payload), encoding="utf-8")
 
         assert download_state.read_path(path) is None
+
+    def test_a_record_without_kind_reads_as_background(self, workspace, tmp_path):
+        """Ticket case 9. Every record written before `kind` existed was a
+        detached worker, which is what the dataclass default says."""
+        path = tmp_path / "legacy.json"
+        payload = _state().to_dict()
+        del payload["kind"]
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        state = download_state.read_path(path)
+        assert state is not None
+        assert state.kind == "background"
+        assert state.is_foreground is False
+
+    @pytest.mark.parametrize("value", ["worker", "", None, 3])
+    def test_an_unrecognized_kind_drops_the_field_not_the_record(self, workspace, tmp_path, value):
+        """`kind` is the one *tolerant* field: a bad value drops the field rather
+        than the whole record.
+
+        Rejecting the record is the far more dangerous outcome. A record that
+        reads as absent is invisible to the destination-claim scan too, so one
+        unrecognized `kind` on a *live* download would un-claim its destination
+        and let a second writer into the same file — the exact corruption the
+        claim exists to prevent.
+        """
+        path = tmp_path / "odd-kind.json"
+        payload = _state().to_dict()
+        payload["kind"] = value
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+        state = download_state.read_path(path)
+        assert state is not None
+        assert state.kind == "background"
+
+    @pytest.mark.parametrize("kind", ["background", "foreground"])
+    def test_the_status_row_reports_the_kind(self, kind):
+        """`comfy model downloads` is now the only place a foreground download is
+        visible, and the two kinds differ in a way a consumer has to act on: a
+        live foreground row cannot be cancelled. Without this field the only way
+        to find that out is to try `download-cancel` and read the refusal."""
+        state = _state(status="downloading")
+        state.kind = kind
+
+        assert download_state.status_payload(state)["kind"] == kind
 
     def test_list_all_skips_a_corrupt_file_instead_of_crashing(self, workspace):
         good = _state()

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -698,6 +698,155 @@ class TestSubmitRefusesAClaimedDestination:
         assert env["error"]["code"] == "model_download_in_flight"
         assert env["error"]["details"]["download_id"] == live.id
 
+    def test_a_live_transfer_beats_the_exists_check(self, workspace, no_spawn, json_renderer):
+        """`--downloader aria2` writes straight to the destination (it owns its
+        own `.aria2` resume file), so a live aria2 transfer makes `exists()` true.
+        Ordered the other way the caller would get `model_file_exists` and its
+        hint to "remove the existing file" — advice that deletes the output a
+        running worker is still writing."""
+        dest = self._dest(workspace)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"partial aria2 output")
+        live = _state(dest=str(dest), status="downloading", pid=1234, downloader="aria2", total_bytes=4096)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == live.id
+        # ...and the bytes the live worker is still writing were not implicated.
+        assert dest.exists()
+
+    def test_a_record_for_another_destination_is_not_reconciled(self, workspace, monkeypatch, json_renderer):
+        """The scan filters by destination *before* reconciling.
+
+        `_reconciled` persists a status correction, so reconciling every record
+        would make a plain `comfy model download` rewrite bookkeeping for
+        unrelated downloads — off `list_all`'s stale snapshot, so a worker that
+        completes during the scan window could have its `completed` record
+        overwritten with `failed`.
+        """
+        other = _state(dest=str(workspace / "models" / "loras" / "other.safetensors"), status="downloading", pid=4242)
+        download_state.write(workspace, other)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        # A dead worker: reconcile *would* demote this record to `failed`. It is
+        # not this command's record to touch.
+        with patch("comfy_cli.utils.is_running", return_value=False):
+            self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+        assert download_state.read(workspace, other.id).status == "downloading"
+
+    def test_a_corrupt_record_does_not_break_the_download(self, workspace, monkeypatch, json_renderer):
+        """The advisory scan has to degrade on a bad record, not traceback.
+
+        Only `list_all` used to sit inside the `try`, so a record that tripped a
+        lookup *inside* the loop — a tampered negative pid reaching
+        `psutil.Process`, say — turned every `comfy model download` in the
+        workspace, foreground included, into a bare traceback.
+        """
+        corrupt = _state(dest=str(self._dest(workspace)), status="downloading", pid=-1)
+        download_state.write(workspace, corrupt)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        assert json_renderer()["ok"] is True
+        # No live worker can be behind a pid that cannot exist, so it demotes.
+        assert download_state.read(workspace, corrupt.id).status == "failed"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
+    def test_a_symlinked_model_directory_is_the_same_destination(self, workspace, no_spawn, json_renderer):
+        """ComfyUI model directories are routinely symlinks (`models/loras` at
+        `/data/loras`) and get addressed both ways. A lexical normalization
+        leaves the two spellings unequal, so both submissions would pass and
+        their transfers would rename onto the same inode."""
+        real_dir = workspace.parent / "data" / "loras"
+        real_dir.mkdir(parents=True)
+        link_dir = workspace / "models" / "loras"
+        link_dir.parent.mkdir(parents=True, exist_ok=True)
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+
+        # The live record names the resolved path; the submission names the link.
+        live = _state(dest=str(real_dir / self.DEST[1]), status="downloading", pid=1234)
+        download_state.write(workspace, live)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit):
+                self._download(background=True)
+
+        assert json_renderer()["error"]["details"]["download_id"] == live.id
+
+    def test_a_claim_that_landed_first_wins_the_post_write_recheck(
+        self, workspace, no_spawn, monkeypatch, json_renderer
+    ):
+        """The pre-flight scan is check-then-act: filename resolution and, for a
+        Hugging Face url, a whole `check_unauthorized` round trip sit between it
+        and the state write, so two near-simultaneous submissions can both pass
+        it, both stream a full copy, and the later `os.replace` can silently
+        overwrite the earlier. The record each one writes is its claim; the
+        re-scan after that write is what turns two winners into one.
+        """
+        dest = self._dest(workspace)
+        competitor = _state(dest=str(dest), status="downloading", pid=1234)
+        competitor.started_at = "2000-01-01T00:00:00+00:00"  # claimed first
+
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                # The competitor's claim lands in exactly the window between our
+                # own claim and the re-check — the race this exists to lose.
+                planted.append(real_write(ws, competitor))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+
+        with patch("comfy_cli.utils.is_running", return_value=True):
+            with pytest.raises(typer.Exit) as exc:
+                self._download(background=True)
+
+        assert exc.value.exit_code == 1
+        env = json_renderer()
+        assert env["error"]["code"] == "model_download_in_flight"
+        assert env["error"]["details"]["download_id"] == competitor.id
+        # The loser withdrew its own claim, so the destination is left owned by
+        # exactly one record — a phantom would refuse every later submission.
+        assert [s.id for s in download_state.list_all(workspace)] == [competitor.id]
+
+    def test_a_claim_that_landed_second_does_not_take_the_destination(self, workspace, monkeypatch, json_renderer):
+        """The other side of the same race: both racers compute `_claim_order`
+        over the same two records, so the one that claimed first proceeds rather
+        than both backing off and neither download happening."""
+        dest = self._dest(workspace)
+        latecomer = _state(dest=str(dest), status="starting", pid=None)
+        latecomer.started_at = "2999-01-01T00:00:00+00:00"  # claimed second
+
+        real_write = download_state.write
+        planted: list = []
+
+        def write_then_race(ws, state):
+            path = real_write(ws, state)
+            if not planted:
+                planted.append(real_write(ws, latecomer))
+            return path
+
+        monkeypatch.setattr(download_state, "write", write_then_race)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        self._download(background=True)
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["download_id"] != latecomer.id
+
 
 class TestSubmitEnvelope:
     def _submit(self, workspace, monkeypatch, **kwargs):
@@ -1476,6 +1625,18 @@ class TestCorruptStateFiles:
         (download_state.state_dir(workspace) / "bad.json").write_text('{"pid": "nope"}', encoding="utf-8")
 
         assert [s.id for s in download_state.list_all(workspace)] == [good.id]
+
+    @pytest.mark.parametrize("pid", [-1, 0])
+    def test_a_nonpositive_pid_is_screened_before_psutil(self, pid):
+        """The field validator only rejects non-ints, so a tampered record can
+        carry a negative pid — and `psutil.Process(-1)` raises ValueError, which
+        `utils.is_running` does not catch (it catches only NoSuchProcess). Every
+        command that reconciles would traceback on one bad file, so screen it
+        here the way `is_worker_process`/`kill_worker` already do."""
+        state = _state(status="downloading", pid=pid)
+
+        # No `pid_alive` injection: the real liveness helper must never be reached.
+        assert download_state.worker_alive(state) is False
 
 
 class TestWorkerIdentity:


### PR DESCRIPTION
**STACKED — merging lands on `matt/be-6469-refuse-download-dest-claimed` (owned by mattmillerai, PR #678), NOT `main`.** Do not merge this before #678. GitHub retargets it to `main` automatically when #678 lands; the diff below is the net change on top of that branch.

## ELI-5

Two people can ask the CLI to download the same model file at the same time, and until now the second one didn't always notice the first. `--background` downloads left a little note saying "I'm writing to this file"; a plain `comfy model download` left no note at all, so it was invisible — a second run would happily start and both would write into the same file, scrambling it. Now every download leaves a note. And because two people can write their notes at the same instant, they both re-read the notes afterwards and use the same rule to decide who was first — so exactly one backs off, instead of both politely refusing and nobody getting the file.

One extra safety rule: you can't `download-cancel` a download that's running in someone's own terminal. The way cancel stops a background download is by signalling its process group — and a foreground download's process group is the user's *shell*, so cancelling it would kill their whole terminal job. It now refuses and tells you to press Ctrl-C in that terminal instead.

## What changed

- **Foreground runs write a `download_state` record.** `comfy model download` now claims its destination before transferring (both the `hf_hub_download` branch and the `download_file` branch), and a `try/finally` marks it `completed` (with a size from a `stat`) or `failed` (with the error text). A SIGKILLed run never reaches the `finally` — `download_state.reconcile()` demotes it exactly like a dead worker, because `pid_create_time` is always recorded (`worker_alive` only falls back to the worker-argv marker when it's `None`).
- **Claim-then-check in both paths.** `_enforce_claim()` is the shared re-scan: write the record, then re-scan for an active record on the same destination excluding our own id. Competitors are ranked by `(started_at, id)` — ISO-8601, so lexicographic is chronological — and the later tuple loses, deletes its own state file (new `download_state.delete()`), and raises `model_download_in_flight` naming the winner. The tie-break is the point: without it both racers see each other, both abort, and the destination is wedged.
- **The cheap pre-flight guard stays.** It refuses the common sequential case early, before filename resolution and the Hugging Face `check_unauthorized` round trip, and without writing a record. The post-write re-scan is the authoritative gate.
- **`kind` on `DownloadState`** (`"background"` default, validator `v in ("background", "foreground")`). It is the one *tolerant* field: an unrecognized value drops the field rather than rejecting the record, because a rejected record is invisible to the claim scan too — that would un-claim a live destination, which is the exact corruption the claim exists to prevent. A record written before the field existed reads as `background`, which is what it was.
- **`download-cancel` refuses a live foreground record** with the new `model_download_foreground_cancel`, before anything is signalled — sentinel included. A *dead* foreground record still goes down the existing path (sweep the partial, mark cancelled).
- **`_dest_key()`** (`normcase(realpath(abspath(...)))`) already landed in #678 and is used for every destination comparison here.

## Judgment calls

- **This is stacked on the unmerged #678, not handed back.** The ticket's precondition says to hand it back `agent-blocked` if #678 is still open. `DIRECTIVES.base.md` carries Matt's explicit standing override for exactly this shape ("ALWAYS-STACK beats a ticket's 'ideally land X first' prose", BE-1457, restated twice since), and #678 has buildable branch code with green CI. Note #678 is currently `CHANGES_REQUESTED`, so its guard internals may still move; if its review resolution renames anything this builds on, this branch needs a `git merge origin/main` after #678 squash-merges (standard stacked-PR follow-up).
- **Beyond the ticket: `status_payload` now reports `kind`**, and the `download_status.json` schema documents it (`additionalProperties` was already `true`; the field is added to `required` and the two shape-pinning tests updated). Without it, `comfy model downloads` shows a `downloading` row with no way to tell it isn't cancellable — the only way to find out would be to try the cancel and read the refusal. Two `--help` strings and the `download_not_found` prose that said "background download" were corrected for the same reason.
- **The refusal is uniform across platforms.** On Windows `kill_worker` kills the process and its children directly rather than a group, so the shell-job hazard is POSIX-specific. Refusing everywhere is the simpler and more predictable contract; a Windows-only carve-out would be a behavior split for no user benefit.
- **`_claim_foreground` returns `None` when the record can't be persisted**, degrading to the old no-claim behavior rather than failing. An unwritable state directory must not turn a download that used to work into an error. The `--background` path still fails there, because a detached worker has nowhere else to report from.
- **`except BaseException`, not `Exception`, around the transfer** — every failure path raises `typer.Exit`, which derives from `click.exceptions.Exit`, a `BaseException`. An `Exception` handler would let the ordinary error paths past and leave the record pinned at `downloading`. It also catches the `KeyboardInterrupt` the new error code's hint tells users to send.

## Negative-claim falsification (required — this diff adds a deny path)

`download-cancel` now refuses a capability. I went and looked for a working path rather than asserting its absence:

- **Enumerated every `comfy model` subcommand** (`download`, `download-status`, `downloads`, `download-cancel`, `remove`, `list`). Only `download-cancel` claims to stop an in-flight transfer; `remove` deletes a completed file, the rest are read-only.
- **The cooperative-cancel mechanism does not reach the foreground path.** Cancellation is signalled by an `<id>.cancel` sentinel, polled from a progress callback that raises `DownloadCancelled` (`file_utils.py:135-142`). The only `progress_callback=` in `models.py` is at line 958, inside the background worker; the foreground call at line 641 passes none, so the sentinel is never read there.
- **The hazard is real, not theoretical.** `kill_worker` does `os.killpg(os.getpgid(pid), SIGTERM/SIGKILL)` on POSIX (`download_state.py:593`), gated only by `is_worker_process`, which returns `True` for a foreground record because it carries a matching `pid_create_time` (`download_state.py:456-457`). Without the refusal the killpg genuinely fires at the user's own foreground process group.
- **Nothing is taken away.** Before this PR the foreground path wrote no record, so no id existed to cancel — the denial is strictly additive, and the redirect it gives (Ctrl-C in the owning terminal) is the path that actually works. With `--downloader aria2` that reaches the child too, since it shares the group.

## Intended behavior change

Foreground downloads now appear in `comfy model downloads` and `comfy model download-status`, with `kind: "foreground"`. That visibility *is* the fix — a claim nobody can see is not a claim.

## Out of scope (documented, not fixed)

Two invocations from **different workspaces** targeting the same file consult disjoint `<workspace>/.comfy-downloads` directories, so no per-workspace claim can see the collision. Stated in `_active_download_for`'s docstring. The only real fixes — an `O_EXCL` sidecar next to the destination, or refusing workspace-escaping `--relative-path` — are design calls that need their own ticket (spike BE-6646's verdict).

Also unchanged from #678: the re-scan *narrows* the race, it does not close it. A competitor whose record lands after we look is still missed. The window shrinks from `[pre-flight scan -> write]` (spanning the `--background` split and an HF round trip) to `[write -> re-scan]`. Closing it needs an atomic claim.

## Verification

- `pytest`: **4156 passed, 37 skipped** (full suite).
- `ruff check` + `ruff format --diff` with the CI-pinned **0.15.15**: clean across `comfy_cli` and `tests`. (A local ruff 0.12.7 reports 17 pre-existing `UP038` findings and one unrelated format diff in `tests/comfy_cli/command/github/test_pr.py` — both are version artifacts, absent under the pinned version, and neither file is touched here.)
- New tests cover all nine cases the ticket enumerates plus five more: second-foreground refusal, background-submit-during-foreground, record-written-before-`download_file` (asserted under `--downloader aria2`), completed/failed/KeyboardInterrupt bookkeeping, dead-pid self-clear, earlier-rival loss (asserting our record is deleted and the rival's untouched), later-rival win, identical-`started_at` single-winner, live-foreground cancel refusal (asserting nothing is signalled), dead-foreground cancel still sweeping, background cancel still signalling, legacy record without `kind`, unrecognized `kind` values, and the `kind` status row.

Closes BE-6646.
