### PR TITLE
feat(cli): templates get --where

### DIFF
--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -733,6 +733,209 @@ def fetch_cmd(
 
 
 # ---------------------------------------------------------------------------
+# templates get — resolve by ls filters + fetch in ONE call
+# ---------------------------------------------------------------------------
+
+# The ONLY filter vocabulary `get --where` accepts: exactly the `templates ls`
+# flags, mapped onto the same `_matches` kwargs — no new query language. Keep
+# this in lockstep with `_matches`' signature.
+_GET_FILTER_KEYS = {
+    "type": "type_",
+    "category": "category",
+    "tag": "tag",
+    "model": "model",
+    "provider": "provider",
+    "name": "name_sub",
+}
+
+
+def _parse_get_filters(renderer, where: list[str]) -> dict[str, str | None]:
+    """Parse repeatable ``--where key=value`` pairs into `_matches` kwargs.
+
+    Strict: a pair without ``=``, an empty/unknown key, or no filters at all is
+    an error — a filterless `get` is just `ls`, and would always be ambiguous.
+    """
+    filters: dict[str, str | None] = {v: None for v in _GET_FILTER_KEYS.values()}
+    valid = ", ".join(sorted(_GET_FILTER_KEYS))
+    if not where:
+        renderer.error(
+            code="template_filter_invalid",
+            message="`templates get` needs at least one --where filter to resolve a single template",
+            hint=f"pass --where key=value (repeatable); keys: {valid} — same semantics as `templates ls`",
+        )
+        raise typer.Exit(code=1)
+    for raw in where:
+        key, sep, value = raw.partition("=")
+        key = key.strip()
+        if not sep or not key:
+            renderer.error(
+                code="template_filter_invalid",
+                message=f"--where must be key=value, got {raw!r}",
+                hint=f"keys: {valid} — e.g. --where type=video --where tag=API",
+            )
+            raise typer.Exit(code=1)
+        if key not in _GET_FILTER_KEYS:
+            renderer.error(
+                code="template_filter_invalid",
+                message=f"unknown --where key {key!r}",
+                hint=f"keys: {valid} — same semantics as the `templates ls` flags",
+                details={"key": key, "valid_keys": sorted(_GET_FILTER_KEYS)},
+            )
+            raise typer.Exit(code=1)
+        filters[_GET_FILTER_KEYS[key]] = value
+    return filters
+
+
+def _get_near_misses(rows: list[dict[str, Any]], filters: dict[str, str | None]) -> list[dict[str, Any]]:
+    """Leave-one-out suggestions for a zero-match filter set: for each active
+    filter, what would have matched with that one filter dropped. Reuses
+    `_matches` verbatim, so the suggestions obey exactly the ls semantics."""
+    active = {k: v for k, v in filters.items() if v is not None}
+    key_by_kwarg = {v: k for k, v in _GET_FILTER_KEYS.items()}
+    near: list[dict[str, Any]] = []
+    if len(active) < 2 and "name_sub" not in active:
+        # With a single non-name filter there is nothing useful to relax against.
+        return near
+    for dropped in active:
+        relaxed = dict(filters)
+        relaxed[dropped] = None
+        names = [r["name"] for r in rows if _matches(r, **relaxed)][:5]
+        if names:
+            near.append({"without": key_by_kwarg[dropped], "names": names})
+    return near
+
+
+@app.command(
+    "get",
+    help=(
+        "Resolve ONE template by `templates ls` filters and fetch its workflow in the same call. "
+        "Filters are repeatable `--where key=value` pairs (keys: type, category, tag, model, "
+        "provider, name — identical semantics to the `templates ls` flags). Errors when zero "
+        "or more than one template matches."
+    ),
+)
+@tracking.track_command("templates")
+def get_cmd(
+    where: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--where",
+            "-w",
+            metavar="KEY=VALUE",
+            show_default=False,
+            help="Filter (repeatable): type=…, category=…, tag=…, model=…, provider=…, name=…",
+        ),
+    ] = None,
+    gallery_path: Annotated[
+        str | None,
+        typer.Option("--gallery", show_default=False, help="Path to a local index.json (skips the cache + fetch)."),
+    ] = None,
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", help="Re-fetch the gallery index from GitHub before resolving."),
+    ] = False,
+):
+    """Fuse `templates ls` (find) + `templates fetch` (get) into one hop.
+
+    Measured agent loops run ls → fetch with the name copied verbatim; `get`
+    resolves the same filter predicates and, when exactly ONE template matches,
+    returns its workflow in the same envelope `fetch` uses.
+    """
+    renderer = get_renderer()
+    filters = _parse_get_filters(renderer, list(where or []))
+
+    try:
+        cats = _load_gallery(gallery_path, refresh=refresh)
+    except _GALLERY_LOAD_ERRORS as e:
+        renderer.error(code="gallery_load_failed", message=str(e))
+        raise typer.Exit(code=1) from e
+
+    rows = _flatten_templates(cats)
+    matched = [r for r in rows if _matches(r, **filters)]
+    shown_filters = {k: filters[v] for k, v in _GET_FILTER_KEYS.items()}
+
+    if not matched:
+        near = _get_near_misses(rows, filters)
+        near_hint = "; ".join(f"drop {n['without']}= to match {', '.join(n['names'])}" for n in near[:2])
+        renderer.error(
+            code="template_not_found",
+            message=f"no template matches {shown_filters}",
+            hint=near_hint or "relax a filter, or browse with `comfy templates ls`",
+            details={"filters": shown_filters, "near_misses": near},
+        )
+        raise typer.Exit(code=1)
+
+    if len(matched) > 1:
+        candidates = [
+            {
+                "name": r["name"],
+                "title": r["title"],
+                "output_type": r["output_type"],
+                "tags": r["tags"],
+                "models": r["models"],
+            }
+            for r in matched[:10]
+        ]
+        renderer.error(
+            code="template_ambiguous",
+            message=f"{len(matched)} templates match {shown_filters}; `get` needs exactly one",
+            hint="add another --where filter (e.g. name=<substring>) to narrow to a single template",
+            details={"filters": shown_filters, "matched": len(matched), "candidates": candidates},
+        )
+        raise typer.Exit(code=1)
+
+    match = matched[0]
+    name = match["name"]
+
+    # From here down this is `fetch` with no --out: same fetch helper, same
+    # error envelopes, workflow riding in the envelope (or pretty stdout).
+    try:
+        body = _fetch_template_workflow(name)
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, RuntimeError, ResponseTooLarge) as e:
+        status = getattr(e, "code", None)
+        renderer.error(
+            code="template_fetch_failed",
+            message=f"failed to fetch workflow for {name!r}: {e}",
+            hint=(
+                "the gallery index references a template whose workflow JSON "
+                "is missing upstream — report at "
+                "https://github.com/Comfy-Org/workflow_templates/issues"
+                if status == 404
+                else "check network connectivity"
+            ),
+            details={"status": status} if status else None,
+        )
+        raise typer.Exit(code=1) from e
+
+    try:
+        wf = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        renderer.error(
+            code="template_workflow_invalid_json",
+            message=f"upstream returned non-JSON for {name!r}: {e}",
+            hint="report at https://github.com/Comfy-Org/workflow_templates/issues",
+        )
+        raise typer.Exit(code=1) from e
+
+    payload = {
+        "name": name,
+        "title": match["title"],
+        "output_type": match["output_type"],
+        "filters": shown_filters,
+        "bytes": len(body),
+        "node_count": _workflow_node_count(wf),
+        "workflow": wf,
+    }
+    if renderer.is_pretty():
+        # Pipeable, exactly like `fetch` with no --out.
+        import sys
+
+        sys.stdout.write(body.decode("utf-8"))
+        sys.stdout.write("\n")
+    renderer.emit(payload, command="templates get")
+
+
+# ---------------------------------------------------------------------------
 # templates check — per-template runnable/missing/api-required/unknown verdict
 # ---------------------------------------------------------------------------
 

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -108,6 +108,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy templates ls": "templates",
     "comfy templates show": "templates",
     "comfy templates fetch": "templates",
