### PR TITLE
fix(jobs): stream live progress in `jobs watch` by attaching as the submitting client (BE-6856)

### DIFF
--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -1,9 +1,17 @@
 """``comfy jobs`` — list, status, and live-watch ComfyUI prompts.
 
-The ComfyUI server already speaks WebSocket: every node-execution event is
-pushed to every connected ``/ws?clientId=…`` client, tagged with the
-``prompt_id`` it belongs to. We use that channel as the live "push" feed —
-no daemon, no polling.
+The ComfyUI server already speaks WebSocket: node-execution events are pushed
+over ``/ws?clientId=…`` tagged with the ``prompt_id`` they belong to. We use
+that channel as the live "push" feed — no daemon, no polling.
+
+One thing that channel is *not* is a broadcast: the executor addresses every
+execution event (``executing`` / ``executed`` / ``progress_state`` /
+``execution_cached`` / ``execution_success``) to the socket of the session that
+submitted the prompt (``send_sync(..., server.client_id)`` in ComfyUI's
+``execution.py``, delivered by ``PromptServer.send_json`` only to that one
+``sid``). A watcher that connects with a *fresh* ``clientId`` therefore receives
+nothing at all — so ``jobs watch`` re-attaches with the submitting client_id
+(see ``_resolve_watch_client_id``).
 
 Three subcommands:
 
@@ -1754,6 +1762,103 @@ def _cloud_cancel(prompt_id: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _client_id_from_extra_data(extra: Any) -> str | None:
+    """Pull ``client_id`` out of a queue/history entry's ``extra_data`` slot."""
+    if isinstance(extra, dict):
+        cid = extra.get("client_id")
+        if isinstance(cid, str) and cid.strip():
+            return cid
+    return None
+
+
+def _resolve_watch_client_id(host: str, port: int, prompt_id: str) -> str | None:
+    """Find the ``client_id`` this prompt was submitted with, or None.
+
+    ComfyUI delivers execution events only to the submitting session's socket
+    (see the module docstring), so watching with a fresh id yields silence. The
+    submitting id is recoverable from three places, cheapest first:
+
+    1. our own on-disk job state, written at submit time by ``comfy run``;
+    2. ``/queue`` ``extra_data`` while the prompt is running or pending;
+    3. ``/history`` ``prompt[3]`` once it has finished.
+
+    Reconnecting under an existing id is ComfyUI's own session-resume mechanism
+    (its ``/ws`` handler pops the previous socket for that id), which is exactly
+    what we want for a prompt whose submitter has exited — the common case, since
+    ``comfy run --async`` returns immediately. The caveat is that a submitter
+    still holding that socket (a browser tab, a blocking ``comfy run``) stops
+    receiving events until it reconnects; pass ``--client-id`` to override the
+    resolution when that matters.
+    """
+    from comfy_cli import jobs_state
+
+    try:
+        job = jobs_state.read(prompt_id)
+    except (ValueError, OSError):  # unsafe prompt_id / unreadable state dir
+        job = None
+    if job is not None and isinstance(job.client_id, str) and job.client_id.strip():
+        return job.client_id
+
+    try:
+        q = _http_get_json(f"http://{host}:{port}/queue")
+    except RuntimeError:
+        q = {}
+    if isinstance(q, dict):
+        for key in ("queue_running", "queue_pending"):
+            for entry in q.get(key) or []:
+                # (number, prompt_id, prompt, extra_data, outputs_to_execute)
+                if isinstance(entry, list) and len(entry) > 3 and entry[1] == prompt_id:
+                    cid = _client_id_from_extra_data(entry[3])
+                    if cid:
+                        return cid
+
+    try:
+        h = _http_get_json(f"http://{host}:{port}/history/{prompt_id}")
+    except RuntimeError:
+        return None
+    body = h.get(prompt_id) if isinstance(h, dict) else None
+    prompt = body.get("prompt") if isinstance(body, dict) else None
+    if isinstance(prompt, list) and len(prompt) > 3:
+        return _client_id_from_extra_data(prompt[3])
+    return None
+
+
+def _history_completed_nodes(host: str, port: int, prompt_id: str) -> set[str]:
+    """Nodes the server itself records as having run, straight from ``/history``.
+
+    Independent of the WS stream on purpose: the terminal envelope must list the
+    nodes that ran even when no live event reached us (attached after the fact,
+    an unresolvable client_id, a third-party submitter). Union of the
+    ``execution_cached`` node ids, the ``executed`` list on an abnormal end, and
+    every node that produced an output.
+    """
+    nodes: set[str] = set()
+    try:
+        h = _http_get_json(f"http://{host}:{port}/history/{prompt_id}")
+    except RuntimeError:
+        return nodes
+    body = h.get(prompt_id) if isinstance(h, dict) else None
+    if not isinstance(body, dict):
+        return nodes
+    status_obj = body.get("status")
+    messages = status_obj.get("messages") if isinstance(status_obj, dict) else None
+    for msg in messages or []:
+        if not (isinstance(msg, list) and len(msg) > 1 and isinstance(msg[1], dict)):
+            continue
+        if msg[0] == "execution_cached":
+            listed = msg[1].get("nodes")
+        elif msg[0] in ("execution_error", "execution_interrupted"):
+            listed = msg[1].get("executed")
+        else:
+            continue
+        for n in listed or []:
+            nodes.add(str(n))
+    outputs = body.get("outputs")
+    if isinstance(outputs, dict):
+        nodes.update(str(n) for n in outputs)
+    return nodes
+
+
 @dataclass
 class _WatchState:
     """Loop-local state shared across the `jobs watch` WS recv loop.
@@ -1774,6 +1879,11 @@ class _WatchState:
     end_reason: str | None = None
     end_details: Any = None
     terminal: bool = False
+    # Nodes whose final (100% / errored) `progress` line has already been
+    # emitted. `progress_state` repeats EVERY non-pending node on every
+    # message, so without this the un-throttled final flush would re-fire for
+    # an already-finished node on each later step of the run.
+    progress_final: set[str] = field(default_factory=set)
 
 
 def _watch_executing(state: _WatchState, data: dict[str, Any]) -> None:
@@ -1818,6 +1928,60 @@ def _watch_progress(state: _WatchState, data: dict[str, Any]) -> None:
     )
 
 
+def _progress_int(value: Any) -> int | None:
+    """Coerce a progress counter to the ``integer|null`` the event schema declares.
+
+    The legacy ``progress`` message carries ints; ``progress_state`` carries
+    floats (``NodeProgressState.value``), and an unvalidated float would break
+    ``run_event.json`` for every NDJSON consumer.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        return int(value)
+    except (ValueError, OverflowError):  # nan / inf
+        return None
+
+
+def _watch_progress_state(state: _WatchState, data: dict[str, Any]) -> None:
+    """Handle ComfyUI's combined per-node ``progress_state`` message.
+
+    Current ComfyUI emits ``progress_state`` (``comfy_execution/progress.py``)
+    rather than the legacy per-node ``progress``; the legacy handler is kept for
+    older servers. The payload is ``{"nodes": {node_id: {value, max, state}}}``
+    holding EVERY non-pending node, resent on each transition — so this is also
+    the most complete source of "which nodes actually ran", including compute
+    nodes that never fire an ``executed`` event (that one only fires for nodes
+    with UI output).
+    """
+    nodes = data.get("nodes")
+    if not isinstance(nodes, dict):
+        return
+    renderer = state.renderer
+    for node_id, node_state in nodes.items():
+        if not isinstance(node_state, dict):
+            continue
+        node = str(node_id)
+        if node in state.progress_final:
+            continue
+        phase = node_state.get("state")
+        fields = {
+            "node": node,
+            "completed": _progress_int(node_state.get("value")),
+            "total": _progress_int(node_state.get("max")),
+            "prompt_id": state.prompt_id,
+        }
+        if phase in ("finished", "error"):
+            state.progress_final.add(node)
+            if phase == "finished":
+                state.completed_nodes.add(node)
+            # Emit the final line unthrottled: a 100%/errored step must not be
+            # swallowed by the rate limiter (`progress_final` keeps it to once).
+            renderer.event("progress", **fields)
+        else:
+            renderer.throttled_event(f"progress:{node}", "progress", max_hz=10, **fields)
+
+
 def _watch_executed(state: _WatchState, data: dict[str, Any]) -> None:
     renderer = state.renderer
     node = str(data.get("node"))
