### PR TITLE
fix(output): populate `where` on error envelopes for every routed command (BE-6275)

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1188,6 +1188,11 @@ def validate(
     # made by string-comparing user input.
     decision = where_module.resolve_default_or_exit(flag=where)
     mode = decision.target.value
+    # Routing resolved — stamp it so the envelopes below (the object_info load
+    # failure and the UI-conversion errors) name the target this validate ran
+    # against. The file-read errors above stay `where: null`: they precede the
+    # decision, as does the `where_invalid` `resolve_default_or_exit` raises.
+    renderer.where = mode
 
     # Resolve the local object_info server the same way `comfy run` does —
     # flag > COMFY_LOCAL_URL > config.background > 127.0.0.1:8188. Without the
@@ -1403,6 +1408,11 @@ def upload(
         raise typer.Exit(code=1)
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
+    # Routing is decided, so every error envelope from here down can name the
+    # target — including the `host_flag_cloud` rejection immediately below,
+    # which never reaches `execute_upload`. The `where_invalid` above stays
+    # `where: null`: it failed before there was a decision to report.
+    renderer.where = effective_where
     # --host/--port address a local ComfyUI; the cloud target's address comes
     # from the signed-in account's base URL and ignores them entirely
     # (``Target.host``/``Target.port`` are documented local-only). Rejecting
@@ -1464,6 +1474,10 @@ def download(
         raise typer.Exit(code=1)
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
+    # As in `upload`: stamped once routing resolves, so the preflight failure
+    # below and `execute_download`'s stdin-parsing errors (which run before it
+    # resolves its own target) all name the backend this invocation routed to.
+    renderer.where = effective_where
     if effective_where == "cloud":
         where_module.cloud_preflight_or_exit()
 

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -682,8 +682,9 @@ def ls_cmd(
 
     # Resolve the routing target once: per-command --where flag > COMFY_WHERE
     # env (how the top-level `comfy --where` arrives) > config default. Both
-    # the server query and the state-file scope key off this single decision.
-    target_where = "cloud" if _is_cloud(where) else "local"
+    # the server query and the state-file scope key off this single decision,
+    # and it is stamped on the renderer so error envelopes carry it too.
+    target_where = _stamp_where(renderer, where)
 
     # --orphaned only makes sense for state files (the server doesn't know
     # whether a watcher crashed), so skip the server query in that mode.
@@ -1099,7 +1100,7 @@ def status_cmd(
     ] = None,
 ):
     renderer = get_renderer()
-    if _is_cloud(where):
+    if _stamp_where(renderer, where) == "cloud":
         return _cloud_status(prompt_id)
 
     with report_usage_error(renderer, command="jobs status"):
@@ -1523,7 +1524,8 @@ def wait_cmd(
     wait_all: Annotated[bool, typer.Option("--all", help="Wait on all locally-tracked non-terminal jobs.")] = False,
 ):
     renderer = get_renderer()
-    cloud = _is_cloud(where)
+    where_label = _stamp_where(renderer, where)
+    cloud = where_label == "cloud"
 
     ids = list(prompt_ids or [])
     if wait_all:
@@ -1587,7 +1589,6 @@ def wait_cmd(
         "elapsed_seconds": round(time.time() - start, 2),
         "jobs": jobs_list,
     }
-    where_label = "cloud" if cloud else "local"
 
     if renderer.is_pretty():
         _render_wait_pretty(summary)
@@ -1636,9 +1637,10 @@ def cancel_cmd(
         typer.Option("--where", help="'local' (default) or 'cloud'."),
     ] = None,
 ):
-    if _is_cloud(where):
+    renderer = get_renderer()
+    if _stamp_where(renderer, where) == "cloud":
         return _cloud_cancel(prompt_id)
-    with report_usage_error(get_renderer(), command="jobs cancel"):
+    with report_usage_error(renderer, command="jobs cancel"):
         h, p = _resolve_host_port(host, port)
     _server_or_error(h, p)
     return _local_cancel(prompt_id, h, p)
@@ -2171,7 +2173,7 @@ def watch_cmd(
     ] = None,
 ):
     renderer = get_renderer()
-    if _is_cloud(where):
+    if _stamp_where(renderer, where) == "cloud":
         return _cloud_watch(prompt_id, poll_interval=poll_interval, max_wait=max_wait)
 
     with report_usage_error(renderer, command="jobs watch"):
@@ -2359,6 +2361,20 @@ def _is_cloud(where: str | None) -> bool:
         # (cmdline.py top-level option) will surface ``where_invalid``.
         return False
     return decision.target is where_module.WhereTarget.CLOUD
+
+
+def _stamp_where(renderer, where: str | None) -> str:
+    """Resolve this invocation's routing target and stamp it on the renderer.
+
+    Every ``jobs`` verb calls this at entry, right where it decides
+    local-vs-cloud, so the error envelopes raised downstream carry ``where``
+    instead of ``null``. Returns the label so callers that also need it (the
+    ``ls``/``wait`` payloads) don't resolve twice. Explicit
+    ``emit(..., where=...)`` arguments still take precedence over the stamp.
+    """
+    label = "cloud" if _is_cloud(where) else "local"
+    renderer.where = label
+    return label
 
 
 def _cloud_job_to_row(j: dict) -> JobRow:

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -801,6 +801,11 @@ def logs(tail: int = 200, where: str | None = None, port: int | None = None):
             command="logs",
         )
         raise typer.Exit(code=1)
