### PR TITLE
fix(jobs): sweep stranded atomic-write .tmp files in the state reap pass (BE-6680)

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -320,7 +320,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
     """
     import re as _re
 
-    from comfy_cli import jobs_state
+    from comfy_cli import file_utils, jobs_state
 
     # Reasonable prompt_ids are alphanumeric + dashes + underscores (UUIDs,
     # short hex IDs). Anything wilder (e.g. legacy MagicMock leak from tests)
@@ -328,6 +328,11 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
     _SANE_ID = _re.compile(r"^[A-Za-z0-9_-]{1,128}$")
     rows: list[JobRow] = []
     state_dir = jobs_state.state_dir()
+    # Sweep atomic-write temps stranded by a watcher that died mid-write — the
+    # same unclean deaths the ``watcher_crashed`` reap below exists for. Purely
+    # hygiene, so it rides this scan rather than a command of its own and its
+    # count is never surfaced.
+    file_utils.cleanup_stale_tmp_files(state_dir)
     for path in sorted(state_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
         if not _SANE_ID.match(path.stem):
             continue

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -301,6 +301,28 @@ def _state_where(value: Any) -> str:
     return value if value in ("local", "cloud") else "local"
 
 
+def _sweep_state_tmp_files() -> None:
+    """Sweep atomic-write temps stranded in the jobs state dir.
+
+    Same unclean deaths the ``watcher_crashed`` reap in
+    :func:`_gather_local_state_files` exists for — a watcher SIGKILLed mid-write
+    leaves a ``<prompt_id>.json.<token>.tmp`` corpse nothing will ever collect.
+    Purely hygiene, so it rides the ``jobs ls`` reap rather than earning a
+    command of its own, and its count is never surfaced.
+
+    Deliberately *not* inside ``_gather_local_state_files``: that one is a
+    read-only listing helper, and ``jobs ls --watch`` re-enters it every 2s —
+    re-traversing the directory that often to look for hour-old corpses buys
+    nothing. Called once per ``jobs ls`` instead, watch or not.
+    """
+    from comfy_cli import file_utils, jobs_state
+
+    # ``stem_suffix``: every destination this dir owns is ``<prompt_id>.json``,
+    # so requiring it keeps the sweep off a coincidental ``<x>.<8 chars>.tmp``
+    # that mkstemp's shape alone would happily claim.
+    file_utils.cleanup_stale_tmp_files(jobs_state.state_dir(), stem_suffix=".json")
+
+
 def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where: str | None = None) -> list[JobRow]:
     """Read every state file in the jobs state dir → JobRow.
 
