### PR TITLE
feat(downloads): bound .comfy-downloads/ growth with download_state.prune (BE-6897)

### DIFF
--- a/comfy_cli/command/models/models.py
+++ b/comfy_cli/command/models/models.py
@@ -739,6 +739,12 @@ def _submit_background_download(
         needs_hf_auth=needs_hf_auth,
     )
 
+    # Retire finished records before adding one, so submitting downloads is what
+    # bounds the state directory rather than something the user has to remember
+    # to do. Purely bookkeeping: never let it fail a submit.
+    with contextlib.suppress(Exception):
+        download_state.prune(workspace)
+
     try:
         # The parent directory has to exist before the worker starts writing, and
         # creating it here means a permission problem surfaces synchronously.
@@ -980,7 +986,12 @@ def download_status(
 def downloads(_ctx: typer.Context):
     """List every background download this workspace knows about, newest first."""
     renderer = get_renderer()
-    rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(get_workspace())]
+    workspace = get_workspace()
+    # Trim before listing: this is the verb whose cost — and whose output — grows
+    # with every record the directory has ever accumulated.
+    with contextlib.suppress(Exception):
+        download_state.prune(workspace)
+    rows = [download_state.status_payload(_reconciled(s)[0]) for s in download_state.list_all(workspace)]
     if not rows:
         print("No background downloads found.")
     else:

--- a/comfy_cli/download_state.py
+++ b/comfy_cli/download_state.py
@@ -61,7 +61,7 @@ import sys
 import time
 import uuid
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -91,6 +91,14 @@ PID_CREATE_TIME_TOLERANCE_S = 1.0
 # Every worker's argv contains this; used to identify a worker when its start
 # time was never recorded.
 WORKER_ARGV_MARKER = "_download-worker"
+
+# How long a finished download's record is kept before :func:`prune` drops it.
+PRUNE_MAX_AGE_S = 7 * 24 * 60 * 60
+
+# Hard ceiling on retained *terminal* records, applied on top of the age rule so
+# a burst of downloads can't leave the directory (and `downloads`' output) large
+# for a week. Active records are never counted or evicted.
+PRUNE_MAX_TERMINAL_RECORDS = 200
 
 _SAFE_ID = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
@@ -312,14 +320,116 @@ def read_path(path: Path) -> DownloadState | None:
         return None
 
 
+def _sort_key(state: DownloadState) -> tuple[str, str]:
+    """The newest-first ordering :func:`list_all` and :func:`prune` share.
+
+    They must agree: ``prune`` evicts the records that fall off the end of the
+    list ``downloads`` shows, so a divergent tiebreak would drop a record the
+    user is still looking at while keeping one they aren't.
+    """
+    return (state.started_at or "", state.id)
+
+
 def list_all(workspace: Path) -> list[DownloadState]:
     """Every readable state file, newest ``started_at`` first."""
     base = Path(workspace) / STATE_DIRNAME
     if not base.is_dir():
         return []
     states = [s for s in (read_path(p) for p in sorted(base.glob("*.json"))) if s is not None]
-    states.sort(key=lambda s: (s.started_at or "", s.id), reverse=True)
+    states.sort(key=_sort_key, reverse=True)
     return states