+    # Routing is confirmed local, so every envelope from here down can name it —
+    # matching the `where="local"` the success emit already passes explicitly.
+    # Both `where_invalid` errors above stay `where: null`: they *are* the failed
+    # decision, and the second one rejects a target this command won't route to.
+    renderer.where = "local"
 
     resolved = resolve_background_log_path(port)
     if resolved is None:

--- a/comfy_cli/command/models/search.py
+++ b/comfy_cli/command/models/search.py
@@ -177,6 +177,22 @@ def _emit_http_error(e: urllib.error.HTTPError, *, renderer, target, message: st
     raise typer.Exit(code=1) from e
 
 
+def _resolve_and_stamp(renderer, where: str | None):
+    """Resolve the routing Target for a ``models`` verb and stamp it on the renderer.
+
+    Every verb here calls this at the point it decides local-vs-cloud, so the
+    error envelopes raised downstream carry ``where`` instead of ``null``.
+    Errors raised *before* this (an unsafe path segment) keep ``where: null``,
+    which is correct — nothing had routed yet. Explicit
+    ``emit(..., where=...)`` arguments still take precedence over the stamp.
+    """
+    from comfy_cli.target import resolve_target
+
+    target = resolve_target(where=where)
+    renderer.where = target.kind
+    return target
+
+
 # ---------------------------------------------------------------------------
 # list-folders / list-folder — runtime introspection
 # ---------------------------------------------------------------------------
@@ -193,10 +209,8 @@ def list_folders_cmd(
         typer.Option("--where", show_default=False, help="Override the resolved routing mode."),
     ] = None,
 ):
-    from comfy_cli.target import resolve_target
-
     renderer = get_renderer()
-    target = resolve_target(where=where)
+    target = _resolve_and_stamp(renderer, where)
     url = target.url(*_models_path_parts(target))
 
     try:
@@ -268,11 +282,9 @@ def list_folder_cmd(
         typer.Option("--limit", show_default=False, help="Cap output to N rows."),
     ] = None,
 ):
-    from comfy_cli.target import resolve_target
-
     renderer = get_renderer()
     _reject_unsafe_path_segment(folder, kind="folder", renderer=renderer)
-    target = resolve_target(where=where)
+    target = _resolve_and_stamp(renderer, where)
     # Percent-encoded for the same reason `_local_folder_matches` does it: the
     # relaxed validation above admits spaces, `?`/`#`, and non-ASCII, none of
     # which may be allowed to alter the request. Error payloads below carry the
@@ -646,12 +658,10 @@ def search_cmd(
         typer.Option("--where", show_default=False, help="Override the resolved routing mode."),
     ] = None,
 ):
-    from comfy_cli.target import resolve_target
-
     renderer = get_renderer()
     if type_ is not None:
         _reject_unsafe_path_segment(type_, kind="type", renderer=renderer)
-    target = resolve_target(where=where)
+    target = _resolve_and_stamp(renderer, where)
 
     try:
         if target.is_cloud:
@@ -717,10 +727,8 @@ def show_cmd(
         typer.Option("--where", show_default=False, help="Override the resolved routing mode."),
     ] = None,
 ):
-    from comfy_cli.target import resolve_target
-
     renderer = get_renderer()