@@ -320,7 +342,7 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
     """
     import re as _re
 
-    from comfy_cli import file_utils, jobs_state
+    from comfy_cli import jobs_state
 
     # Reasonable prompt_ids are alphanumeric + dashes + underscores (UUIDs,
     # short hex IDs). Anything wilder (e.g. legacy MagicMock leak from tests)
@@ -328,11 +350,6 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
     _SANE_ID = _re.compile(r"^[A-Za-z0-9_-]{1,128}$")
     rows: list[JobRow] = []
     state_dir = jobs_state.state_dir()
-    # Sweep atomic-write temps stranded by a watcher that died mid-write — the
-    # same unclean deaths the ``watcher_crashed`` reap below exists for. Purely
-    # hygiene, so it rides this scan rather than a command of its own and its
-    # count is never surfaced.
-    file_utils.cleanup_stale_tmp_files(state_dir)
     for path in sorted(state_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True):
         if not _SANE_ID.match(path.stem):
             continue
@@ -624,14 +641,21 @@ def ls_cmd(
     # applies exactly the same filters as the one-shot listing.
     state_where = None if (all_wheres or orphaned) else target_where
 
+    if watch and not renderer.is_pretty():
+        renderer.error(
+            code="json_incompatible",
+            message="--watch requires pretty mode (TTY). For JSON, poll with a shell loop.",
+            hint="drop --json, or run `while true; do comfy --json jobs ls; sleep 2; done`",
+        )
+        raise typer.Exit(code=1)
+
+    # Once per invocation, and above the watch branch rather than inside the
+    # gatherer: the live table re-gathers every 2s and would otherwise re-sweep
+    # on every refresh. Below the validation above so a rejected invocation
+    # touches nothing on disk.
+    _sweep_state_tmp_files()
+
     if watch:
-        if not renderer.is_pretty():
-            renderer.error(
-                code="json_incompatible",
-                message="--watch requires pretty mode (TTY). For JSON, poll with a shell loop.",
-                hint="drop --json, or run `while true; do comfy --json jobs ls; sleep 2; done`",
-            )
-            raise typer.Exit(code=1)
         _watch_ls(
             host=host,
             port=port,

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -550,6 +550,63 @@ def cleanup_partials(local_filepath: pathlib.Path) -> int:
     return removed
 
 
+# The atomic-write helpers above stream through a sibling named
+# ``<dest name>.<mkstemp token>.tmp``. Unlike ``.part``, nothing ever *asks* for
+# one by name — they are pure in-flight scaffolding — so the only reason to name
+# the suffix here is to sweep up the corpses a killed writer leaves behind.
+_TMP_SUFFIX = ".tmp"
+# An in-flight atomic write lives for milliseconds; an hour is conservative
+# enough that no live write is ever a candidate, while still bounding how long a
+# corpse survives in a long-running agent/CI environment.
+_TMP_STALE_SECONDS = 3600
+
+
+def cleanup_stale_tmp_files(directory: pathlib.Path, *, older_than_seconds: float = _TMP_STALE_SECONDS) -> int:
+    """Best-effort removal of stranded ``atomic_write_*`` temps in ``directory``.
+
+    A writer killed uncleanly (SIGKILL, OOM, power loss) never runs its
+    unlink-on-exception cleanup, so its ``<dest>.<mkstemp token>.tmp`` sibling
+    outlives it — and mkstemp mints a fresh token per attempt, so nothing bounds
+    how many a crash-prone process leaves. Matches the exact mkstemp token shape
+    (like :func:`partial_paths_for` does for ``.part``) so an unrelated user file
+    ending in ``.tmp`` is never claimed, and only removes files whose mtime is
+    older than ``older_than_seconds`` so an in-flight write can't be raced.
+    Returns how many files were removed. Never raises.
+    """
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return 0
+
+    now = time.time()
+    removed = 0
+    for entry in entries:
+        name = entry.name
+        if not name.endswith(_TMP_SUFFIX):
+            continue
+        # ``<stem>.<token>`` — the stem is the destination file name, so it must
+        # be non-empty, and the token must have mkstemp's exact shape. That pair
+        # of checks is what keeps a hand-made ``notes.tmp`` (no token segment) or
+        # a ``.lock``/``.part`` sibling (wrong suffix entirely) off the list.
+        stem, sep, token = name[: -len(_TMP_SUFFIX)].rpartition(".")
+        if not sep or not stem:
+            continue
+        if len(token) != _MKSTEMP_TOKEN_LEN or not set(token) <= _MKSTEMP_TOKEN_CHARS:
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if now - mtime <= older_than_seconds:
+            continue
+        try:
+            entry.unlink()
+        except OSError:
+            continue
+        removed += 1
+    return removed
+
+
 def _friendly_network_error(exc: Exception) -> str:
     """Return a user-friendly description of a network error."""
     if isinstance(exc, _TransientHTTPStatusError):

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import pathlib
 import stat
@@ -15,6 +16,8 @@ from pathspec import PathSpec
 
 from comfy_cli import constants, ui
 from comfy_cli.output.sanitize import sanitize_value
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Atomic writes — the write policy
@@ -555,55 +558,94 @@ def cleanup_partials(local_filepath: pathlib.Path) -> int:
 # one by name — they are pure in-flight scaffolding — so the only reason to name
 # the suffix here is to sweep up the corpses a killed writer leaves behind.
 _TMP_SUFFIX = ".tmp"
-# An in-flight atomic write lives for milliseconds; an hour is conservative
-# enough that no live write is ever a candidate, while still bounding how long a
-# corpse survives in a long-running agent/CI environment.
+# An in-flight atomic write lives for milliseconds, so an hour puts a live write
+# far outside the window under any normal clock — see the caveat in
+# ``cleanup_stale_tmp_files`` for the abnormal ones — while still bounding how
+# long a corpse survives in a long-running agent/CI environment.
 _TMP_STALE_SECONDS = 3600
 
 
-def cleanup_stale_tmp_files(directory: pathlib.Path, *, older_than_seconds: float = _TMP_STALE_SECONDS) -> int:
+def cleanup_stale_tmp_files(
+    directory: pathlib.Path,
+    *,
+    older_than_seconds: float = _TMP_STALE_SECONDS,
+    stem_suffix: str = "",
+) -> int:
     """Best-effort removal of stranded ``atomic_write_*`` temps in ``directory``.
 
     A writer killed uncleanly (SIGKILL, OOM, power loss) never runs its
     unlink-on-exception cleanup, so its ``<dest>.<mkstemp token>.tmp`` sibling
     outlives it — and mkstemp mints a fresh token per attempt, so nothing bounds
