### PR TITLE
feat(cli): nodes search --expand-top N

### DIFF
--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -459,6 +459,18 @@ def search_cmd(
         ),
     ],
     limit: Annotated[int, typer.Option(help="Cap output to N rows.")] = 20,
+    expand_top: Annotated[
+        int,
+        typer.Option(
+            "--expand-top",
+            metavar="N",
+            help=(
+                "Also attach the full `nodes show` schema (inputs, defaults, enum choices, outputs) "
+                "for the top-N hits under `expanded`, so no follow-up `show` calls are needed. "
+                "0 (the default) leaves the output unchanged."
+            ),
+        ),
+    ] = 0,
     input_path: Annotated[
         str | None,
         typer.Option("--input", show_default=False, help="Path to a local object_info JSON (offline mode)."),
@@ -568,6 +580,31 @@ def search_cmd(
             for m in matched
         ],
     }
+
+    # --expand-top N: kill the search → show × N loop (measured on prod agent
+    # traces: the follow-up `show` args are overwhelmingly a verbatim copy of the
+    # hit name). The top-N returned rows are re-resolved through the SAME catalog
+    # path `nodes show` uses (graph.node → morphism_to_dict), so `expanded[i]` is
+    # exactly the show payload plus a `class_type` key to join back on the row.
+    # A per-hit miss degrades to a per-hit error entry — it never fails the
+    # search, since the rows themselves are still perfectly good results.
+    if expand_top > 0:
+        expanded: list[dict[str, Any]] = []
+        for m in matched[: max(0, expand_top)]:
+            resolved = graph.node(m.id)
+            if resolved is None:
+                expanded.append(
+                    {
+                        "class_type": m.id,
+                        "error": {
+                            "code": "expand_miss",
+                            "message": f"search matched {m.id!r} but the catalog could not resolve its schema",
+                        },
+                    }
+                )
+                continue
+            expanded.append({"class_type": m.id, **graph.morphism_to_dict(resolved)})
+        payload["expanded"] = expanded
 
     if _stale:
         payload["stale"] = True

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -620,6 +620,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "Requested node class isn't in the loaded environment.",
         "see `details.close_matches` or run `comfy nodes search`",
     ),