-    target = resolve_target(where=where)
+    target = _resolve_and_stamp(renderer, where)
 
     if not target.is_cloud:
         # On local there's no asset catalog. We can confirm the file exists by

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -74,6 +74,13 @@ def _get_graph(
     and fired when a stale-cache fallback occurs (see loader for signature).
     """
     mode = _resolved_where(where)
+    # Every `comfy nodes` verb routes through here, so this is the one place
+    # the target is decided — stamp it on the renderer so the envelopes emitted
+    # downstream (the `cql_no_graph` error below included) carry `where`
+    # instead of `null`. `--input` reads a dump instead of talking to the
+    # backend, but `mode` still says which catalog the dump is interpreted as,
+    # which is what `where` reports (see the field's schema description).
+    get_renderer().where = mode
     # Resolve the local server the same way `comfy run` / `comfy jobs` do —
     # flag > COMFY_LOCAL_URL > config.background > 127.0.0.1:8188. `resolve_target`
     # deliberately skips the `config.background` step (other callers must not

--- a/comfy_cli/command/project.py
+++ b/comfy_cli/command/project.py
@@ -219,6 +219,10 @@ def assets_push_cmd(
         renderer.error(code="invalid_argument", message=str(e))
         raise typer.Exit(code=1) from e
     where_kind = target.kind
+    # Routing resolved — stamp it so the upload failures below name the backend
+    # this push targeted. The `project_not_found` and `invalid_argument` errors
+    # above precede the decision and stay `where: null`.
+    renderer.where = where_kind
 
     assets_dir = project.root / "assets"
     lock_path = project.root / ".comfy" / "assets.lock.json"

--- a/comfy_cli/command/system.py
+++ b/comfy_cli/command/system.py
@@ -4,6 +4,10 @@ Thin wrappers over ComfyUI's own ``GET /system_stats`` and ``POST /free``
 endpoints (routed through :class:`comfy_cli.comfy_client.Client`, cloud or
 local via ``resolve_target``), so agents can read VRAM state and free it
 without any direct HTTP.
+
+Both entry points stamp ``renderer.where`` from the resolved target right
+after ``resolve_target``, so every envelope they emit — the unreachable-server
+errors especially — names the backend the command routed to.
 """
 
 from __future__ import annotations
@@ -95,6 +99,7 @@ def _handle_unreachable(renderer, e: Exception, *, target, operation: str) -> No
 def system_stats_execute(renderer, *, where: str | None = None) -> None:
     """Entry point wired from ``comfy system-stats`` in cmdline.py."""
     target = resolve_target(where=where)
+    renderer.where = target.kind
     client = Client(target)
     try:
         stats = client.get_system_stats()
@@ -124,6 +129,7 @@ def free_execute(
 ) -> None:
     """Entry point wired from ``comfy free`` in cmdline.py."""
     target = resolve_target(where=where)
+    renderer.where = target.kind
     client = Client(target)
     try:
         client.post_free(unload_models=unload_models, free_memory=free_memory)

--- a/comfy_cli/command/transfer.py
+++ b/comfy_cli/command/transfer.py
@@ -435,6 +435,11 @@ def execute_upload(
         if port is not None and not (1 <= port <= 65535):
             raise typer.BadParameter(f"invalid port: {port} is out of range (1-65535)")
     target = resolve_target(where=where, host=host, port=port)
+    # Same defence-in-depth as the validation above: ``cmdline.upload`` already
+    # stamps the renderer with its own resolved target (it has to — its
+    # `host_flag_cloud` rejection fires before we're called), but a direct
+    # caller like comfy-mcp never goes through that path, so stamp here too.
+    renderer.where = target.kind
 
     uploads: list[dict[str, Any]] = []
     cloud_names: list[str] = []
@@ -853,6 +858,10 @@ def execute_download(
         raise typer.Exit(code=1)
 
     target = resolve_target(where=where)
+    # Stamp the routed target for direct callers (comfy-mcp); `cmdline.download`
+    # already stamped its own before calling us, which is what gives the
+    # stdin-parsing errors above a non-null `where` on the CLI path.
+    renderer.where = target.kind
 
     # -- Resolve output URLs --------------------------------------------------
     # The state file is read regardless of the URL source: its `record` +

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -111,6 +111,11 @@ def _get_graph(input_path: str | None, host: str | None, port: int | None, on_st
         # becomes a clean `where_invalid` envelope rather than a traceback.
         decision = where_module.resolve_default_or_exit()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
+        # Routing resolved — stamp it so the `cql_no_graph` envelope below names
+        # the catalog these verbs annotated against, matching what `nodes` does
+        # from its own `_get_graph`. The `where_invalid` raised just above stays
+        # `where: null`: it *is* the failed decision.
+        renderer.where = mode
         from comfy_cli.cql.loader import resilient_load_object_info
 
         raw = resilient_load_object_info(
@@ -637,10 +642,20 @@ _LOCAL_SORT_KEYS = {"create_time": "created", "update_time": "modified", "name":
 
 
 def _resolve_where_target(where: str | None):
-    """Resolve the routing Target for a saved-workflow verb (cloud or local)."""
+    """Resolve the routing Target for a saved-workflow verb (cloud or local).
+
+    This is the single point where ``workflow list/get/save/delete`` decide
+    local-vs-cloud, so it is also where the routed target gets stamped on the
+    renderer: every error envelope emitted downstream then carries ``where``
+    instead of ``null``. Explicit ``emit(..., where=...)`` arguments still win
+    (they resolve as ``where or self.where``), so the success envelopes are
+    unchanged.
+    """
     from comfy_cli.target import resolve_target
 
-    return resolve_target(where=where)
+    target = resolve_target(where=where)
+    get_renderer().where = target.kind
+    return target
 
 
 # Unicode categories that survive the C0/C1 filter but still let untrusted text

--- a/comfy_cli/command/workflow_fragments.py
+++ b/comfy_cli/command/workflow_fragments.py
@@ -344,6 +344,11 @@ def _load_object_info(renderer, *, input_path: str | None, host: str | None, por
         # handler below is for object_info failures, not routing ones).
         decision = where_module.resolve_default_or_exit()
         mode = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
+        # Routing resolved — stamp it so the `object_info_unavailable` envelope
+        # below names the catalog this conversion routed to, the same way
+        # `nodes` and `workflow`'s own `_get_graph` do. The `where_invalid` that
+        # `_or_exit` raises above stays `where: null`: it *is* the failed decision.
+        renderer.where = mode
         return resilient_load_object_info(mode=mode, host=host, port=port)
     except (OSError, json.JSONDecodeError, LoadError) as e:
         renderer.error(

--- a/tests/comfy_cli/output/test_error_envelope_where.py
+++ b/tests/comfy_cli/output/test_error_envelope_where.py
@@ -1,0 +1,385 @@
+"""BE-6275: `where` on the ERROR envelopes of the routed commands.
+
+BE-6274 fixed `Renderer.error()` and the `run` path. This module pins the same
+property for every other command that resolves a local/cloud target: once the
+routing decision is made, the failure envelope names the target it routed to
+instead of `where: null`.
+
+Shape of every test here: drive the real CLI (`comfy --json <cmd> --where …`)
+with a forced downstream failure *after* target resolution, then assert
+`envelope["where"]`. Driving the CLI rather than calling the inner function is
+the point — the assignment under test lives at each command's routing decision,
+and the top-level callback is what installs the per-invocation renderer.
+
+The two negative tests at the bottom are the other half of the contract:
+errors raised *before* a target is resolved must keep `where: null`, which is
+why the field stays nullable in `comfy_cli/schemas/envelope.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import cmdline
+from comfy_cli import where as where_module
+from comfy_cli.cql.engine import LoadError
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_where(monkeypatch: pytest.MonkeyPatch):
+    """`--where` must be the only routing input.
+
+    `COMFY_WHERE` is set process-wide by the top-level `comfy --where` flag, so
+    a value left behind by another test (or by the developer's shell) would
+    silently decide the target these tests are asserting on.
+    """
+    monkeypatch.delenv("COMFY_WHERE", raising=False)
+
+
+def _run(argv: list[str]) -> dict:
+    """Invoke the CLI and return the terminating envelope."""
+    result = CliRunner().invoke(cmdline.app, argv)
+    lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
+    assert lines, f"no envelope on stdout (rc={result.exit_code}, exc={result.exception!r})"
+    envelope = json.loads(lines[-1])
+    assert envelope.get("ok") is False, f"expected a failure envelope, got {envelope}"
+    return envelope
+
+
+@contextmanager
+def _cloud_signed_out():
+    """Fail the shared cloud preflight — the cheapest post-routing failure for
+    any command whose cloud branch starts with `cloud_preflight_or_exit()`."""
+    err = where_module.CloudError(
+        code="cloud_not_configured",
+        message="not signed in",
+        hint="run: comfy cloud login",
+        details={},
+    )
+    with patch("comfy_cli.where.cloud_preflight", return_value=err):
+        yield
+
+
+_NETWORK_DOWN = urllib.error.URLError("connection refused")
+_LOAD_ERROR = LoadError("no object_info", details={"hint": "start the server"})
+
+
+# ---------------------------------------------------------------------------
+# jobs
+# ---------------------------------------------------------------------------
+
+
+class TestJobs:
+    def test_status_cloud(self):
+        with _cloud_signed_out():
+            env = _run(["--json", "jobs", "status", "abc123", "--where", "cloud"])
+        assert env["error"]["code"] == "cloud_not_configured"
+        assert env["where"] == "cloud"
+
+    def test_status_local(self):
+        with (
+            patch("comfy_cli.command.jobs._server_or_error", return_value=False),
+            patch("comfy_cli.command.jobs._state_file_for_local_target", return_value=None),
+        ):
+            env = _run(["--json", "jobs", "status", "abc123", "--where", "local"])
+        assert env["error"]["code"] == "server_not_running"
+        assert env["where"] == "local"
+
+    def test_cancel_cloud(self):
+        with _cloud_signed_out():
+            env = _run(["--json", "jobs", "cancel", "abc123", "--where", "cloud"])
+        assert env["where"] == "cloud"
+
+    def test_watch_cloud(self):
+        with _cloud_signed_out():
+            env = _run(["--json", "jobs", "watch", "abc123", "--where", "cloud"])
+        assert env["where"] == "cloud"
+
+    def test_wait_cloud(self):
+        # `no_prompt_ids` is raised straight after the routing decision, so it
+        # is the narrowest probe of the stamp on the `wait` path.
+        env = _run(["--json", "jobs", "wait", "--where", "cloud"])
+        assert env["error"]["code"] == "no_prompt_ids"
+        assert env["where"] == "cloud"
+
+    def test_wait_local(self):
+        env = _run(["--json", "jobs", "wait", "--where", "local"])
+        assert env["error"]["code"] == "no_prompt_ids"
+        assert env["where"] == "local"
+
+    def test_ls_rejects_watch_in_json_mode_with_target(self):
+        env = _run(["--json", "jobs", "ls", "--where", "cloud", "--watch"])
+        assert env["error"]["code"] == "json_incompatible"
+        assert env["where"] == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# workflow (saved-workflow verbs)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflow:
+    def test_list_cloud(self):
+        with patch("comfy_cli.command.workflow._http_request", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "workflow", "list", "--where", "cloud"])
+        assert env["where"] == "cloud"
+
+    def test_list_local(self):
+        with patch("comfy_cli.command.workflow._userdata_request", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "workflow", "list", "--where", "local"])
+        assert env["where"] == "local"
+
+    def test_get_cloud(self):
+        with patch("comfy_cli.command.workflow._http_request", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "workflow", "get", "some-id", "--where", "cloud"])
+        assert env["where"] == "cloud"
+
+    def test_delete_local(self):
+        with patch("comfy_cli.command.workflow._userdata_request", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "workflow", "delete", "flux.json", "--where", "local"])
+        assert env["where"] == "local"
+
+    def test_slots_stamps_the_object_info_route(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """`slots`/`set-slot`/`vary`/`notes` route through `workflow._get_graph`,
+        a different resolver than the saved-workflow verbs above — it has no
+        per-command `--where`, so routing arrives via `COMFY_WHERE`."""
+        path = tmp_path / "wf.json"
+        path.write_text(json.dumps({"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}))
+        monkeypatch.setenv("COMFY_WHERE", "cloud")
+        with patch("comfy_cli.cql.loader.resilient_load_object_info", side_effect=_LOAD_ERROR):
+            env = _run(["--json", "workflow", "slots", str(path)])
+        assert env["error"]["code"] == "cql_no_graph"
+        assert env["where"] == "cloud"
+
+    def test_decompose_stamps_the_object_info_route(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """`workflow decompose` loads object_info through its own resolver in
+        `workflow_fragments`, reached only for a frontend-format workflow."""
+        path = tmp_path / "ui.json"
+        path.write_text(json.dumps({"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}))
+        monkeypatch.setenv("COMFY_WHERE", "cloud")
+        with patch("comfy_cli.cql.loader.resilient_load_object_info", side_effect=_LOAD_ERROR):
+            env = _run(["--json", "workflow", "decompose", str(path)])
+        assert env["error"]["code"] == "object_info_unavailable"
+        assert env["where"] == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# transfer (upload / download)
+# ---------------------------------------------------------------------------
+
+
+class TestTransfer:
+    def test_upload_rejects_host_with_cloud_target(self):
+        """The `--host/--port + cloud` rejection fires before `execute_upload`
+        is ever called, so it can only carry `where` via the stamp in
+        `cmdline.upload`."""
+        env = _run(["--json", "upload", "x.png", "--where", "cloud", "--host", "1.2.3.4"])
+        assert env["error"]["code"] == "host_flag_cloud"
+        assert env["where"] == "cloud"
+
+    def test_upload_local_missing_file(self, tmp_path):
+        env = _run(["--json", "upload", str(tmp_path / "nope.png"), "--where", "local"])
+        assert env["error"]["code"] == "upload_failed"
+        assert env["where"] == "local"
+
+    def test_download_cloud(self):
+        with _cloud_signed_out():
+            env = _run(["--json", "download", "abc123", "--where", "cloud"])
+        assert env["error"]["code"] == "cloud_not_configured"
+        assert env["where"] == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# system (system-stats / free)
+# ---------------------------------------------------------------------------
+
+
+class TestSystem:
+    def test_system_stats_local(self):
+        with patch("comfy_cli.comfy_client.Client.get_system_stats", side_effect=OSError("boom")):
+            env = _run(["--json", "system-stats", "--where", "local"])
+        assert env["error"]["code"] == "server_not_running"
+        assert env["where"] == "local"
+
+    def test_system_stats_cloud(self, monkeypatch: pytest.MonkeyPatch):
+        # A credential is required for `Client(target)` to construct at all on
+        # the cloud branch — without one it raises `Unauthenticated` before any
+        # envelope is written (pre-existing, unrelated to the stamp).
+        monkeypatch.setenv("COMFY_CLOUD_API_KEY", "test-key")
+        with patch("comfy_cli.comfy_client.Client.get_system_stats", side_effect=OSError("boom")):
+            env = _run(["--json", "system-stats", "--where", "cloud"])
+        assert env["error"]["code"] == "cloud_http_error"
+        assert env["where"] == "cloud"
+
+    def test_free_local(self):
+        with patch("comfy_cli.comfy_client.Client.post_free", side_effect=OSError("boom")):
+            env = _run(["--json", "free", "--where", "local"])
+        assert env["error"]["code"] == "server_not_running"
+        assert env["where"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# nodes
+# ---------------------------------------------------------------------------
+
+
+class TestNodes:
+    def test_ls_local(self):
+        with patch("comfy_cli.cql.loader.resilient_load_object_info", side_effect=_LOAD_ERROR):
+            env = _run(["--json", "nodes", "ls", "--where", "local"])
+        assert env["error"]["code"] == "cql_no_graph"
+        assert env["where"] == "local"
+
+    def test_ls_cloud(self):
+        with patch("comfy_cli.cql.loader.resilient_load_object_info", side_effect=_LOAD_ERROR):
+            env = _run(["--json", "nodes", "ls", "--where", "cloud"])
+        assert env["error"]["code"] == "cql_no_graph"
+        assert env["where"] == "cloud"
+
+    def test_show_cloud(self):
+        with patch("comfy_cli.cql.loader.resilient_load_object_info", side_effect=_LOAD_ERROR):
+            env = _run(["--json", "nodes", "show", "KSampler", "--where", "cloud"])
+        assert env["where"] == "cloud"
+
+
+# ---------------------------------------------------------------------------
+# models
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_search_cloud(self):
+        with patch("comfy_cli.command.models.search._cloud_search", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "models", "search", "--where", "cloud"])
+        assert env["error"]["code"] == "cloud_http_error"
+        assert env["where"] == "cloud"
+
+    def test_search_local(self):
+        with patch("comfy_cli.command.models.search._local_search", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "models", "search", "--where", "local"])
+        assert env["error"]["code"] == "server_not_running"
+        assert env["where"] == "local"
+
+    def test_list_folders_local(self):
+        with patch("comfy_cli.command.models.search._http_get_json", side_effect=_NETWORK_DOWN):
+            env = _run(["--json", "models", "list-folders", "--where", "local"])
+        assert env["where"] == "local"
+
+    def test_show_local_is_unsupported_but_still_names_the_target(self):
+        env = _run(["--json", "models", "show", "vae.safetensors", "--where", "local"])
+        assert env["error"]["code"] == "models_show_local_unsupported"
+        assert env["where"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# assets push (project)
+# ---------------------------------------------------------------------------
+
+
+class TestAssetsPush:
+    @staticmethod
+    def _project(tmp_path, monkeypatch):
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "comfy.yaml").write_text("schema: project/1\nname: t\n")
+        for d in ("assets", ".comfy"):
+            (root / d).mkdir()
+        (root / "assets" / "a.png").write_bytes(b"png")
+        monkeypatch.chdir(root)
+
+    def test_push_cloud(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        self._project(tmp_path, monkeypatch)
+        err = urllib.error.HTTPError("http://x", 500, "boom", {}, None)
+        with patch("comfy_cli.command.project._upload_file", side_effect=err):
+            env = _run(["--json", "assets", "push", "--where", "cloud"])
+        assert env["error"]["code"] == "upload_failed"
+        assert env["where"] == "cloud"
+
+    def test_push_local(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        self._project(tmp_path, monkeypatch)
+        err = urllib.error.HTTPError("http://x", 500, "boom", {}, None)
+        with patch("comfy_cli.command.project._upload_file", side_effect=err):
+            env = _run(["--json", "assets", "push", "--where", "local"])
+        assert env["error"]["code"] == "upload_failed"
+        assert env["where"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    @staticmethod
+    def _workflow(tmp_path):
+        path = tmp_path / "wf.json"
+        path.write_text(json.dumps({"1": {"class_type": "KSampler", "inputs": {}}}))
+        return str(path)
+
+    def test_cloud(self, tmp_path):
+        err = LoadError("no object_info", details={"hint": "sign in"})
+        with patch("comfy_cli.cql.engine.Graph.load", side_effect=err):
+            env = _run(["--json", "validate", "--workflow", self._workflow(tmp_path), "--where", "cloud"])
+        assert env["error"]["code"] == "cql_no_graph"
+        assert env["where"] == "cloud"
+
+    def test_local(self, tmp_path):
+        err = LoadError("no object_info", details={"hint": "comfy launch"})
+        with patch("comfy_cli.cql.engine.Graph.load", side_effect=err):
+            env = _run(["--json", "validate", "--workflow", self._workflow(tmp_path), "--where", "local"])
+        assert env["error"]["code"] == "cql_no_graph"
+        assert env["where"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# logs (local-only routing)
+# ---------------------------------------------------------------------------
+
+
+class TestLogs:
+    def test_no_log_file_local(self):
+        with patch("comfy_cli.command.launch.resolve_background_log_path", return_value=None):
+            env = _run(["--json", "logs", "--where", "local"])
+        assert env["error"]["code"] == "no_log_file"
+        assert env["where"] == "local"
+
+    def test_cloud_routing_rejected_before_the_decision_lands(self):
+        """`comfy logs` refuses cloud routing outright, so that rejection is a
+        failed decision — it keeps `where: null` like any other `where_invalid`."""
+        env = _run(["--json", "logs", "--where", "cloud"])
+        assert env["error"]["code"] == "where_invalid"
+        assert env["where"] is None
+
+
+# ---------------------------------------------------------------------------
+# Pre-decision errors keep `where: null`
+# ---------------------------------------------------------------------------
+
+
+class TestPreDecisionErrorsStayNull:
+    def test_where_invalid_on_upload(self):
+        env = _run(["--json", "upload", "x.png", "--where", "nowhere"])
+        assert env["error"]["code"] == "where_invalid"
+        assert env["where"] is None
+
+    def test_where_invalid_on_validate(self, tmp_path):
+        path = tmp_path / "wf.json"
+        path.write_text("{}")
+        env = _run(["--json", "validate", "--workflow", str(path), "--where", "nowhere"])
+        assert env["error"]["code"] == "where_invalid"
+        assert env["where"] is None
+
+    def test_validate_file_error_precedes_routing(self, tmp_path):
+        env = _run(["--json", "validate", "--workflow", str(tmp_path / "gone.json"), "--where", "cloud"])
+        assert env["error"]["code"] == "workflow_not_found"
+        assert env["where"] is None
+
+    def test_models_list_folder_rejects_unsafe_segment_before_routing(self):
+        env = _run(["--json", "models", "list-folder", "../etc", "--where", "cloud"])
+        assert env["where"] is None


### PR DESCRIPTION
## ELI-5

When a `--json` command fails, it hands back an "envelope" that says what went wrong. That envelope has a `where` field meant to say *which backend* the command was talking to — your local ComfyUI, or Comfy Cloud. Until now it always said `null` on failures, so an agent reading a "server not running" error couldn't tell which server. This fills it in: once a command has decided local-vs-cloud, every error it reports from that point on names the target. Errors that happen *before* that decision (like "`--where nowhere` isn't a thing") still say `null`, because there genuinely isn't an answer yet.

## What changed

Phase 1 (#665 / BE-6274) fixed `Renderer.error()`'s `where` override and stamped the `run` path. Every other routed command still fell through to `where: null` because nothing assigned `renderer.where`. Rather than edit ~130 individual `renderer.error(...)` call sites, this assigns `renderer.where` **once per command, at the point its effective target is decided** — the pattern phase 1 established:

| Surface | Assignment point |
|---|---|
| `jobs ls/status/wait/cancel/watch` | new `_stamp_where()` helper, at each verb's local-vs-cloud decision |
| `workflow list/get/save/delete` | `_resolve_where_target()` |
| `workflow slots/set-slot/vary/notes` | `workflow._get_graph()`, after the object_info route resolves |
| `workflow decompose` | `workflow_fragments._load_object_info()` |
| `upload` / `download` | `cmdline.py` after `effective_where`, and again in `transfer.execute_*` for direct (comfy-mcp) callers |
| `system-stats` / `free` | `system.py` after `resolve_target` (these are what `cmdline.py:1381/1408` delegate to) |
| `nodes *` | `nodes._get_graph()` |
| `models list-folders/list-folder/search/show` | new `_resolve_and_stamp()` helper |
| `assets push` | after `resolve_target` |
| `validate` | after `resolve_default_or_exit` |
| `logs` | after the local-only routing check passes |

Rules held throughout: vocabulary is strictly `"local"`/`"cloud"` (`target.kind` and `WhereTarget.value` are the only sources — no invented labels); the stamp lands **only after a successful decision**, so `where_invalid` and other pre-routing errors keep `where: null`; every existing explicit `emit(..., where=...)` argument is left in place and still wins (`where or self.where`). `comfy_cli/schemas/envelope.json` is unchanged — it already declared `where` as a nullable `local`/`cloud` enum.

## Tests

New `tests/comfy_cli/output/test_error_envelope_where.py` (36 cases) drives the real CLI with a forced failure *after* target resolution and asserts `where` on the `ok:false` envelope — one or more per touched command, both targets where both exist. Four negative cases pin the other half of the contract (pre-decision errors stay `where: null`). Full suite: **4569 passed, 36 skipped**; `ruff check` + `ruff format --diff` clean (against the CI-pinned ruff 0.15.15).

## Judgment calls

- **Scope went slightly wider than the ticket's list, deliberately.** The ticket enumerates workflow/jobs/transfer/system/nodes/models. I also stamped `validate`, `assets push`, `logs`, `workflow slots/set-slot/vary/notes`, and `workflow decompose` — every one of them resolves a local/cloud routing decision and then emits error envelopes, so leaving them out would have shipped the exact inconsistency the ticket exists to remove (`nodes ls` reporting `local` on an object_info failure while `workflow slots` reported `null` on the identical failure). Each is the same one-line assignment at the same kind of decision point.
- **Some success envelopes now carry `where` too, where they previously said `null`.** `nodes *`, `models *`, `validate`, and `assets push` never passed `where=` to `emit()` explicitly (they carry the target as a *payload* field instead), so the stamp fills the envelope-level fallback on success as well as failure. This is additive and matches the schema's own description of the field; no test asserted the old `null`. Commands that pass `where=` explicitly (`workflow`, `jobs`, `run`, `logs`) are byte-identical on success.
- **Out of scope, unchanged:** `env`, `which`, `feedback`, `nodes refresh` (its `--where` is documented as accepted-and-ignored), `setup`, and `templates` — none of them route, so their envelopes correctly stay `where: null`.
- **Known bound (not introduced here):** `Renderer` is a process-wide singleton, and these stamps are not unset at command exit the way `run`'s `finally` unsets its own. On the CLI this cannot leak — `cmdline.entry()` installs a *fresh* `Renderer` per invocation. It is only observable in a long-lived process that calls two different comfy-cli command functions in-process without reinstalling a renderer, where the second one fails *before* it routes; each entry point re-resolves and re-stamps before any post-routing error, so the window is limited to pre-routing failures. Left as-is rather than adding a `try/finally` to a dozen command bodies; happy to follow up if that in-process pattern matters to comfy-mcp.

## Verification of the acceptance criteria

- Failing `comfy workflow list --where cloud --json` → `where: "cloud"`; `--where local` → `"local"` (`TestWorkflow`).
- Failing `comfy jobs status --json` → `"cloud"`/`"local"` per routing (`TestJobs`).
- Failing `comfy upload --where cloud --json` → `"cloud"`, including the `--host` + cloud rejection that never reaches `execute_upload` (`TestTransfer`).
- `where_invalid` still emits `where: null` (`TestPreDecisionErrorsStayNull`).
- Full suite green; `comfy_cli/schemas/envelope.json` untouched.
