### PR TITLE
fix(jobs): make schemas/jobs.json host/port required only for non-cloud payloads

### DIFF
--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -4,11 +4,18 @@
   "title": "comfy jobs --json data payload",
   "description": "Union schema for `jobs ls`, `jobs status`, and `jobs watch`.",
   "type": "object",
-  "required": ["host", "port"],
+  "required": [],
+  "if": {"required": ["base_url"]},
+  "then": {},
+  "else": {"required": ["host", "port"]},
   "additionalProperties": true,
   "properties": {
     "host": {"type": "string"},
     "port": {"type": "integer"},
+    "base_url": {
+      "type": "string",
+      "description": "Cloud-only counterpart to `host` + `port`: the cloud API base URL a `jobs status`/`jobs watch --where cloud` payload came from. A payload carrying it is exempt from the host+port requirement, since cloud has no host/port to report."
+    },
     "prompt_id": {"type": "string"},
     "status": {
       "type": "string",

--- a/comfy_cli/schemas/jobs.json
+++ b/comfy_cli/schemas/jobs.json
@@ -5,7 +5,7 @@
   "description": "Union schema for `jobs ls`, `jobs status`, and `jobs watch`.",
   "type": "object",
   "required": [],
-  "if": {"required": ["base_url"]},
+  "if": {"required": ["base_url"], "properties": {"base_url": {"minLength": 1}}},
   "then": {},
   "else": {"required": ["host", "port"]},
   "additionalProperties": true,
@@ -14,7 +14,8 @@
     "port": {"type": "integer"},
     "base_url": {
       "type": "string",
-      "description": "Cloud-only counterpart to `host` + `port`: the cloud API base URL a `jobs status`/`jobs watch --where cloud` payload came from. A payload carrying it is exempt from the host+port requirement, since cloud has no host/port to report."
+      "minLength": 1,
+      "description": "Cloud-only counterpart to `host` + `port`: the cloud API base URL a `jobs status`/`jobs watch --where cloud` payload came from. A payload carrying a non-empty one is exempt from the host+port requirement, since cloud has no host/port to report. An empty string identifies no source URL, so it neither satisfies this property nor buys the exemption — the `if` re-checks `minLength` so such a payload falls to the `else` branch and still owes `host` + `port`."
     },
     "prompt_id": {"type": "string"},
     "status": {

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -3431,3 +3431,30 @@ def test_jobs_schema_still_requires_host_and_port_without_base_url():
     # Both legitimate shapes still validate.
     validator.validate({"prompt_id": "p", "status": "completed", "host": "127.0.0.1", "port": 8188})
     validator.validate({"prompt_id": "p", "status": "completed", "base_url": "https://api.comfy.example"})
+
+
+def test_jobs_schema_empty_base_url_does_not_buy_the_host_port_exemption():
+    """An empty `base_url` names no source URL, so it must not be the key that
+    unlocks the cloud exemption. Guarded twice on purpose: `minLength` on the
+    property rejects the empty string outright, and the same `minLength` inside
+    the `if` keeps such a payload in the `else` branch, where it still owes
+    `host` + `port` — so neither guard alone is load-bearing."""
+    import jsonschema
+
+    schema = _jobs_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate({"prompt_id": "p", "status": "completed", "base_url": ""})
+
+    # The `if` branch alone: strip the property-level `minLength` and the empty
+    # `base_url` must STILL be rejected, now for missing `host` + `port`.
+    del schema["properties"]["base_url"]["minLength"]
+    errors = list(
+        jsonschema.Draft202012Validator(schema).iter_errors({"prompt_id": "p", "status": "completed", "base_url": ""})
+    )
+    assert errors, "empty base_url must fall to the `else` branch and be held to host+port"
+    assert any("host" in e.message for e in errors), [e.message for e in errors]
+
+    # A real cloud payload is untouched by either guard.
+    validator.validate({"prompt_id": "p", "status": "completed", "base_url": "https://api.comfy.example"})

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -3345,3 +3345,89 @@ def test_ls_payload_validates_against_the_jobs_schema(capsys, monkeypatch):
     # asserting against an enum that never sees this value.
     assert data["jobs"][0]["status"] == "cancelled"
     assert schema["properties"]["jobs"]["items"]["properties"]["error_code"]["type"] == ["string", "null"]
+
+
+# ---------------------------------------------------------------------------
+# schemas/jobs.json — host/port is required only for host/port-shaped payloads
+# ---------------------------------------------------------------------------
+
+
+def _jobs_schema() -> dict:
+    return json.loads((Path(jobs_mod.__file__).parent.parent / "schemas" / "jobs.json").read_text())
+
+
+def _fake_cloud_client(raw_status: str, outputs: list[dict] | None = None):
+    """Stand-in for `comfy_cli.api.Client` covering everything the cloud
+    status/watch path touches: the three calls `_cloud_status_snapshot` makes
+    and the `target.base_url` it stamps onto every snapshot."""
+    return SimpleNamespace(
+        target=SimpleNamespace(base_url="https://api.comfy.example"),
+        get_job_status=lambda pid: {
+            "status": raw_status,
+            "assigned_inference": "inference-1",
+            "error_message": None,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:01:00Z",
+        },
+        get_history=lambda pid: {"outputs": {}},
+        extract_outputs=lambda record: list(outputs or []),
+    )
+
+
+def test_jobs_watch_cloud_terminal_envelope_is_schema_conformant(monkeypatch: pytest.MonkeyPatch):
+    """`comfy --json jobs watch --where cloud <id>` emits a terminal payload
+    that validates against `schemas/jobs.json` with ZERO tolerated errors.
+
+    Cloud has no host/port to report — `_cloud_status_snapshot` reports the
+    `base_url` it polled instead — so the schema's top-level requirement is
+    conditional: a payload carrying `base_url` is exempt from `host` + `port`.
+    """
+    import jsonschema
+    from typer.testing import CliRunner
+
+    from comfy_cli.output import Renderer, set_renderer
+    from comfy_cli.output.renderer import OutputMode
+
+    monkeypatch.setattr(jobs_mod, "_is_cloud", lambda w: True)
+    monkeypatch.setattr(jobs_mod, "cloud_preflight_or_exit", lambda: None)
+    monkeypatch.setattr(
+        jobs_mod,
+        "_cloud_client",
+        lambda: _fake_cloud_client("success", outputs=[{"url": "https://cdn.example/out.png", "node_id": "9"}]),
+    )
+
+    set_renderer(Renderer(mode=OutputMode.NDJSON, command="jobs watch"))
+    result = CliRunner().invoke(jobs_mod.app, ["watch", "cloud-p1", "--where", "cloud"])
+    assert result.exit_code == 0, result.output
+
+    data = _last_json(result.stdout)["data"]
+    # The shape the conditional exists for: base_url present, host/port absent.
+    assert data["base_url"] == "https://api.comfy.example"
+    assert "host" not in data and "port" not in data
+    assert data["status"] == "completed"
+    assert data["outputs"] == ["https://cdn.example/out.png"]
+
+    errors = list(jsonschema.Draft202012Validator(_jobs_schema()).iter_errors(data))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_jobs_schema_still_requires_host_and_port_without_base_url():
+    """The `if base_url / else host+port` conditional must not weaken the local
+    guarantee: a payload with neither `base_url` nor `host`/`port` is still a
+    contract violation. Without this, a future edit to the conditional could
+    silently drop the requirement for every payload, not just cloud ones."""
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(_jobs_schema())
+
+    # Local-shaped payload missing both — the `else` branch must reject it.
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate({"prompt_id": "p", "status": "completed"})
+
+    # A partial local payload is still short of the requirement.
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate({"prompt_id": "p", "status": "completed", "host": "127.0.0.1"})
+
+    # Both legitimate shapes still validate.
+    validator.validate({"prompt_id": "p", "status": "completed", "host": "127.0.0.1", "port": 8188})
+    validator.validate({"prompt_id": "p", "status": "completed", "base_url": "https://api.comfy.example"})

--- a/tests/comfy_cli/output/test_envelope_schemas.py
+++ b/tests/comfy_cli/output/test_envelope_schemas.py
@@ -52,6 +52,10 @@ def _validator_for(name: str) -> jsonschema.Validator:
         "download.json",
         "download_status.json",
         "downloads.json",
+        # Carries an `if`/`then`/`else` conditional (host+port required only
+        # for payloads without a cloud `base_url`), so its well-formedness is
+        # worth pinning rather than assuming.
+        "jobs.json",
     ],
 )
 def test_schemas_are_well_formed(schema_name):


### PR DESCRIPTION
## ELI-5

`comfy jobs status`/`jobs watch` publish a machine-readable JSON schema so agents know what a payload looks like. That schema said "every payload must have a `host` and a `port`" — but cloud jobs don't run on a host and port, they run behind a cloud URL, so every cloud `status`/`watch` payload broke its own published contract. This makes the requirement conditional: if a payload reports a cloud `base_url`, it doesn't need `host`/`port`; otherwise it still does.

## What changed

`comfy_cli/schemas/jobs.json` — the schema `comfy --json discover --schemas-only` publishes for `jobs ls`/`status`/`watch` (wired in `comfy_cli/discovery.py`'s `COMMAND_SCHEMAS`) — declared a flat top-level `"required": ["host", "port"]`. The cloud producer `_cloud_status_snapshot` (behind `comfy --json jobs status --where cloud <id>` and `comfy --json jobs watch --where cloud <id>`) stamps the `base_url` it polled and never sets `host`/`port`, because cloud has none to report. Every such payload therefore failed strict validation against the CLI's own published schema.

- Replaced the unconditional `required` with `"required": []` + `"if": {"required": ["base_url"]}` / `"then": {}` / `"else": {"required": ["host", "port"]}` at the same top level. Local payloads are unchanged — with no `base_url` the `else` branch still requires both fields.
- Declared `base_url` in `properties` (previously only tolerated via `additionalProperties: true`, undeclared) with a description noting it is the cloud-only counterpart to `host` + `port`.
- Added `jobs.json` to the existing `test_schemas_are_well_formed` parametrization in `tests/comfy_cli/output/test_envelope_schemas.py`, which runs `jsonschema.Draft202012Validator.check_schema` — reusing the existing schema-validity test rather than adding a new one, since the schema now carries a conditional worth pinning.
- `tests/comfy_cli/jobs/test_jobs.py`: a new end-to-end test drives `_cloud_watch` through the CLI against a fake cloud client, captures the terminal NDJSON envelope, and asserts it validates against `schemas/jobs.json` with **zero** errors (no filtering).
- `tests/comfy_cli/jobs/test_jobs.py`: a negative-case test asserting a minimal local-shaped payload with neither `base_url` nor `host`/`port` still raises `ValidationError`, so a future edit to the conditional can't silently weaken the local guarantee. It also pins that both legitimate shapes (host+port, and base_url) validate.

Deliberately untouched, per scope: `schemas/jobs_wait.json` (`jobs wait --where cloud` validates against it and it has no host/port requirement), `_cloud_job_to_row`, and `jobs ls`'s emit call (`jobs ls --where cloud` always populates host/port from local defaults before emitting, so it was already conformant — and its existing `test_ls_payload_validates_against_the_jobs_schema` still passes unchanged).

## Verification

- `pytest` (full suite): **4340 passed, 36 skipped** — includes `tests/comfy_cli/jobs/` and `tests/comfy_cli/output/test_discovery.py`, which round-trips `load_all_schemas()` over every shipped schema.
- `ruff check` / `ruff format --check` clean on every touched file. (`ruff check .` repo-wide reports 17 pre-existing `UP038` hits in `comfy_cli/workflow_to_api.py`, untouched by this PR.)
- Verified the change is load-bearing rather than cosmetic: the pre-change schema rejects a cloud payload with `'host' is a required property` / `'port' is a required property`; the post-change schema accepts it and still rejects a host/port-less local payload.

## Judgment calls / things a reviewer should know

- **PR #685 (`matt/be-6644-cloud-status-aliases`) had not merged when this was written** (checked: `state: OPEN`, `mergedAt: null`). That PR adds `test_jobs_status_cloud_in_progress_envelope_is_schema_conformant`, which currently filters out exactly the `required: ["host", "port"]` errors this PR eliminates. **The two PRs need a human reconciliation on whichever lands second:** once both are in, that test's error filter (`if not (e.validator == "required" and e.validator_value == ["host", "port"])`) is dead weight and should be simplified to `errors = list(jsonschema.Draft202012Validator(schema).iter_errors(data))`, with the docstring paragraph explaining the tolerated violation dropped — there is no longer a tolerated violation. I did not touch that test because it does not exist on `main` yet.
- Consequently this branch's only cloud schema-conformance test covers the `jobs watch` terminal payload. It exercises the same producer (`_cloud_status_snapshot`) that `jobs status --where cloud` emits, so the schema fix is covered either way; #685 adds the `status`-side test.
- `"then": {}` is a no-op in JSON Schema (an absent `then` behaves identically), but it is kept explicit so the three-way conditional reads as one unit rather than looking like a half-written branch.
- `base_url`'s description is a full property object rather than a one-liner because the note about why it exempts host/port is the useful part for a schema consumer; this matches how the other explanatory properties in this file are written.
