### PR TITLE
docs+ops: freeze the op vocabulary (op-vocabulary-v1.md) + $-alias sugar + batch-clear hint

### DIFF
--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -478,6 +478,11 @@ def apply_cmd(
         workflow, ops, aliases = workflow_ops.apply_specs(
             workflow, graph, specs, actor=actor, base_version=base_version
         )
+    except workflow_ops.NotBatchableError as e:
+        # A standalone-only op (clear) inside the batch: its own registered code,
+        # with the hint naming the standalone command to run instead.
+        renderer.error(code=e.code, message=f"batch failed: {e}", hint=e.hint)
+        raise typer.Exit(code=1) from e
     except (ValueError, KeyError) as e:
         # Atomic batch: nothing is written if any spec fails.
         renderer.error(code="workflow_edit_invalid", message=f"batch failed: {e}")
@@ -589,6 +594,19 @@ def foreach_cmd(
             target = out / f"{name}_{i:03d}.json"
             _atomic_write_text(target, json.dumps(wf, indent=2))
             written.append(str(target))
+    except workflow_ops.NotBatchableError as e:
+        renderer.error(
+            code=e.code,
+            message=f"foreach failed: {e}",
+            hint=e.hint
+            + (
+                f" ({len(written)} workflow(s) were already written to {out} — delete them or re-run)"
+                if written
+                else ""
+            ),
+            details={"written": written} if written else None,
+        )
+        raise typer.Exit(code=1) from e
     except (workflow_ops.RecipeError, ValueError, KeyError) as e:
         # foreach writes one file per param-set as it goes, so a mid-batch failure
         # leaves the earlier files on disk. Surface them (in the hint AND machine-

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -514,6 +514,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "run `comfy workflow slots <file>` for widget addresses or `comfy nodes types` for class_types",
     ),
     ErrorCode(
+        "workflow_clear_not_batchable",
+        "A batch (`workflow apply` / `workflow foreach`) contained a `clear` op. `clear` wipes the whole "
+        "graph and is standalone-only (docs/op-vocabulary-v1.md: batchable = no), so the batch was "
+        "rejected atomically — nothing was applied.",
+        "run the standalone `comfy workflow clear <file>` first, then apply the remaining ops as a batch",
+    ),
+    ErrorCode(
         "normalized_value",
         "Warning (not fatal): a set-widget value wasn't an exact COMBO option, so "
         "the nearest matching option was used. Surfaced in the op's `warnings`.",

--- a/comfy_cli/layout.py
+++ b/comfy_cli/layout.py
@@ -101,6 +101,10 @@ def assign_positions(workflow: dict, graph, specs: list) -> list:
 
     def endpoint(ref):
         node_part = str(ref).partition(".")[0].strip()
+        # `$alias` is sugar for `alias` (see workflow_ops.resolve_ref); `${...}`
+        # is a recipe-param hole that apply_specs rejects — not an alias.
+        if node_part.startswith("$") and not node_part.startswith("${"):
+            node_part = node_part[1:]
         if node_part in adds:
             return ("new", node_part)
         nid = int(node_part) if node_part.lstrip("-").isdigit() else node_part

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -81,6 +81,48 @@ def _new_op(kind: str, actor: str, base_version: int, **fields: Any) -> dict[str
     }
 
 
+# ---------------------------------------------------------------------------
+# The frozen op vocabulary — the normative contract is docs/op-vocabulary-v1.md;
+# these constants are its machine-readable projection, and
+# tests/comfy_cli/test_op_vocabulary_contract.py pins doc == constants == the
+# dispatch tables in apply_op / apply_specs. Amend the doc (versioned amendment
+# section) before touching any of the three.
+# ---------------------------------------------------------------------------
+
+#: Every op kind in the v1 vocabulary, including defined-but-deferred kinds.
+FROZEN_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node", "clear", "reset_doc")
+
+#: Kinds frozen in the contract whose replay is not implemented yet
+#: (``reset_doc`` is specified in op-vocabulary-v1.md; implementation is
+#: deferred to the bulk-writers ticket). ``apply_op`` must keep rejecting these.
+DEFERRED_OPS: tuple[str, ...] = ("reset_doc",)
+
+#: Kinds a batch (``apply_specs``) dispatches. ``clear`` and ``reset_doc`` are
+#: standalone-only: they rewrite the whole document, so they never ride inside
+#: an atomic batch.
+BATCHABLE_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node")
+
+
+class NotBatchableError(ValueError):
+    """A frozen op kind that is standalone-only was submitted inside a batch.
+
+    The command layer renders this with the registered ``code``/``hint`` below
+    (see ``comfy_cli/error_codes.py``) instead of the generic
+    ``workflow_edit_invalid``, so a caller learns the exact standalone command
+    to run rather than re-trying the batch.
+    """
+
+    code = "workflow_clear_not_batchable"
+    hint = "run the standalone `comfy workflow clear <file>` first, then apply the remaining ops as a batch"
+
+    def __init__(self, index: int):
+        super().__init__(
+            f"spec #{index}: `clear` wipes the whole graph and is standalone-only (op-vocabulary-v1: "
+            "batchable = no) — it never rides inside a batch. No changes were applied — the batch was "
+            "discarded. Run `comfy workflow clear <file>` as its own command, then apply the remaining ops."
+        )
+
+
 # Node types that live only in the UI graph and never reach the API — the
 # frontend's isVirtualNode set. Mirrors workflow_to_api._UI_ONLY_NODE_TYPES;
 # duplicated rather than imported to keep workflow_ops import-free of the
@@ -1022,8 +1064,24 @@ def _slot_name(slots: Any, idx: Any) -> Any:
 
 
 def resolve_ref(ref: Any, aliases: dict[str, Any]) -> Any:
-    """Map an alias to its minted id; pass ints/unknown strings through."""
+    """Map an alias (bare or ``$``-prefixed) to its minted id; pass ints and
+    unknown strings through.
+
+    ``$up`` and ``up`` address the same alias — exactly one leading ``$`` is
+    stripped before lookup (``$``-prefixed is the canonical documented form; see
+    docs/op-vocabulary-v1.md). ``${name}`` is NOT an alias: that shape is
+    reserved for recipe parameters (filled by :func:`substitute_params`), so an
+    unsubstituted one is rejected loudly here instead of falling through to a
+    misleading "node not found"."""
     if isinstance(ref, str):
+        if ref.startswith("${"):
+            raise ValueError(
+                f"{ref!r} looks like an unsubstituted recipe parameter — `${{name}}` is reserved for recipe "
+                "params (declare it under `params` and fill it with --param); an alias reference is `$name` "
+                "(or bare `name`)"
+            )
+        if ref.startswith("$"):
+            ref = ref[1:]
         if ref in aliases:
             return aliases[ref]
         if ref.lstrip("-").isdigit():
@@ -1086,11 +1144,20 @@ def apply_specs(
                     workflow, op = delete_node(
                         workflow, graph, resolve_ref(spec["node"], aliases), actor=actor, base_version=base_version
                     )
+                elif kind == "clear":
+                    # In the frozen vocabulary but standalone-only — surfaced with
+                    # its own registered code so the caller learns the standalone
+                    # command instead of a generic "unknown op".
+                    raise NotBatchableError(i)
                 else:
                     raise ValueError(f"spec #{i}: unknown op {kind!r}")
             except KeyError as e:
                 raise ValueError(f"spec #{i} ({kind}) is missing required field {e}") from e
             ops.append(op)
+    except NotBatchableError:
+        # Already carries the registered code, the standalone command, and the
+        # nothing-was-applied statement — don't wrap it into a generic hint.
+        raise
     except (ValueError, KeyError) as e:
         raise _rehint_discarded_batch(e, pre_batch_hint) from e
     return workflow, ops, aliases

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -1,0 +1,282 @@
+# Op vocabulary — v1 (frozen)
+
+Status: **FROZEN**. This document is the normative contract for the structured-edit
+op vocabulary in `comfy_cli/workflow_ops.py`: the op kinds, their argument shapes,
+their idempotency and conflict rules, and the batch protocol. Downstream repos
+(cloud `services/agent`, `harness`, the merge consumer) cite this document **by
+commit SHA**, not by branch.
+
+Machine-readable projection: `workflow_ops.FROZEN_OPS`, `workflow_ops.DEFERRED_OPS`,
+`workflow_ops.BATCHABLE_OPS`. `tests/comfy_cli/test_op_vocabulary_contract.py`
+enforces that this document, those constants, and the `apply_op` / `apply_specs`
+dispatch tables agree. A change to any of the three without the others fails CI.
+
+This freeze describes the code on the **unmerged branch
+`fix/validate-lowers-ui-to-api`**. Until that branch merges to `master`, a SHA
+citation must point at a commit on that branch.
+
+## 1. Frozen op kinds
+
+Six kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
+`ValueError("unknown op ...")` — it never ignores one.
+
+| Kind | Batchable | Standalone command | Summary |
+|------|-----------|--------------------|---------|
+| `add_node` | yes | `comfy workflow add-node` | Mint and insert one node |
+| `connect` | yes | `comfy workflow connect` | Wire one output slot to one input slot |
+| `set_widget` | yes | `comfy workflow set-widget` | Set one widget value by name |
+| `delete_node` | yes | `comfy workflow delete` | Remove one node and its incident links |
+| `clear` | no | `comfy workflow clear` | Remove every node, link, and group |
+| `reset_doc` | no | (deferred) | Reset the whole document to an empty baseline |
+
+Batchable = the kind is accepted by `apply_specs` (the `workflow apply` /
+`workflow foreach` batch surface). `clear` and `reset_doc` rewrite the whole
+document, so they are standalone-only: a batch containing `clear` is rejected
+atomically with error code `workflow_clear_not_batchable` and a hint naming the
+standalone `comfy workflow clear` command. Nothing from such a batch is applied.
+
+Every op carries the common envelope stamped by `_new_op`:
+
+```json
+{
+  "op": "<kind>",
+  "op_id": "<uuid4 hex>",
+  "actor": "<origin string, section 7>",
+  "base_version": 0,
+  "stamp": [<base_version>, "<actor>"]
+}
+```
+
+### 1.1 `add_node`
+
+Spec form (batch input):
+
+```json
+{"op": "add_node", "class_type": "KSampler", "at": [x, y], "as": "sampler"}
+```
+
+`at` is optional (layout assigns a collision-free position at mint time; the
+position freezes into the op). `as` is optional and declares a batch-local alias
+(section 5). Minted op fields beyond the envelope: `node_id` (mint_id int),
+`class_type`, `pos`, `node` (the complete node object — replay inserts it verbatim).
+
+* Idempotency: re-applying the same `op_id` is a no-op; independently, replaying
+  an `add_node` whose `node_id` already exists in the graph is a no-op.
+* Conflict: none — ids are minted leaderlessly (section 6), so two concurrent
+  `add_node` ops never target the same identity.
+* Invalid: an unknown `class_type` is rejected at mint time (`UnknownNodeType`,
+  rendered as `node_not_found` with close matches).
+
+### 1.2 `connect`
+
+Spec form:
+
+```json
+{"op": "connect", "from": "$up.MODEL", "to": "$sampler.model"}
+```
+
+`from`/`to` are `<node>.<slot>` where `<node>` is an int id, a bare alias, or a
+`$`-prefixed alias, and `<slot>` is a name or an index. Minted op fields:
+`link_id` (mint_id int), `from_node`, `from_slot` (resolved output index),
+`to_node`, `to_slot` (resolved input index; `null` for autogrow), `link_type`,
+and optionally `grow` (autogrow slot descriptor: `{name, type, widget?, inputcount?}`).
+
+* Idempotency: `op_id` no-op; a link tuple with an already-present `link_id` is
+  not appended twice.
+* Conflict: a concrete input holds at most one link — a connect to an occupied
+  input replaces it and fully retires the prior link (`_remove_link`). Two
+  concurrent connects to the same concrete input are an update-vs-update
+  conflict on that input (section 3). Autogrow connects are non-clobbering:
+  each grows a fresh slot keyed by `grow_id` (the link id), so both survive.
+* Invalid: type-mismatched slots are rejected at mint time; a link cannot cross
+  a subgraph boundary (rejected with the boundary explanation).
+
+### 1.3 `set_widget`
+
+Spec form:
+
+```json
+{"op": "set_widget", "node": "$sampler", "widget": "steps", "value": 30}
+```
+
+`node` is an int id, alias, `$alias`, or a subgraph-scoped id (section 6).
+Minted op fields: `node_id`, `widget` (name, never index), `value`, `old`; for a
+subgraph interior write also `path` (resolved node path, list of strings) and
+`inner_widget`; optionally `warnings` (e.g. `normalized_value`).
+
+* Idempotency: `op_id` no-op.
+* Conflict: last-writer-wins per `(node, widget)` target (section 3).
+* Invalid: an unknown widget name or shape-mismatched value is rejected at mint
+  time; at replay an unknown widget name on a live node also rejects
+  (`_widget_index` raises), while a missing node is a no-op (delete wins).
+
+### 1.4 `delete_node`
+
+Spec form:
+
+```json
+{"op": "delete_node", "node": "$sampler"}
+```
+
+Minted op fields: `node_id`, `removed_links` (ids of every link incident to the
+node at mint time). Replay removes the node, drops incident links (both the
+recorded ones and any link whose endpoint is the node), and scrubs dangling
+input/output references.
+
+* Idempotency: `op_id` no-op; replaying a delete of an already-absent node is a
+  no-op.
+* Conflict: delete wins over concurrent updates (section 3).
+* Invalid: deleting a node that does not exist is rejected at mint time
+  (`node not found` with the live node inventory).
+
+### 1.5 `clear` — standalone only
+
+Command: `comfy workflow clear <file>`. Minted op fields: `removed_nodes` (ids
+present at mint time). Replay empties `nodes`, `links`, and `groups`.
+`last_node_id` / `last_link_id` are preserved so ids minted after a clear stay
+monotonic — id reuse would let a merge resurrect a deleted node's identity.
+
+* Batchable: **no**. `apply_specs` rejects it with the registered code
+  `workflow_clear_not_batchable`; the batch is discarded atomically and the hint
+  names the standalone command.
+* Idempotency: `op_id` no-op; clearing an empty document changes nothing.
+
+### 1.6 `reset_doc` — standalone only, deferred
+
+Defined here; **implementation is deferred to the bulk-writers ticket**.
+`apply_op` currently rejects it (`unknown op 'reset_doc'`), and the contract
+tests pin that it stays rejected until it is un-deferred by amendment.
+
+Semantics when implemented: replace the entire document with the empty baseline,
+including apply bookkeeping — unlike `clear`, which preserves the id high-water
+marks and the applied-op history. Because it erases replay history, it is a
+history barrier: ops minted against a pre-reset `base_version` do not replay
+across it. Guard semantics: the CLI surface requires an explicit `--confirm`
+flag; without it the command fails closed and applies nothing. Not batchable,
+for the same reason as `clear`.
+
+## 2. Idempotency and identity
+
+* Every op carries `op_id`: uuid4 hex, minted by the **creator, before
+  dispatch** (`_new_op`). Receivers never regenerate or rewrite an `op_id`.
+* `apply_op` records applied `op_id`s in the document's `_applied_ops` list and
+  drops any op whose `op_id` is already there. **Uniqueness scope is
+  PER-WORKFLOW**: the same `op_id` can exist in two different workflow documents
+  without interaction; within one document each op applies exactly once.
+* `_applied_ops` (and `_widget_stamps`) are apply-time bookkeeping, stripped
+  before serialization to disk (`strip_internal`).
+
+## 3. Conflict rules
+
+Scalar conflicts resolve by last-writer-wins on the op stamp. The stamp is
+`stamp = [base_version, actor]` (stamped by `_new_op`); the exact comparison is
+`_stamp_key` in `workflow_ops.py`:
+
+```python
+def _stamp_key(op: dict) -> list:
+    stamp = op.get("stamp") or [op.get("base_version", 0), op.get("actor", "")]
+    return [stamp[0], stamp[1], op["op_id"]]
+```
+
+and the gate is `_lww_gate`: a write applies iff `_stamp_key(op) > list(prior)`
+for its target. Higher `base_version` wins; ties break by `actor`, then by the
+unique `op_id` — so no two distinct ops ever compare equal, the order is total,
+and the surviving value is independent of apply order.
+
+| Scenario | Ruling | Where in code |
+|----------|--------|---------------|
+| update vs update (same widget) | LWW on `stamp` with `op_id` tiebreak; loser dropped | `_lww_gate` / `_stamp_key` |
+| update vs delete | **delete wins**: `set_widget` to a deleted node is a no-op; `connect` with either endpoint deleted is a no-op; replay never raises on a since-removed target | `_apply_set_widget` (missing node → return), `_apply_connect` (missing endpoint → return) |
+| concurrent moves | no `move` op exists in v1 — positions are decided once at `add_node` mint time and frozen into the op; live position editing is frontend view state, out of scope until the FE stable-ID reconciliation (section 6) | `add_node` / `layout.cascade_pos` |
+| edges referencing deleted nodes | the connect no-ops (delete wins); a delete removes incident links and scrubs every dangling input/output reference, so no dangling edge survives either order | `_apply_connect`, `_apply_delete_node` |
+| duplicate entity creation | impossible by construction across writers (random 53-bit `mint_id`, no shared counter); a replayed `add_node` whose `node_id` already exists is a no-op; a re-sent op is dropped by `op_id` | `mint_id`, `_apply_add_node` |
+| concurrent autogrow connects to one base | both survive: each grows a fresh slot keyed by `grow_id`; their display order is the one sequence decision a leaderless writer cannot make and is surfaced by `detect_conflict` for the merge consumer | `_apply_connect` (grow path), `detect_conflict` |
+| invalid / inapplicable ops | explicit per kind — unknown kind: **reject** (`apply_op` raises); malformed op (missing required field): **reject**; well-formed op whose target node is gone: **no-op** (delete wins); `set_widget` naming a widget the live schema does not have: **reject**; `clear`/`reset_doc` inside a batch: **reject** with `workflow_clear_not_batchable` / `unknown op`. Rejection is never silent | `apply_op`, `apply_specs`, `_widget_index` |
+
+## 4. Partial batches: abort-remainder
+
+Ruling: **abort-remainder**. In a batch of `n` ops, if op `k` fails, ops
+`k..n` are **not applied**. The ack reports:
+
+```json
+{"applied_count": <k-1>, "failed": {"index": <k>, "op": {...}, "code": "<error code>"}}
+```
+
+A retried batch converges by the idempotency rule: every op that did apply is
+dropped on re-apply by its `op_id`, so retrying the whole batch is exactly-once
+per op. The retrier fixes or removes the failing op; it never re-mints `op_id`s
+for ops that may already have landed.
+
+The local CLI batch surface (`comfy workflow apply`) is stricter than the
+minimum: it discards the **entire** batch on any failure (`applied_count` is
+always 0 on failure — nothing is written) and restates the surviving node
+inventory in the error. That is a conforming implementation of abort-remainder;
+a merge consumer MUST NOT apply any op after the failing index and MUST report
+`applied_count` truthfully.
+
+## 5. Aliases
+
+An `add_node` spec may declare a batch-local alias with `"as": "<name>"`. Later
+specs in the same batch reference the minted node by alias.
+
+* Both reference forms are valid: bare (`"up.MODEL"`, `"node": "up"`) and
+  `$`-prefixed (`"$up.MODEL"`, `"node": "$up"`). Exactly one leading `$` is
+  stripped before lookup (`resolve_ref`); the two forms resolve identically.
+* **`$`-prefixed is the canonical form** — use it in documentation and
+  generated batches. It makes an alias visually distinct from a node id or a
+  class name.
+* `${` is **rejected**: `${name}` is reserved for recipe parameters
+  (`substitute_params` fills them from `--param`; an undeclared `${name}` is a
+  `RecipeError`). A `${...}` reaching `resolve_ref` means an unsubstituted
+  recipe parameter and fails with a message saying exactly that — it is never
+  treated as an alias or a node id.
+* A duplicate alias in one batch is rejected (`alias ... is already defined by
+  an earlier spec`); an unknown alias falls through to id resolution and fails
+  as `node not found` with the live node inventory. Both behaviors predate this
+  freeze and are unchanged.
+* Aliases are batch-scoped. They do not persist into the document or across
+  batches; the ack maps each alias to its minted `node_id`.
+
+## 6. Stamping and IDs
+
+* `op_id`: uuid4 hex, minted by the creator pre-dispatch. Receivers never
+  regenerate one (section 2).
+* Node and link ids: `mint_id()` — random ints in `[2^40, 2^53)`. Leaderless
+  and collision-free without coordination; always inside JS
+  `Number.MAX_SAFE_INTEGER`; always larger than small frontend counter ids.
+  `last_node_id` / `last_link_id` are advisory high-water marks, never
+  allocators.
+* Subgraph-scoped ids: an interior node is addressed as `57:3` (the flattened
+  form the UI→API lowering mints and `validate` / server errors print) or
+  `57/3` (the edit-path form); both resolve to the same interior target. **Ops
+  must carry fully-scoped ids** — a bare interior id is meaningless at the top
+  level and is rejected, not guessed.
+* OPEN: ID representation is to be reconciled with the FE stable-ID workstream
+  before this document's v1.1. Until then, the shapes above are the contract.
+
+## 7. Attribution origins
+
+The `actor` field carries the origin of the op. Frozen origin grammar:
+
+| Origin | Format | Example |
+|--------|--------|---------|
+| agent turn | `agent:<thread>:<turn>` | `agent:th_8f2c:12` |
+| human editor | `human:<user>:<tab>` | `human:u_41ab:tab_2` |
+| system-minted | `system:mint` | `system:mint` |
+
+The actor participates in LWW tie-breaking (section 3), so origin strings must
+be stable within a writer session. The CLI's `--actor` flag carries the origin;
+its default `cli` is a legacy value accepted for interactive local use —
+merge-consumer traffic uses the structured forms above.
+
+## 8. Amendments
+
+* Post-freeze changes require a **versioned amendment section** appended to
+  this document (`## Amendment v1.x — <date>`), stating what changed and why.
+  Silent edits to frozen sections are not valid; the contract tests pin the
+  frozen table against the code.
+* Downstream repos cite this document by commit SHA and upgrade by moving the
+  SHA, never by tracking a branch.
+* Adding, removing, or re-scoping an op kind requires updating `FROZEN_OPS` /
+  `DEFERRED_OPS` / `BATCHABLE_OPS`, the dispatch tables, and this document in
+  one commit — `tests/comfy_cli/test_op_vocabulary_contract.py` fails otherwise.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -269,7 +269,128 @@ be stable within a writer session. The CLI's `--actor` flag carries the origin;
 its default `cli` is a legacy value accepted for interactive local use —
 merge-consumer traffic uses the structured forms above.
 
-## 8. Amendments
+## 8. Replication and replay semantics
+
+Rules a second implementation (JS/TS merge consumer, multi-player) must follow
+to converge with the Python applier. Grounded against `workflow_ops.py` and the
+V1-007 CRDT replay spike. The unit of replication is the **op**: every replica
+applies every op exactly once (any order) through an applier with these
+semantics. Exchanging raw document state between concurrently-editing replicas
+is not equivalent and does not inherit these guarantees.
+
+### 8.1 Stamp comparison is code-point lexicographic
+
+`_stamp_key` builds `[base_version, actor, op_id]` and relies on Python
+sequence comparison: element-wise, first difference decides. The frozen rule,
+so any implementation compares identically:
+
+* `base_version`: numeric comparison.
+* `actor`, then `op_id`: **Unicode code point order** (Python `str` `<`),
+  compared character by character; a strict prefix sorts before its extension.
+* No locale, no case folding, no normalization.
+
+`op_id` is lowercase ASCII hex (8.2), so code-point order equals byte order
+for it. `actor` strings MUST be ASCII (the section 7 grammar is) — for ASCII,
+JS UTF-16 `<` agrees with code-point order; above the Basic Multilingual Plane
+it does not, which is why non-ASCII actors are not valid.
+
+### 8.2 `op_id` format is LWW-load-bearing
+
+`_new_op` emits `uuid.uuid4().hex`: exactly **32 lowercase hex characters
+`[0-9a-f]`, no dashes**. This is a frozen format, not an implementation
+detail: `op_id` is the final LWW tiebreaker (8.1), so its generation and its
+lexicographic comparison decide conflict outcomes, not just deduplication. An
+implementation that emits a different shape (uppercase, dashed UUID, shorter)
+changes who wins ties. Receivers never regenerate or normalize an `op_id`.
+
+### 8.3 `last_node_id` / `last_link_id` are max-registers
+
+Both are advisory high-water marks, never allocators (ids come from
+`mint_id`). Register semantics: **max-register** — a write is
+`max(current, new)`, and merging two replicas' values is `max(a, b)`; a plain
+overwrite is wrong under concurrency.
+
+`_apply_add_node` implements this for nodes:
+`workflow["last_node_id"] = max(workflow.get("last_node_id") or 0, op["node_id"])`.
+`_apply_connect` does **not** bump `last_link_id` today — no apply path writes
+it. The intended, frozen rule is symmetric: connect SHOULD set
+`last_link_id = max(last_link_id, link_id)`; the omission is a known gap, and
+because the field is advisory, an implementation that already bumps it does
+not diverge semantically from one that does not. `clear` preserves both
+(section 1.5).
+
+### 8.4 `inputcount`-family autogrow: one op, two registers
+
+A connect whose `grow.inputcount` is set (the kijai `*Multi` family) performs
+two writes under one `op_id`:
+
+1. **Structural growth**: a new input slot with a bare `{elem}_N` name
+   (`_next_inputcount_name` — never the dotted `base.elemN` autogrow shape),
+   keyed by `grow_id = link_id` for idempotent, non-clobbering replay.
+2. **A stamped widget write** to the family's count widget
+   (`_apply_inputcount_bump`), passing through the same `_lww_gate` /
+   `_lww_commit` as an explicit `set_widget`, **stamped with the connect's own
+   `op_id` / `stamp` / `base_version`**. It therefore occupies the same LWW
+   register (`("widget", node_id, widget)`) as a concurrent explicit
+   `set_widget` on that widget, and the winner is decided by 8.1 regardless of
+   apply order.
+
+The written value is the mint-time-planned count — a static property of the
+op, never re-derived from a post-collision slot number — so both apply orders
+carry the same winning value and the graph converges. Known, accepted
+limitation: the register is LWW, not a monotonic counter, so a slot that loses
+a bare-key naming race can leave the count low until the next write to that
+widget. When the applier has no catalog (`graph is None`), the slot still
+grows and the count write is skipped.
+
+### 8.5 `op.node` on `add_node` is authoritative
+
+`_apply_add_node` inserts `op["node"]` verbatim (`copy.deepcopy`, one append).
+Receivers MUST use the payload as-is and MUST NOT re-mint the node from the
+schema catalog at apply time: widget defaults drift between catalog versions,
+so a re-derived node diverges from the creator's. No catalog is needed to
+apply an `add_node`.
+
+### 8.6 Bootstrap: one common initial snapshot
+
+All replicas of a workflow document MUST fork from one seeded initial
+snapshot. Independently re-seeding the same base workflow on two replicas
+creates content with distinct internal identities that **duplicates on first
+merge** — silently, because each replica looks correct alone (verified in the
+spike). Creating a document and seeding its base state is a single-writer
+event; replication starts from that snapshot.
+
+### 8.7 Subgraph scope
+
+Current contract, pinned:
+
+* **Only `set_widget` is subgraph-scoped.** Three address forms are accepted
+  and normalize to ONE write target: flat promoted (`57.text`, routed through
+  the instance's `proxyWidgets`), nested interior (`57/3.steps`), and the
+  flattened UI→API alias (`57:3.cfg`). The minted op carries the **resolved**
+  `path` (e.g. `["57", "27"]`) plus `inner_widget`, so replay needs no
+  proxyWidgets logic, and the LWW target is
+  `("widget", ("57", "27"), "text")` — a flat-form and a nested-form
+  concurrent write to the same interior widget converge under 8.1.
+* **`connect` refuses subgraph scope** with a structural explanation: an
+  interior endpoint is rejected with "a link cannot cross the subgraph
+  boundary"; a promoted-widget target is rejected with "promoted widget (a
+  value), not a link input".
+* **`add_node` and `delete_node` cannot address interior nodes** at all; an
+  interior id fails as node-not-found against the top-level inventory.
+* An interior write to a **shared** definition forks the definition at apply
+  time (`engine._isolate_shared_subgraph`): the definition is deep-copied
+  under `"sg-" + sha256(def_id + "\x00" + instance_id)[:32]` — deterministic,
+  never random — and the instance's `type` is repointed, so two replicas
+  replaying the same op produce byte-identical graphs and sibling instances
+  are never aliased.
+* OPEN: the shared-definition forking semantics above are apply-time behavior
+  that rewrites `instance.type` without an explicit op saying so. A full
+  specification (fork visibility, interaction with concurrent interior writes
+  to sibling instances, definition garbage collection) is owed before this
+  document's v1.1, together with the FE stable-ID reconciliation (section 6).
+
+## 9. Amendments
 
 * Post-freeze changes require a **versioned amendment section** appended to
   this document (`## Amendment v1.x — <date>`), stating what changed and why.

--- a/tests/comfy_cli/test_op_vocabulary_contract.py
+++ b/tests/comfy_cli/test_op_vocabulary_contract.py
@@ -13,6 +13,7 @@ tests pin it two ways so neither the doc nor the code can drift silently:
 
 from __future__ import annotations
 
+import re
 import uuid
 from pathlib import Path
 from typing import Any
@@ -205,7 +206,30 @@ def test_dollar_brace_rejected():
 
 
 # ---------------------------------------------------------------------------
-# 6. clear in a batch: registered code, hint names the standalone command
+# 6. op_id format (doc section 8.2): LWW-load-bearing, so its shape is contract
+# ---------------------------------------------------------------------------
+
+
+def test_op_id_format_is_frozen():
+    """op_id is the final LWW tiebreaker (doc sections 8.1/8.2): exactly 32
+    lowercase hex chars, no dashes, on every minted op kind — its lexicographic
+    comparison decides conflict outcomes, not just deduplication."""
+    op_id_re = re.compile(r"^[0-9a-f]{32}$")
+    g = _graph()
+    wf: dict[str, Any] = {"nodes": [], "links": []}
+    wf, add_op = workflow_ops.add_node(wf, g, "TinyLoader")
+    wf, add2_op = workflow_ops.add_node(wf, g, "TinySink")
+    wf, conn_op = workflow_ops.connect(wf, g, add_op["node_id"], "MODEL", add2_op["node_id"], "model")
+    wf, set_op = workflow_ops.set_widget(wf, g, add_op["node_id"], "ckpt_name", "a.safetensors")
+    wf, del_op = workflow_ops.delete_node(wf, g, add2_op["node_id"])
+    wf, clear_op = workflow_ops.clear(wf)
+    for op in (add_op, add2_op, conn_op, set_op, del_op, clear_op):
+        assert op_id_re.match(op["op_id"]), f"{op['op']} minted op_id {op['op_id']!r}, not 32 lowercase hex chars"
+        assert op["stamp"] == [op["base_version"], op["actor"]]
+
+
+# ---------------------------------------------------------------------------
+# 7. clear in a batch: registered code, hint names the standalone command
 # ---------------------------------------------------------------------------
 
 

--- a/tests/comfy_cli/test_op_vocabulary_contract.py
+++ b/tests/comfy_cli/test_op_vocabulary_contract.py
@@ -1,0 +1,225 @@
+"""Enforce docs/op-vocabulary-v1.md against the code it freezes.
+
+The doc is the normative contract for the structured-edit op vocabulary; these
+tests pin it two ways so neither the doc nor the code can drift silently:
+
+  * the doc's frozen-kinds table == ``workflow_ops.FROZEN_OPS`` == the kinds
+    ``apply_op`` actually replays (minus the explicitly deferred ones);
+  * the doc's ``Batchable`` column == the kinds ``apply_specs`` actually
+    dispatches;
+  * the ``$``-alias sugar and the batch-``clear`` rejection behave exactly as
+    the doc rules.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from comfy_cli import error_codes, workflow_ops
+from comfy_cli.cql.engine import Graph
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "op-vocabulary-v1.md"
+
+
+# ---------------------------------------------------------------------------
+# doc parsing — the frozen-kinds table is the machine-readable surface
+# ---------------------------------------------------------------------------
+
+
+def _parse_frozen_table() -> dict[str, bool]:
+    """Parse the doc's frozen-kinds markdown table into {kind: batchable}.
+
+    The table is identified by a header row containing both ``Kind`` and
+    ``Batchable``; the ``Batchable`` cell must be exactly ``yes`` or ``no``.
+    """
+    assert DOC.is_file(), f"contract doc missing: {DOC}"
+    lines = DOC.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not (stripped.startswith("|") and "Kind" in stripped and "Batchable" in stripped):
+            continue
+        header = [c.strip() for c in stripped.strip("|").split("|")]
+        kind_col = header.index("Kind")
+        batch_col = header.index("Batchable")
+        table: dict[str, bool] = {}
+        for row in lines[i + 2 :]:  # skip the |---| separator
+            row = row.strip()
+            if not row.startswith("|"):
+                break
+            cells = [c.strip() for c in row.strip("|").split("|")]
+            kind = cells[kind_col].strip("`")
+            batchable = cells[batch_col]
+            assert batchable in ("yes", "no"), f"Batchable cell for {kind!r} must be exactly yes/no, got {batchable!r}"
+            table[kind] = batchable == "yes"
+        assert table, "frozen-kinds table has a header but no rows"
+        return table
+    raise AssertionError("no markdown table with `Kind` and `Batchable` columns found in the doc")
+
+
+# ---------------------------------------------------------------------------
+# probes — what the code actually accepts, discovered behaviorally
+# ---------------------------------------------------------------------------
+
+
+def _apply_op_accepts(kind: str) -> bool:
+    """True iff ``apply_op`` dispatches ``kind`` (vs rejecting it as unknown).
+
+    A malformed-but-dispatched probe op fails with KeyError etc. — that still
+    counts as accepted; only the explicit ``unknown op`` rejection counts as no.
+    """
+    wf: dict[str, Any] = {"nodes": [], "links": []}
+    op = {"op": kind, "op_id": uuid.uuid4().hex, "actor": "probe", "base_version": 0, "stamp": [0, "probe"]}
+    try:
+        workflow_ops.apply_op(wf, op, None)
+    except ValueError as e:
+        if "unknown op" in str(e):
+            return False
+    except Exception:
+        pass  # dispatched into a handler, probe op just lacks that kind's fields
+    return True
+
+
+def _apply_specs_accepts(kind: str) -> bool:
+    """True iff ``apply_specs`` dispatches ``kind`` inside a batch."""
+    try:
+        workflow_ops.apply_specs({"nodes": [], "links": []}, _graph(), [{"op": kind}])
+    except workflow_ops.NotBatchableError:
+        return False
+    except (ValueError, KeyError) as e:
+        return "unknown op" not in str(e)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# a two-node catalog: one MODEL producer, one MODEL consumer
+# ---------------------------------------------------------------------------
+
+
+def _object_info() -> dict[str, Any]:
+    return {
+        "TinyLoader": {
+            "input": {"required": {"ckpt_name": [["a.safetensors", "b.safetensors"]]}},
+            "input_order": {"required": ["ckpt_name"]},
+            "output": ["MODEL"],
+            "output_name": ["MODEL"],
+            "category": "loaders",
+            "display_name": "Tiny Loader",
+            "python_module": "nodes",
+        },
+        "TinySink": {
+            "input": {"required": {"model": "MODEL"}},
+            "input_order": {"required": ["model"]},
+            "output": [],
+            "output_name": [],
+            "category": "test",
+            "display_name": "Tiny Sink",
+            "python_module": "nodes",
+        },
+    }
+
+
+def _graph() -> Graph:
+    return Graph.from_object_info(_object_info())
+
+
+def _connect_specs(from_ref: str, to_ref: str) -> list[dict]:
+    return [
+        {"op": "add_node", "class_type": "TinyLoader", "as": "up"},
+        {"op": "add_node", "class_type": "TinySink", "as": "sink"},
+        {"op": "connect", "from": from_ref, "to": to_ref},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. the doc's frozen kinds == FROZEN_OPS == apply_op's dispatch table
+# ---------------------------------------------------------------------------
+
+
+def test_doc_lists_exactly_the_apply_op_kinds():
+    table = _parse_frozen_table()
+    assert set(table) == set(workflow_ops.FROZEN_OPS), (
+        f"doc table {sorted(table)} != FROZEN_OPS {sorted(workflow_ops.FROZEN_OPS)}"
+    )
+    # The probe must be able to tell acceptance from rejection at all.
+    assert not _apply_op_accepts("definitely_not_an_op")
+    accepted = {k for k in workflow_ops.FROZEN_OPS if _apply_op_accepts(k)}
+    expected = set(workflow_ops.FROZEN_OPS) - set(workflow_ops.DEFERRED_OPS)
+    assert accepted == expected, (
+        f"apply_op accepts {sorted(accepted)} but the frozen vocabulary (minus deferred "
+        f"{sorted(workflow_ops.DEFERRED_OPS)}) is {sorted(expected)}"
+    )
+    # Deferred kinds are frozen in the doc but must NOT be replayable yet.
+    for kind in workflow_ops.DEFERRED_OPS:
+        assert kind in workflow_ops.FROZEN_OPS
+        assert not _apply_op_accepts(kind), f"deferred op {kind!r} is implemented; un-defer it in the contract"
+
+
+# ---------------------------------------------------------------------------
+# 2. the doc's Batchable column == apply_specs' dispatch table
+# ---------------------------------------------------------------------------
+
+
+def test_batchability_matches_apply_specs():
+    table = _parse_frozen_table()
+    doc_batchable = {k for k, batchable in table.items() if batchable}
+    assert doc_batchable == set(workflow_ops.BATCHABLE_OPS)
+    probed = {k for k in workflow_ops.FROZEN_OPS if _apply_specs_accepts(k)}
+    assert probed == doc_batchable, (
+        f"apply_specs dispatches {sorted(probed)} but the doc marks {sorted(doc_batchable)} batchable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3./4./5. alias rules: bare and $-prefixed resolve identically; ${ rejects
+# ---------------------------------------------------------------------------
+
+
+def test_dollar_prefixed_alias_resolves():
+    specs = _connect_specs("$up.MODEL", "$sink.model")
+    specs.append({"op": "set_widget", "node": "$up", "widget": "ckpt_name", "value": "b.safetensors"})
+    wf, ops, aliases = workflow_ops.apply_specs({"nodes": [], "links": []}, _graph(), specs)
+    links = wf["links"]
+    assert len(links) == 1
+    assert links[0][1] == aliases["up"] and links[0][3] == aliases["sink"]
+    set_op = next(op for op in ops if op["op"] == "set_widget")
+    assert set_op["node_id"] == aliases["up"]
+    assert set_op["value"] == "b.safetensors"
+
+
+def test_bare_alias_still_resolves():
+    wf, _ops, aliases = workflow_ops.apply_specs(
+        {"nodes": [], "links": []}, _graph(), _connect_specs("up.MODEL", "sink.model")
+    )
+    links = wf["links"]
+    assert len(links) == 1
+    assert links[0][1] == aliases["up"] and links[0][3] == aliases["sink"]
+
+
+def test_dollar_brace_rejected():
+    with pytest.raises(ValueError, match="recipe param"):
+        workflow_ops.apply_specs({"nodes": [], "links": []}, _graph(), _connect_specs("${up}.MODEL", "$sink.model"))
+
+
+# ---------------------------------------------------------------------------
+# 6. clear in a batch: registered code, hint names the standalone command
+# ---------------------------------------------------------------------------
+
+
+def test_clear_rejected_in_batch_with_registered_hint():
+    with pytest.raises(workflow_ops.NotBatchableError) as ei:
+        workflow_ops.apply_specs(
+            {"nodes": [], "links": []},
+            _graph(),
+            [{"op": "add_node", "class_type": "TinyLoader"}, {"op": "clear"}],
+        )
+    err = ei.value
+    assert error_codes.is_registered(err.code), f"{err.code!r} is not in error_codes.REGISTRY"
+    registered = error_codes.get(err.code)
+    assert registered is not None and "comfy workflow clear" in (registered.hint or "")
+    assert "comfy workflow clear" in err.hint
+    # Atomicity is part of the message contract: the caller must learn nothing landed.
+    assert "no changes were applied" in str(err).lower()


### PR DESCRIPTION
Implements Linear **BE-7142** (V1-001): freeze the structured-edit op vocabulary as a normative, versioned contract, enforced by tests, plus the two small code changes the freeze rules require.

## What

- **`docs/op-vocabulary-v1.md`** — the frozen contract:
  - Six frozen kinds (`add_node`, `connect`, `set_widget`, `delete_node`, `clear`, `reset_doc`) with exact arg shapes (spec form + minted op fields), batchability, idempotency (`op_id` no-op on re-apply, uniqueness scope = **per-workflow**), and the LWW conflict rule (`stamp = [base_version, actor]`, `op_id` tiebreak — quoting the exact `_stamp_key` / `_lww_gate` comparison).
  - Concurrency semantics table: update-vs-update (LWW), update-vs-delete (**delete wins** — verified against `_apply_set_widget` / `_apply_connect`), concurrent moves (no `move` op in v1; positions frozen at mint), edges referencing deleted nodes, duplicate entity creation (leaderless `mint_id`), invalid/inapplicable ops (explicit reject/no-op per kind).
  - Stamping/ID rules (uuid4 `op_id` minted by creator pre-dispatch, receivers never regenerate; 53-bit `mint_id` node/link ids; subgraph-scoped `57:3` / `57/3` ids must be fully scoped) with an **OPEN marker** for reconciliation with the FE stable-ID workstream before v1.1.
  - Attribution origins (`agent:<thread>:<turn>` / `human:<user>:<tab>` / `system:mint`), the amendment rule (versioned amendment sections; downstream cites by commit SHA), and an explicit note that this freezes code on the unmerged `fix/validate-lowers-ui-to-api` branch.
- **`workflow_ops.FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS`** — the machine-readable projection of the doc.
- **`$`-alias sugar** in `resolve_ref`: exactly one leading `$` stripped before lookup; `$up` ≡ `up`, `$`-prefixed is the canonical documented form. `layout.assign_positions` strips the same `$` so `$`-aliased connects keep dataflow layering.
- **`${` rejected**: an unsubstituted `${name}` reaching `resolve_ref` now fails loudly as a reserved recipe-parameter shape instead of falling through to a misleading "node not found". Recipe-param substitution (`substitute_params`) is untouched; duplicate/unknown-alias errors unchanged.
- **Batch `clear` rejection is now a registered contract**: `apply_specs` raises `NotBatchableError` (code **`workflow_clear_not_batchable`**, registered in `error_codes.py`) instead of the generic `unknown op` → `workflow_edit_invalid`; `workflow apply` / `workflow foreach` render the code with a hint naming the standalone `comfy workflow clear` command. The batch stays atomic — nothing is applied.

## Design rulings encoded

- **D2 — aliases**: bare names and `$alias` sugar are both valid; `$` stripped before lookup; `${` rejected (recipe-param collision); `$`-prefixed is the canonical form in docs/examples.
- **D5 — partial batches**: **abort-remainder** — op *k* of *n* fails ⇒ ops *k..n* not applied; ack reports `failed:{index, op, code}` + `applied_count`; retried batches converge via `op_id` drop (exactly-once per op). The CLI's discard-all atomic `apply` is documented as a conforming, stricter implementation.
- `clear`: **not batchable**, standalone only. `reset_doc`: defined with `--confirm` guard semantics, **implementation deferred** to the bulk-writers ticket; contract tests pin that `apply_op` keeps rejecting it until un-deferred by amendment.

## Test evidence

New enforcement suite `tests/comfy_cli/test_op_vocabulary_contract.py` (TDD — written first, red before implementation):

- red: `5 failed, 1 passed` (doc/constants/`NotBatchableError` missing, `$up` unresolved, `${up}` passed through; `test_bare_alias_still_resolves` green as expected — pre-existing behavior)
- green after implementation: `6 passed`

Checks:
- `test_doc_lists_exactly_the_apply_op_kinds` — doc table == `FROZEN_OPS` == kinds `apply_op` dispatches (behavioral probe), deferred kinds stay rejected
- `test_batchability_matches_apply_specs` — doc `Batchable` column == `BATCHABLE_OPS` == kinds `apply_specs` dispatches
- `test_dollar_prefixed_alias_resolves` / `test_bare_alias_still_resolves` / `test_dollar_brace_rejected`
- `test_clear_rejected_in_batch_with_registered_hint` — code registered both ways, hint names `comfy workflow clear`, message states nothing was applied
- `test_op_id_format_is_frozen` — every minted op kind emits a 32-char lowercase-hex `op_id` (no dashes) + the `[base_version, actor]` stamp envelope; the format is LWW-load-bearing (tiebreak), so it is contract

Verification:
- `uv run pytest tests/comfy_cli/test_op_vocabulary_contract.py -q` → **7 passed**
- Neighbouring suites (`test_workflow_edit.py`, `test_error_code_registry.py`, `test_layout.py`, `test_workflow_apply_rollback.py`) → **115 passed** (the two-way error-code registry gate covers the new code)
- Full suite: `uv run pytest -q -x` → **1 failed, 806 passed** (3m16s). The failure, `tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py::test_default_omitted_does_not_force_uv_compile`, is **pre-existing on the base commit `42f56e5`** — verified by re-running it at the base with this PR's changes stashed; it fails identically and is unrelated to this diff. (`--timeout=120` is unusable here: pytest-timeout is not installed in this repo.)
- `ruff check` / `ruff format` clean on changed files
- End-to-end CLI smoke: `comfy --json workflow apply` with a `clear` in the batch emits `error.code=workflow_clear_not_batchable` + the standalone-command hint (exit 1); a `$`-aliased add/add/connect batch applies and mints 53-bit ids

## Follow-up: replication/replay semantics from the V1-007 CRDT replay spike

Second commit appends frozen **section 8 "Replication and replay semantics"** to the doc (part of the initial freeze, not an amendment — the doc had not shipped). It pins the LWW/replication load-bearing rules the code implements but nothing pinned, grounded against `workflow_ops.py` and the spike findings:

- **8.1 stamp comparison** is code-point lexicographic (`[base_version` numeric, then `actor`, then `op_id]` in Unicode code-point order — Python `str <`); actor ids must be ASCII so a JS/TS UTF-16 comparison agrees.
- **8.2 `op_id` format** is frozen and LWW-load-bearing: `uuid4().hex` — exactly 32 lowercase hex chars, no dashes; its lexicographic comparison decides tie outcomes, not just dedupe.
- **8.3 `last_node_id`/`last_link_id` are max-registers** (write = `max(current, new)`, merge = `max`); pins that `connect` does not bump `last_link_id` today and states the intended symmetric rule.
- **8.4 `inputcount`-family autogrow**: one connect op writing two registers — `grow_id`-keyed slot growth plus a count-widget write stamped with the connect's own `op_id`/`stamp` through the same LWW gate, value planned at mint time (LWW register, not a monotonic counter — known undercount race documented).
- **8.5 `op.node` on `add_node` is authoritative** — receivers apply the payload verbatim, never re-mint from the catalog (defaults drift).
- **8.6 bootstrap rule** — all replicas fork one common initial snapshot; independent re-seeding duplicates content on first merge.
- **8.7 subgraph scope** — `set_widget`-only; the three address forms (`57.text` flat-promoted / `57/3` nested / `57:3` flattened) normalize to one resolved-path write target; `connect`/`add_node`/`delete_node` refuse interior scope; deterministic `sg-` + sha256 definition forking; OPEN marker for full shared-definition forking semantics before v1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