-    how many a crash-prone process leaves. Matches the exact mkstemp token shape
-    (like :func:`partial_paths_for` does for ``.part``) so an unrelated user file
-    ending in ``.tmp`` is never claimed, and only removes files whose mtime is
-    older than ``older_than_seconds`` so an in-flight write can't be raced.
+    how many a crash-prone process leaves.
+
+    A candidate must be a *regular file* (the entry's own metadata decides, so a
+    symlink shaped like a temp can't lend an unrelated target's mtime to the age
+    test, and a dangling one is skipped rather than raised on), carry mkstemp's
+    exact ``<stem>.<8 chars>.tmp`` shape, and have an mtime older than
+    ``older_than_seconds``.
+
+    Two honest limits on that, both worth knowing before adding a caller:
+
+    * The shape proves nothing about *who* wrote the file. ``db.a1b2c3d4.tmp``
+      matches it by coincidence, and this repo's own bespoke temps in
+      ``auth/store.py`` / ``download_state.py``
+      (``<name>.<pid>.<secrets.token_hex(4)>.tmp``) match it by construction.
+      Pass ``stem_suffix`` to also require the destination stem to end in it
+      (e.g. ``".json"`` in a directory whose only destinations are
+      ``<id>.json``) and give the match some actual ownership evidence.
+    * The age cutoff is a heuristic, not a lock. There is no coordination with
+      the writer, so a forward clock step (NTP correction, VM/laptop resume), a
+      lagging network-filesystem clock, or a writer stalled past the cutoff
+      inside ``fsync`` can still make a live temp eligible — and unlinking it
+      makes that writer's ``os.replace`` fail. An hour makes that vanishingly
+      unlikely, not impossible; keep the default unless a caller can afford the
+      loss.
+
     Returns how many files were removed. Never raises.
     """
-    try:
-        entries = list(directory.iterdir())
-    except OSError:
-        return 0
-
     now = time.time()
     removed = 0
-    for entry in entries:
-        name = entry.name
-        if not name.endswith(_TMP_SUFFIX):
-            continue
-        # ``<stem>.<token>`` — the stem is the destination file name, so it must
-        # be non-empty, and the token must have mkstemp's exact shape. That pair
-        # of checks is what keeps a hand-made ``notes.tmp`` (no token segment) or
-        # a ``.lock``/``.part`` sibling (wrong suffix entirely) off the list.
-        stem, sep, token = name[: -len(_TMP_SUFFIX)].rpartition(".")
-        if not sep or not stem:
-            continue
-        if len(token) != _MKSTEMP_TOKEN_LEN or not set(token) <= _MKSTEMP_TOKEN_CHARS:
-            continue
-        try:
-            mtime = entry.stat().st_mtime
-        except OSError:
-            continue
-        if now - mtime <= older_than_seconds:
-            continue
-        try:
-            entry.unlink()
-        except OSError:
-            continue
-        removed += 1
+    try:
+        # Streamed rather than materialized: the docstring's own premise is that
+        # nothing bounds how many corpses a crash-loop leaves, and there is no
+        # reason to hold the whole listing to delete entries one at a time.
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                name = entry.name
+                if not name.endswith(_TMP_SUFFIX):
+                    continue
+                # ``<stem>.<token>`` — the stem is the destination file name, so
+                # it must be a real name (``.``/``..`` are not) and, when the
+                # caller says so, carry ``stem_suffix``; the token must have
+                # mkstemp's exact shape. Together that keeps a hand-made
+                # ``notes.tmp`` (no token segment) or a ``.lock``/``.part``
+                # sibling (wrong suffix entirely) off the list.
+                stem, sep, token = name[: -len(_TMP_SUFFIX)].rpartition(".")
+                if not sep or not stem.strip(".") or not stem.endswith(stem_suffix):
+                    continue
+                if len(token) != _MKSTEMP_TOKEN_LEN or not set(token) <= _MKSTEMP_TOKEN_CHARS:
+                    continue
+                try:
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if not stat.S_ISREG(st.st_mode):
+                    continue
+                if now - st.st_mtime <= older_than_seconds:
+                    continue
+                try:
+                    os.unlink(entry.path)
+                except OSError:
+                    continue
+                # The count goes nowhere useful at the call sites (this is
+                # hygiene, not a user-facing action), so a debug line is the
+                # only way to attribute a file's disappearance after the fact.
+                logger.debug("swept stranded atomic-write temp: %s", entry.path)
+                removed += 1
+    except OSError:
+        # scandir failed to open, or died mid-iteration. Whatever we already
+        # removed still counts.
+        return removed
     return removed
 
 

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -3135,6 +3135,26 @@ def test_gather_local_state_files_reports_the_reaped_watcher_code(monkeypatch):
     assert row.error_code == "watcher_crashed"
 
 
+def test_gather_local_state_files_sweeps_stranded_atomic_write_temps():
+    """The scan that reaps crashed watchers also sweeps the temps those same
+    unclean deaths strand — without disturbing the state files it lists."""
+    import time as _time
+
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(state_dir, "job-1", status="completed")
+    corpse = state_dir / "job-1.json.abcd1234.tmp"
+    corpse.write_text("half a write")
+    old = _time.time() - 7200
+    os.utime(corpse, (old, old))
+
+    (row,) = jobs_mod._gather_local_state_files(limit=10)
+    assert row.prompt_id == "job-1"
+    assert not corpse.exists(), "the stranded atomic-write temp should have been swept"
+    assert (state_dir / "job-1.json").exists()
+
+
 def _row(prompt_id: str, status: str, **kw) -> jobs_mod.JobRow:
     return jobs_mod.JobRow(
         prompt_id=prompt_id,

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -3135,9 +3135,38 @@ def test_gather_local_state_files_reports_the_reaped_watcher_code(monkeypatch):
     assert row.error_code == "watcher_crashed"
 
 
-def test_gather_local_state_files_sweeps_stranded_atomic_write_temps():
-    """The scan that reaps crashed watchers also sweeps the temps those same
+def test_jobs_ls_sweeps_stranded_atomic_write_temps():
+    """The command that reaps crashed watchers also sweeps the temps those same
     unclean deaths strand — without disturbing the state files it lists."""
