### PR TITLE
feat(cli): workflow delete-nodes batch verb

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -1482,6 +1482,10 @@ app.command("add-node", help="Add a node to the graph; emits an add_node op.")(_
 app.command("connect", help="Wire an output slot to an input slot; emits a connect op.")(_wedit.connect_cmd)
 app.command("set-widget", help="Set a widget by name (`<id>.<widget>`); emits a set_widget op.")(_wedit.set_widget_cmd)
 app.command("delete-node", help="Delete a node and its links; emits a delete_node op.")(_wedit.delete_cmd)
+app.command(
+    "delete-nodes",
+    help="Delete N nodes in one atomic write; emits one delete_node op per id (all-or-nothing).",
+)(_wedit.delete_nodes_cmd)
 app.command("clear", help="Remove every node, link, and group; emits one clear op.")(_wedit.clear_cmd)
 app.command("ls-nodes", help="List nodes (id/type/title) in a workflow file.")(_wedit.ls_nodes_cmd)
 app.command("apply", help="Apply a recipe / batch of edits in one pass; supports node aliases + --param.")(

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -263,6 +263,76 @@ def delete_cmd(
 
 
 # ---------------------------------------------------------------------------
+# delete-nodes — batch delete: N ids, ONE atomic write
+# ---------------------------------------------------------------------------
+
+
+@tracking.track_command("workflow")
+def delete_nodes_cmd(
+    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
+    nodes: Annotated[list[str], typer.Argument(help="Node ids to delete (one or more).")],
+    actor: ActorOpt = "cli",
+    base_version: BaseVersionOpt = 0,
+    stdout: StdoutOpt = False,
+    input_path: InputOpt = None,
+    host: HostOpt = None,
+    port: PortOpt = None,
+    where: WhereOpt = None,
+):
+    """Delete N nodes in one pass: one file load, one catalog load, ONE atomic
+    write, and one frozen ``delete_node`` op per id (via
+    ``workflow_ops.delete_node`` — no new op kind). Any invalid id fails the
+    whole batch atomically: the file is left byte-identical.
+    """
+    renderer = get_renderer()
+    renderer.command = "workflow delete-nodes"
+    p, workflow = _load_workflow_or_fail(renderer, file)
+    graph = _graph_or_exit(input_path, host, port, renderer, where)
+    # Snapshot the inventory BEFORE any delete mutates the in-memory graph: on
+    # failure nothing is written, so a mid-batch "nodes in this workflow" hint
+    # must describe the graph as it still stands on disk (the same pre-batch
+    # re-hinting `apply` does — advertising already-discarded state is exactly
+    # the phantom-id failure mode the batch surfaces were bitten by).
+    pre_batch_hint = workflow_ops._available_nodes_hint(workflow)
+    ops: list[dict] = []
+    try:
+        for raw in nodes:
+            raw = raw.strip()
+            node_id: Any = int(raw) if raw.lstrip("-").isdigit() else raw
+            workflow, op = workflow_ops.delete_node(workflow, graph, node_id, actor=actor, base_version=base_version)
+            ops.append(op)
+    except ValueError as e:
+        renderer.error(
+            code="workflow_edit_invalid",
+            message=f"batch failed: {workflow_ops._rehint_discarded_batch(e, pre_batch_hint)}",
+            hint="run `comfy workflow ls-nodes <file>` for the live node ids; the file was not modified",
+        )
+        raise typer.Exit(code=1) from e
+
+    workflow_ops.strip_internal(workflow)
+    serialized = json.dumps(workflow, indent=2)
+    wrote: str | None = None
+    if stdout:
+        import sys
+
+        sys.stdout.write(serialized + "\n")
+    else:
+        _atomic_write_text(p, serialized)
+        wrote = str(p)
+    payload = {
+        "workflow": str(p),
+        "count": len(ops),
+        "ops": ops,
+        "base_version": base_version,
+        "version": base_version + len(ops),
+        "wrote": wrote,
+    }
+    if renderer.is_pretty():
+        rprint(f"[bold green]✓[/bold green] deleted {len(ops)} node(s) → [dim]{p}[/dim]")
+    renderer.emit(payload, command="workflow delete-nodes", changed=True)
+
+
+# ---------------------------------------------------------------------------
 # clear
 # ---------------------------------------------------------------------------
 

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -61,6 +61,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy workflow connect": "workflow",
     "comfy workflow set-widget": "workflow",
     "comfy workflow delete-node": "workflow",
+    "comfy workflow delete-nodes": "workflow",
     "comfy workflow ls-nodes": "workflow",
     "comfy workflow apply": "workflow",
     "comfy workflow capture": "workflow",

--- a/tests/comfy_cli/command/test_workflow_delete_nodes.py
+++ b/tests/comfy_cli/command/test_workflow_delete_nodes.py
@@ -1,0 +1,215 @@
+"""Tests for ``comfy workflow delete-nodes <id...>`` (V1-020 / BE-7153).
+
+The measured agent loop runs ``delete-node`` once per doomed node (×22 runs) —
+N file loads, N writes, N catalog loads. ``delete-nodes`` is the batch verb:
+N ids, ONE atomic write, one frozen ``delete_node`` op per id (via
+``workflow_ops.delete_node`` — no new op kind).
+
+Contract under test:
+  * batch removes every named node in one write; ``data.ops`` carries one
+    stamped ``delete_node`` op per id (``--actor``/``--base-version`` honored).
+  * any invalid id fails the WHOLE batch atomically — file unchanged — with
+    the node-inventory hint rendered from the PRE-batch graph.
+  * dangling links are cleaned exactly as the single-delete verb cleans them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.command import workflow_edit
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _object_info() -> dict[str, Any]:
+    return {
+        "TinyLatent": {
+            "input": {"required": {}},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "latent",
+            "display_name": "Tiny Latent",
+            "python_module": "nodes",
+        },
+        "TinyKS": {
+            "input": {"required": {"latent_image": ["LATENT"]}},
+            "input_order": {"required": ["latent_image"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "Tiny KSampler",
+            "python_module": "nodes",
+        },
+        "TinyNote": {
+            "input": {"required": {}},
+            "output": [],
+            "category": "util",
+            "display_name": "Tiny Note",
+            "python_module": "nodes",
+        },
+    }
+
+
+def _graph() -> Graph:
+    return Graph.from_object_info(_object_info())
+
+
+@pytest.fixture
+def patched_graph(monkeypatch):
+    monkeypatch.setattr(workflow_edit, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _workflow() -> dict:
+    """TinyLatent(7) --link 1--> TinyKS(3); TinyNote(5) free-standing."""
+    return {
+        "last_node_id": 7,
+        "last_link_id": 1,
+        "nodes": [
+            {
+                "id": 3,
+                "type": "TinyKS",
+                "pos": [200, 100],
+                "inputs": [{"name": "latent_image", "type": "LATENT", "link": 1}],
+                "outputs": [{"name": "LATENT", "type": "LATENT", "links": []}],
+                "widgets_values": [],
+            },
+            {
+                "id": 5,
+                "type": "TinyNote",
+                "pos": [0, 300],
+                "inputs": [],
+                "outputs": [],
+                "widgets_values": [],
+            },
+            {
+                "id": 7,
+                "type": "TinyLatent",
+                "pos": [0, 100],
+                "inputs": [],
+                "outputs": [{"name": "LATENT", "type": "LATENT", "links": [1]}],
+                "widgets_values": [],
+            },
+        ],
+        "links": [[1, 7, 0, 3, 0, "LATENT"]],
+    }
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "delete_nodes_wf.json"
+    p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return p
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    _force_json_renderer()
+    runner = CliRunner()
+    result = runner.invoke(workflow_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+class TestDeleteNodesBatch:
+    def test_batch_removes_all_and_emits_stamped_ops(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _workflow())
+        env = _run(
+            ["delete-nodes", str(path), "7", "5", "--actor", "agent-x", "--base-version", "4"],
+            capsys,
+        )
+        assert env["ok"] is True, env
+        data = env["data"]
+        assert data["count"] == 2
+        ops = data["ops"]
+        # One frozen delete_node op per id — NOT a new op kind.
+        assert [op["op"] for op in ops] == ["delete_node", "delete_node"]
+        assert [op["node_id"] for op in ops] == [7, 5]
+        for op in ops:
+            assert op["actor"] == "agent-x"
+            assert op["base_version"] == 4
+            assert op["stamp"] == [4, "agent-x"]
+            assert isinstance(op["op_id"], str) and op["op_id"]
+        assert data["base_version"] == 4
+        assert data["version"] == 4 + len(ops)
+        # ONE write, both nodes gone.
+        on_disk = json.loads(path.read_text())
+        assert {n["id"] for n in on_disk["nodes"]} == {3}
+        # Bookkeeping never serialized.
+        assert "_applied_ops" not in on_disk
+
+    def test_dangling_links_cleaned_exactly_like_single_delete(self, patched_graph, tmp_path, capsys):
+        batch_path = _write(tmp_path, _workflow())
+        env = _run(["delete-nodes", str(batch_path), "7"], capsys)
+        assert env["ok"] is True
+        batch_disk = json.loads(batch_path.read_text())
+
+        single_path = tmp_path / "delete_nodes_single_wf.json"
+        single_path.write_text(json.dumps(_workflow(), indent=2), encoding="utf-8")
+        env2 = _run(["delete-node", str(single_path), "7"], capsys)
+        assert env2["ok"] is True
+        single_disk = json.loads(single_path.read_text())
+
+        assert batch_disk["links"] == single_disk["links"] == []
+        for disk in (batch_disk, single_disk):
+            ks = next(n for n in disk["nodes"] if n["id"] == 3)
+            assert ks["inputs"][0]["link"] is None
+
+    def test_invalid_id_fails_whole_batch_atomically(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _workflow())
+        before = path.read_text()
+        env = _run(["delete-nodes", str(path), "7", "999"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_edit_invalid"
+        # File untouched even though id 7 was valid and listed first.
+        assert path.read_text() == before
+        # The node-inventory hint reflects the PRE-batch graph: node 7 still
+        # exists on disk, so it must still be advertised.
+        msg = env["error"]["message"]
+        assert "999" in msg
+        assert "7 (TinyLatent)" in msg
+        assert "No changes were applied" in msg
+
+    def test_stdout_mode_writes_nothing(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _workflow())
+        before = path.read_text()
+        env = _run(["delete-nodes", str(path), "7", "--stdout"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["wrote"] is None
+        assert path.read_text() == before


### PR DESCRIPTION
**Linear: BE-7153 (V1-020)** · Layer 4/4 (top) of the V1 hop-killer stack, stacks on #709.

## The hop it kills

Measured: **×22** `workflow delete-node` runs fired one-per-node — N file loads, N catalog loads, N writes. `delete-nodes` is the batch verb: N ids, ONE atomic write.

## Semantics

- `comfy workflow delete-nodes <file> <id...>`: one file load, one catalog load, one `_atomic_write_text` write; emits **one frozen `delete_node` op per id** via `workflow_ops.delete_node` — **no new op kind**, so every CRDT/merge consumer replays it unchanged.
- **Atomic on any invalid id**: the whole batch fails, the file stays byte-identical, and the error carries the node-inventory hint re-rendered from the **pre-batch** graph (`_rehint_discarded_batch`) — the same phantom-id guard `apply` grew, so a failed batch never advertises already-discarded state. Registered code `workflow_edit_invalid`.
- Dangling links cleaned **exactly** as the single-delete verb (same `_apply_delete_node` path; the test diffs batch-vs-single on-disk results).
- Carries `--actor` / `--base-version` (stamped into every op) plus `--stdout/--in-place`, `--input`, `--host`/`--port`, `--where` like every edit verb; envelope is `{workflow, count, ops, base_version, version, wrote}` (the `apply` shape).
- Mounted beside the other edit verbs in `workflow.py`; registered in `discovery.COMMAND_SCHEMAS` (`workflow` schema).

## Test evidence

`tests/comfy_cli/command/test_workflow_delete_nodes.py` — TDD: red first (4/4 fail: no such command), then green.

- batch removes all + emits stamped ops (`actor`/`base_version`/`stamp` honored; `version = base + N`; one write; no `_applied_ops` leakage)
- **atomicity**: valid id listed first + one bad id → file byte-identical, message names the bad id, still advertises the surviving node, says "No changes were applied"
- dangling-link cleanup byte-equal to single `delete-node`
- `--stdout` writes nothing
- neighbors: `test_workflow_edit.py`, registry + discovery tests green (`test_op_vocabulary_contract.py` does not exist on this base — it arrives with #704); ruff clean
- full-stack sweep on this branch: `tests/comfy_cli/command` + `tests/comfy_cli/output` → 2552 passed (the only failures in the full repo suite are 29 pre-existing on the base branch in untouched files: test_logs/test_jobs/test_host_port/test_onboarding/test_restore_snapshot_fast_deps)

## Sibling-PR notes

- #704/#705/#706 rebase awareness: this layer adds no op kinds and no vocabulary, so the freeze contract test (#704) should pass over it as-is; only `discovery.py`/`workflow.py` mount lines could need trivial rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
