### PR TITLE
feat(cli): nodes path --emit-ops (round-trips through apply_specs)

### DIFF
--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -782,6 +782,83 @@ def downstream_cmd(
     renderer.emit(payload, command="nodes downstream")
 
 
+def _alias_slug(class_type: str) -> str:
+    """A spec-batch alias for a class name — the same slugging
+    ``workflow_ops.capture_recipe`` uses, so the two surfaces mint identical
+    alias vocabulary."""
+    import re
+
+    return re.sub(r"[^a-z0-9]+", "_", str(class_type or "node").lower()).strip("_") or "node"
+
+
+def _emit_path_ops(graph, steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project a routed path (``steps`` from ``find_paths``/``exact_paths``)
+    into a ready-to-apply spec batch in the frozen edit vocabulary.
+
+    THE CONTRACT IS THE ROUND-TRIP: the returned specs must pass
+    ``workflow_ops.apply_specs`` unchanged. Shape:
+
+    * one ``add_node`` per step, with a deterministic dedup-suffixed ``as:``
+      alias (``tinysampler``, ``tinysampler_2``, …);
+    * one ``connect`` per step whose consumed type is produced by an earlier
+      step — from the NEAREST prior producer's matching output to this step's
+      first link input accepting that type. Alias references are emitted as
+      bare names (the freeze vocabulary's valid form; the ``$``-canonical
+      sugar lands with the vocabulary-freeze PR).
+
+    The path's seed FROM type is produced by nothing in the path, so the first
+    step's input deliberately stays unbound — never a phantom connect.
+    """
+    from comfy_cli.workflow_ops import _types_compatible
+
+    # Deterministic dedup-suffixed aliases, one add_node per step.
+    counts: dict[str, int] = {}
+    aliases: list[str] = []
+    specs: list[dict[str, Any]] = []
+    for step in steps:
+        class_type = str(step.get("node") or "")
+        slug = _alias_slug(class_type)
+        counts[slug] = counts.get(slug, 0) + 1
+        alias = slug if counts[slug] == 1 else f"{slug}_{counts[slug]}"
+        aliases.append(alias)
+        specs.append({"op": "add_node", "class_type": class_type, "as": alias})
+
+    def _producer_output(class_type: str, want: str) -> str | None:
+        m = graph.node(class_type)
+        for p in m.outputs if m is not None else ():
+            types = {t.strip() for t in str(p.type).split(",") if t.strip()}
+            if want in types or "*" in types:
+                return p.name
+        return None
+
+    def _consumer_input(class_type: str, want: str) -> str | None:
+        m = graph.node(class_type)
+        ports = [p for p in (m.inputs if m is not None else ()) if p.is_link]
+        # Required inputs first — that's the slot the plan is routing through.
+        for p in sorted(ports, key=lambda p: not p.required):
+            if _types_compatible(want, p.type):
+                return p.name
+        return None
+
+    for j, step in enumerate(steps):
+        want = str(step.get("input_type") or "")
+        if not want:
+            continue  # step consumes nothing from the path (e.g. a loader)
+        # Nearest prior step whose node actually produces `want` — in exact
+        # mode the recorded per-step output_type is one of possibly several
+        # outputs, so resolve against the schema, not just the step record.
+        for k in range(j - 1, -1, -1):
+            src_class = str(steps[k].get("node") or "")
+            out_name = _producer_output(src_class, want)
+            if out_name is None:
+                continue
+            in_name = _consumer_input(str(step.get("node") or ""), want)
+            if in_name is not None:
+                specs.append({"op": "connect", "from": f"{aliases[k]}.{out_name}", "to": f"{aliases[j]}.{in_name}"})
+            break
+    return specs
+
+
 @app.command("path", help="Routed paths from one type to another (e.g. MODEL -> IMAGE).")
 @tracking.track_command("nodes")
 def path_cmd(
@@ -796,6 +873,17 @@ def path_cmd(
             help="Exact: every step's required link inputs must be satisfiable from the path so far. Loose: any routed sequence.",
         ),
     ] = True,
+    emit_ops: Annotated[
+        bool,
+        typer.Option(
+            "--emit-ops",
+            help=(
+                "Attach each path's plan as a ready-to-apply spec batch under `paths[].ops` "
+                "(frozen add_node/connect vocabulary with `as:` aliases) — feed it straight "
+                "to `comfy workflow apply --ops`."
+            ),
+        ),
+    ] = False,
     input_path: Annotated[str | None, typer.Option("--input", show_default=False)] = None,
     host: Annotated[str | None, typer.Option(show_default=False)] = None,
     port: Annotated[int | None, typer.Option(show_default=False)] = None,
@@ -836,6 +924,10 @@ def path_cmd(
                     }
                     for s in (p.get("steps") or [])
                 ],
+                # --emit-ops: the plan as a ready-to-apply spec batch (round-trips
+                # through workflow_ops.apply_specs unchanged). Absent without the
+                # flag so the default output stays byte-identical.
+                **({"ops": _emit_path_ops(graph, list(p.get("steps") or []))} if emit_ops else {}),
             }
             for p in paths
         ],

--- a/tests/comfy_cli/command/test_nodes_path_emit_ops.py
+++ b/tests/comfy_cli/command/test_nodes_path_emit_ops.py
@@ -1,0 +1,169 @@
+"""Tests for ``comfy nodes path --emit-ops`` (V1-019 / BE-7152).
+
+``nodes path`` reports a plan (a routed node sequence); agents then hand-build
+the apply batch from it. ``--emit-ops`` closes that gap: each returned path
+gains ``ops`` — a ready-to-apply spec batch in the frozen edit vocabulary
+(``add_node`` with ``as:`` aliases + ``connect`` referencing those aliases as
+bare names).
+
+THE CONTRACT IS THE ROUND-TRIP: the emitted specs must pass
+``workflow_ops.apply_specs`` unchanged — the tests feed them to ``apply_specs``
+on an empty workflow and assert the nodes and links exist.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.caller import Caller
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _object_info() -> dict[str, Any]:
+    """A minimal MODEL → LATENT → IMAGE chain so `path MODEL IMAGE --exact`
+    finds exactly one two-step path."""
+    return {
+        "TinySampler": {
+            "input": {"required": {"model": ["MODEL"]}},
+            "input_order": {"required": ["model"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "Tiny Sampler",
+            "python_module": "nodes",
+        },
+        "TinyDecode": {
+            "input": {"required": {"samples": ["LATENT"]}},
+            "input_order": {"required": ["samples"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "latent",
+            "display_name": "Tiny Decode",
+            "python_module": "nodes",
+        },
+    }
+
+
+def _graph() -> Graph:
+    return Graph.from_object_info(_object_info())
+
+
+@pytest.fixture
+def patched_loader(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    _force_json_renderer()
+    runner = CliRunner()
+    result = runner.invoke(nodes_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+class TestEmitOps:
+    def test_round_trip_through_apply_specs(self, patched_loader, capsys):
+        """The emitted specs ARE the contract: applied unchanged onto an empty
+        workflow they materialize the path's nodes and intra-path links."""
+        env = _run(["path", "MODEL", "IMAGE", "--emit-ops"], capsys)
+        assert env["ok"] is True
+        paths = env["data"]["paths"]
+        assert paths, env["data"]
+        specs = paths[0]["ops"]
+
+        # Shape: frozen vocabulary only, bare alias references.
+        kinds = [s["op"] for s in specs]
+        assert kinds == ["add_node", "add_node", "connect"]
+        adds = [s for s in specs if s["op"] == "add_node"]
+        assert [a["class_type"] for a in adds] == ["TinySampler", "TinyDecode"]
+        assert all(a.get("as") for a in adds)
+        connect = next(s for s in specs if s["op"] == "connect")
+        assert connect["from"] == f"{adds[0]['as']}.LATENT"
+        assert connect["to"] == f"{adds[1]['as']}.samples"
+
+        # Round-trip: apply_specs on an empty workflow, unchanged.
+        wf: dict = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        wf, ops, aliases = workflow_ops.apply_specs(wf, _graph(), specs)
+        assert {n["type"] for n in wf["nodes"]} == {"TinySampler", "TinyDecode"}
+        assert len(wf["links"]) == 1
+        decode = next(n for n in wf["nodes"] if n["type"] == "TinyDecode")
+        samples = next(i for i in decode["inputs"] if i["name"] == "samples")
+        assert samples["link"] == wf["links"][0][0]
+        # The link's source really is the sampler minted by the batch.
+        sampler_id = aliases[adds[0]["as"]]
+        assert wf["links"][0][1] == sampler_id
+
+    def test_loose_mode_also_emits_ops(self, patched_loader, capsys):
+        env = _run(["path", "MODEL", "IMAGE", "--loose", "--emit-ops"], capsys)
+        assert env["ok"] is True
+        for p in env["data"]["paths"]:
+            assert isinstance(p["ops"], list) and p["ops"]
+
+    def test_without_flag_byte_identical(self, patched_loader, capsys):
+        base = _run(["path", "MODEL", "IMAGE"], capsys)
+        again = _run(["path", "MODEL", "IMAGE"], capsys)
+        assert again["data"] == base["data"]
+        for p in base["data"]["paths"]:
+            assert "ops" not in p
+        assert "emit_ops" not in base["data"]
+
+    def test_alias_uniqueness_is_deterministic(self):
+        """Two steps with the same class dedup deterministically (slug, slug_2)
+        and later connects reference the deduped alias, not the clobbered one."""
+        steps = [
+            {"node": "TinySampler", "input_type": "MODEL", "output_type": "LATENT"},
+            {"node": "TinyDecode", "input_type": "LATENT", "output_type": "IMAGE"},
+            {"node": "TinyDecode", "input_type": "LATENT", "output_type": "IMAGE"},
+        ]
+        specs = nodes_cmd._emit_path_ops(_graph(), steps)
+        aliases = [s["as"] for s in specs if s["op"] == "add_node"]
+        assert aliases == ["tinysampler", "tinydecode", "tinydecode_2"]
+        assert len(set(aliases)) == len(aliases)
+        connects = [s for s in specs if s["op"] == "connect"]
+        # Each decode is fed by the nearest prior LATENT producer (the sampler).
+        assert {c["to"] for c in connects} == {"tinydecode.samples", "tinydecode_2.samples"}
+        # Deterministic: same input → same output.
+        assert specs == nodes_cmd._emit_path_ops(_graph(), steps)
+
+    def test_seed_type_has_no_phantom_producer(self, patched_loader, capsys):
+        """The path's FROM type is an unbound input by design (nothing in the
+        path produces it) — no connect spec may reference a nonexistent source."""
+        env = _run(["path", "MODEL", "IMAGE", "--emit-ops"], capsys)
+        specs = env["data"]["paths"][0]["ops"]
+        aliases = {s["as"] for s in specs if s["op"] == "add_node"}
+        for c in (s for s in specs if s["op"] == "connect"):
+            assert c["from"].partition(".")[0] in aliases
+            assert c["to"].partition(".")[0] in aliases


### PR DESCRIPTION
**Linear: BE-7152 (V1-019)** · Layer 3/4 of the V1 hop-killer stack, stacks on #708.

## The gap it closes

`nodes path` reports a plan (a routed node sequence); agents then hand-build the apply batch from it. `--emit-ops` emits the plan **as** the batch: each returned path gains `paths[].ops` — a ready-to-apply spec batch in the frozen edit vocabulary, feedable straight into `comfy workflow apply --ops`.

## Semantics

- One `add_node` spec per step with a deterministic **dedup-suffixed `as:` alias** (`tinysampler`, `tinysampler_2`, … — the same slugging `capture_recipe` uses, so both surfaces mint identical alias vocabulary).
- One `connect` spec per step whose consumed type is produced earlier in the path: from the **nearest prior producer**'s matching output (resolved against the schema, since in `--exact` mode a step's recorded output_type is only one of possibly several) to the consumer's first link input accepting that type (required inputs first).
- The path's seed FROM type is produced by nothing in the path, so the first step's input deliberately stays unbound — never a phantom connect.
- Works in both `--exact` and `--loose` modes. Without the flag the payload is **byte-identical**.

**THE CONTRACT IS THE ROUND-TRIP:** the emitted specs must pass `workflow_ops.apply_specs` **unchanged**. The test feeds them to `apply_specs` on an empty workflow and asserts the nodes and links exist (including that the minted link's source is the alias-minted node).

## $-form note

The vocabulary-freeze PR #704 adds `$`-sugar for alias references; this base branch predates it, so connect specs reference aliases as **bare names** — the freeze doc's valid form. Migrating emission to the `$`-canonical form is a small follow-up once #704 lands.

## Test evidence

`tests/comfy_cli/command/test_nodes_path_emit_ops.py` — TDD: red first (4 fail: unknown option/helper; the byte-identical baseline trivially passes pre-change and pins the invariant after), then green.

- **round-trip through `apply_specs`** on an empty workflow: 2 nodes + 1 link materialize, link source = aliased node
- alias uniqueness deterministic (`tinydecode`, `tinydecode_2`; same input → same output)
- loose mode emits too; no phantom producers (every connect endpoint is a minted alias)
- neighbors: `test_nodes_introspect.py`, `test_nodes_search_expand.py`, `test_workflow_edit.py` (150 total) green; ruff clean

## Sibling-PR notes

- #704 rebase: when the freeze lands, only the emission site (`_emit_path_ops`) needs the `$`-form switch; the round-trip test is the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
