### PR TITLE
feat(cli): --ack summary|full on workflow apply (default full; pinned summary shape)

### DIFF
--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -423,6 +423,15 @@ def apply_cmd(
         list[str] | None,
         typer.Option("--param", show_default=False, help="Recipe param as key=value; repeatable."),
     ] = None,
+    ack: Annotated[
+        str,
+        typer.Option(
+            "--ack",
+            help="Envelope acknowledgment detail: 'full' (default) echoes every applied op in "
+            "`data.ops`; 'summary' returns a compact receipt (counts, minted/deleted node ids, "
+            "aliases) with no ops echo.",
+        ),
+    ] = "full",
     actor: ActorOpt = "cli",
     base_version: BaseVersionOpt = 0,
     stdout: StdoutOpt = False,
@@ -436,6 +445,9 @@ def apply_cmd(
     minted node by alias instead of a captured id."""
     renderer = get_renderer()
     renderer.command = "workflow apply"
+    if ack not in ("full", "summary"):
+        renderer.error(code="workflow_edit_invalid", message=f"--ack must be 'summary' or 'full', got {ack!r}")
+        raise typer.Exit(code=1)
     p, workflow = _load_workflow_or_fail(renderer, file)
     graph = _graph_or_exit(input_path, host, port, renderer, where)
 
@@ -479,8 +491,22 @@ def apply_cmd(
             workflow, graph, specs, actor=actor, base_version=base_version
         )
     except (ValueError, KeyError) as e:
-        # Atomic batch: nothing is written if any spec fails.
-        renderer.error(code="workflow_edit_invalid", message=f"batch failed: {e}")
+        # Atomic batch: nothing is written if any spec fails. Same error code
+        # and exit in both ack modes — `--ack summary` only ADDS a structured
+        # receipt (`failed` position + `applied_count`) to `error.details`;
+        # the default envelope stays exactly what it is today.
+        details = None
+        if ack == "summary":
+            details = {
+                "failed": {
+                    "index": getattr(e, "spec_index", None),
+                    "op": getattr(e, "spec_op", None),
+                    "code": "workflow_edit_invalid",
+                },
+                # Specs applied before the abort — all discarded (atomic batch).
+                "applied_count": getattr(e, "applied_count", 0),
+            }
+        renderer.error(code="workflow_edit_invalid", message=f"batch failed: {e}", details=details)
         raise typer.Exit(code=1) from e
 
     workflow_ops.strip_internal(workflow)
@@ -493,17 +519,40 @@ def apply_cmd(
     else:
         _atomic_write_text(p, serialized)
         wrote = str(p)
-    payload = {
-        "workflow": str(p),
-        "count": len(ops),
-        "ops": ops,
-        "aliases": aliases,
-        "base_version": base_version,
-        "version": base_version + len(ops),
-        "wrote": wrote,
-    }
+    if ack == "summary":
+        # PINNED shape — these field names feed the cloud field-contract
+        # manifest; add/rename only with a contract bump on that side.
+        ops_by_kind: dict[str, int] = {}
+        for op in ops:
+            ops_by_kind[op["op"]] = ops_by_kind.get(op["op"], 0) + 1
+        payload = {
+            "count": len(ops),
+            "ops_by_kind": ops_by_kind,
+            "nodes_added": [op["node_id"] for op in ops if op["op"] == "add_node"],
+            "nodes_deleted": [op["node_id"] for op in ops if op["op"] == "delete_node"],
+            "aliases": aliases,
+            "base_version": base_version,
+            "version": base_version + len(ops),
+            "changed": True,
+        }
+    else:
+        payload = {
+            "workflow": str(p),
+            "count": len(ops),
+            "ops": ops,
+            "aliases": aliases,
+            "base_version": base_version,
+            "version": base_version + len(ops),
+            "wrote": wrote,
+        }
     if renderer.is_pretty():
         rprint(f"[bold green]✓[/bold green] applied {len(ops)} edit(s) → [dim]{p}[/dim]")
+        if ack == "summary":
+            kinds = ", ".join(f"{k} ×{n}" for k, n in payload["ops_by_kind"].items())
+            if kinds:
+                rprint(f"  [dim]{kinds}[/dim]")
+            for alias, node_id in aliases.items():
+                rprint(f"  [dim]alias {alias} → {node_id}[/dim]")
     renderer.emit(payload, command="workflow apply", changed=True)
 
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1092,7 +1092,16 @@ def apply_specs(
                 raise ValueError(f"spec #{i} ({kind}) is missing required field {e}") from e
             ops.append(op)
     except (ValueError, KeyError) as e:
-        raise _rehint_discarded_batch(e, pre_batch_hint) from e
+        err = _rehint_discarded_batch(e, pre_batch_hint)
+        # Structured failure position for callers that report a summary
+        # receipt (`apply --ack summary`): which spec aborted the batch, its
+        # op kind, and how many specs had applied before the abort (all of
+        # them then discarded — the batch is atomic). `i`/`spec` are the loop
+        # variables at raise time; guard for a non-dict spec.
+        err.spec_index = i  # type: ignore[attr-defined]
+        err.spec_op = spec.get("op") if isinstance(spec, dict) else None  # type: ignore[attr-defined]
+        err.applied_count = len(ops)  # type: ignore[attr-defined]
+        raise err from e
     return workflow, ops, aliases
 
 

--- a/tests/comfy_cli/command/test_ack_flag.py
+++ b/tests/comfy_cli/command/test_ack_flag.py
@@ -1,0 +1,267 @@
+"""`comfy workflow apply --ack summary|full` — envelope acknowledgment detail.
+
+The default `full` ack echoes every applied op back in `data.ops` — for a big
+batch that is the whole batch again, and an agent that just SENT the ops
+learns nothing new from the echo. `--ack summary` returns a compact receipt
+instead. The summary payload shape is PINNED (its field names feed the cloud
+field-contract manifest):
+
+    {count, ops_by_kind: {<kind>: n}, nodes_added: [ids], nodes_deleted: [ids],
+     aliases: {alias: id}, base_version, version, changed}
+
+with NO `ops` echo. `--ack` only changes the SHAPE of the payload — never the
+outcome: file writes, version bookkeeping, error codes, and exit semantics are
+identical in both modes, and the default (no flag) payload stays byte-identical
+to today's.
+
+`foreach` deliberately has no `--ack`: its payload never echoed ops (it reports
+`{recipe, count, out_dir, written}`), so there is nothing to summarize.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from test_workflow_edit import (  # type: ignore[import-not-found]
+    _base_workflow,
+    _force_json_renderer,
+    _graph,
+    _run,
+    _write,
+    reset_singleton,  # noqa: F401  (autouse fixture)
+)
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.command import workflow_edit
+
+# The pinned summary payload contract — exactly these keys, nothing else.
+SUMMARY_KEYS = {
+    "count",
+    "ops_by_kind",
+    "nodes_added",
+    "nodes_deleted",
+    "aliases",
+    "base_version",
+    "version",
+    "changed",
+}
+
+
+@pytest.fixture
+def patched_graph(monkeypatch):
+    monkeypatch.setattr(workflow_edit, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _empty(tmp_path):
+    return _write(tmp_path, {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0})
+
+
+def _ops_file(tmp_path, specs: list[dict], name: str = "ops.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(specs), encoding="utf-8")
+    return p
+
+
+def _three_op_specs() -> list[dict]:
+    """A 3-op batch: two aliased add_nodes + a connect through the aliases."""
+    return [
+        {"op": "add_node", "class_type": "CheckpointLoaderSimple", "as": "ckpt"},
+        {"op": "add_node", "class_type": "CLIPTextEncode", "as": "pos"},
+        {"op": "connect", "from": "ckpt.CLIP", "to": "pos.clip"},
+    ]
+
+
+class TestAckSummary:
+    def test_apply_ops_ack_summary_returns_counts_and_aliases(self, patched_graph, tmp_path, capsys):
+        path = _empty(tmp_path)
+        ops_path = _ops_file(tmp_path, _three_op_specs())
+        env = _run(["apply", str(path), "--ops", str(ops_path), "--ack", "summary"], capsys)
+        assert env["ok"] is True, env
+        data = env["data"]
+        # Exactly the pinned shape — a stray extra field would silently enter
+        # the cloud field-contract manifest, a missing one would break it.
+        assert set(data) == SUMMARY_KEYS, data
+        assert "ops" not in data
+        assert data["count"] == 3
+        assert data["ops_by_kind"] == {"add_node": 2, "connect": 1}
+        assert set(data["aliases"]) == {"ckpt", "pos"}
+        assert sorted(data["nodes_added"]) == sorted(data["aliases"].values())
+        assert data["nodes_deleted"] == []
+        assert data["base_version"] == 0
+        assert data["version"] == 3  # base_version + len(ops), same math as full mode
+        assert data["changed"] is True
+        assert env["changed"] is True  # envelope-level flag identical to full mode
+        # The file really was written — summary changes the receipt, not the write.
+        assert len(json.loads(path.read_text())["nodes"]) == 2
+
+    def test_ack_summary_reports_deleted_nodes(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        ops_path = _ops_file(tmp_path, [{"op": "delete_node", "node": 7}])
+        env = _run(["apply", str(path), "--ops", str(ops_path), "--ack", "summary"], capsys)
+        assert env["ok"] is True, env
+        data = env["data"]
+        assert set(data) == SUMMARY_KEYS
+        assert data["ops_by_kind"] == {"delete_node": 1}
+        assert data["nodes_added"] == []
+        assert data["nodes_deleted"] == [7]
+
+    def test_ack_rejects_unknown_value(self, patched_graph, tmp_path, capsys):
+        path = _empty(tmp_path)
+        ops_path = _ops_file(tmp_path, _three_op_specs())
+        env = _run(["apply", str(path), "--ops", str(ops_path), "--ack", "bogus"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_edit_invalid"
+
+
+class TestAckDefaultUnchanged:
+    def test_apply_ack_default_byte_identical(self, patched_graph, tmp_path, capsys, monkeypatch):
+        """`--ack full` must be byte-identical to today's default payload.
+
+        Soundness of the assertion: node ids (`mint_id`, `random.getrandbits`)
+        and op ids (`uuid.uuid4`) are the ONLY nondeterminism in the apply
+        path (layout is documented "no randomness, no clock"; the CRDT stamp
+        is [base_version, actor]). We pin both to counters, run the same batch
+        on the same file path twice — resetting the file content and the
+        counters in between — so the two invocations are observationally
+        identical except for the explicit `--ack full` flag. Byte-equal
+        envelope lines then prove `--ack full` == default. The shape
+        assertions below additionally pin that default to TODAY'S payload
+        (full `ops` echo + aliases), so a change to either mode fails here.
+        """
+        state = {"node": 0, "op": 0}
+
+        def fake_mint() -> int:
+            state["node"] += 1
+            return (1 << 40) + state["node"]
+
+        class _FakeUUID:
+            def __init__(self, n: int):
+                self.hex = f"{n:032x}"
+
+        class _FakeUuidModule:
+            @staticmethod
+            def uuid4() -> Any:
+                state["op"] += 1
+                return _FakeUUID(state["op"])
+
+        monkeypatch.setattr(workflow_ops, "mint_id", fake_mint)
+        monkeypatch.setattr(workflow_ops, "uuid", _FakeUuidModule)
+
+        initial = json.dumps({"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}, indent=2)
+        path = tmp_path / "wf.json"
+        ops_path = _ops_file(tmp_path, _three_op_specs())
+
+        def run_once(extra: list[str]) -> str:
+            path.write_text(initial, encoding="utf-8")
+            state["node"] = state["op"] = 0
+            _force_json_renderer()
+            runner = CliRunner()
+            result = runner.invoke(
+                workflow_cmd.app, ["apply", str(path), "--ops", str(ops_path), *extra], standalone_mode=False
+            )
+            out = capsys.readouterr().out or result.stdout or ""
+            lines = [ln for ln in out.strip().splitlines() if ln.strip()]
+            for line in reversed(lines):
+                try:
+                    json.loads(line)
+                    return line
+                except json.JSONDecodeError:
+                    continue
+            raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception})")
+
+        default_line = run_once([])
+        full_line = run_once(["--ack", "full"])
+        assert default_line == full_line
+
+        data = json.loads(default_line)["data"]
+        # Today's payload, pinned: full ops echo with per-op identity.
+        assert set(data) == {"workflow", "count", "ops", "aliases", "base_version", "version", "wrote"}
+        assert data["count"] == 3 and len(data["ops"]) == 3
+        assert all("op_id" in op and "op" in op for op in data["ops"])
+        assert data["version"] == 3
+
+
+class TestAckSummaryPartialFailure:
+    def test_ack_summary_partial_failure_reports_index_and_code(self, patched_graph, tmp_path, capsys):
+        """Op 2 of 3 (0-based index 1) fails → same code/atomicity as full
+        mode, plus a structured receipt: failed.{index,op,code} + applied_count.
+
+        `applied_count` counts specs applied before the abort; the batch is
+        atomic, so all of them were then discarded (nothing was written).
+        """
+        path = _empty(tmp_path)
+        before = path.read_text()
+        specs = [
+            {"op": "add_node", "class_type": "KSampler", "as": "ks"},
+            {"op": "add_node", "class_type": "NoSuchNode"},  # fails
+            {"op": "set_widget", "node": "ks", "widget": "steps", "value": 30},
+        ]
+        ops_path = _ops_file(tmp_path, specs)
+        env = _run(["apply", str(path), "--ops", str(ops_path), "--ack", "summary"], capsys)
+        assert env["ok"] is False
+        # Outcome identical to full mode: same code, nothing written.
+        assert env["error"]["code"] == "workflow_edit_invalid"
+        assert path.read_text() == before
+        details = env["error"]["details"]
+        assert details["failed"] == {"index": 1, "op": "add_node", "code": "workflow_edit_invalid"}
+        assert details["applied_count"] == 1
+
+    def test_full_mode_failure_envelope_unchanged(self, patched_graph, tmp_path, capsys):
+        """Default mode keeps today's failure envelope: no details block."""
+        path = _empty(tmp_path)
+        specs = [
+            {"op": "add_node", "class_type": "KSampler", "as": "ks"},
+            {"op": "add_node", "class_type": "NoSuchNode"},
+        ]
+        ops_path = _ops_file(tmp_path, specs)
+        env = _run(["apply", str(path), "--ops", str(ops_path)], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_edit_invalid"
+        assert env["error"]["details"] is None
+
+
+class TestSingleEditVerbsUnaffected:
+    def test_single_edit_verbs_unaffected(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(["add-node", str(path), "VAEDecode"], capsys)
+        assert env["ok"] is True, env
+        # Today's single-edit payload shape, untouched by the ack work.
+        assert set(env["data"]) == {"workflow", "op", "base_version", "version", "wrote"}
+        assert "ops_by_kind" not in env["data"]
+
+    def test_single_edit_verbs_do_not_take_ack(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        _force_json_renderer()
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow_cmd.app, ["add-node", str(path), "VAEDecode", "--ack", "summary"], standalone_mode=False
+        )
+        assert result.exit_code != 0 or result.exception is not None
+
+
+class TestAckSummaryPretty:
+    def test_pretty_summary_renders_counts_and_aliases(self, patched_graph, tmp_path, capsys):
+        from comfy_cli.caller import Caller
+        from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+
+        r = Renderer.resolve(
+            is_stdout_tty=True,
+            env={},
+            caller=Caller(kind="user", agentic=False, source_env=None),
+        )
+        r.mode = OutputMode.PRETTY
+        set_renderer(r)
+        path = _empty(tmp_path)
+        ops_path = _ops_file(tmp_path, _three_op_specs())
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow_cmd.app, ["apply", str(path), "--ops", str(ops_path), "--ack", "summary"], standalone_mode=False
+        )
+        out = capsys.readouterr().out + (result.stdout or "")
+        assert "applied 3 edit(s)" in out
+        assert "add_node" in out and "2" in out  # per-kind count line
+        assert "ckpt" in out and "pos" in out  # aliases rendered


### PR DESCRIPTION
Implements Linear BE-7149 (ticket V1-012).

`comfy workflow apply` echoes the full ops array back in the success envelope. The sender already has the batch it sent, so for a large batch the echo is pure transcript weight. This adds `--ack summary|full` to `apply`.

## Pinned summary shape

`--ack summary` returns exactly (field names feed the cloud field-contract manifest — add/rename only with a contract bump on that side):

```json
{
  "count": 4,
  "ops_by_kind": {"add_node": 2, "connect": 1, "set_widget": 1},
  "nodes_added": [3504687186153845, 1916471524889913],
  "nodes_deleted": [],
  "aliases": {"ckpt": 3504687186153845, "pos": 1916471524889913},
  "base_version": 0,
  "version": 4,
  "changed": true
}
```

No `ops` echo. `changed` and version bookkeeping (`base_version`, `version = base_version + len(ops)`) are computed identically in both modes; the envelope-level `changed` flag is unchanged.

Live smoke (temp project, offline catalog):

```
$ comfy --json workflow apply wf.json --ops ops.json --ack summary --input sd15_object_info.json
{"schema": "envelope/1", "type": "envelope", "ok": true, "command": "workflow apply", "version": "0.0.0", "where": null, "data": {"count": 4, "ops_by_kind": {"add_node": 2, "connect": 1, "set_widget": 1}, "nodes_added": [3504687186153845, 1916471524889913], "nodes_deleted": [], "aliases": {"ckpt": 3504687186153845, "pos": 1916471524889913}, "base_version": 0, "version": 4, "changed": true}, "error": null, "changed": true}
```

Pretty mode renders the summary as per-kind counts + alias lines under the existing `✓ applied N edit(s)` line.

## Default unchanged (proof)

The default (no flag) payload is byte-identical to today's, and `--ack full` is an explicit synonym: `test_apply_ack_default_byte_identical` pins the only nondeterminism in the apply path (node ids via `mint_id`/`random.getrandbits`, op ids via `uuid.uuid4`; layout is documented "no randomness, no clock", the CRDT stamp is `[base_version, actor]`) to counters, runs the same batch on the same file path with and without `--ack full` (resetting file content + counters in between), and byte-compares the envelope lines. It additionally pins the default payload to today's exact key set (`{workflow, count, ops, aliases, base_version, version, wrote}`) with the full per-op echo.

## Partial-failure semantics

The batch stays atomic (op k of n fails → abort, nothing written). `--ack` never changes the outcome: both modes keep `error.code = workflow_edit_invalid` and exit 1. Summary mode only ADDS a structured receipt to `error.details`:

```json
{"failed": {"index": 1, "op": "add_node", "code": "workflow_edit_invalid"}, "applied_count": 1}
```

`failed.index` is 0-based (matching the existing `spec #N` message convention); `applied_count` counts specs applied before the abort — all discarded, per the atomic batch. Default mode's failure envelope is unchanged (`details: null`, pinned by `test_full_mode_failure_envelope_unchanged`). To carry the failing spec's position out of `workflow_ops.apply_specs`, the batch-level wrap now stamps `spec_index`/`spec_op`/`applied_count` attributes on the wrapped `ValueError` (message and type unchanged).

`foreach` deliberately takes no `--ack`: its payload never echoed ops (`{recipe, count, out_dir, written}`), so there is nothing to summarize.

## Sibling-PR rebase notes

Two sibling drafts sit on this same base branch:

* **#704** (touches `workflow_ops.py`, `error_codes.py`, and `workflow_edit.py`'s NotBatchableError catch): this PR edits the tail of `workflow_ops.apply_specs` (the `except (ValueError, KeyError)` wrap) and `apply_cmd`'s batch-failure `except` block in `workflow_edit.py` — if #704's NotBatchableError catch lands on the same `except` in `apply_cmd`, whichever merges second needs a manual rebase of that block (keep both the structured `details` receipt and the new catch). No new error codes here, so `error_codes.py` is untouched.
* **#705** (touches `renderer.py` `extra` param, `error_codes.py`): no overlap — this PR does not modify `renderer.py` or `error_codes.py`.

## Test evidence

New `tests/comfy_cli/command/test_ack_flag.py`, written red-first (6 failed / 3 baseline-passed before the implementation; 9 passed after):

* `test_apply_ops_ack_summary_returns_counts_and_aliases` — 3-op batch with `as:` aliases → exact pinned key set, `"ops" not in data`
* `test_ack_summary_reports_deleted_nodes` — `nodes_deleted` carries real ids
* `test_ack_rejects_unknown_value` — `--ack bogus` → `workflow_edit_invalid`
* `test_apply_ack_default_byte_identical` — see proof above
* `test_ack_summary_partial_failure_reports_index_and_code` — op 2 of 3 invalid → `failed == {index: 1, op: "add_node", code: "workflow_edit_invalid"}`, `applied_count == 1`, file untouched
* `test_full_mode_failure_envelope_unchanged`
* `test_single_edit_verbs_unaffected` + `test_single_edit_verbs_do_not_take_ack`
* `test_pretty_summary_renders_counts_and_aliases`

Verification run:

* `uv run pytest tests/comfy_cli/command/test_workflow_edit.py tests/comfy_cli/command/test_ack_flag.py tests/comfy_cli/command/test_workflow_apply_rollback.py tests/comfy_cli/output/test_error_code_registry.py -q` → **115 passed** (includes the error-code registry gate)
* Full suite: 4584 passed, 29 failed, 38 skipped — all 29 failures (test_logs/test_jobs/test_onboarding/test_host_port/restore_snapshot) reproduce identically at the base commit with this change stashed; pre-existing on `fix/validate-lowers-ui-to-api`, unrelated.
* `ruff check` + `ruff format --check` clean on the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)