### PR TITLE
feat(cli): --select projection on the heavy four (one selector, fail-open, selected/total_bytes)

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -841,12 +841,20 @@ def _list_models(extra_args: list[str]) -> None:
     partner = _arg_value(clean, "--partner", "-p")
     category = _arg_value(clean, "--category", "--style", "-c")
     query = _arg_value(clean, "--query", "-q")
+    # `list`-only, deliberately NOT in `_separate_meta_flags`' meta_names: that
+    # set applies to every generate sub-action, and --select belongs to the
+    # four heavy read commands only (V1-011).
+    select_expr = _arg_value(clean, "--select")
     eps = spec.list_endpoints(partner=partner, category=category, query=query)
     payload = {
         "models": [_model_record(e) for e in eps],
         "count": len(eps),
         "filters": {"partner": partner, "category": category, "query": query},
     }
+    if select_expr is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select_expr, command="generate list")
     if renderer.is_pretty():
         if not eps:
             rprint("[yellow]No models match those filters.[/yellow]")

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -340,6 +340,14 @@ def show_cmd(
             show_default=False, help="ComfyUI port (defaults to COMFY_LOCAL_URL, the background server, or 8188)."
         ),
     ] = None,
+    select: Annotated[
+        str | None,
+        typer.Option(
+            "--select",
+            show_default=False,
+            help="Project the payload: dot path (inputs.0.name), wildcard (inputs.#.name), comma multi-select.",
+        ),
+    ] = None,
 ):
     renderer = get_renderer()
     _stale: dict = {}
@@ -400,6 +408,11 @@ def show_cmd(
                 "message": f"served from cache ({_stale['source']}): {_stale['reason']}",
             }
         ]
+
+    if select is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select, command="nodes show")
 
     if renderer.is_pretty():
         from rich.table import Table

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -395,6 +395,14 @@ def ls_cmd(
         bool,
         typer.Option("--refresh", help="Re-fetch index.json from GitHub before listing."),
     ] = False,
+    select: Annotated[
+        str | None,
+        typer.Option(
+            "--select",
+            show_default=False,
+            help="Project the payload: dot path (rows.0.name), wildcard (rows.#.name), comma multi-select.",
+        ),
+    ] = None,
 ):
     renderer = get_renderer()
 
@@ -457,6 +465,11 @@ def ls_cmd(
             for r in rows
         ],
     }
+
+    if select is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select, command="templates ls")
 
     if renderer.is_pretty():
         from rich.table import Table

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -194,6 +194,14 @@ def slots_cmd(
         str,
         typer.Option("--id", show_default=False, help="Template ID label; cosmetic only — defaults to the filename."),
     ] = "",
+    select: Annotated[
+        str | None,
+        typer.Option(
+            "--select",
+            show_default=False,
+            help="Project the payload: dot path (slots.0.address), wildcard (slots.#.address), comma multi-select.",
+        ),
+    ] = None,
 ):
     renderer = get_renderer()
     p, workflow = _load_workflow_or_fail(renderer, file)
@@ -221,6 +229,11 @@ def slots_cmd(
         payload["warnings"] = [
             {"code": "object_info_stale", "message": f"served from cache ({_stale['source']}): {_stale['reason']}"}
         ]
+
+    if select is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select, command="workflow slots")
 
     if renderer.is_pretty():
         from rich.table import Table

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -484,6 +484,16 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "Requested feature is not available in JSON output mode.",
         "drop `--json` (or pass `--no-json`) for this command",
     ),
+    ErrorCode(
+        "select_no_match",
+        "A `--select <expr>` projection was malformed or matched nothing in the payload. The command "
+        "fails open — `ok` stays true and exit code stays 0 — and `data` carries a bounded key "
+        "inventory of the full payload (`data.inventory`: top-level keys, value types, sizes, one "
+        "nested level of keys) plus this advisory in `data.warnings[]`.",
+        "read `data.inventory` for the payload's real keys, then re-run with a corrected --select; "
+        "grammar: dot path `a.b.c`, array index `a.0.b`, wildcard `items.#.name`, comma multi-select "
+        "`name,inputs`",
+    ),
     # --- skills --------------------------------------------------------------
     ErrorCode(
         "unknown_skill",

--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -251,6 +251,7 @@ class Renderer:
         where: str | None = None,
         changed: bool | None = None,
         ok: bool = True,
+        extra: Mapping[str, Any] | None = None,
     ) -> None:
         """Emit the final envelope. In pretty mode this is a no-op (data was
         already shown by ``print``/``success``/etc).
@@ -260,6 +261,12 @@ class Renderer:
         on an invalid workflow, which still emits its error/warning payload as
         data) pass ``ok=False`` so the envelope's ``ok`` agrees with the
         process exit code.
+
+        ``extra`` merges additional top-level fields into the envelope
+        (additive-optional under envelope/1, e.g. ``--select``'s
+        ``selected_bytes``/``total_bytes``). Core envelope keys are never
+        overridden; when ``extra`` is absent the envelope is byte-identical to
+        an emit without it.
         """
         if self.is_pretty():
             return