+
+
+def _has_partials(dest: str) -> bool:
+    """True while a ``.part`` sibling of ``dest`` still holds bytes on disk.
+
+    This is the same set of files ``download-cancel`` reclaims, so it is also
+    the only handle a user has left on those bytes once a download has failed.
+    """
+    from comfy_cli import file_utils
+
+    try:
+        return bool(file_utils.partial_paths_for(Path(dest)))
+    except (OSError, ValueError):
+        # An unreadable parent or a nonsense dest tells us nothing about the
+        # partial; assume there is one rather than deleting the record that
+        # points at it.
+        return True
+
+
+def _remove_record(path: Path) -> bool:
+    """Delete one state file and its companions. False if the record survived.
+
+    The ``<id>.log`` and ``<id>.cancel`` siblings are unreachable once the
+    record naming them is gone — no verb can look them up — so they go with it,
+    otherwise pruning the records alone would leave the directory growing.
+    """
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        return False
+    for companion in (path.with_name(f"{path.stem}.log"), cancel_marker_for(path)):
+        try:
+            companion.unlink(missing_ok=True)
+        except OSError:
+            continue
+    return True
+
+
+def prune(workspace: Path) -> int:
+    """Drop finished download records that are stale or over the retention cap.
+
+    Nothing else ever removes a record, so ``<workspace>/.comfy-downloads``
+    would otherwise grow for the life of the workspace — and ``list_all`` reads
+    and JSON-parses every file in it on every ``comfy model downloads`` call.
+
+    A record is removed when it is **terminal** (:data:`TERMINAL_STATUSES`) and
+    either:
+
+    * its ``updated_at`` is older than :data:`PRUNE_MAX_AGE_S` — except for a
+      ``failed``/``cancelled`` record whose destination still has a ``.part``
+      sibling. Those bytes are on disk and the record is the user's only handle
+      for reclaiming them with ``download-cancel``, which is the same contract
+      :func:`comfy_cli.file_utils.cleanup_partials` is written to; or
+    * it falls outside the newest :data:`PRUNE_MAX_TERMINAL_RECORDS` terminal
+      records. That ceiling is what makes the directory *bounded* rather than
+      merely self-expiring, so unlike the age rule it applies unconditionally.
+
+    An in-flight record (``starting``/``downloading``) is never touched at any
+    age, and never counts toward — or is evicted by — the cap.
+
+    Every step is best effort, exactly like :func:`write_path`'s OSError
+    handling: a read-only state directory, a permissions problem, or a file a
+    concurrent prune already removed must never raise into a download. Returns
+    the number of records actually removed.
+    """
+    base = Path(workspace) / STATE_DIRNAME
+    try:
+        if not base.is_dir():
+            return 0
+        paths = sorted(base.glob("*.json"))
+    except OSError:
+        return 0
+
+    terminal: list[tuple[DownloadState, Path]] = []
+    for path in paths:
+        state = read_path(path)
+        if state is not None and state.status in TERMINAL_STATUSES:
+            terminal.append((state, path))
+    terminal.sort(key=lambda item: _sort_key(item[0]), reverse=True)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=PRUNE_MAX_AGE_S)
+    removed = 0
+    for index, (state, path) in enumerate(terminal):
+        if index < PRUNE_MAX_TERMINAL_RECORDS:
+            updated = _parse_iso(state.updated_at)
+            if updated is None or updated >= cutoff:
+                continue
+            if state.status in ("failed", "cancelled") and _has_partials(state.dest):
+                continue
+        if _remove_record(path):
+            removed += 1
+    return removed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,7 +21,7 @@ import httpx
 import pytest
 import typer
 
-from comfy_cli import download_state
+from comfy_cli import download_state, file_utils
 from comfy_cli.command.models import models
 from comfy_cli.file_utils import DownloadException, _download_file_httpx, download_file
 from comfy_cli.output import Renderer, set_renderer