@@ -1835,20 +1999,54 @@ def _watch_executed(state: _WatchState, data: dict[str, Any]) -> None:
     renderer.event("executed", node=node, prompt_id=state.prompt_id)
 
 
+def _absorb_executed_list(state: _WatchState, data: dict[str, Any]) -> None:
+    """Fold an event's ``executed`` node list into ``completed_nodes``.
+
+    ``execution_error`` and ``execution_interrupted`` both carry the full list
+    of nodes that had already run when the prompt ended — the only place that
+    list is available on an abnormal exit.
+    """
+    for n in data.get("executed") or []:
+        state.completed_nodes.add(str(n))
+
+
 def _watch_execution_error(state: _WatchState, data: dict[str, Any]) -> None:
+    _absorb_executed_list(state, data)
     state.end_reason = "error"
     state.end_details = data
     state.terminal = True
 
 
+def _watch_execution_success(state: _WatchState, data: dict[str, Any]) -> None:
+    """Current ComfyUI's end-of-prompt signal.
+
+    Older servers marked the end with ``executing`` + ``node: null`` (still
+    handled above). Without this, a successful watch only ended once a ``recv``
+    timed out and the ``/history`` snapshot showed completion — i.e. it sat idle
+    for the full ``--timeout`` (30s by default) after the job was already done.
+    """
+    state.end_reason = "completed"
+    state.terminal = True
+
+
+def _watch_execution_interrupted(state: _WatchState, data: dict[str, Any]) -> None:
+    _absorb_executed_list(state, data)
+    state.end_reason = "cancelled"
+    state.end_details = data
+    state.terminal = True
+
+
 # type → pure per-message handler. Each mutates ``state`` (and sets
-# ``state.terminal`` for the two terminal events); the recv loop owns the break.
+# ``state.terminal`` for the terminal events); the recv loop owns the break.
 _WATCH_HANDLERS = {
     "executing": _watch_executing,
     "execution_cached": _watch_execution_cached,
     "progress": _watch_progress,
+    "progress_state": _watch_progress_state,
     "executed": _watch_executed,
     "execution_error": _watch_execution_error,
+    "execution_success": _watch_execution_success,
+    "execution_interrupted": _watch_execution_interrupted,
 }
 
 
@@ -1871,6 +2069,17 @@ def watch_cmd(
         float,
         typer.Option("--max-wait", help="Cloud-only: give up after this many seconds total."),
     ] = 600.0,
