### PR TITLE
feat: derive comfy_usage_source from caller detection (BE-6800)

### DIFF
--- a/comfy_cli/caller.py
+++ b/comfy_cli/caller.py
@@ -18,6 +18,11 @@ own env var (set in every Bash subprocess it spawns). Checking it
 explicitly means analytics can distinguish "Claude Code" from "some
 other agent" without requiring Claude Code users to set AI_AGENT.
 
+This module also derives the ``comfy_usage_source`` attribution value
+(``usage_source`` below) that rides every workflow submission, so
+server-side partner-node billing can tell a human-driven CLI run apart
+from an agent-driven one.
+
 Tested in ``tests/comfy_cli/output/test_caller.py``.
 """
 
@@ -27,6 +32,7 @@ import os
 import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import lru_cache
 
 
 @dataclass(frozen=True)
@@ -116,3 +122,45 @@ def detect_caller(
 
     # 5. Human at a terminal.
     return Caller(kind="user", agentic=False, source_env=None)
+
+
+# A custom COMFY_USER_AGENT is arbitrary user-supplied text, and the value
+# derived from it rides a request body the server bills against, so bound it
+# the way `tracking._sanitize_caller_kind` bounds `caller_kind` rather than
+# forwarding an unbounded label.
+_USAGE_SOURCE_MAX_LEN = 64
+
+
+def usage_source_for(caller: Caller) -> str:
+    """Map a caller to its ``comfy_usage_source`` attribution value.
+
+    A human at a terminal keeps the bare ``comfy-cli``, so dashboards and
+    margin queries that exact-match ``usage_source = 'comfy-cli'`` keep
+    working — they narrow to human-driven CLI use, which is what those
+    consumers already assume. Every agentic caller gets the slash-scoped
+    ``comfy-cli/<kind>`` (``comfy-cli/comfy-mcp``, ``comfy-cli/claude-code``,
+    ``comfy-cli/agent``, ``comfy-cli/pipe``), matching the
+    ``comfy-cloud-mcp/<tool>`` convention already in production; a
+    ``usage_source LIKE 'comfy-cli%'`` prefix query covers the whole family.
+
+    The human case keys off ``agentic``, not ``kind == "user"``: a caller that
+    self-attributes ``COMFY_USER_AGENT=user`` produces the *string* "user"
+    while being exactly the agentic case, and a kind test would let it pass
+    itself off as a human. This mirrors ``tracking._caller_kind_is_custom``.
+    """
+    if not caller.agentic:
+        return "comfy-cli"
+    return f"comfy-cli/{caller.kind[:_USAGE_SOURCE_MAX_LEN]}"
+
+
+@lru_cache(maxsize=1)
+def usage_source() -> str:
+    """The ``comfy_usage_source`` value for this process.
+
+    Computed once — ``detect_caller`` is env + isatty only, but the answer
+    cannot change within a process, matching how ``tracking`` computes
+    ``_caller_kind`` at import. Tests that vary the caller patch the name
+    where it is *used* (the call sites import it directly) and/or call
+    ``usage_source.cache_clear()``.
+    """
+    return usage_source_for(detect_caller())

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from comfy_cli.caller import usage_source
 from comfy_cli.http import (
     NoRedirectHandler,
     ResponseTooLarge,
@@ -340,7 +341,9 @@ class Client:
             merged_extra: dict[str, Any] = dict(extra_data or {})
             # Usage-source attribution rides extra_data too — the execution
             # record keeps it even when the HTTP header is dropped by proxies.
-            merged_extra.setdefault("comfy_usage_source", "comfy-cli")
+            # Derived from the caller, so agent-driven runs are attributable
+            # server-side; an explicit caller-supplied value still wins.
+            merged_extra.setdefault("comfy_usage_source", usage_source())
             # Partner-API nodes (BFL, Gemini, Bria, ByteDance, etc.) read the
             # caller's comfy.org credential out of extra_data. Rebuild this at
             # send time so an OAuth refresh updates both the header and body.

--- a/comfy_cli/command/run/execution.py
+++ b/comfy_cli/command/run/execution.py
@@ -37,6 +37,7 @@ from rich.progress import BarColumn, Progress, TimeElapsedColumn
 from rich.table import Column, Table
 
 from comfy_cli import execution_errors
+from comfy_cli.caller import usage_source
 from comfy_cli.command.run.loader import _MAX_BODY_PREVIEW, _node_errors_to_list
 from comfy_cli.http import no_redirect_urlopen
 from comfy_cli.output import get_renderer
@@ -165,8 +166,10 @@ class WorkflowExecution:
     def queue(self):
         data: dict = {"prompt": self.workflow, "client_id": self.client_id}
         # Usage-source attribution rides extra_data so the server can tell
-        # CLI-originated executions apart from web-UI ones (upstream #468).
-        data["extra_data"] = {"comfy_usage_source": "comfy-cli"}
+        # CLI-originated executions apart from web-UI ones (upstream #468) —
+        # and, via the caller-derived value, human-driven CLI runs apart from
+        # agent-driven ones. `self.extra_data` still overwrites it below.
+        data["extra_data"] = {"comfy_usage_source": usage_source()}
         if self.extra_data:
             data["extra_data"].update(self.extra_data)
         elif self.api_key:

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -14,7 +14,17 @@ from unittest.mock import patch
 import pytest
 
 from comfy_cli import comfy_client
+from comfy_cli.caller import Caller, usage_source_for
 from comfy_cli.target import Target
+
+
+def _mcp_usage_source() -> str:
+    """What ``usage_source()`` returns under ``COMFY_USER_AGENT=comfy-mcp``.
+
+    Built through the real mapper so these tests pin the wiring, not a
+    hand-copied string; only the environment probe is stubbed out.
+    """
+    return usage_source_for(Caller(kind="comfy-mcp", agentic=True, source_env="COMFY_USER_AGENT"))
 
 
 def _mock_response(payload):
@@ -161,6 +171,37 @@ class TestSubmitPrompt:
         body = json.loads(urlopen.call_args.args[0].data)
         # setdefault — caller wins.
         assert body["extra_data"]["auth_token_comfy_org"] == "caller-token"
+
+    def test_usage_source_is_derived_from_the_caller(self, monkeypatch):
+        """An agentic caller is attributed as ``comfy-cli/<kind>`` so
+        partner-node billing can tell MCP-driven runs from human ones. (The
+        assertions above pin the human case, via the conftest fixture.)"""
+        monkeypatch.setattr(comfy_client, "usage_source", _mcp_usage_source)
+        with patch.object(
+            comfy_client._OPENER,
+            "open",
+            return_value=_mock_response({"prompt_id": "pid", "number": 1, "node_errors": {}}),
+        ) as urlopen:
+            comfy_client.Client(CLOUD).submit_prompt({"1": {"class_type": "X", "inputs": {}}}, "cid")
+        body = json.loads(urlopen.call_args.args[0].data)
+        assert body["extra_data"]["comfy_usage_source"] == "comfy-cli/comfy-mcp"
+
+    def test_caller_supplied_usage_source_still_wins(self, monkeypatch):
+        """setdefault semantics are unchanged by the derivation: a caller that
+        names its own ``comfy_usage_source`` keeps it."""
+        monkeypatch.setattr(comfy_client, "usage_source", _mcp_usage_source)
+        with patch.object(
+            comfy_client._OPENER,
+            "open",
+            return_value=_mock_response({"prompt_id": "pid", "number": 1, "node_errors": {}}),
+        ) as urlopen:
+            comfy_client.Client(CLOUD).submit_prompt(
+                {"1": {"class_type": "X", "inputs": {}}},
+                "cid",
+                extra_data={"comfy_usage_source": "some-other-surface"},
+            )
+        body = json.loads(urlopen.call_args.args[0].data)
+        assert body["extra_data"]["comfy_usage_source"] == "some-other-surface"
 
     def test_oauth_refresh_rebuilds_partner_auth_extra_data(self):
         cloud = Target(

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -9,6 +9,7 @@ import pytest
 import typer
 from websocket import WebSocketException, WebSocketTimeoutException
 
+from comfy_cli.caller import Caller, usage_source_for
 from comfy_cli.command.run import (
     _TELEMETRY_NODE_NAME_MAX_LEN,
     WorkflowExecution,
@@ -17,10 +18,20 @@ from comfy_cli.command.run import (
     _resolve_partner_credential,
     _returned_output_node_count,
     execute,
+    execution,
     fetch_object_info,
     is_ui_workflow,
     preflight,
 )
+
+
+def _mcp_usage_source() -> str:
+    """What ``usage_source()`` returns under ``COMFY_USER_AGENT=comfy-mcp``.
+
+    Built through the real mapper so these tests pin the wiring, not a
+    hand-copied string; only the environment probe is stubbed out.
+    """
+    return usage_source_for(Caller(kind="comfy-mcp", agentic=True, source_env="COMFY_USER_AGENT"))
 
 
 @pytest.fixture
@@ -172,7 +183,7 @@ class TestFetchObjectInfo:
 class TestWorkflowExecutionAuth:
     """X-API-Key is the credential the ComfyUI server forwards to Partner Nodes."""
 
-    def _make_exec(self, workflow, api_key=None):
+    def _make_exec(self, workflow, api_key=None, extra_data=None):
         progress = MagicMock()
         progress.add_task.return_value = 0
         return WorkflowExecution(
@@ -184,6 +195,7 @@ class TestWorkflowExecutionAuth:
             progress=progress,
             timeout=30,
             api_key=api_key,
+            extra_data=extra_data,
         )
 
     def test_queue_embeds_api_key_in_extra_data(self, workflow):
@@ -215,6 +227,30 @@ class TestWorkflowExecutionAuth:
             "client_id": ex.client_id,
             "extra_data": {"comfy_usage_source": "comfy-cli"},
         }
+
+    def test_queue_derives_usage_source_from_the_caller(self, workflow, monkeypatch):
+        """An agentic caller is attributed as ``comfy-cli/<kind>`` in the
+        ``/prompt`` payload so partner-node billing can tell MCP-driven runs
+        from human ones. (The assertions above pin the human case, via the
+        conftest fixture.)"""
+        monkeypatch.setattr(execution, "usage_source", _mcp_usage_source)
+        ex = self._make_exec(workflow)
+        with patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "abc"}).encode()
+            ex.queue()
+        body = json.loads(mock_open.call_args[0][0].data)
+        assert body["extra_data"] == {"comfy_usage_source": "comfy-cli/comfy-mcp"}
+
+    def test_queue_lets_explicit_extra_data_override_the_usage_source(self, workflow, monkeypatch):
+        """``self.extra_data`` is applied with ``update()`` after the derived
+        default, so an explicit value still wins — ordering unchanged."""
+        monkeypatch.setattr(execution, "usage_source", _mcp_usage_source)
+        ex = self._make_exec(workflow, extra_data={"comfy_usage_source": "some-other-surface"})
+        with patch("comfy_cli.http._AUTHED_OPENER.open") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = json.dumps({"prompt_id": "abc"}).encode()
+            ex.queue()
+        body = json.loads(mock_open.call_args[0][0].data)
+        assert body["extra_data"] == {"comfy_usage_source": "some-other-surface"}
 
     def test_queue_sends_usage_source_header(self, workflow):
         ex = self._make_exec(workflow)

--- a/tests/comfy_cli/conftest.py
+++ b/tests/comfy_cli/conftest.py
@@ -75,6 +75,34 @@ def _isolate_jobs_state_dir(tmp_path, monkeypatch):
     yield fake
 
 
+@pytest.fixture(autouse=True)
+def _pin_usage_source_to_human(monkeypatch):
+    """Pin the submit paths' ``comfy_usage_source`` to the human-caller value.
+
+    ``caller.usage_source()`` is derived from the live environment, which under
+    pytest is not a stable input: stdout is captured (so ``detect_caller``
+    answers "pipe"), and a run driven by an agent harness exports
+    ``CLAUDECODE`` / ``AI_AGENT`` / ``COMFY_USER_AGENT`` into the test process.
+    Left alone, the same payload assertion would pass in a terminal and fail in
+    CI or under an agent.
+
+    So pin the baseline to the human-at-a-terminal value — the one that stayed
+    the bare ``comfy-cli`` — at the two places that send it. The patch is
+    deliberately applied to the *importing* modules rather than to
+    ``caller.detect_caller``: a global detect_caller patch also rewrites what
+    ``tracking`` and ``renderer`` see. A test that wants a different caller
+    re-patches the same names (see ``cloud/test_client.py``,
+    ``command/test_run.py``); ``caller.usage_source_for`` is tested directly in
+    ``output/test_caller.py`` and needs no pinning.
+    """
+    from comfy_cli import comfy_client
+    from comfy_cli.command.run import execution
+
+    for module in (comfy_client, execution):
+        monkeypatch.setattr(module, "usage_source", lambda: "comfy-cli")
+    yield
+
+
 @pytest.fixture
 def pretty_no_stdout(capsys):
     """Assert pretty-mode commands write nothing to stdout.