@@ -274,6 +281,9 @@ class Renderer:
             changed=changed,
             error=None,
         )
+        if extra:
+            for key, value in extra.items():
+                envelope.setdefault(key, value)
         self._write_json_line(envelope)
         self._envelope_emitted = True
 

--- a/comfy_cli/selector.py
+++ b/comfy_cli/selector.py
@@ -1,0 +1,245 @@
+"""The ONE ``--select`` projection grammar over envelope ``data`` payloads.
+
+This module is the single selector implementation for the CLI (V1-011 / C4):
+the four heaviest read commands (``templates ls``, ``nodes show``,
+``workflow slots``, ``generate list``) accept ``--select <expr>`` and project
+their JSON payload through it. No second dialect will ever be added — keep the
+grammar exactly this small.
+
+Grammar (gjson-style dot paths):
+
+  - **dot path** — ``a.b.c`` walks object keys.
+  - **array index** — ``a.0.b`` indexes into an array (non-negative decimal).
+    On an object, a digit segment is an ordinary key lookup.
+  - **array wildcard** — ``items.#.name`` maps the rest of the path over every
+    array element and returns the array of matches; per-element misses are
+    dropped. ``items.#`` alone returns the whole array. A wildcard whose
+    remainder matches zero elements of a non-empty array is a miss; over an
+    empty array it matches and returns ``[]``. Wildcards compose
+    (``rows.#.tags.#``).
+  - **multi-select** — ``name,inputs`` splits on commas and returns an object
+    keyed by each sub-expression that matched. It is a miss only when every
+    part misses.
+
+There is no escaping: keys containing ``.``, ``,`` or ``#`` cannot be
+addressed. Malformed expressions (empty, empty segment, empty part) are
+reported as a miss, never an error — the CLI fails open (see
+``selected_payload``): the command still succeeds and returns a bounded key
+inventory of the full payload plus a ``select_no_match`` advisory so the
+caller can correct the expression from what it just learned.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+# Hard bound on the serialized fail-open inventory (~1-2KB per V1-011).
+_INVENTORY_MAX_BYTES = 2048
+# (top-level key cap, nested key cap) attempts, largest first; the first
+# rendering that fits under the byte bound wins.
+_INVENTORY_CAPS = ((40, 16), (16, 6), (6, 0))
+
+WILDCARD = "#"
+
+
+def select(data: Any, expr: str) -> tuple[Any, bool]:
+    """Evaluate ``expr`` against ``data``. Pure; never raises on bad input.
+
+    Returns ``(result, matched)``. ``matched`` is False for both a malformed
+    expression and a well-formed one that matched nothing — the caller's
+    fail-open path treats them identically.
+    """
+    if not isinstance(expr, str) or not expr.strip():
+        return None, False
+    parts = [p.strip() for p in expr.split(",")]
+    if len(parts) > 1:
+        out: dict[str, Any] = {}
+        for part in parts:
+            result, matched = _select_one(data, part)
+            if matched:
+                out[part] = result
+        if out:
+            return out, True
+        return None, False
+    return _select_one(data, parts[0])
+
+
+def _select_one(data: Any, path: str) -> tuple[Any, bool]:
+    if not path:
+        return None, False
+    segments = path.split(".")
+    if any(seg == "" for seg in segments):
+        return None, False
+    return _walk(data, segments)
+
+
+def _walk(current: Any, segments: list[str]) -> tuple[Any, bool]:
+    if not segments:
+        return current, True
+    seg, rest = segments[0], segments[1:]
+    if seg == WILDCARD:
+        if not isinstance(current, list):
+            return None, False
+        if not rest:
+            return list(current), True
+        out = []
+        for element in current:
+            result, matched = _walk(element, rest)
+            if matched:
+                out.append(result)
+        if out or not current:
+            return out, True
+        return None, False
+    if isinstance(current, Mapping):
+        if seg in current:
+            return _walk(current[seg], rest)
+        return None, False
+    if isinstance(current, list):
+        if seg.isdigit():
+            index = int(seg)
+            if index < len(current):
+                return _walk(current[index], rest)
+        return None, False
+    return None, False
+
+
+# ---------------------------------------------------------------------------
+# Fail-open inventory
+# ---------------------------------------------------------------------------
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int | float):
+        return "number"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, Mapping):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    return type(value).__name__
+
+
+def _capped_keys(mapping: Mapping, cap: int) -> list[str]:
+    keys = [str(k) for k in mapping]
+    if cap and len(keys) > cap:
+        return keys[:cap] + [f"…+{len(keys) - cap} more"]
+    return keys if cap else []
+
+
+def _describe(value: Any, nested_cap: int) -> Any:
+    """One level of shape for a top-level value: type, size, and (for
+    objects / arrays-of-objects) one level of keys."""
+    if isinstance(value, Mapping):
+        desc: dict[str, Any] = {"type": "object", "size": len(value)}
+        if nested_cap:
+            desc["keys"] = _capped_keys(value, nested_cap)
+        return desc
+    if isinstance(value, list):
+        desc = {"type": "array", "size": len(value)}
+        if nested_cap and value and isinstance(value[0], Mapping):
+            desc["item_keys"] = _capped_keys(value[0], nested_cap)
+        return desc
+    return {"type": _type_name(value)}
+
+
+def _inventory(data: Any, top_cap: int, nested_cap: int) -> Any:
+    if isinstance(data, Mapping):
+        keys = list(data)
+        inv: dict[str, Any] = {str(k): _describe(data[k], nested_cap) for k in keys[:top_cap]}
+        if len(keys) > top_cap:
+            inv["…"] = f"+{len(keys) - top_cap} more keys"
+        return inv
+    return _describe(data, nested_cap)
+
+
+def key_inventory(data: Any) -> Any:
+    """A bounded (~2KB serialized) shape summary of ``data``: top-level keys,
+    value types, sizes for objects/arrays, one nested level of keys."""
+    inv: Any = None
+    for caps in _INVENTORY_CAPS:
+        inv = _inventory(data, *caps)
+        if len(_dumps(inv).encode("utf-8")) <= _INVENTORY_MAX_BYTES:
+            return inv
+    return inv
+
+
+# ---------------------------------------------------------------------------
+# Shared emit path for the four --select commands
+# ---------------------------------------------------------------------------
+
+
+def _dumps(obj: Any) -> str:
+    # Same serialization convention as the envelope writer (renderer
+    # _write_json_line): compact-ish, non-ASCII passthrough, best-effort
+    # coercion for stray non-JSON types.
+    from comfy_cli.output.renderer import _json_default
+
+    return json.dumps(obj, default=_json_default, ensure_ascii=False)
+
+
+def _num_bytes(obj: Any) -> int:
+    return len(_dumps(obj).encode("utf-8"))
+
+
+def selected_payload(payload: Any, expr: str) -> tuple[Any, bool, dict[str, int]]:
+    """Apply ``expr`` to a command's full ``data`` payload.
+
+    Returns ``(data, matched, meta)`` where ``data`` is what the envelope
+    should carry (the selected slice, or — fail-open — the key inventory plus
+    a ``select_no_match`` advisory in ``warnings``), and ``meta`` holds the
+    envelope's sibling byte counts: ``selected_bytes`` (serialized emitted
+    slice) and ``total_bytes`` (serialized full payload).
+    """
+    result, matched = select(payload, expr)
+    if matched:
+        data: Any = result
+    else:
+        from comfy_cli import error_codes
+
+        registered = error_codes.get("select_no_match")
+        data = {
+            "inventory": key_inventory(payload),
+            "warnings": [
+                {
+                    "code": "select_no_match",
+                    "message": f"--select {expr!r} matched nothing in the payload",
+                    "hint": registered.hint if registered else None,
+                }
+            ],
+        }
+    meta = {"selected_bytes": _num_bytes(data), "total_bytes": _num_bytes(payload)}
+    return data, matched, meta
+
+
+def emit_selected(renderer: Any, payload: Any, expr: str, *, command: str) -> None:
+    """Render/emit a command payload through ``--select``.
+
+    JSON modes: one envelope whose ``data`` is the selected slice and which
+    carries sibling ``selected_bytes`` / ``total_bytes`` fields. Pretty mode:
+    the selected slice pretty-printed as JSON (bare strings printed plain), or
+    — fail-open — a yellow advisory plus the key inventory. Exit code is the
+    caller's (always 0): a miss is never an error.
+    """
+    data, matched, meta = selected_payload(payload, expr)
+    if renderer.is_pretty():
+        if matched:
+            if isinstance(data, str):
+                # A selected bare string is almost always feeding a shell /
+                # human eyeball; don't wrap it in JSON quotes. markup=False so
+                # payload text can't be interpreted as Rich tags.
+                renderer.console().print(data, markup=False)
+            else:
+                renderer.console().print_json(_dumps(data))
+        else:
+            warning = data["warnings"][0]
+            renderer.warn(warning["message"], hint=warning["hint"])
+            renderer.console().print_json(_dumps(data["inventory"]))
+        return
+    renderer.emit(data, command=command, extra=meta)

--- a/tests/comfy_cli/command/test_select_flag.py
+++ b/tests/comfy_cli/command/test_select_flag.py
@@ -1,0 +1,414 @@
+"""`--select <expr>` wiring on the four heaviest read commands (V1-011).
+
+ONE selector implementation (``comfy_cli.selector``) projected onto:
+
+  - ``comfy templates ls --select``
+  - ``comfy nodes show --select``
+  - ``comfy workflow slots --select``
+  - ``comfy generate list --select``  (the invocation the cloud agent's
+    ``list_generate_models`` tool shells — services/agent/internal/loop/tools.go
+    execs ``generate list --json``)
+
+Pinned here per command: the envelope's ``data`` becomes the selected slice,
+sibling ``selected_bytes``/``total_bytes`` fields appear, fail-open on a miss
+(ok:true, exit 0, key inventory + ``select_no_match`` advisory), pretty-mode
+rendering, and — crucially — that WITHOUT ``--select`` the envelope is
+byte-identical to the pre-flag output (``test_no_select_output_unchanged``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.command import templates as templates_cmd
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _force_pretty_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=True,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        no_json_flag=True,
+    )
+    r.mode = OutputMode.PRETTY
+    set_renderer(r)
+    return r
+
+
+def _envelope(stdout: str) -> dict:
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope in stdout:\n{stdout}")
+
+
+def _assert_byte_fields(env: dict) -> None:
+    # selected_bytes counts the serialized emitted slice; total_bytes the full
+    # payload. On a fail-open miss the inventory slice can serialize LARGER
+    # than a small payload, so no ordering is asserted here — match-path tests
+    # assert selected < total themselves.
+    assert env["selected_bytes"] == len(json.dumps(env["data"], ensure_ascii=False).encode("utf-8"))
+    assert isinstance(env["total_bytes"], int) and env["total_bytes"] > 0
+
+
+def _assert_fail_open(env: dict) -> None:
+    assert env["ok"] is True
+    assert env["error"] is None
+    assert "inventory" in env["data"]
+    assert env["data"]["warnings"][0]["code"] == "select_no_match"
+
+
+# ---------------------------------------------------------------------------
+# templates ls
+# ---------------------------------------------------------------------------
+
+GALLERY_FIXTURE = [
+    {
+        "moduleName": "default",
+        "category": "GENERATION TYPE",
+        "title": "Image",
+        "type": "image",
+        "templates": [
+            {
+                "name": "image_flux2",
+                "title": "Flux 2 Image",
+                "description": "Text-to-image using Flux 2 via the BFL API.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["API", "Text to Image"],
+                "models": ["Flux 2"],
+                "logos": [{"provider": ["Black Forest Labs"]}],
+            },
+            {
+                "name": "image_z_image",
+                "title": "Z Image",
+                "description": "Local SDXL-style text-to-image.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["Local", "Text to Image"],
+                "models": ["Z Image"],
+                "logos": [{"provider": "Z"}],
+            },
+        ],
+    },
+]
+
+
+@pytest.fixture
+def gallery_file(tmp_path: Path) -> str:
+    path = tmp_path / "index.json"
+    path.write_text(json.dumps(GALLERY_FIXTURE))
+    return str(path)
+
+
+class TestTemplatesLsSelect:
+    def test_select_projects_data(self, gallery_file):
+        _force_json_renderer()
+        result = runner.invoke(templates_cmd.app, ["ls", "--gallery", gallery_file, "--select", "rows.#.name"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        assert env["data"] == ["image_flux2", "image_z_image"]
+        _assert_byte_fields(env)
+        assert env["selected_bytes"] < env["total_bytes"]
+
+    def test_select_miss_fails_open_with_inventory(self, gallery_file):
+        _force_json_renderer()
+        result = runner.invoke(templates_cmd.app, ["ls", "--gallery", gallery_file, "--select", "not.a.key"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        _assert_fail_open(env)
+        assert set(env["data"]["inventory"]) >= {"rows", "matched", "filters"}
+        _assert_byte_fields(env)
+
+    def test_select_works_in_pretty_mode(self, gallery_file):
+        _force_pretty_renderer()
+        result = runner.invoke(templates_cmd.app, ["ls", "--gallery", gallery_file, "--select", "rows.#.name"])
+        assert result.exit_code == 0, result.output
+        assert "image_flux2" in result.output
+        assert "image_z_image" in result.output
+        # The selection replaced the human table.
+        assert "Flux 2 Image" not in result.output
+
+    def test_pretty_miss_prints_inventory_and_hint(self, gallery_file):
+        _force_pretty_renderer()
+        result = runner.invoke(templates_cmd.app, ["ls", "--gallery", gallery_file, "--select", "not.a.key"])
+        assert result.exit_code == 0, result.output
+        assert "matched nothing" in result.output
+        assert "rows" in result.output  # inventory names the real keys
+
+    def test_no_select_output_unchanged(self, gallery_file):
+        """WITHOUT --select the envelope is byte-identical to the pre-flag
+        serialization: exact key set, exact order, no byte-count siblings."""
+        _force_json_renderer()
+        result = runner.invoke(templates_cmd.app, ["ls", "--gallery", gallery_file])
+        assert result.exit_code == 0, result.output
+        line = result.output.strip().splitlines()[-1]
+        rows = [
+            {
+                "name": t["name"],
+                "title": t["title"],
+                "output_type": "image",
+                "category_title": "Image",
+                "tags": t["tags"],
+                "models": t["models"],
+                "providers": ["Black Forest Labs"] if t["name"] == "image_flux2" else ["Z"],
+                "description": t["description"][:120],
+            }
+            for t in GALLERY_FIXTURE[0]["templates"]
+        ]
+        expected = {
+            "schema": "envelope/1",
+            "type": "envelope",
+            "ok": True,
+            "command": "templates ls",
+            "version": "",
+            "where": None,
+            "data": {
+                "total_in_gallery": 2,
+                "matched": 2,
+                "shown": 2,
+                "filters": {
+                    "type": None,
+                    "category": None,
+                    "tag": None,
+                    "model": None,
+                    "provider": None,
+                    "name": None,
+                },
+                "rows": rows,
+            },
+            "error": None,
+        }
+        assert line == json.dumps(expected, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# nodes show
+# ---------------------------------------------------------------------------
+
+
+def _nodes_object_info() -> dict[str, Any]:
+    return {
+        "KSampler": {
+            "input": {
+                "required": {
+                    "model": ["MODEL"],
+                    "steps": ["INT", {"default": 20, "min": 1, "max": 10000}],
+                    "sampler_name": [["euler", "heun", "dpmpp_2m"]],
+                },
+            },
+            "input_order": {"required": ["model", "steps", "sampler_name"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "KSampler",
+            "description": "Denoise the latent via the provided model.",
+            "output_node": False,
+            "python_module": "nodes",
+        },
+    }
+
+
+@pytest.fixture
+def patched_nodes_graph(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: Graph.from_object_info(_nodes_object_info()))
+
+
+class TestNodesShowSelect:
+    def test_select_projects_inputs(self, patched_nodes_graph):
+        _force_json_renderer()
+        result = runner.invoke(nodes_cmd.app, ["show", "KSampler", "--select", "inputs.#.name"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        assert env["data"] == ["model", "steps", "sampler_name"]
+        _assert_byte_fields(env)
+
+    def test_select_comma_multi(self, patched_nodes_graph):
+        _force_json_renderer()
+        result = runner.invoke(nodes_cmd.app, ["show", "KSampler", "--select", "name,category"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["data"] == {"name": "KSampler", "category": "sampling"}
+
+    def test_select_miss_fails_open(self, patched_nodes_graph):
+        _force_json_renderer()
+        result = runner.invoke(nodes_cmd.app, ["show", "KSampler", "--select", "a..b"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        _assert_fail_open(env)
+        assert "inputs" in env["data"]["inventory"]
+
+    def test_select_scalar_pretty_prints_plain(self, patched_nodes_graph):
+        _force_pretty_renderer()
+        result = runner.invoke(nodes_cmd.app, ["show", "KSampler", "--select", "category"])
+        assert result.exit_code == 0, result.output
+        assert "sampling" in result.output
+        assert '"sampling"' not in result.output  # bare string, no JSON quotes
+
+
+# ---------------------------------------------------------------------------
+# workflow slots
+# ---------------------------------------------------------------------------
+
+
+def _slots_object_info() -> dict[str, Any]:
+    return {
+        "CLIPTextEncode": {
+            "input": {
+                "required": {
+                    "text": ["STRING", {"multiline": True}],
+                    "clip": ["CLIP"],
+                },
+            },
+            "input_order": {"required": ["clip", "text"]},
+            "output": ["CONDITIONING"],
+            "output_name": ["CONDITIONING"],
+            "category": "conditioning",
+            "display_name": "CLIP Text Encode",
+            "python_module": "nodes",
+        },
+    }
+
+
+def _slots_workflow() -> dict:
+    return {
+        "nodes": [
+            {"id": 6, "type": "CLIPTextEncode", "widgets_values": ["a cat in space"]},
+        ],
+        "links": [],
+    }
+
+
+@pytest.fixture
+def patched_workflow_graph(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(workflow_cmd, "_get_graph", lambda *a, **kw: Graph.from_object_info(_slots_object_info()))
+
+
+class TestWorkflowSlotsSelect:
+    def _write(self, tmp_path: Path) -> Path:
+        p = tmp_path / "wf.json"
+        p.write_text(json.dumps(_slots_workflow()), encoding="utf-8")
+        return p
+
+    def test_select_projects_addresses(self, patched_workflow_graph, tmp_path):
+        _force_json_renderer()
+        path = self._write(tmp_path)
+        result = runner.invoke(workflow_cmd.app, ["slots", str(path), "--select", "slots.#.address"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        assert env["data"] == ["6.text"]
+        _assert_byte_fields(env)
+
+    def test_select_count(self, patched_workflow_graph, tmp_path):
+        _force_json_renderer()
+        path = self._write(tmp_path)
+        result = runner.invoke(workflow_cmd.app, ["slots", str(path), "--select", "count"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["data"] == 1
+
+    def test_select_miss_fails_open(self, patched_workflow_graph, tmp_path):
+        _force_json_renderer()
+        path = self._write(tmp_path)
+        result = runner.invoke(workflow_cmd.app, ["slots", str(path), "--select", "widgets"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        _assert_fail_open(env)
+        assert "slots" in env["data"]["inventory"]
+
+
+# ---------------------------------------------------------------------------
+# generate list  (what the cloud agent's list_generate_models tool shells)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _disable_tracking(monkeypatch):
+    monkeypatch.setattr("comfy_cli.tracking.prompt_tracking_consent", lambda *a, **kw: None)
+    monkeypatch.setattr("comfy_cli.tracking.track_event", lambda *a, **kw: None)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_spec_caches():
+    from comfy_cli.command.generate import spec as _spec
+
+    _spec.load_raw_spec.cache_clear()
+    _spec._registry.cache_clear()
+    yield
+    _spec.load_raw_spec.cache_clear()
+    _spec._registry.cache_clear()
+
+
+class TestGenerateListSelect:
+    def test_select_projects_aliases(self):
+        from comfy_cli.cmdline import app as cli_app
+
+        _force_json_renderer()
+        result = runner.invoke(cli_app, ["generate", "list", "--json", "--select", "models.#.alias"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        assert env["command"] == "generate list"
+        assert isinstance(env["data"], list) and env["data"]
+        assert "flux-pro" in env["data"]
+        _assert_byte_fields(env)
+
+    def test_select_eq_form(self):
+        from comfy_cli.cmdline import app as cli_app
+
+        _force_json_renderer()
+        result = runner.invoke(cli_app, ["generate", "list", "--json", "--select=count"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert isinstance(env["data"], int) and env["data"] >= 1
+
+    def test_select_miss_fails_open(self):
+        from comfy_cli.cmdline import app as cli_app
+
+        _force_json_renderer()
+        result = runner.invoke(cli_app, ["generate", "list", "--json", "--select", "bogus.path"])
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        _assert_fail_open(env)
+        assert set(env["data"]["inventory"]) >= {"models", "count"}

--- a/tests/comfy_cli/test_selector.py
+++ b/tests/comfy_cli/test_selector.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``comfy_cli.selector`` — the ONE `--select` projection grammar.
+
+Grammar under test (deliberately small, see the module docstring; no second
+dialect will ever be added):
+
+  - dot path:        ``a.b.c``
+  - array index:     ``a.0.b``
+  - array wildcard:  ``items.#.name``  -> array of per-element matches
+  - multi-select:    ``name,inputs``   -> object keyed by each sub-expression
+
+Fail-open semantics (malformed expression / zero matches) and the byte-count
+envelope fields are covered here at the pure-function level; the per-command
+wiring is covered in each command's test file.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from comfy_cli import error_codes
+from comfy_cli.selector import key_inventory, select, selected_payload
+
+PAYLOAD = {
+    "name": "KSampler",
+    "category": "sampling",
+    "inputs": [
+        {"name": "seed", "type": "INT", "options": {"default": 0}},
+        {"name": "steps", "type": "INT", "options": {"default": 20}},
+        {"name": "sampler_name", "type": "COMBO"},
+    ],
+    "output_types": ["LATENT"],
+    "nested": {"a": {"b": {"c": 42}}},
+}
+
+
+class TestPath:
+    def test_top_level_key(self):
+        result, matched = select(PAYLOAD, "name")
+        assert matched is True
+        assert result == "KSampler"
+
+    def test_nested_dot_path(self):
+        result, matched = select(PAYLOAD, "nested.a.b.c")
+        assert matched is True
+        assert result == 42
+
+    def test_path_returns_subtree(self):
+        result, matched = select(PAYLOAD, "nested.a")
+        assert matched is True
+        assert result == {"b": {"c": 42}}
+
+    def test_missing_key_is_a_miss(self):
+        result, matched = select(PAYLOAD, "nope")
+        assert matched is False
+        assert result is None
+
+    def test_missing_nested_key_is_a_miss(self):
+        _, matched = select(PAYLOAD, "nested.a.zzz")
+        assert matched is False
+
+    def test_traversal_into_scalar_is_a_miss(self):
+        _, matched = select(PAYLOAD, "name.deeper")
+        assert matched is False
+
+
+class TestIndex:
+    def test_array_index(self):
+        result, matched = select(PAYLOAD, "inputs.1.name")
+        assert matched is True
+        assert result == "steps"
+
+    def test_index_out_of_range_is_a_miss(self):
+        _, matched = select(PAYLOAD, "inputs.99.name")
+        assert matched is False
+
+    def test_index_returns_element(self):
+        result, matched = select(PAYLOAD, "output_types.0")
+        assert matched is True
+        assert result == "LATENT"
+
+    def test_digit_segment_on_dict_is_key_lookup(self):
+        result, matched = select({"0": "zero"}, "0")
+        assert matched is True
+        assert result == "zero"
+
+
+class TestWildcard:
+    def test_wildcard_projects_each_element(self):
+        result, matched = select(PAYLOAD, "inputs.#.name")
+        assert matched is True
+        assert result == ["seed", "steps", "sampler_name"]
+
+    def test_bare_wildcard_returns_whole_array(self):
+        result, matched = select(PAYLOAD, "inputs.#")
+        assert matched is True
+        assert result == PAYLOAD["inputs"]
+
+    def test_wildcard_drops_per_element_misses(self):
+        result, matched = select(PAYLOAD, "inputs.#.options.default")
+        assert matched is True
+        assert result == [0, 20]
+
+    def test_wildcard_on_non_array_is_a_miss(self):
+        _, matched = select(PAYLOAD, "nested.#")
+        assert matched is False
+
+    def test_wildcard_zero_element_matches_is_a_miss(self):
+        _, matched = select(PAYLOAD, "inputs.#.bogus")
+        assert matched is False
+
+    def test_wildcard_over_empty_array_matches_empty(self):
+        result, matched = select({"items": []}, "items.#.name")
+        assert matched is True
+        assert result == []
+
+    def test_nested_wildcards_compose(self):
+        data = {"rows": [{"tags": ["a", "b"]}, {"tags": ["c"]}]}
+        result, matched = select(data, "rows.#.tags.#")
+        assert matched is True
+        assert result == [["a", "b"], ["c"]]
+
+
+class TestComma:
+    def test_multi_select_returns_object_of_matches(self):
+        result, matched = select(PAYLOAD, "name,category")
+        assert matched is True
+        assert result == {"name": "KSampler", "category": "sampling"}
+
+    def test_multi_select_mixed_expressions(self):
+        result, matched = select(PAYLOAD, "name,inputs.#.name")
+        assert matched is True
+        assert result == {"name": "KSampler", "inputs.#.name": ["seed", "steps", "sampler_name"]}
+
+    def test_multi_select_drops_missing_parts(self):
+        result, matched = select(PAYLOAD, "name,nope")
+        assert matched is True
+        assert result == {"name": "KSampler"}
+
+    def test_multi_select_all_missing_is_a_miss(self):
+        _, matched = select(PAYLOAD, "nope,alsonope")
+        assert matched is False
+
+
+class TestMalformed:
+    @pytest.mark.parametrize("expr", ["", "   ", ".", "a..b", ".a", "a.", ",", ",,"])
+    def test_malformed_expressions_are_misses(self, expr):
+        result, matched = select(PAYLOAD, expr)
+        assert matched is False
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-open inventory + byte accounting (the shared emit path)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_selector_fails_open_with_key_inventory():
+    data, matched, meta = selected_payload(PAYLOAD, "a..b")
+    assert matched is False
+    inv = data["inventory"]
+    # Top-level keys with value types; dicts/lists carry sizes; nested one
+    # level of keys.
+    assert set(inv) >= {"name", "inputs", "nested"}
+    assert inv["inputs"]["type"] == "array"
+    assert inv["inputs"]["size"] == 3
+    assert inv["nested"]["type"] == "object"
+    assert "a" in inv["nested"]["keys"]
+    # Advisory hint under a registered code; the command still succeeds.
+    warning = data["warnings"][0]
+    assert warning["code"] == "select_no_match"
+    registered = error_codes.get("select_no_match")
+    assert registered is not None, "select_no_match must be registered in error_codes.py"
+    assert warning["hint"] == registered.hint
+    # Inventory stays bounded.
+    assert len(json.dumps(inv)) <= 2048
+
+
+def test_zero_match_selector_fails_open_like_malformed():
+    data, matched, _ = selected_payload(PAYLOAD, "definitely.not.here")
+    assert matched is False
+    assert "inventory" in data
+    assert data["warnings"][0]["code"] == "select_no_match"
+
+
+def test_inventory_is_bounded_on_huge_payloads():
+    huge = {f"key_{i}": {f"sub_{j}": "x" * 50 for j in range(50)} for i in range(200)}
+    inv = key_inventory(huge)
+    assert len(json.dumps(inv)) <= 2048
+
+
+def test_envelope_reports_selected_and_total_bytes():
+    data, matched, meta = selected_payload(PAYLOAD, "inputs.#.name")
+    assert matched is True
+    assert data == ["seed", "steps", "sampler_name"]
+    assert meta["selected_bytes"] == len(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+    assert meta["total_bytes"] == len(json.dumps(PAYLOAD, ensure_ascii=False).encode("utf-8"))
+    assert meta["selected_bytes"] < meta["total_bytes"]
+
+
+def test_selected_bytes_counts_the_inventory_slice_on_miss():
+    data, matched, meta = selected_payload(PAYLOAD, "nope")
+    assert matched is False
+    assert meta["selected_bytes"] == len(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+    assert meta["total_bytes"] == len(json.dumps(PAYLOAD, ensure_ascii=False).encode("utf-8"))
+
+
+def test_select_is_pure_and_does_not_mutate():
+    snapshot = json.dumps(PAYLOAD, sort_keys=True)
+    select(PAYLOAD, "inputs.#.name")
+    select(PAYLOAD, "nope")
+    selected_payload(PAYLOAD, "a..b")
+    assert json.dumps(PAYLOAD, sort_keys=True) == snapshot


### PR DESCRIPTION
Implements Linear **BE-7148** (V1-011).

## What

ONE selector implementation — `comfy_cli/selector.py` — wired as `--select <expr>` into the four heaviest read commands, and nothing else:

| Command | Wire point |
|---|---|
| `comfy templates ls` | `templates.py ls_cmd` |
| `comfy nodes show` | `nodes.py show_cmd` |
| `comfy workflow slots` | `workflow.py slots_cmd` (command name confirmed: `slots`) |
| `comfy generate list` | `generate/app.py _list_models` — **this** is the models listing the cloud agent shells: `services/agent/internal/loop/tools.go` `list_generate_models` execs `generate list --json` |

`comfy model list` (models/models.py) was NOT covered: it is not what the agent shells and it emits no envelope at all (plain `typer.echo`/table), so adding `--select` there would be a full envelope migration, not a trivial add.

## Grammar (small by design — no second dialect will ever be added, C4)

gjson-style dot paths over the envelope's `data` payload:

- **dot path** — `a.b.c`
- **array index** — `a.0.b` (non-negative decimal; digit segment on an object is a key lookup)
- **array wildcard** — `items.#.name` → array of per-element matches, misses dropped; `items.#` alone returns the whole array; wildcards compose (`rows.#.tags.#`); zero element matches over a non-empty array = miss, empty array = `[]`
- **multi-select** — `name,inputs` → object keyed by each sub-expression that matched; miss only when every part misses

No escaping: keys containing `.` `,` `#` cannot be addressed. `select(data, expr) -> (result, matched)` is pure and never raises.

## Envelope semantics

- With `--select`: `data` = the selected slice; envelope gains **additive sibling fields** `selected_bytes` (serialized slice) and `total_bytes` (serialized full payload). envelope/1 unchanged (`additionalProperties: true`; additive-optional = no bump). Live example: `generate list --json --select 'models.#.alias'` → 780 bytes selected vs 9301 total.
- **Fail-open**: malformed expression or zero matches ⇒ `ok: true`, exit 0, `data` = bounded (~2KB) key inventory of the full payload (top-level keys, value types, object/array sizes, one nested level of keys) plus a `select_no_match` advisory in `data.warnings[]`. `select_no_match` is registered in `error_codes.py` (meaning + hint); the two-way registry test passes.
- **Pretty mode** (the CLI/agent litmus): `--select` renders the slice as indented JSON — a selected bare string prints plain, unquoted; a miss prints the yellow advisory + hint + inventory.
- **No `--select` ⇒ byte-identical output to today**, proven by `test_no_select_output_unchanged`, which byte-compares the full envelope line (exact keys, order, serialization) against the pre-flag shape.

## Tests (TDD, red → green)

- `tests/comfy_cli/test_selector.py` — 35 unit tests: grammar (path/index/wildcard/comma/miss/malformed), `test_malformed_selector_fails_open_with_key_inventory`, `test_envelope_reports_selected_and_total_bytes`, inventory bounding on huge payloads, purity. Written first; red (module missing) → green.
- `tests/comfy_cli/command/test_select_flag.py` — 15 CliRunner tests, one class per command (existing fixture/mock patterns reused: gallery index fixture, `_get_graph` monkeypatch, bundled generate spec), incl. pretty-mode rendering, fail-open exit-0, `--select=expr` form on the hand-parsed `generate` tail, and `test_no_select_output_unchanged`. Red (14 failed) → green.
- Existing suites for every touched surface stay green: `test_templates.py`, `test_workflow_slots.py`, `test_workflow_edit.py`, `test_nodes_introspect.py`, `test_nodes_show_subgraph.py`, `tests/.../generate/`, `tests/.../output/` (registry test included) — **759 passed**.
- `ruff check` + `ruff format --check` clean on all changed files.

## Relationship to #704

Independent feature, but **one shared file**: `comfy_cli/error_codes.py` (#704 also touches it). My change is a single appended registry entry (`select_no_match`) next to `json_incompatible`; whichever lands second rebases with at worst a trivial append-adjacent conflict in that file. No other overlap (#704's `workflow_edit.py`/`layout.py`/`workflow_ops.py` are untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)