+    import time as _time
+
+    from typer.testing import CliRunner
+
+    from comfy_cli import jobs_state
+
+    state_dir = jobs_state.state_dir()
+    _write_state(state_dir, "job-1", status="completed")
+    corpse = state_dir / "job-1.json.abcd1234.tmp"
+    corpse.write_text("half a write")
+    old = _time.time() - 7200
+    os.utime(corpse, (old, old))
+    # A coincidental temp whose stem is not a state file: same mkstemp shape,
+    # not ours, must survive.
+    bystander = state_dir / "notes.abcd1234.tmp"
+    bystander.write_text("mine, not yours")
+    os.utime(bystander, (old, old))
+
+    result = CliRunner().invoke(jobs_mod.app, ["ls", "--local-only", "--where", "local"])
+
+    assert result.exit_code == 0, result.output
+    assert not corpse.exists(), "the stranded atomic-write temp should have been swept"
+    assert bystander.exists(), "a temp with no state-file stem is not ours to delete"
+    assert (state_dir / "job-1.json").exists()
+
+
+def test_gather_local_state_files_does_not_mutate_temps():
+    """The listing helper is read-only: the sweep belongs to the ``ls`` command
+    so ``--watch``'s 2s refresh doesn't re-run it on every table build."""
     import time as _time
 
     from comfy_cli import jobs_state
@@ -3151,8 +3180,7 @@ def test_gather_local_state_files_sweeps_stranded_atomic_write_temps():
 
     (row,) = jobs_mod._gather_local_state_files(limit=10)
     assert row.prompt_id == "job-1"