--- a/tests/comfy_cli/output/test_caller.py
+++ b/tests/comfy_cli/output/test_caller.py
@@ -9,7 +9,8 @@ import sys
 
 import pytest
 
-from comfy_cli.caller import detect_caller
+from comfy_cli import caller
+from comfy_cli.caller import detect_caller, usage_source_for
 
 
 def test_tty_no_env_is_user():
@@ -184,3 +185,68 @@ class TestStdoutProbeIsFailSafe:
 
         monkeypatch.setattr(sys, "stdout", RaisingGetattr())
         assert detect_caller(env={}).kind == "pipe"
+
+
+class TestUsageSource:
+    """``usage_source()`` — the ``comfy_usage_source`` attribution value.
+
+    Human-driven runs keep the bare ``comfy-cli`` so existing exact-match
+    dashboards/queries keep their meaning; every agentic caller gets the
+    slash-scoped ``comfy-cli/<kind>``, matching the ``comfy-cloud-mcp/<tool>``
+    convention already in production.
+    """
+
+    @staticmethod
+    def _source(env, *, is_tty=True):
+        """The value the CLI would send for a caller derived from *env*."""
+        return usage_source_for(detect_caller(env=env, is_tty=is_tty))
+
+    def test_human_at_a_terminal_keeps_the_bare_value(self):
+        assert self._source({}) == "comfy-cli"
+
+    def test_comfy_mcp_is_scoped(self):
+        """comfy-mcp exports COMFY_USER_AGENT=comfy-mcp on every subprocess."""
+        assert self._source({"COMFY_USER_AGENT": "comfy-mcp"}) == "comfy-cli/comfy-mcp"
+
+    def test_generic_agent_is_scoped(self):
+        assert self._source({"AI_AGENT": "1"}) == "comfy-cli/agent"
+
+    def test_claude_code_is_scoped(self):
+        assert self._source({"CLAUDECODE": "1"}) == "comfy-cli/claude-code"
+
+    def test_pipe_is_scoped(self):
+        assert self._source({}, is_tty=False) == "comfy-cli/pipe"
+
+    def test_an_agent_that_opts_out_is_treated_as_human(self):
+        """``AI_AGENT=0`` is a deliberate opt-out of the agentic path, so it
+        keeps the human value — the mapping follows ``agentic``, nothing else."""
+        assert self._source({"AI_AGENT": "0"}) == "comfy-cli"
+
+    def test_self_attributed_user_label_does_not_pass_as_human(self):
+        """``COMFY_USER_AGENT=user`` yields the *string* "user" while being
+        exactly the agentic case — keying off ``kind`` instead of ``agentic``
+        would let an agent bill itself as a human."""
+        assert self._source({"COMFY_USER_AGENT": "user"}) == "comfy-cli/user"
+
+    def test_a_custom_label_is_length_bounded(self):
+        """COMFY_USER_AGENT is arbitrary user text and this value rides a
+        request body the server bills against, so it cannot be unbounded."""
+        assert self._source({"COMFY_USER_AGENT": "x" * 500}) == "comfy-cli/" + "x" * 64
+
+    def test_the_value_is_computed_once_per_process(self, monkeypatch):
+        """``usage_source()`` memoises: the answer cannot change within a
+        process, and every workflow submission calls it."""
+        calls = []
+
+        def counting():
+            calls.append(1)
+            return detect_caller(env={"AI_AGENT": "1"}, is_tty=True)
+
+        monkeypatch.setattr(caller, "detect_caller", counting)
+        caller.usage_source.cache_clear()
+        try:
+            assert caller.usage_source() == "comfy-cli/agent"
+            assert caller.usage_source() == "comfy-cli/agent"
+            assert calls == [1]
+        finally:
+            caller.usage_source.cache_clear()