+    "comfy templates get": "templates",
     "comfy templates refresh": "templates",
     "comfy templates check": "templates",
     # lifecycle

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -354,6 +354,20 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "report at https://github.com/Comfy-Org/workflow_templates/issues",
     ),
     ErrorCode(
+        "template_ambiguous",
+        "`comfy templates get --where …` matched more than one template; `get` resolves exactly one. "
+        "`details.candidates` carries up to 10 matches (name + title/type/tags/models) and "
+        "`details.matched` the full count.",
+        "add another --where filter (e.g. name=<substring>) to narrow to a single template",
+    ),
+    ErrorCode(
+        "template_filter_invalid",
+        "A `comfy templates get --where` filter was malformed (not key=value), used an unknown key, "
+        "or no filter was given at all. Valid keys: type, category, tag, model, provider, name — "
+        "identical semantics to the `templates ls` flags.",
+        "pass repeatable `--where key=value` pairs, e.g. `--where type=video --where tag=API`",
+    ),
+    ErrorCode(
         "cancel_failed",
         "`comfy jobs cancel` could not reach the local server to cancel the prompt.",
         "check the server is still running on the host/port",

--- a/tests/comfy_cli/command/test_templates_get.py
+++ b/tests/comfy_cli/command/test_templates_get.py
@@ -1,0 +1,295 @@
+"""Tests for ``comfy templates get --where k=v`` (V1-018 / BE-7151).
+
+The measured agent loop is ``templates ls`` (to find the name) → ``templates
+fetch`` (copying that name back, 100% verbatim). ``get`` fuses the two: the
+same ls filter predicates (``_matches``, reused exactly — no new query
+language) resolve the template, and when exactly one matches its workflow is
+fetched and returned in one envelope.
+
+Contract under test:
+  * exactly one match → fetch + return the workflow in one envelope.
+  * zero matches → ``template_not_found`` + nearest-candidate suggestions.
+  * >1 matches → ``template_ambiguous`` with ≤10 candidates (name + meta).
+  * malformed / unknown ``--where`` key → ``template_filter_invalid``.
+  * existing ls/show/fetch surfaces untouched (their own tests pin that).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import templates as templates_cmd
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+# Same schema as the real gallery index (mirrors test_templates.py's fixture,
+# with names distinct enough to pin single/ambiguous/none per filter).
+GET_FIXTURE = [
+    {
+        "moduleName": "default",
+        "category": "GENERATION TYPE",
+        "title": "Image",
+        "type": "image",
+        "templates": [
+            {
+                "name": "image_flux_dev",
+                "title": "Flux Dev Image",
+                "description": "Text-to-image with Flux Dev.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["Local", "Text to Image"],
+                "models": ["Flux Dev"],
+                "logos": [{"provider": ["Black Forest Labs"]}],
+                "openSource": True,
+                "usage": 90,
+            },
+            {
+                "name": "image_flux_pro_api",
+                "title": "Flux Pro (API)",
+                "description": "Text-to-image via the BFL API.",
+                "mediaType": "image",
+                "mediaSubtype": "webp",
+                "tags": ["API", "Text to Image"],
+                "models": ["Flux Pro"],
+                "logos": [{"provider": ["Black Forest Labs"]}],
+                "openSource": False,
+                "usage": 100,
+            },
+        ],
+    },
+    {
+        "moduleName": "default",
+        "category": "GENERATION TYPE",
+        "title": "Video",
+        "type": "video",
+        "templates": [
+            {
+                "name": "video_kling_i2v",
+                "title": "Kling Image to Video",
+                "description": "Image-to-video via Kling.",
+                "mediaType": "video",
+                "mediaSubtype": "mp4",
+                "tags": ["API", "Image to Video"],
+                "models": ["Kling 2.5"],
+                "logos": [{"provider": ["Kling"]}],
+                "openSource": False,
+                "usage": 75,
+            }
+        ],
+    },
+]
+
+
+@pytest.fixture
+def gallery_file(tmp_path: Path) -> str:
+    path = tmp_path / "get_index.json"
+    path.write_text(json.dumps(GET_FIXTURE))
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _envelope(stdout: str) -> dict:
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope in stdout:\n{stdout}")
+
+
+def _stub_workflow_fetch(monkeypatch, body_or_exc):
+    def _impl(name, timeout=15.0):
+        if isinstance(body_or_exc, Exception):
+            raise body_or_exc
+        return body_or_exc
+
+    monkeypatch.setattr(templates_cmd, "_fetch_template_workflow", _impl)
+
+
+WORKFLOW_BODY = json.dumps({"9": {"class_type": "KSampler", "inputs": {}}}).encode()
+
+
+class TestGetSingleMatch:
+    def test_unique_filter_fetches_and_returns_workflow(self, gallery_file, monkeypatch):
+        _force_json_renderer()
+        _stub_workflow_fetch(monkeypatch, WORKFLOW_BODY)
+        runner = CliRunner()
+        result = runner.invoke(
+            templates_cmd.app,
+            ["get", "--gallery", gallery_file, "--where", "type=video"],
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["ok"] is True
+        data = env["data"]
+        assert data["name"] == "video_kling_i2v"
+        assert data["title"] == "Kling Image to Video"
+        assert data["output_type"] == "video"
+        assert data["node_count"] == 1
+        # The whole point: the workflow rides in the same envelope.
+        assert data["workflow"] == json.loads(WORKFLOW_BODY)
+
+    def test_filters_and_together_narrow_to_one(self, gallery_file, monkeypatch):
+        _force_json_renderer()
+        _stub_workflow_fetch(monkeypatch, WORKFLOW_BODY)
+        runner = CliRunner()
+        result = runner.invoke(
+            templates_cmd.app,
+            ["get", "--gallery", gallery_file, "--where", "type=image", "--where", "tag=API"],
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["data"]["name"] == "image_flux_pro_api"
+
+    def test_name_filter_is_the_ls_substring_predicate(self, gallery_file, monkeypatch):
+        _force_json_renderer()
+        _stub_workflow_fetch(monkeypatch, WORKFLOW_BODY)
+        runner = CliRunner()
+        result = runner.invoke(
+            templates_cmd.app,
+            ["get", "--gallery", gallery_file, "--where", "name=kling"],
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result.output)
+        assert env["data"]["name"] == "video_kling_i2v"
+
+
+class TestGetAmbiguous:
+    def test_multi_match_errors_with_candidates(self, gallery_file, monkeypatch):
+        _force_json_renderer()
+
+        def _should_not_fire(name, timeout=15.0):
+            raise AssertionError("workflow fetch must not fire on an ambiguous filter")
+
+        monkeypatch.setattr(templates_cmd, "_fetch_template_workflow", _should_not_fire)
+        runner = CliRunner()
+        result = runner.invoke(
+            templates_cmd.app,
+            ["get", "--gallery", gallery_file, "--where", "type=image"],
+        )
+        assert result.exit_code != 0
+        env = _envelope(result.output)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "template_ambiguous"
+        candidates = env["error"]["details"]["candidates"]
+        assert len(candidates) == 2
+        names = {c["name"] for c in candidates}
+        assert names == {"image_flux_dev", "image_flux_pro_api"}
+        # One-line meta per candidate so the agent can pick without another ls.
+        for c in candidates:
+            assert c["title"]
+            assert c["output_type"] == "image"
+
+    def test_candidates_are_capped_at_ten(self, tmp_path, monkeypatch):
+        _force_json_renderer()
+        many = [
+            {
+                "moduleName": "default",
+                "category": "GENERATION TYPE",
+                "title": "Image",
+                "type": "image",
+                "templates": [
+                    {
+                        "name": f"image_bulk_{i:02d}",
+                        "title": f"Bulk {i}",
+                        "description": "",
+                        "mediaType": "image",
+                        "mediaSubtype": "webp",
+                        "tags": ["Local"],
+                        "models": [],
+                        "logos": [],
+                    }
+                    for i in range(14)
+                ],
+            }
+        ]
+        path = tmp_path / "get_index_many.json"
+        path.write_text(json.dumps(many))
+        runner = CliRunner()
+        result = runner.invoke(templates_cmd.app, ["get", "--gallery", str(path), "--where", "type=image"])
+        assert result.exit_code != 0
+        env = _envelope(result.output)
+        assert env["error"]["code"] == "template_ambiguous"
+        assert env["error"]["details"]["matched"] == 14
+        assert len(env["error"]["details"]["candidates"]) == 10
+
+
+class TestGetNoMatch:
+    def test_zero_matches_errors_with_suggestions(self, gallery_file, monkeypatch):
+        _force_json_renderer()
+
+        def _should_not_fire(name, timeout=15.0):
+            raise AssertionError("workflow fetch must not fire on zero matches")
+
+        monkeypatch.setattr(templates_cmd, "_fetch_template_workflow", _should_not_fire)
+        runner = CliRunner()
+        # type=video AND tag=Local matches nothing; dropping either filter finds rows.
+        result = runner.invoke(
+            templates_cmd.app,
+            ["get", "--gallery", gallery_file, "--where", "type=video", "--where", "tag=Local"],
+        )
+        assert result.exit_code != 0
+        env = _envelope(result.output)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "template_not_found"
+        near = env["error"]["details"]["near_misses"]
+        # Leave-one-out: dropping `tag` finds the video template, dropping `type`
+        # finds the Local image template.
+        by_dropped = {n["without"]: n["names"] for n in near}
+        assert "video_kling_i2v" in by_dropped["tag"]
+        assert "image_flux_dev" in by_dropped["type"]
+
+
+class TestGetFilterValidation:
+    @pytest.mark.parametrize("bad", ["type", "flavor=spicy", "=video"])
+    def test_malformed_or_unknown_where_is_rejected(self, gallery_file, bad):
+        _force_json_renderer()
+        runner = CliRunner()
+        result = runner.invoke(templates_cmd.app, ["get", "--gallery", gallery_file, "--where", bad])
+        assert result.exit_code != 0
+        env = _envelope(result.output)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "template_filter_invalid"
+
+    def test_no_filters_at_all_is_rejected(self, gallery_file):
+        _force_json_renderer()
+        runner = CliRunner()
+        result = runner.invoke(templates_cmd.app, ["get", "--gallery", gallery_file])
+        assert result.exit_code != 0
+        env = _envelope(result.output)
+        assert env["error"]["code"] == "template_filter_invalid"
+
+
+class TestGetErrorCodesRegistered:
+    def test_new_codes_are_registered(self):
+        from comfy_cli import error_codes
+
+        assert error_codes.is_registered("template_ambiguous")
+        assert error_codes.is_registered("template_filter_invalid")


### PR DESCRIPTION
**Linear: BE-7151 (V1-018)** · Layer 2/4 of the V1 hop-killer stack, stacks on #707.

## The hop it kills

Measured: `templates ls` → `templates fetch`, **×42 occurrences**, with the fetched name a **100% verbatim copy** of an ls row. `get` fuses find + fetch into one call.

## Semantics

- `comfy templates get --where key=value` (repeatable, `-w`): keys `type|category|tag|model|provider|name`, evaluated by the **exact ls predicates** (`_matches`, reused verbatim — no new query language; `name` is the same substring predicate as `ls --name`).
- Exactly one match → fetches `templates/<name>.json` (same helper + error envelopes as `fetch`) and returns it **in one envelope**: `{name, title, output_type, filters, bytes, node_count, workflow}`; pretty mode streams the raw JSON to stdout exactly like `fetch` with no `--out`.
- Zero matches → `template_not_found` with **leave-one-out near-miss suggestions** (`details.near_misses`: for each active filter, what matches with it dropped — also computed via `_matches`).
- \>1 matches → `template_ambiguous` with ≤10 candidates (name + one-line meta: title/type/tags/models) and the full `matched` count.
- Malformed / unknown / missing `--where` → `template_filter_invalid`.
- `ls`/`show`/`fetch` untouched — their suites pin byte-identical behavior.
- New registry codes: `template_ambiguous`, `template_filter_invalid`. Registered in `discovery.COMMAND_SCHEMAS` (`templates` schema).

## Test evidence

`tests/comfy_cli/command/test_templates_get.py` against a fixture gallery index (same schema/mocking pattern as `test_templates.py`) — TDD: red first (11/11 fail: no such command), then green.

- single match returns workflow in-envelope; AND-composition of filters; name substring predicate
- ambiguous: candidates + cap at 10, fetch never fires; zero matches: near-misses, fetch never fires
- filter validation (3 malformed shapes + filterless)
- neighbors: `test_templates.py`, `test_run_template.py`, registry + discovery tests green; ruff clean

## Sibling-PR notes

- #704/#705/#706: no shared files with this layer beyond `error_codes.py`, which this stack serializes (each layer stacks on the previous precisely so registry/test additions never conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