+    client_id: Annotated[
+        str | None,
+        typer.Option(
+            "--client-id",
+            help=(
+                "Local-only: attach as this WS client_id instead of the submitting one. "
+                "ComfyUI sends execution events only to the submitting session, so watch "
+                "resolves that id automatically; override it if resolution picks wrong."
+            ),
+        ),
+    ] = None,
 ):
     renderer = get_renderer()
     if _is_cloud(where):
@@ -1883,6 +2092,9 @@ def watch_cmd(
     # be no more WS events.
     snap = _snapshot(h, p, prompt_id)
     if snap and snap["status"] in {"completed", "error", "cancelled"}:
+        # No stream to summarise, so the node list has to come from /history —
+        # `completed_nodes` is part of the watch envelope on every exit path.
+        snap["completed_nodes"] = sorted(_history_completed_nodes(h, p, prompt_id))
         if renderer.is_pretty():
             renderer.console().print(f"[dim]Prompt {prompt_id} already {snap['status']}; nothing more to watch.[/dim]")
             _render_status_pretty(snap, host=h, port=p)
@@ -1890,9 +2102,12 @@ def watch_cmd(
         return
 
     ws = WebSocket()
-    client_id = str(uuid.uuid4())
+    # Re-attach as the submitting session, otherwise the server addresses every
+    # execution event to a socket we are not holding and this watch sees nothing.
+    attached_client_id = client_id or _resolve_watch_client_id(h, p, prompt_id)
+    ws_client_id = attached_client_id or str(uuid.uuid4())
     try:
-        ws.connect(f"ws://{h}:{p}/ws?clientId={client_id}")
+        ws.connect(f"ws://{h}:{p}/ws?clientId={urllib.parse.quote(ws_client_id, safe='')}")
     except (WebSocketException, ConnectionError, OSError) as e:
         renderer.error(
             code="ws_disconnected",
@@ -1913,6 +2128,11 @@ def watch_cmd(
 
     if renderer.is_pretty():
         renderer.console().print(f"[bold]Watching prompt[/bold] {prompt_id} on {h}:{p}   [dim](Ctrl-C to stop)[/dim]")
+        if attached_client_id is None:
+            renderer.console().print(
+                "[yellow]![/yellow] [dim]could not resolve the submitting client_id — the server "
+                "may not send live events for this prompt; pass --client-id if you know it[/dim]"
+            )
 
     try:
         while True:
@@ -1981,6 +2201,10 @@ def watch_cmd(
 
     elapsed = time.time() - start
     final_status = state.end_reason or ("completed" if state.completed_nodes else "unknown")
+    # Union in the server's own record of what ran. Strictly additive and done
+    # AFTER `final_status` is derived, so it can only correct an under-reported
+    # node list — never invent a terminal status the stream did not observe.
+    state.completed_nodes |= _history_completed_nodes(h, p, prompt_id)
     if renderer.is_pretty():
         from rich.text import Text
 
@@ -2001,6 +2225,11 @@ def watch_cmd(
         "elapsed_seconds": elapsed,
         "host": h,
         "port": p,
+        # Which session this watch listened as, and whether that was the
+        # prompt's real submitter — the difference between a live stream and
+        # silence, so it belongs in the envelope rather than only in the logs.
+        "client_id": ws_client_id,
+        "attached": attached_client_id is not None,
     }
     if state.end_details is not None:
         payload["details"] = state.end_details if isinstance(state.end_details, dict) else {"raw": state.end_details}

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -2095,6 +2095,11 @@ def watch_cmd(
         # No stream to summarise, so the node list has to come from /history —
         # `completed_nodes` is part of the watch envelope on every exit path.
         snap["completed_nodes"] = sorted(_history_completed_nodes(h, p, prompt_id))
+        # Same envelope shape as the live path — a consumer reading
+        # `data.attached` must never hit a missing key. The prompt already
+        # ended, so no session was attached and there is no id to report.
+        snap["client_id"] = None
+        snap["attached"] = False
         if renderer.is_pretty():
             renderer.console().print(f"[dim]Prompt {prompt_id} already {snap['status']}; nothing more to watch.[/dim]")
             _render_status_pretty(snap, host=h, port=p)

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -35,6 +35,14 @@
     },
     "elapsed_seconds": {"type": ["number", "null"]},
     "completed_nodes": {"type": "array", "items": {"type": "string"}},
+    "client_id": {
+      "type": ["string", "null"],
+      "description": "`jobs watch` local terminal: the WS session id this watch listened as. ComfyUI addresses execution events to the submitting session only, so watch re-attaches with the prompt's own client_id when it can resolve one (job state file, /queue, /history) and falls back to a fresh id otherwise."
+    },
+    "attached": {
+      "type": "boolean",
+      "description": "`jobs watch` local terminal: true when `client_id` is the prompt's real submitting session — i.e. live execution events could reach this watch. False means the id could not be resolved and the envelope is snapshot-derived."
+    },
     "count": {"type": "integer"},
     "jobs": {
       "type": "array",

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -20,6 +20,23 @@ flag switches the process-wide renderer into NDJSON streaming mode. The same
 event names are used by `comfy jobs watch` in stream mode, so the run stream
 and the watch stream speak one dialect.
 
+### `jobs watch` attaches as the submitting session
+
+A local ComfyUI server does **not** broadcast execution events: it addresses
+`executing` / `executed` / `progress_state` / `execution_cached` /
+`execution_success` to the websocket session that submitted the prompt. So
+`comfy jobs watch <prompt_id>` resolves that prompt's `client_id` — from the job
+state file `comfy run` wrote, else `/queue`, else `/history` — and reconnects
+under it; the terminal envelope reports which id it used (`data.client_id`) and
+whether it was the real submitter (`data.attached`). Use `--client-id` to force a
+specific one. Reconnecting under an existing id is ComfyUI's own session-resume
+path, so a submitter that is *still* holding that socket (an open browser tab, a
+blocking `comfy run`) stops receiving events until it reconnects.
+
+`data.completed_nodes` on the terminal envelope does not depend on the stream: it
+is the union of what the watch observed and what `/history` records for the
+prompt, so it is populated even for a watch that attached after the job ended.
+
 ## Overview
 
 When `--json` is passed, `comfy run` switches into a strict

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -20,7 +20,7 @@ flag switches the process-wide renderer into NDJSON streaming mode. The same
 event names are used by `comfy jobs watch` in stream mode, so the run stream
 and the watch stream speak one dialect.
 
-### `jobs watch` attaches as the submitting session
+## `jobs watch` attaches as the submitting session
 
 A local ComfyUI server does **not** broadcast execution events: it addresses
 `executing` / `executed` / `progress_state` / `execution_cached` /
@@ -29,9 +29,12 @@ A local ComfyUI server does **not** broadcast execution events: it addresses
 state file `comfy run` wrote, else `/queue`, else `/history` — and reconnects
 under it; the terminal envelope reports which id it used (`data.client_id`) and
 whether it was the real submitter (`data.attached`). Use `--client-id` to force a
-specific one. Reconnecting under an existing id is ComfyUI's own session-resume
-path, so a submitter that is *still* holding that socket (an open browser tab, a
-blocking `comfy run`) stops receiving events until it reconnects.
+specific one. Both keys are present on *every* `jobs watch` terminal envelope: a
+watch of an already-finished prompt short-circuits without opening a socket, and
+reports `client_id: null` / `attached: false`. Reconnecting under an existing id
+is ComfyUI's own session-resume path, so a submitter that is *still* holding that
+socket (an open browser tab, a blocking `comfy run`) stops receiving events until
+it reconnects.
 
 `data.completed_nodes` on the terminal envelope does not depend on the stream: it
 is the union of what the watch observed and what `/history` records for the

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2569,6 +2569,19 @@ def test_watch_progress_state_reports_each_finished_node_once():
     assert st.completed_nodes == {"4"}
 
 
+def test_watch_progress_state_errored_node_is_final_but_not_completed():
+    """An `error` node is final — it must flush its progress line once and never
+    fire again — but it did NOT complete, so it stays out of `completed_nodes`."""
+    st, r = _watch_state()
+    msg = {"prompt_id": "pid", "nodes": {"5": {"value": 1, "max": 8, "state": "error"}}}
+    jobs_mod._watch_progress_state(st, msg)
+    jobs_mod._watch_progress_state(st, dict(msg))
+    assert st.completed_nodes == set()
+    assert "5" in st.progress_final
+    assert r.throttled == []
+    assert r.events == [("progress", {"node": "5", "completed": 1, "total": 8, "prompt_id": "pid"})]
+
+
 def test_watch_progress_state_ignores_malformed_payloads():
     st, r = _watch_state()
     jobs_mod._watch_progress_state(st, {"prompt_id": "pid", "nodes": "not-a-dict"})
@@ -2846,7 +2859,11 @@ def test_watch_terminal_envelope_backfills_completed_nodes_without_events(monkey
 
 
 def test_watch_already_terminal_job_still_lists_completed_nodes(monkeypatch, capsys):
-    """The short-circuit path (job already finished) also carries the node list."""
+    """The short-circuit path (job already finished) also carries the node list —
+    and the `client_id`/`attached` pair, so a consumer reading `data.attached`
+    never hits a missing key on this exit path."""
+    import jsonschema
+
     monkeypatch.setattr(
         jobs_mod,
         "_snapshot",
@@ -2856,6 +2873,12 @@ def test_watch_already_terminal_job_still_lists_completed_nodes(monkeypatch, cap
     result, _ws, lines = _run_local_watch(monkeypatch, capsys, messages=[])
     assert result.exit_code == 0, result.output
     assert lines[-1]["data"]["completed_nodes"] == ["1", "2"]
+    # Nothing was attached: no socket was ever opened on this path.
+    assert lines[-1]["data"]["client_id"] is None
+    assert lines[-1]["data"]["attached"] is False
+
+    schema_path = Path(jobs_mod.__file__).parent.parent / "schemas" / "jobs.json"
+    jsonschema.Draft202012Validator(json.loads(schema_path.read_text())).validate(lines[-1]["data"])
 
 
 def test_watch_client_id_flag_overrides_resolution(monkeypatch, capsys):

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -2468,8 +2468,15 @@ def test_watch_handlers_registry_covers_the_protocol_types():
         "executing",
         "execution_cached",
         "progress",
+        # Current ComfyUI's per-step channel; `progress` is the legacy name and
+        # both stay mapped so old and new servers both stream.
+        "progress_state",
         "executed",
         "execution_error",
+        # Current ComfyUI's end-of-prompt signals — without them a successful
+        # watch only ends when a recv times out (a full `--timeout` of silence).
+        "execution_success",
+        "execution_interrupted",
     }
     assert jobs_mod._WATCH_HANDLERS.get("unknown_type") is None
 
@@ -2519,11 +2526,82 @@ def test_watch_executed_collects_output_urls_with_host_port():
 
 def test_watch_execution_error_is_terminal_and_carries_details():
     st, _ = _watch_state()
-    data = {"node_id": "5", "exception_message": "boom"}
+    data = {"node_id": "5", "exception_message": "boom", "executed": ["1", 2]}
     jobs_mod._watch_execution_error(st, data)
     assert st.terminal is True
     assert st.end_reason == "error"
     assert st.end_details == data
+    # The `executed` list is the only record of what ran before the failure.
+    assert st.completed_nodes == {"1", "2"}
+
+
+def test_watch_progress_state_streams_per_node_and_marks_finished_nodes():
+    """`progress_state` (current ComfyUI) must produce per-step progress events
+    and count finished nodes — including compute nodes that never fire
+    `executed`. Regression: watch only understood the legacy `progress` type."""
+    st, r = _watch_state()
+    jobs_mod._watch_progress_state(
+        st,
+        {
+            "prompt_id": "pid",
+            "nodes": {
+                "3": {"value": 2.0, "max": 8.0, "state": "running"},
+                "4": {"value": 8.0, "max": 8.0, "state": "finished"},
+            },
+        },
+    )
+    assert [t[0] for t in r.throttled] == ["progress:3"]
+    # Floats coerced to the integer|null the event schema declares.
+    assert r.throttled[0][2] == {"max_hz": 10, "node": "3", "completed": 2, "total": 8, "prompt_id": "pid"}
+    # The 100% line is emitted unthrottled so it can never be swallowed.
+    assert r.events == [("progress", {"node": "4", "completed": 8, "total": 8, "prompt_id": "pid"})]
+    assert st.completed_nodes == {"4"}
+
+
+def test_watch_progress_state_reports_each_finished_node_once():
+    """`progress_state` repeats every non-pending node on every message, so the
+    un-throttled final flush must not re-fire for an already-finished node."""
+    st, r = _watch_state()
+    msg = {"prompt_id": "pid", "nodes": {"4": {"value": 8, "max": 8, "state": "finished"}}}
+    jobs_mod._watch_progress_state(st, msg)
+    jobs_mod._watch_progress_state(st, dict(msg))
+    assert len(r.events) == 1 and r.throttled == []
+    assert st.completed_nodes == {"4"}
+
+
+def test_watch_progress_state_ignores_malformed_payloads():
+    st, r = _watch_state()
+    jobs_mod._watch_progress_state(st, {"prompt_id": "pid", "nodes": "not-a-dict"})
+    jobs_mod._watch_progress_state(st, {"prompt_id": "pid"})
+    jobs_mod._watch_progress_state(st, {"prompt_id": "pid", "nodes": {"3": "nope"}})
+    assert r.throttled == [] and r.events == []
+    assert st.completed_nodes == set()
+
+
+def test_watch_execution_success_is_terminal_completed():
+    st, r = _watch_state()
+    jobs_mod._watch_execution_success(st, {"prompt_id": "pid"})
+    assert st.terminal is True
+    assert st.end_reason == "completed"
+    assert r.events == []
+
+
+def test_watch_execution_interrupted_is_terminal_cancelled_and_keeps_nodes():
+    st, _ = _watch_state()
+    data = {"prompt_id": "pid", "node_id": "7", "executed": ["1", "2"]}
+    jobs_mod._watch_execution_interrupted(st, data)
+    assert st.terminal is True
+    assert st.end_reason == "cancelled"
+    assert st.end_details == data
+    assert st.completed_nodes == {"1", "2"}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(3, 3), (3.7, 3), (None, None), ("8", None), (True, None), (float("nan"), None), (float("inf"), None)],
+)
+def test_progress_int_coerces_to_the_event_schema_type(value, expected):
+    assert jobs_mod._progress_int(value) == expected
 
 
 class _PrettyRecordingRenderer(_RecordingRenderer):
@@ -2557,6 +2635,257 @@ def test_watch_executing_escapes_server_controlled_node_markup():
     assert r"\[red]evil\[/red]" in r.printed[0]
     # The event stream still carries the raw node id.
     assert ("executing", {"node": "[red]evil[/red]", "prompt_id": "pid"}) in r.events
+
+
+# ---------------------------------------------------------------------------
+# `jobs watch` — attaching as the submitting client_id (the reason the stream
+# was silent) and the history-derived completed_nodes backfill
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_watch_client_id_prefers_the_job_state_file(monkeypatch):
+    """`comfy run` records the submitting client_id on disk — cheapest source,
+    and no HTTP call should be needed when it is there."""
+    from comfy_cli import jobs_state
+
+    jobs_state.write(jobs_state.new(prompt_id="pid-a", client_id="cid-from-state", workflow="w", where="local"))
+
+    def _no_http(url, **kw):
+        raise AssertionError(f"should not have queried the server: {url}")
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", _no_http)
+    assert jobs_mod._resolve_watch_client_id("127.0.0.1", 8188, "pid-a") == "cid-from-state"
+
+
+def test_resolve_watch_client_id_falls_back_to_queue_extra_data(monkeypatch):
+    """A prompt submitted by something else (browser, older CLI) has no state
+    file — /queue's extra_data still carries the submitting client_id."""
+
+    def fake_get(url, **kw):
+        if url.endswith("/queue"):
+            return {
+                "queue_running": [[0, "other", {}, {"client_id": "nope"}, {}]],
+                "queue_pending": [[1, "pid-b", {}, {"client_id": "cid-from-queue"}, {}]],
+            }
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", fake_get)
+    assert jobs_mod._resolve_watch_client_id("127.0.0.1", 8188, "pid-b") == "cid-from-queue"
+
+
+def test_resolve_watch_client_id_falls_back_to_history_then_none(monkeypatch):
+    def fake_get(url, **kw):
+        if url.endswith("/queue"):
+            return {"queue_running": [], "queue_pending": []}
+        if url.endswith("/history/pid-c"):
+            return {"pid-c": {"prompt": [0, "pid-c", {}, {"client_id": "cid-from-history"}, {}]}}
+        return {}
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", fake_get)
+    assert jobs_mod._resolve_watch_client_id("127.0.0.1", 8188, "pid-c") == "cid-from-history"
+    # Nothing anywhere -> None, so the caller can warn instead of pretending.
+    assert jobs_mod._resolve_watch_client_id("127.0.0.1", 8188, "pid-missing") is None
+
+
+def test_resolve_watch_client_id_survives_an_unreachable_server(monkeypatch):
+    def boom(url, **kw):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", boom)
+    assert jobs_mod._resolve_watch_client_id("127.0.0.1", 8188, "pid-x") is None
+
+
+def test_history_completed_nodes_unions_cached_executed_and_output_nodes(monkeypatch):
+    """The end-state node list must not depend on the live stream at all."""
+
+    def fake_get(url, **kw):
+        assert url.endswith("/history/pid-h")
+        return {
+            "pid-h": {
+                "status": {
+                    "completed": True,
+                    "messages": [
+                        ["execution_start", {"prompt_id": "pid-h"}],
+                        ["execution_cached", {"nodes": [1, "2"]}],
+                        ["execution_interrupted", {"executed": ["3"]}],
+                    ],
+                },
+                "outputs": {"9": {"images": []}},
+            }
+        }
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", fake_get)
+    assert jobs_mod._history_completed_nodes("127.0.0.1", 8188, "pid-h") == {"1", "2", "3", "9"}
+
+
+def test_history_completed_nodes_tolerates_junk(monkeypatch):
+    def fake_get(url, **kw):
+        return {"pid-j": {"status": {"messages": [["execution_cached"], "junk", ["x", 1]]}, "outputs": "nope"}}
+
+    monkeypatch.setattr(jobs_mod, "_http_get_json", fake_get)
+    assert jobs_mod._history_completed_nodes("127.0.0.1", 8188, "pid-j") == set()
+    monkeypatch.setattr(jobs_mod, "_http_get_json", lambda url, **kw: (_ for _ in ()).throw(RuntimeError("down")))
+    assert jobs_mod._history_completed_nodes("127.0.0.1", 8188, "pid-j") == set()
+
+
+class _ScriptedWS:
+    """A `websocket.WebSocket` stand-in that replays a scripted message list.
+
+    Once the script is exhausted every `recv` raises the same timeout the real
+    socket raises, which is how the watch loop is driven to its snapshot check.
+    """
+
+    def __init__(self, messages):
+        self._messages = [m if isinstance(m, str) else json.dumps(m) for m in messages]
+        self.url = None
+        self.closed = False
+
+    def connect(self, url):
+        self.url = url
+
+    def settimeout(self, _t):
+        pass
+
+    def recv(self):
+        if not self._messages:
+            raise jobs_mod.WebSocketTimeoutException("timed out")
+        return self._messages.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+def _run_local_watch(monkeypatch, capsys, *, messages, prompt_id="pid-w", argv_extra=()):
+    """Drive `jobs watch` (local, NDJSON) over a scripted WS; return the lines."""
+    from typer.testing import CliRunner
+
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    ws = _ScriptedWS(messages)
+    monkeypatch.setattr(jobs_mod, "_server_or_error", lambda h, p, **kw: True)
+    monkeypatch.setattr(jobs_mod, "WebSocket", lambda *a, **k: ws)
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    result = CliRunner().invoke(
+        jobs_mod.app,
+        ["watch", prompt_id, "--where", "local", "--timeout", "1", *argv_extra],
+    )
+    # NDJSON goes to the CliRunner's captured stdout, not capsys — the renderer
+    # resolves its machine stream lazily, i.e. after the runner swapped it in.
+    capsys.readouterr()
+    lines = [json.loads(ln) for ln in result.output.splitlines() if ln.startswith("{")]
+    return result, ws, lines
+
+
+def test_watch_streams_events_and_reports_completed_nodes(monkeypatch, capsys):
+    """The BE-6856 regression, end to end: a multi-node job must produce MORE
+    THAN ONE NDJSON line during the watch, and the terminal envelope's
+    `completed_nodes` must list the nodes that ran."""
+    from comfy_cli import jobs_state
+
+    jobs_state.write(jobs_state.new(prompt_id="pid-w", client_id="cid-sub", workflow="w", where="local"))
+    monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: {"prompt_id": pid, "status": "running", "outputs": []})
+    monkeypatch.setattr(jobs_mod, "_history_completed_nodes", lambda h, p, pid: {"1"})
+
+    messages = [
+        {"type": "status", "data": {"status": {}, "sid": "cid-sub"}},  # no prompt_id -> ignored
+        {"type": "execution_cached", "data": {"prompt_id": "pid-w", "nodes": ["1"]}},
+        {"type": "executing", "data": {"prompt_id": "pid-w", "node": "3"}},
+        {
+            "type": "progress_state",
+            "data": {"prompt_id": "pid-w", "nodes": {"3": {"value": 4, "max": 8, "state": "running"}}},
+        },
+        {
+            "type": "progress_state",
+            "data": {"prompt_id": "pid-w", "nodes": {"3": {"value": 8, "max": 8, "state": "finished"}}},
+        },
+        {"type": "executed", "data": {"prompt_id": "pid-w", "node": "9", "output": {}}},
+        {"type": "execution_success", "data": {"prompt_id": "pid-w"}},
+    ]
+    result, ws, lines = _run_local_watch(monkeypatch, capsys, messages=messages)
+
+    assert result.exit_code == 0, result.output
+    # 1. The watch attached as the submitting session — the whole reason events
+    #    reach us at all (ComfyUI addresses them to that sid only).
+    assert "clientId=cid-sub" in ws.url
+    # 2. Intermediate events actually reached the stream.
+    assert len(lines) > 1, f"expected a stream, got a single envelope: {lines}"
+    types = [ln.get("type") for ln in lines[:-1]]
+    assert "execution_cached" in types and "executing" in types and "executed" in types
+    assert types.count("progress") >= 2, types
+    # 3. The terminal envelope is last, ok, and names the nodes that ran.
+    env = lines[-1]
+    assert env["type"] == "envelope" and env["ok"] is True
+    assert env["data"]["status"] == "completed"
+    assert env["data"]["completed_nodes"] == ["1", "3", "9"]
+    assert env["data"]["attached"] is True and env["data"]["client_id"] == "cid-sub"
+
+
+def test_watch_terminal_envelope_backfills_completed_nodes_without_events(monkeypatch, capsys):
+    """Symptom 2 is independent of streaming: even with zero WS events, the
+    envelope's `completed_nodes` comes from the server's own /history record."""
+    snapshots = iter(
+        [
+            {"prompt_id": "pid-w", "status": "running", "outputs": []},
+            {"prompt_id": "pid-w", "status": "completed", "outputs": ["http://x/view?f=1"]},
+        ]
+    )
+    monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: next(snapshots, None))
+    monkeypatch.setattr(jobs_mod, "_resolve_watch_client_id", lambda h, p, pid: None)
+    monkeypatch.setattr(jobs_mod, "_history_completed_nodes", lambda h, p, pid: {"4", "1"})
+
+    result, ws, lines = _run_local_watch(monkeypatch, capsys, messages=[])
+    assert result.exit_code == 0, result.output
+    env = lines[-1]
+    assert env["data"]["status"] == "completed"
+    assert env["data"]["completed_nodes"] == ["1", "4"]
+    # Unresolvable id -> a fresh one, flagged so a caller knows why it saw no
+    # events rather than guessing the job was silent.
+    assert env["data"]["attached"] is False
+    assert "clientId=" in ws.url
+
+
+def test_watch_already_terminal_job_still_lists_completed_nodes(monkeypatch, capsys):
+    """The short-circuit path (job already finished) also carries the node list."""
+    monkeypatch.setattr(
+        jobs_mod,
+        "_snapshot",
+        lambda h, p, pid: {"prompt_id": pid, "status": "completed", "outputs": [], "host": h, "port": p},
+    )
+    monkeypatch.setattr(jobs_mod, "_history_completed_nodes", lambda h, p, pid: {"2", "1"})
+    result, _ws, lines = _run_local_watch(monkeypatch, capsys, messages=[])
+    assert result.exit_code == 0, result.output
+    assert lines[-1]["data"]["completed_nodes"] == ["1", "2"]
+
+
+def test_watch_client_id_flag_overrides_resolution(monkeypatch, capsys):
+    monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: {"prompt_id": pid, "status": "running", "outputs": []})
+    monkeypatch.setattr(jobs_mod, "_resolve_watch_client_id", lambda h, p, pid: "resolved")
+    monkeypatch.setattr(jobs_mod, "_history_completed_nodes", lambda h, p, pid: set())
+    messages = [{"type": "execution_success", "data": {"prompt_id": "pid-w"}}]
+    _result, ws, lines = _run_local_watch(
+        monkeypatch, capsys, messages=messages, argv_extra=("--client-id", "forced id")
+    )
+    # Percent-encoded into the query string, never interpolated raw.
+    assert "clientId=forced%20id" in ws.url
+    assert lines[-1]["data"]["client_id"] == "forced id"
+
+
+def test_watch_terminal_envelope_validates_against_the_jobs_schema(monkeypatch, capsys):
+    """The additive `client_id`/`attached` keys are a published contract."""
+    import jsonschema
+
+    monkeypatch.setattr(jobs_mod, "_snapshot", lambda h, p, pid: {"prompt_id": pid, "status": "running", "outputs": []})
+    monkeypatch.setattr(jobs_mod, "_resolve_watch_client_id", lambda h, p, pid: "cid")
+    monkeypatch.setattr(jobs_mod, "_history_completed_nodes", lambda h, p, pid: {"1"})
+    messages = [{"type": "execution_success", "data": {"prompt_id": "pid-w"}}]
+    _result, _ws, lines = _run_local_watch(monkeypatch, capsys, messages=messages)
+
+    schema_path = Path(jobs_mod.__file__).parent.parent / "schemas" / "jobs.json"
+    schema = json.loads(schema_path.read_text())
+    jsonschema.Draft202012Validator(schema).validate(lines[-1]["data"])
+    assert schema["properties"]["attached"]["type"] == "boolean"
+    assert schema["properties"]["client_id"]["type"] == ["string", "null"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

`comfy --json-stream jobs watch <prompt_id>` used to sit there in total silence while a job ran, then print one line at the end that claimed no nodes had run. It turns out ComfyUI does not shout its progress to everyone connected — it whispers it to whoever submitted the job. `jobs watch` was walking in wearing a brand new name tag, so nobody ever spoke to it. Now it walks in wearing the *submitter's* name tag, understands the newer per-step progress message ComfyUI actually sends, and — separately from the live stream — asks the server directly which nodes ran so the final line is right no matter when you started watching.

## Problem

Reproduced by driving comfy-cli directly (no MCP layer): `comfy jobs watch` emitted exactly one envelope, at the end, with `completed_nodes: []` and `elapsed_seconds` suspiciously equal to the 30s `--timeout`.

Three distinct causes, all in the local WS path:

1. **A local ComfyUI server does not broadcast execution events.** It addresses `executing` / `executed` / `execution_cached` / `progress_state` / `execution_success` to the socket of the session that submitted the prompt — `send_sync(event, data, server.client_id)` in `execution.py` (and `server.client_id` is set from the submitting prompt's `extra_data["client_id"]`), delivered by `PromptServer.send_json` only when `sid in self.sockets`. `jobs watch` connected with a fresh `uuid4()` clientId, so **zero** execution events could ever reach it. The one envelope it did print came from the `recv`-timeout `/history` snapshot fallback — hence the ~30s elapsed even for a job that finished sooner.
2. **Current ComfyUI sends `progress_state`, not `progress`.** Per-step progress moved to `comfy_execution/progress.py`'s combined per-node `progress_state` message; `watch` only knew the legacy `progress` type, so even with the right client_id there would have been no per-step events.
3. **`completed_nodes` was stream-only.** Nothing ever reconciled it against the server's own record, so the end-state summary was wrong independently of streaming — exactly as the ticket scoped it.

Modern ComfyUI also no longer ends a prompt with `executing` + `node: null`; it sends `execution_success`. `watch` did not handle that either, which is why even a correctly-attached watch would have idled for a full `--timeout` after the job was already done.

## What changed

- `_resolve_watch_client_id()` — find the prompt's submitting `client_id` and reconnect under it: the job state file `comfy run` writes at submit, else `/queue` `extra_data`, else `/history` `prompt[3]`. Falls back to a fresh id (previous behaviour) and, in pretty mode, says so.
- `--client-id` — explicit override; the id is percent-encoded into the query string rather than interpolated raw.
- `progress_state` handler — per-node `progress` events throttled at 10 Hz, with the terminal 100%/errored line emitted unthrottled and exactly once (`progress_state` resends every non-pending node on every message). Values are coerced to the `integer|null` `run_event.json` declares, since `NodeProgressState.value` is a float. The legacy `progress` handler is untouched, so older servers keep working.
- `execution_success` / `execution_interrupted` handlers — end on the server's signal instead of idling out `--timeout`; the latter (and `execution_error`) also fold their `executed` node list into `completed_nodes`, the only record of what ran on an abnormal exit.
- `_history_completed_nodes()` — the server's own answer to "which nodes ran", union'd into `completed_nodes` on every exit path (including the already-finished short-circuit, which previously had no `completed_nodes` key at all). Derived *after* `final_status`, so it can only correct an under-reported node list and can never invent a terminal status the stream did not observe.
- Envelope gains `client_id` and `attached`; `schemas/jobs.json` and `docs/json-output.md` document both plus the attach semantics.

## Verify

Per the ticket: a stream of per-node/per-step events during execution, and a terminal envelope whose `completed_nodes` lists the nodes that ran.

- `test_watch_streams_events_and_reports_completed_nodes` — drives the real `watch` command over a scripted WS and asserts **more than one NDJSON line** for a multi-node job, that `execution_cached`/`executing`/`executed` and ≥2 `progress` lines are among them, that the connect URL carried the submitting `clientId`, and that the terminal envelope's `completed_nodes == ["1", "3", "9"]`.
- `test_watch_terminal_envelope_backfills_completed_nodes_without_events` — symptom 2 with **zero** WS events: `completed_nodes` still non-empty.
- `test_watch_already_terminal_job_still_lists_completed_nodes`, `test_watch_client_id_flag_overrides_resolution`, `test_watch_terminal_envelope_validates_against_the_jobs_schema`, plus unit coverage for each new handler, `_progress_int` coercion (incl. `nan`/`inf`/`bool`), the three client_id resolution sources + the unreachable-server and junk-payload paths.

`ruff check` and `ruff format --check` are clean on the touched files, and the full `pytest` suite is green: **4360 passed, 36 skipped** in 12m44s.

## Judgment calls

- **Re-attaching under an existing `client_id` evicts a submitter that is still holding that socket.** ComfyUI's `/ws` handler pops the previous socket for a reused id — that is its own session-resume mechanism (a browser reload relies on it), and it is the only way to receive events at all, since there is no broadcast path for an already-submitted prompt. The dominant case is harmless: `comfy run --async` has exited by the time you watch. But a live submitter (an open browser tab, a concurrent blocking `comfy run`) stops receiving events until it reconnects. `--client-id` is the escape hatch; resolution prefers the CLI's own job state file, which is the zero-risk source. Flagging it rather than hiding it — an alternative that keeps a live submitter whole does not exist server-side today.
- **Scope held to `jobs watch`.** `comfy run --wait --json` shares cause 2 (it also only handles the legacy `progress` type, so it streams `executing`/`executed` but no per-step progress). That is a real adjacent gap and a natural follow-up; it is not what this ticket reproduced, and folding it in would widen the diff past what the fix needs. The cloud watch path (`--where cloud`) polls and is unaffected.
- `git log -L` on the old `client_id = str(uuid.uuid4())` line shows it arrived in the initial `jobs.py` commit (#470) with no intent behind the freshness — it was not a deliberate isolation choice, so replacing it is a fix, not a reversal of a decision.