### PR DESCRIPTION
## ELI-5

Every workflow the CLI submits carries a little label saying "this came from comfy-cli", which is what the server bills and attributes partner-node (BFL, Gemini, …) usage against. That label was hardcoded, so a run you typed by hand and a run an AI agent kicked off through comfy-mcp looked identical. The CLI already knows which one it is — it detects its caller to pick JSON-vs-pretty output — so this just feeds that answer into the label. Humans keep the plain `comfy-cli`; agents get `comfy-cli/comfy-mcp`, `comfy-cli/claude-code`, `comfy-cli/agent`, `comfy-cli/pipe`.

## What changed

`comfy_cli/caller.py` grows the derivation (`usage_source_for` + a memoised `usage_source()`), and the two attribution call sites use it instead of the literal:

- `comfy_cli/comfy_client.py` — the cloud/unified submit path (`setdefault`, so an explicit caller-supplied `comfy_usage_source` still wins).
- `comfy_cli/command/run/execution.py` — the local `/prompt` path (`self.extra_data.update()` still runs after the derived default, so an explicit value still overrides — ordering untouched).

Mapping: a non-agentic caller keeps the exact string `comfy-cli`, so existing exact-match consumers (`usage_source = 'comfy-cli'` in PostHog insights and Hex margin queries) keep working and simply narrow to human-driven use — which is what those consumers already assume. Agentic callers become `comfy-cli/<kind>`, the same slash-scoped convention as the `comfy-cloud-mcp/<tool>` values already in production, so `usage_source LIKE 'comfy-cli%'` covers the whole family. The alternative (`comfy-cli/<kind>` for every kind including `user`) is a cleaner taxonomy but breaks every existing exact-match consumer; per the ticket I took the compat-preserving mapping.