-    assert not corpse.exists(), "the stranded atomic-write temp should have been swept"
-    assert (state_dir / "job-1.json").exists()
+    assert corpse.exists()
 
 
 def _row(prompt_id: str, status: str, **kw) -> jobs_mod.JobRow:

--- a/tests/comfy_cli/test_file_utils.py
+++ b/tests/comfy_cli/test_file_utils.py
@@ -1,6 +1,8 @@
 import os
+import pathlib
 import stat
 import sys
+import time
 import zipfile
 
 import pytest
@@ -312,3 +314,144 @@ def test_atomic_write_bytes_new_file_uses_umask_default(tmp_path):
         assert stat.S_IMODE(os.stat(target).st_mode) == (0o666 & ~0o022)
     finally:
         os.umask(old_umask)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_stale_tmp_files — sweeping stranded atomic-write temps
+# ---------------------------------------------------------------------------
+
+
+def _backdate(path, seconds: float) -> None:
+    """Push ``path``'s mtime ``seconds`` into the past."""
+    when = time.time() - seconds
+    os.utime(path, (when, when))
+
+
+def test_cleanup_stale_tmp_files_removes_old_stranded_temp(tmp_path):
+    """A SIGKILLed writer's ``<dest>.<token>.tmp`` corpse is swept once it ages out."""
+    corpse = tmp_path / "job-1.json.abcd1234.tmp"
+    corpse.write_text("half a write")
+    _backdate(corpse, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 1
+    assert not corpse.exists()
+
+
+def test_cleanup_stale_tmp_files_keeps_in_flight_temp(tmp_path):
+    """A temp written moments ago may belong to a live write — never race it."""
+    live = tmp_path / "job-1.json.abcd1234.tmp"
+    live.write_text("in flight")
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
+    assert live.exists()
+
+
+def test_cleanup_stale_tmp_files_age_threshold_is_configurable(tmp_path):
+    """``older_than_seconds`` moves the cutoff; the same file falls either side."""
+    corpse = tmp_path / "job-1.json.abcd1234.tmp"
+    corpse.write_text("x")
+    _backdate(corpse, 120)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path, older_than_seconds=3600) == 0
+    assert corpse.exists()
+    assert file_utils.cleanup_stale_tmp_files(tmp_path, older_than_seconds=60) == 1
+    assert not corpse.exists()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "notes.tmp",  # no token segment at all — a user's own scratch file
+        "job-1.json.abc123.tmp",  # token too short
+        "job-1.json.abcd12345.tmp",  # token too long
+        "job-1.json.ABCD1234.tmp",  # mkstemp never emits uppercase
+        "job-1.json.abcd-234.tmp",  # '-' is not in mkstemp's alphabet
+        ".abcd1234.tmp",  # token shape, but no destination stem
+    ],
+)
+def test_cleanup_stale_tmp_files_ignores_wrong_shapes(tmp_path, name):
+    """Only mkstemp's exact ``<stem>.<8 chars>.tmp`` shape is ever claimed."""
+    survivor = tmp_path / name
+    survivor.write_text("mine, not yours")
+    _backdate(survivor, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
+    assert survivor.exists()
+
+
+def test_cleanup_stale_tmp_files_leaves_lock_and_part_siblings(tmp_path):
+    """``.lock`` (never safe to unlink) and ``.part`` (download-owned) are untouched."""
+    lock = tmp_path / "job-1.lock"
+    part = tmp_path / "model.safetensors.abcd1234.part"
+    state = tmp_path / "job-1.json"
+    corpse = tmp_path / "job-1.json.abcd1234.tmp"
+    for p in (lock, part, state, corpse):
+        p.write_text("x")
+        _backdate(p, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 1
+    assert lock.exists()
+    assert part.exists()
+    assert state.exists()
+    assert not corpse.exists()
+
+
+def test_cleanup_stale_tmp_files_survives_unreadable_directory(tmp_path):
+    """An unlistable directory returns 0 rather than propagating the OSError."""
+    assert file_utils.cleanup_stale_tmp_files(tmp_path / "does-not-exist") == 0
+
+
+def test_cleanup_stale_tmp_files_survives_unlink_failure(tmp_path, monkeypatch):
+    """A temp that can't be removed is skipped, not fatal — and isn't counted."""
+    corpse = tmp_path / "job-1.json.abcd1234.tmp"
+    corpse.write_text("x")
+    _backdate(corpse, 7200)
+
+    def boom(self):
+        raise PermissionError("nope")
+
+    monkeypatch.setattr(pathlib.Path, "unlink", boom)
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
+    assert corpse.exists()
+
+
+def test_cleanup_stale_tmp_files_sweeps_every_token_a_crash_loop_left(tmp_path):
+    """mkstemp mints a fresh token per attempt, so corpses accumulate — sweep them all."""
+    corpses = [tmp_path / f"job-1.json.tok0000{i}.tmp" for i in range(5)]
+    for p in corpses:
+        p.write_text("x")
+        _backdate(p, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 5
+    assert not any(p.exists() for p in corpses)
+
+
+def test_cleanup_stale_tmp_files_matches_a_real_atomic_write_temp(tmp_path, monkeypatch):
+    """End-to-end on a name ``atomic_write_text`` actually produced.
+
+    The sweeper hardcodes the temp shape rather than sharing a constant with
+    ``_atomic_write``, so this is the guard against the two drifting apart: the
+    temp here is minted by the real writer, and a SIGKILL is simulated by
+    suppressing the unlink-on-exception cleanup — which is precisely what a
+    killed process never gets to run.
+    """
+    # Autouse conftest fixtures seed tmp_path, so give the writer its own dir.
+    workdir = tmp_path / "state"
+    workdir.mkdir()
+    target = workdir / "job-1.json"
+
+    def fail_replace(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    monkeypatch.setattr(os, "unlink", lambda path: None)  # the cleanup a SIGKILL skips
+    with pytest.raises(OSError):
+        atomic_write_text(target, "content")
+    monkeypatch.undo()
+
+    (leftover,) = list(workdir.iterdir())
+    assert leftover.name.startswith("job-1.json."), f"unexpected temp name {leftover.name}"
+    _backdate(leftover, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(workdir) == 1
+    assert not leftover.exists()

--- a/tests/comfy_cli/test_file_utils.py
+++ b/tests/comfy_cli/test_file_utils.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import stat
 import sys
 import time
@@ -367,6 +366,8 @@ def test_cleanup_stale_tmp_files_age_threshold_is_configurable(tmp_path):
         "job-1.json.ABCD1234.tmp",  # mkstemp never emits uppercase
         "job-1.json.abcd-234.tmp",  # '-' is not in mkstemp's alphabet
         ".abcd1234.tmp",  # token shape, but no destination stem
+        "..abcd1234.tmp",  # stem is "." — truthy, but not a real destination
+        "...abcd1234.tmp",  # ditto ".."
     ],
 )
 def test_cleanup_stale_tmp_files_ignores_wrong_shapes(tmp_path, name):
@@ -396,6 +397,70 @@ def test_cleanup_stale_tmp_files_leaves_lock_and_part_siblings(tmp_path):
     assert not corpse.exists()
 
 
+def test_cleanup_stale_tmp_files_honours_stem_suffix(tmp_path):
+    """``stem_suffix`` is the ownership evidence the token shape can't give.
+
+    ``db.a1b2c3d4.tmp`` has mkstemp's exact shape by coincidence; in a directory
+    whose only destinations are ``<id>.json`` it is plainly somebody else's.
+    """
+    ours = tmp_path / "job-1.json.abcd1234.tmp"
+    theirs = tmp_path / "db.a1b2c3d4.tmp"
+    for p in (ours, theirs):
+        p.write_text("x")
+        _backdate(p, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path, stem_suffix=".json") == 1
+    assert not ours.exists()
+    assert theirs.exists()
+    # Without the hint the shape alone claims both — which is exactly why
+    # callers that know their directory should pass it.
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 1
+    assert not theirs.exists()
+
+
+def test_cleanup_stale_tmp_files_ignores_a_directory(tmp_path):
+    """A directory shaped like a temp is not a regular file — and ``unlink`` on
+    one raises ``IsADirectoryError`` into the swallowing handler, so it would
+    have been retried fruitlessly on every sweep."""
+    a_dir = tmp_path / "job-1.json.aaaa1111.tmp"
+    a_dir.mkdir()
+    _backdate(a_dir, 7200)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
+    assert a_dir.is_dir()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
+def test_cleanup_stale_tmp_files_ignores_symlinks(tmp_path):
+    """Only the entry's own metadata decides, so nothing borrows a target's age.
+
+    A symlink to a *fresh* file and a dangling symlink both survive — the second
+    is the regression that matters: with ``stat()`` it raised on every sweep and
+    so could never be reasoned about at all.
+    """
+    fresh_target = tmp_path / "target.bin"
+    fresh_target.write_text("live")
+    to_fresh = tmp_path / "job-1.json.bbbb2222.tmp"
+    to_fresh.symlink_to(fresh_target)
+
+    dangling = tmp_path / "job-1.json.cccc3333.tmp"
+    dangling.symlink_to(tmp_path / "gone")
+
+    # An old symlink pointing at an old file is still a symlink — not swept.
+    old_target = tmp_path / "old.bin"
+    old_target.write_text("old")
+    _backdate(old_target, 7200)
+    to_old = tmp_path / "job-1.json.dddd4444.tmp"
+    to_old.symlink_to(old_target)
+    os.utime(to_old, (time.time() - 7200, time.time() - 7200), follow_symlinks=False)
+
+    assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
+    assert to_fresh.is_symlink()
+    assert dangling.is_symlink()
+    assert to_old.is_symlink()
+    assert old_target.exists()
+
+
 def test_cleanup_stale_tmp_files_survives_unreadable_directory(tmp_path):
     """An unlistable directory returns 0 rather than propagating the OSError."""
     assert file_utils.cleanup_stale_tmp_files(tmp_path / "does-not-exist") == 0
@@ -407,10 +472,10 @@ def test_cleanup_stale_tmp_files_survives_unlink_failure(tmp_path, monkeypatch):
     corpse.write_text("x")
     _backdate(corpse, 7200)
 
-    def boom(self):
+    def boom(path):
         raise PermissionError("nope")
 
-    monkeypatch.setattr(pathlib.Path, "unlink", boom)
+    monkeypatch.setattr(os, "unlink", boom)
     assert file_utils.cleanup_stale_tmp_files(tmp_path) == 0
     assert corpse.exists()
 
@@ -443,11 +508,15 @@ def test_cleanup_stale_tmp_files_matches_a_real_atomic_write_temp(tmp_path, monk
     def fail_replace(src, dst):
         raise OSError("disk full")
 
-    monkeypatch.setattr(os, "replace", fail_replace)
-    monkeypatch.setattr(os, "unlink", lambda path: None)  # the cleanup a SIGKILL skips
-    with pytest.raises(OSError):
-        atomic_write_text(target, "content")
-    monkeypatch.undo()
+    # A scoped context, not ``monkeypatch.undo()``: undo() reverts *every* patch
+    # on this function-scoped instance, including the autouse conftest fixtures
+    # that pin the config and jobs-state dirs — dropping the isolation they
+    # exist to guarantee for the rest of the test.
+    with monkeypatch.context() as m:
+        m.setattr(os, "replace", fail_replace)
+        m.setattr(os, "unlink", lambda path: None)  # the cleanup a SIGKILL skips
+        with pytest.raises(OSError):
+            atomic_write_text(target, "content")
 
     (leftover,) = list(workdir.iterdir())
     assert leftover.name.startswith("job-1.json."), f"unexpected temp name {leftover.name}"


### PR DESCRIPTION
## ELI-5

When the CLI saves a job's state file it doesn't write over the file directly — it writes a scratch file next to it (`myjob.json.a1b2c3d4.tmp`) and then renames it into place, so a crash can never leave you with a half-written state file. If something goes wrong *during* the write, the CLI deletes the scratch file on its way out.

But a process that is SIGKILLed, OOM-killed, or loses power never gets to run that cleanup — and the scratch name is randomised per attempt, so every crash leaves behind a *different* file that nothing ever deletes. A reviewer measured 13 survivors from 20 mid-write SIGKILLs. The background job watcher is the heaviest writer here (one write per state transition) and its unclean deaths are already a known thing — that's what the existing `watcher_crashed` reap exists for. Nothing globbed `*.tmp` anywhere, so in a long-running agent or CI box the corpses just piled up forever.

This adds a small sweeper and hangs it off the scan `comfy jobs ls` / `--watch` already runs, right next to the crashed-watcher reap. No new command, no new flag, nothing new in the output — it's hygiene.

## What changed

**`comfy_cli/file_utils.py` — new `cleanup_stale_tmp_files(directory, *, older_than_seconds=3600)`.** Best-effort, returns how many files it removed, never raises. It sits beside the existing `.part` helpers (`partial_paths_for` / `cleanup_partials`) and reuses their `_MKSTEMP_TOKEN_LEN` / `_MKSTEMP_TOKEN_CHARS` constants.

Three independent gates decide whether a file is claimed, and all three have to pass:

1. **Exact `mkstemp` shape.** The name must end in `.tmp`, and what's left must split into a non-empty destination stem plus a token of exactly 8 characters drawn from mkstemp's alphabet (lowercase + digits + `_`). This is the same check `partial_paths_for` makes for `.part`, and it's what stops the sweeper claiming a user's own `notes.tmp`.
2. **Age.** The file's mtime must be older than `older_than_seconds` (default 1h). An in-flight atomic write lives for milliseconds, so an hour is conservative — a live write can never be raced.
3. **It survives its own failures.** An unlistable directory returns `0`; a file whose `stat` or `unlink` fails is skipped rather than fatal, and isn't counted.

`.lock` files (created by `locking.file_lock`, never safe to unlink) and `.part` files (owned by the download machinery) can't match at all — they fail on the suffix before any other check runs.

**`comfy_cli/command/jobs.py` — one best-effort call** in `_gather_local_state_files`, immediately after `state_dir = jobs_state.state_dir()`. Same trigger as the existing crashed-watcher reap; the return count is deliberately not surfaced in the UI.

## Testing

Full suite green: `4351 passed, 37 skipped`. `ruff check` / `ruff format --check` clean on every touched file (the repo has 17 pre-existing `ruff check` findings and one pre-existing format finding in `tests/comfy_cli/command/github/test_pr.py`, both present on `main` and untouched here).

15 new tests covering every branch:

- old stranded temp → removed and counted; young temp → kept; `older_than_seconds` moves the cutoff either side of the same file
- wrong token shapes all kept — token too short, too long, uppercase, a `-` outside mkstemp's alphabet, `notes.tmp` with no token segment, and `.abcd1234.tmp` with a token but no destination stem
- `.lock` and `.part` siblings (and the state file itself) untouched while the corpse beside them goes
- unreadable directory → returns `0`, no raise; an `unlink` that raises → skipped, not counted, not fatal
- five corpses from a crash loop → all five swept (the mkstemp-mints-a-fresh-token-per-attempt case)
- end-to-end against a temp minted by the **real** `atomic_write_text` (with the unlink-on-exception cleanup suppressed, which is exactly what a SIGKILLed process skips) — this is the guard against the sweeper's hardcoded shape drifting from `_atomic_write`'s
- integration: a jobs state dir seeded with a valid `*.json` state file plus one old stranded `<id>.json.<token>.tmp`, through `_gather_local_state_files(limit=10)` — the row comes back and the temp is gone

The integration test was mutation-checked: with the `cleanup_stale_tmp_files` call removed from `jobs.py` it fails, so it's testing the wiring rather than the helper twice.

## Judgment calls

- **Deliberately not wired into the other `atomic_write_*` call sites** (auth store, `download_state`, templates). The helper is general and reusable, but per the plan this PR only adds the jobs-scan wiring; the open PR #661 migrates those sites and the helper rebases trivially beside them (it's purely additive next to the `.part` block).
- **`.tmp` is hardcoded in the sweeper rather than shared as a constant with `_atomic_write`'s `suffix=` argument.** The constant lives next to the `.part` machinery (where the plan places it) and `_atomic_write` is ~390 lines above it, so sharing it would mean a forward reference that reads worse than the duplication. The end-to-end test above is the drift guard instead: it asserts the sweeper claims a name the real writer produced, so a change to either side fails a test rather than silently disabling the sweep.
- **Risk review of the one deleting line.** `entry.unlink()` is the only destructive operation. It's reachable only for a file matching mkstemp's exact 8-char token shape *and* older than an hour, in a directory the caller names — for the wired call site that's the jobs state dir, which contains only `<id>.json` and `<id>.lock`. `unlink` never follows symlinks, so a symlinked match removes the link and not its target, and a directory that somehow matched raises `IsADirectoryError` (an `OSError`) and is skipped.