+    ErrorCode(
+        "expand_miss",
+        "`comfy nodes search --expand-top N` matched a node class but could not resolve its full schema "
+        "from the catalog. Surfaced as a per-hit error entry inside `data.expanded[]` (not as an error "
+        "envelope) — the search itself still succeeds and the other hits still expand.",
+        "the hit itself is still valid; inspect it directly with `comfy nodes show <class_type>`",
+    ),
     # --- file transfer (upload / download) -----------------------------------
     ErrorCode(
         "upload_failed",

--- a/tests/comfy_cli/command/test_nodes_search_expand.py
+++ b/tests/comfy_cli/command/test_nodes_search_expand.py
@@ -1,0 +1,204 @@
+"""Tests for ``comfy nodes search --expand-top N`` (V1-017 / BE-7150).
+
+The measured agent loop is search → show × N (the show args are ~92% a copy of
+the search hit). ``--expand-top N`` folds the show payload for the top-N hits
+into the search envelope so the follow-up ``show`` calls disappear.
+
+Contract under test:
+  * ``--expand-top N`` attaches ``data.expanded`` — one entry per expanded hit,
+    carrying ``class_type`` plus the exact ``nodes show`` field vocabulary
+    (``inputs`` with options/defaults/choices, ``outputs``, …).
+  * ``--expand-top 0`` / flag omitted → payload byte-identical to today.
+  * a per-hit catalog miss degrades to a per-hit error entry (code
+    ``expand_miss``) and never fails the search.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _object_info() -> dict[str, Any]:
+    return {
+        "KSampler": {
+            "input": {
+                "required": {
+                    "model": ["MODEL"],
+                    "steps": ["INT", {"default": 20, "min": 1, "max": 10000}],
+                    "sampler_name": [["euler", "heun", "dpmpp_2m"]],
+                },
+            },
+            "input_order": {"required": ["model", "steps", "sampler_name"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "KSampler",
+            "description": "Denoise the latent via the provided model.",
+            "output_node": False,
+            "python_module": "nodes",
+        },
+        "KSamplerAdvanced": {
+            "input": {"required": {"model": ["MODEL"]}},
+            "input_order": {"required": ["model"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "KSampler (Advanced)",
+            "description": "Denoise the latent with extra knobs.",
+            "output_node": False,
+            "python_module": "nodes",
+        },
+        "VAEDecode": {
+            "input": {"required": {"samples": ["LATENT"], "vae": ["VAE"]}},
+            "input_order": {"required": ["samples", "vae"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "latent",
+            "display_name": "VAE Decode",
+            "description": "Turn a latent back into pixels.",
+            "output_node": False,
+            "python_module": "nodes",
+        },
+    }
+
+
+def _graph():
+    from comfy_cli.cql.engine import Graph
+
+    return Graph.from_object_info(_object_info())
+
+
+@pytest.fixture
+def patched_loader(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    _force_json_renderer()
+    runner = CliRunner()
+    result = runner.invoke(nodes_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+class TestExpandTop:
+    def test_expand_returns_top_hit_schema(self, patched_loader, capsys):
+        """--expand-top 1 folds the full `nodes show` payload for the top hit
+        into the search envelope: inputs with defaults + enum choices, outputs."""
+        env = _run(["search", "KSampler", "--expand-top", "1"], capsys)
+        assert env["ok"] is True
+        data = env["data"]
+        # Ranking unchanged: exact name is the top hit.
+        assert data["rows"][0]["name"] == "KSampler"
+        expanded = data["expanded"]
+        assert len(expanded) == 1
+        entry = expanded[0]
+        assert entry["class_type"] == "KSampler"
+        # `nodes show` field vocabulary, verbatim (morphism_to_dict).
+        inputs = {i["name"]: i for i in entry["inputs"]}
+        assert inputs["steps"]["options"]["default"] == 20
+        assert inputs["steps"]["options"]["min"] == 1
+        assert inputs["sampler_name"]["choices"] == ["euler", "heun", "dpmpp_2m"]
+        assert inputs["model"]["is_link"] is True
+        assert entry["outputs"] == [{"name": "LATENT", "type": "LATENT"}]
+        assert entry["output_types"] == ["LATENT"]
+
+    def test_expand_covers_top_n_in_rank_order(self, patched_loader, capsys):
+        env = _run(["search", "sampler", "--expand-top", "2"], capsys)
+        assert env["ok"] is True
+        expanded = env["data"]["expanded"]
+        assert [e["class_type"] for e in expanded] == [r["name"] for r in env["data"]["rows"][:2]]
+        assert len(expanded) == 2
+
+    def test_omitted_and_zero_are_byte_identical_to_baseline(self, patched_loader, capsys):
+        base = _run(["search", "KSampler"], capsys)
+        zero = _run(["search", "KSampler", "--expand-top", "0"], capsys)
+        assert zero["data"] == base["data"]
+        assert "expanded" not in base["data"]
+        assert "expanded" not in zero["data"]
+
+    def test_zero_matches_baseline_yields_empty_expanded(self, patched_loader, capsys):
+        """A query with no hits (and no close-name fallback) still succeeds and
+        carries an empty `expanded` — never an error."""
+        env = _run(["search", "xyzzy_zzq_nothing", "--expand-top", "3"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["total"] == 0
+        assert env["data"]["rows"] == []
+        assert env["data"]["expanded"] == []
+
+    def test_per_hit_catalog_miss_degrades_to_error_entry(self, monkeypatch, capsys):
+        """A hit that can't be re-resolved through the show path yields a per-hit
+        `expand_miss` error entry; the search itself still succeeds and the other
+        hits still expand."""
+        graph = _graph()
+        real_node = graph.node
+
+        def flaky_node(name: str):
+            if name == "KSampler":
+                return None  # simulate a catalog miss for this one hit
+            return real_node(name)
+
+        monkeypatch.setattr(graph, "node", flaky_node)
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: graph)
+
+        env = _run(["search", "sampler", "--expand-top", "2"], capsys)
+        assert env["ok"] is True
+        expanded = env["data"]["expanded"]
+        assert len(expanded) == 2
+        by_class = {e["class_type"]: e for e in expanded}
+        miss = by_class["KSampler"]
+        assert miss["error"]["code"] == "expand_miss"
+        assert "inputs" not in miss
+        hit = by_class["KSamplerAdvanced"]
+        assert "error" not in hit
+        assert {i["name"] for i in hit["inputs"]} == {"model"}
+
+    def test_expand_applies_to_close_match_fallback_rows(self, patched_loader, capsys):
+        """Typo queries fall back to close-name matches; those rows are real
+        catalog nodes and expand the same way."""
+        env = _run(["search", "KSampeler", "--expand-top", "1"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["close_match"] is True
+        expanded = env["data"]["expanded"]
+        assert len(expanded) == 1
+        assert expanded[0]["class_type"] == env["data"]["rows"][0]["name"]
+        assert "inputs" in expanded[0]
+
+    def test_expand_miss_is_registered(self):
+        from comfy_cli import error_codes
+
+        assert error_codes.is_registered("expand_miss")


### PR DESCRIPTION
**Linear: BE-7150 (V1-017)** · Layer 1/4 of the V1 hop-killer stack (707 → 708 → 709 → 710), stacked on `fix/validate-lowers-ui-to-api`.

## The hop it kills

Measured on prod agent traces: `nodes search` → `nodes show` × N, **×76 occurrences**, with ~92% of the `show` args a verbatim copy of the search hit. One flag folds the show payloads into the search envelope.

## Semantics

- `comfy nodes search <q> --expand-top N` re-resolves the top-N **returned** rows through the exact catalog path `nodes show` uses (`graph.node` → `morphism_to_dict`) and attaches them under `data.expanded[]`, each entry `{class_type, ...full show payload}` (inputs with `options.default`/`min`/`max`, enum `choices`, `outputs`, `output_types`, …) — the grounded `show` field vocabulary, not a new one.
- `--expand-top 0` / omitted → payload **byte-identical** to today (no `expanded` key).
- Per-hit catalog miss degrades to a per-hit error entry `{class_type, error: {code: "expand_miss", …}}` inside `expanded[]`; the search itself never fails. `expand_miss` is registered in `error_codes.REGISTRY` (advisory, surfaced in-data).
- Close-name fallback rows (typo queries) expand the same way.

## Test evidence

`tests/comfy_cli/command/test_nodes_search_expand.py` — TDD: captured red first (7/7 fail: unknown option + unregistered code), then green.

- top-hit schema (defaults, choices, outputs) — green
- top-N rank order; omitted/`0` byte-identical; zero-matches baseline (`expanded: []`)
- per-hit miss degrades (`expand_miss` entry, sibling hits still expand); close-match rows expand
- neighbors: `test_nodes_introspect.py`, `test_error_code_registry.py`, `test_discovery.py` green; ruff + format clean on touched files

## Sibling-PR notes

- #704 (op-vocabulary freeze) adds `test_op_vocabulary_contract.py`; it does not exist on this base and is not claimed here. No overlap with this layer.
- Stack layers #708/#709/#710 build on this branch so `error_codes.py` additions never conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