`detect_caller()` is env + isatty only, but the answer cannot change within a process, so `usage_source()` is `lru_cache`d — the same once-per-process shape `tracking.py` uses for `_caller_kind`.

## Judgment calls (flagged for review)

1. **The human case keys off `caller.agentic`, not `kind == "user"`.** The ticket's snippet used `kind == "user"`. Those differ in exactly one case: `COMFY_USER_AGENT=user`, which produces the *string* `"user"` while being precisely the self-attributed agentic case — a `kind` test would let an agent bill itself as a human. This is the same reasoning already documented in `tracking._caller_kind_is_custom` (#647), which takes the authoritative signal from `source_env` rather than from set membership. Every other caller maps identically to the ticket's snippet. Pinned by `test_self_attributed_user_label_does_not_pass_as_human`.
2. **The custom label is length-bounded to 64 chars.** `COMFY_USER_AGENT` is arbitrary user-supplied text and this value now rides a request body the server bills against, so it gets the same bound `tracking._sanitize_caller_kind` applies to `caller_kind`. Not asked for by the ticket; happy to drop it if you'd rather the two bounds not be duplicated (the alternative is exporting tracking's sanitizer, which drags `_scrub_value` into the request path).
3. **The three `Comfy-Usage-Source: comfy-cli` request *headers* are deliberately untouched** (`comfy_client.py:243`, `execution.py:175`, `command/generate/client.py:104`). The ticket scopes the change to the two `extra_data` sites, and the header is read at a different layer (CLI-vs-web-UI traffic identification at the gateway) with its own possible exact-match consumers — changing it is a separate decision, not a silent side effect of this one. Say the word and I'll file the follow-up, or widen this PR.
4. **Test determinism.** `usage_source()` reads the live environment, which under pytest is not a stable input: stdout is captured (so the caller detects as `pipe`), and a suite run from an agent harness exports `CLAUDECODE` / `AI_AGENT` / `COMFY_USER_AGENT` into the test process — the existing payload assertions would then pass in a terminal and fail in CI. An autouse fixture in `tests/comfy_cli/conftest.py` pins the two submit modules to the human value; it patches the *importing* modules rather than `caller.detect_caller`, because a global `detect_caller` patch also rewrites what `tracking` and `renderer` see (I tried that first — it broke five `test_tracking.py` cases). Verified load-bearing: with the fixture reverted, `COMFY_USER_AGENT=comfy-mcp pytest tests/comfy_cli/cloud/test_client.py` fails 4 tests, which is also an end-to-end confirmation that the new value really reaches the payload.