@@ -120,6 +121,235 @@ class TestStatePersistence:
 
     def test_list_all_on_missing_dir(self, tmp_path):
         assert download_state.list_all(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# 1.5 retention: prune() is the only thing that removes a record
+# ---------------------------------------------------------------------------
+
+_OLD_S = download_state.PRUNE_MAX_AGE_S + 3600
+
+
+def _stamp(seconds_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat(timespec="seconds")
+
+
+def _record(workspace, *, status="completed", age_s=0.0, dest=None):
+    """Persist a state file with an exact age.
+
+    Written by hand rather than through ``write()``, which stamps ``updated_at``
+    with *now* and so can't produce the stale records prune is about.
+    """
+    dest = Path(dest) if dest is not None else workspace / "m.safetensors"
+    state = download_state.new(url="https://example.com/m.safetensors", dest=str(dest))
+    state.status = status
+    state.started_at = state.updated_at = _stamp(age_s)
+    path = download_state.state_path(workspace, state.id)
+    path.write_text(json.dumps(state.to_dict(), indent=2), encoding="utf-8")
+    return state
+
+
+def _make_partial(dest: Path) -> Path:
+    """A ``.part`` sibling shaped exactly like the ones the downloader mkstemps."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    partial = dest.parent / f"{dest.name}.ab3d9f01.part"
+    partial.write_bytes(b"partial bytes")
+    assert file_utils.partial_paths_for(dest) == [partial], "test fixture is not shaped like a real .part"
+    return partial
+
+
+def _ids_on_disk(workspace) -> set[str]:
+    return {p.stem for p in download_state.state_dir(workspace).glob("*.json")}
+
+
+class TestPrune:
+    def test_stale_terminal_record_is_removed(self, workspace):
+        state = _record(workspace, status="completed", age_s=_OLD_S)
+
+        assert download_state.prune(workspace) == 1
+        assert download_state.read(workspace, state.id) is None
+
+    def test_fresh_terminal_record_is_kept(self, workspace):
+        state = _record(workspace, status="completed", age_s=3600)
+
+        assert download_state.prune(workspace) == 0
+        assert download_state.read(workspace, state.id) is not None
+
+    @pytest.mark.parametrize("status", ["starting", "downloading"])
+    def test_in_flight_records_are_never_removed_at_any_age(self, workspace, status):
+        """An active worker still owns its record — age says nothing about that."""
+        state = _record(workspace, status=status, age_s=_OLD_S * 100)
+
+        assert download_state.prune(workspace) == 0
+        assert download_state.read(workspace, state.id) is not None
+
+    @pytest.mark.parametrize("status", ["failed", "cancelled"])
+    def test_a_partial_pins_a_failed_or_cancelled_record(self, workspace, status):
+        """Those bytes are on disk and this record is the only handle on them."""
+        dest = workspace / "models" / "m.safetensors"
+        state = _record(workspace, status=status, age_s=_OLD_S, dest=dest)
+        partial = _make_partial(dest)
+
+        assert download_state.prune(workspace) == 0
+        assert download_state.read(workspace, state.id) is not None
+
+        # Once the disk is reclaimed there is nothing left to point at.
+        partial.unlink()
+        assert download_state.prune(workspace) == 1
+        assert download_state.read(workspace, state.id) is None
+
+    def test_a_partial_does_not_pin_a_completed_record(self, workspace):
+        """The carve-out is about unreclaimed bytes; a completed download's are
+        at `dest`, and any leftover `.part` is unrelated debris."""
+        dest = workspace / "models" / "m.safetensors"
+        state = _record(workspace, status="completed", age_s=_OLD_S, dest=dest)
+        partial = _make_partial(dest)
+
+        assert download_state.prune(workspace) == 1
+        assert download_state.read(workspace, state.id) is None
+        assert partial.exists(), "prune must not touch the user's bytes"
+
+    def test_the_cap_keeps_the_newest_records_and_evicts_oldest_first(self, workspace):
+        cap = download_state.PRUNE_MAX_TERMINAL_RECORDS
+        # All well inside the 7-day window, so only the cap can remove them.
+        states = [_record(workspace, status="completed", age_s=i) for i in range(cap + 5)]
+        newest = {s.id for s in states[:cap]}
+
+        assert download_state.prune(workspace) == 5
+        assert _ids_on_disk(workspace) == newest
+        assert len(download_state.list_all(workspace)) == cap
+
+    def test_the_cap_ignores_in_flight_records(self, workspace):
+        cap = download_state.PRUNE_MAX_TERMINAL_RECORDS
+        terminal = [_record(workspace, status="completed", age_s=i) for i in range(cap)]
+        active = [_record(workspace, status="downloading", age_s=1000 + i) for i in range(5)]
+
+        assert download_state.prune(workspace) == 0
+        assert _ids_on_disk(workspace) == {s.id for s in terminal + active}
+
+    def test_the_cap_overrides_the_partial_carve_out(self, workspace):
+        """The cap is what makes the directory bounded rather than merely
+        self-expiring, so unlike the age rule it applies unconditionally."""
+        cap = download_state.PRUNE_MAX_TERMINAL_RECORDS
+        dest = workspace / "models" / "m.safetensors"
+        _make_partial(dest)
+        oldest = _record(workspace, status="failed", age_s=10_000, dest=dest)
+        [_record(workspace, status="completed", age_s=i) for i in range(cap)]
+
+        assert download_state.prune(workspace) == 1
+        assert download_state.read(workspace, oldest.id) is None
+
+    def test_companion_log_and_cancel_files_go_with_the_record(self, workspace):
+        state = _record(workspace, status="completed", age_s=_OLD_S)
+        log = download_state.log_path(workspace, state.id)
+        log.write_text("worker output")
+        cancel = download_state.cancel_path(workspace, state.id)
+        cancel.touch()
+
+        assert download_state.prune(workspace) == 1
+        assert not log.exists()
+        assert not cancel.exists()
+
+    def test_a_corrupt_file_is_left_alone(self, workspace):
+        """`read_path` reads it as absent, so prune has no status to judge it by
+        and must not guess — deleting unparseable state is not its job."""
+        path = download_state.state_path(workspace, "deadbeefcafe")
+        path.write_text("{not json")
+
+        assert download_state.prune(workspace) == 0
+        assert path.exists()
+
+    def test_a_garbage_timestamp_is_not_treated_as_ancient(self, workspace):
+        state = _record(workspace, status="completed", age_s=_OLD_S)
+        path = download_state.state_path(workspace, state.id)
+        data = json.loads(path.read_text())
+        data["updated_at"] = "not a timestamp"
+        path.write_text(json.dumps(data))
+
+        assert download_state.prune(workspace) == 0
+        assert path.exists()
+
+    def test_missing_state_dir_is_a_no_op(self, tmp_path):
+        assert download_state.prune(tmp_path / "nope") == 0
+
+    def test_an_undeletable_record_is_a_silent_no_op(self, workspace, monkeypatch):
+        """A read-only state directory must never raise into a download."""
+        state = _record(workspace, status="completed", age_s=_OLD_S)
+
+        def refuse(*args, **kwargs):
+            raise OSError("Read-only file system")
+
+        monkeypatch.setattr(Path, "unlink", refuse)
+
+        assert download_state.prune(workspace) == 0
+        assert download_state.read(workspace, state.id) is not None
+
+    def test_a_failing_prune_never_blocks_a_submit(self, workspace, monkeypatch, json_renderer):
+        _record(workspace, status="completed", age_s=_OLD_S)
+        monkeypatch.setattr(Path, "unlink", lambda *a, **k: (_ for _ in ()).throw(OSError("Read-only file system")))
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+        )
+
+        env = json_renderer()
+        assert env["ok"] is True
+        assert env["data"]["status"] == "starting"
+
+    def test_an_exploding_prune_never_blocks_a_submit(self, workspace, monkeypatch, json_renderer):
+        """Belt and braces for the call site: even a non-OSError out of prune."""
+
+        def boom(_workspace):
+            raise RuntimeError("prune blew up")
+
+        monkeypatch.setattr(download_state, "prune", boom)
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+        )
+
+        assert json_renderer()["ok"] is True
+
+    def test_submit_prunes(self, workspace, monkeypatch, json_renderer):
+        calls = []
+        monkeypatch.setattr(download_state, "prune", lambda ws: calls.append(ws))
+        monkeypatch.setattr(models, "_spawn_download_worker", lambda state_file, log_file: 31337)
+
+        models.download(
+            None,
+            url="https://example.com/m.safetensors",
+            relative_path="models/loras",
+            filename="m.safetensors",
+            background=True,
+        )
+
+        assert calls == [workspace]
+        # The record submit just wrote must survive its own prune.
+        assert download_state.read(workspace, json_renderer()["data"]["download_id"]) is not None
+
+    def test_downloads_prunes_before_listing(self, workspace, monkeypatch, json_renderer):
+        stale = _record(workspace, status="completed", age_s=_OLD_S)
+        fresh = _record(workspace, status="completed", age_s=60)
+        calls = []
+        real_prune = download_state.prune
+        monkeypatch.setattr(download_state, "prune", lambda ws: (calls.append(ws), real_prune(ws))[1])
+
+        models.downloads(None)
+
+        assert calls == [workspace]
+        listed = {row["id"] for row in json_renderer()["data"]["downloads"]}
+        assert listed == {fresh.id}
+        assert download_state.read(workspace, stale.id) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ELI-5

Every time you start a background model download, comfy-cli drops a little bookkeeping file in `<workspace>/.comfy-downloads/`. Nothing ever threw those away — not `download-cancel`, not any poll command — so the folder grew forever, and `comfy model downloads` had to open and parse every file in it just to show you a list that was mostly ancient history. This adds a tidy-up pass that runs automatically, keeps anything still downloading plus the recent stuff, and throws out the rest.

## What changed

`download_state.prune(workspace) -> int` removes a state record only when it is **terminal** (`completed` / `failed` / `cancelled`) and either:

- its `updated_at` is older than 7 days — **except** a `failed`/`cancelled` record whose `dest` still has a `.part` sibling (`file_utils.partial_paths_for`). Those bytes are on disk and the record is the user's only handle for reclaiming them with `download-cancel`, which is the contract `cleanup_partials` already implements. `completed` gets no such carve-out.
- or it falls outside the newest `PRUNE_MAX_TERMINAL_RECORDS` (200) terminal records, ordered by the same `(started_at, id)` sort `list_all` uses. Evicts oldest-first, regardless of age.

A `starting`/`downloading` record is never touched at any age, and never counts toward — or is evicted by — the cap.

Everything is best effort, matching `write_path`'s OSError handling: every stat/unlink is wrapped, a read-only state directory or a file a concurrent prune already removed is a silent no-op, and nothing can raise into or abort a download. Deletion is `Path.unlink(missing_ok=True)` directly — no public `delete()` helper, so this stays self-contained and does not collide with the unrelated `delete()` introduced by the unmerged #688.

Wired into the only two places that touch `.comfy-downloads/` on `main` today, each wrapped so any exception is swallowed:

1. `_submit_background_download` — prunes just before writing the new record (so the new record can never be pruned by its own call).
2. `downloads()` — prunes before `list_all`, i.e. the verb whose cost and output both grow with the directory.

Scoped strictly to the `--background` path and `download_state.py` per the ticket; nothing here builds against `_active_download_for`, `_enforce_claim`, or a `kind` field, none of which exist on `main`.

## Judgment calls

**1. The 200-record cap overrides the `.part` carve-out.** The ticket says the cap applies "regardless of the 7-day rule", and the carve-out is written as an exception *to* that rule. I implemented it as unconditional because that is what makes the directory genuinely *bounded* rather than merely self-expiring — with the carve-out honoured at the cap, an unbounded pile of failed downloads with `.part` siblings could never be pruned, which is the exact growth this ticket exists to stop. Cost: a user sitting on 200+ terminal records loses the `download-cancel` handle for the oldest ones (the `.part` files themselves are untouched and still removable by hand). Covered by `test_the_cap_overrides_the_partial_carve_out`; happy to flip it if you'd rather the carve-out win.

**2. `prune` also deletes the record's `<id>.log` and `<id>.cancel` siblings.** The ticket only names the `.json`, but the worker's stdout/stderr log is written per-download by `_spawn_download_worker` and becomes unreachable the moment the record naming it is gone — no verb can look it up. Deleting records alone would leave the directory growing on `.log` files, defeating the stated goal. Only companions of a record that was actually removed are touched, and the return value still counts records, not files.

**3. A record with an unparseable `updated_at` is kept, not deleted.** `_parse_iso` returning `None` means we cannot show it is stale, so the age rule declines to act; the cap still bounds it. Same posture for a corrupt/unreadable state file, which `read_path` reports as absent and prune therefore never judges. `test_a_garbage_timestamp_is_not_treated_as_ancient` and `test_a_corrupt_file_is_left_alone` pin both.

**4. `list_all` and `prune` now share a `_sort_key` helper** rather than duplicating the sort lambda. They must agree: prune evicts exactly what falls off the end of the list `downloads` shows, so a divergent tiebreak would drop a record the user is still looking at. Behaviour of `list_all` is unchanged.

## Testing

New `TestPrune` class in `tests/comfy_cli/command/test_model_download_background.py`, alongside the existing `TestStatePersistence` / `TestReconcile` (19 tests): stale terminal removed; fresh terminal kept; `starting`/`downloading` kept at 100× the max age; the `.part` guard pinning `failed` and `cancelled` and releasing once the `.part` is gone; `completed` removable with a `.part` present (and the `.part` left on disk); the cap keeping exactly the newest 200 and evicting oldest-first including sub-7-day records; the cap ignoring in-flight records; companion `.log`/`.cancel` removal; corrupt file and garbage-timestamp no-ops; missing state dir; `Path.unlink` monkeypatched to raise `OSError` being a silent no-op **and** a subsequent `_submit_background_download` still returning its normal envelope; and spy-based assertions that `downloads()` and `_submit_background_download` each actually call `prune()` (not just that `download_state` unit-tests pass).

Verification run in the worktree:

- `ruff check .` and `ruff format --diff .` with the CI-pinned `ruff==0.15.15` — clean across all 277 files.
- `pytest tests/comfy_cli/command/test_model_download_background.py tests/comfy_cli/test_file_utils.py` — **150 passed**, covering both changed modules end to end.
- The repo-wide `pytest .` is running but is very slow on this machine (>15 min, unrelated to this diff — it was already slow before the change); CI's `pytest.yml` is the authoritative run for it.

## Negative-claim falsification

Not applicable — the trigger does not fire. This diff adds no "not supported"/"unavailable"/"STOP" strings, no throw/deny dead-end path, and flips no test to assert a dead-end; it removes stale bookkeeping. The one adjacent capability — reclaiming a dead download's `.part` bytes via `download-cancel` — is preserved by design (the carve-out) and proven by `test_a_partial_pins_a_failed_or_cancelled_record`, with the single deliberate exception documented under judgment call 1.