## Assumption worth naming

This assumes the server accepts a slash-scoped `usage_source` rather than validating against an allowlist of exact values. The ticket's evidence for that is the `comfy-cloud-mcp/<tool>` values already flowing in production (BE-1605); I could not verify the server side from this repo. If comfy-api does allowlist the value, agentic runs would need that list widened before this lands.

## Out of scope (ticket's own note)

Attribution only lights up for real users once a comfy-mcp release ships PR #163 (the one that exports `COMFY_USER_AGENT=comfy-mcp`); the latest release predates that merge. That release cut is not part of this diff.

## Tests

- `tests/comfy_cli/output/test_caller.py` — new `TestUsageSource`: `user` → `comfy-cli`; `COMFY_USER_AGENT=comfy-mcp` → `comfy-cli/comfy-mcp`; `AI_AGENT=1` → `comfy-cli/agent`; `CLAUDECODE=1`, non-TTY, `AI_AGENT=0` opt-out, the self-attributed-`user` case, the length bound, and that the value is computed once per process.
- `tests/comfy_cli/cloud/test_client.py` — the derived value reaches the cloud payload, and a caller-provided `comfy_usage_source` still wins over it.
- `tests/comfy_cli/command/test_run.py` — the `/prompt` payload carries the derived value, and `self.extra_data` still overrides it.

`pytest` (4350 passed, 36 skipped) and `ruff check` / `ruff format --check` are green. Note: `ruff format --check` also reports `docs/DESIGN-uv-compile.md` as unformatted — that is pre-existing on `main` and an artifact of local ruff 0.16.0 vs the 0.15.15 CI pins; untouched by this diff.

## Negative-claim falsification

Not applicable: this diff denies no capability. It adds no deny/dead-end path, no "not supported"/"unavailable" strings, and no test asserting a dead-end — it is a purely additive attribution change whose only behavioral effect is a more specific string in a request body.
