### PR TITLE
fix(launch): escape ComfyUI output before the markup-parsing relay

### DIFF
--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -24,6 +24,7 @@ from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import _bracket_host, check_comfy_server_running
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as print  # context-aware print: stderr in JSON mode
+from comfy_cli.output.sanitize import sanitize_markup
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.workspace_manager import WorkspaceManager, WorkspaceType
 
@@ -113,31 +114,93 @@ def _emit_launch_success(listen, port, pid) -> None:
         )
 
 
+# Backoff for a redirector thread whose pipe has nothing to give (not started,
+# exited, or mid-reboot). Long enough that an idle pump costs nothing, short
+# enough that a rebooted server's first lines are not visibly delayed.
+_REDIRECTOR_IDLE_SLEEP = 0.05
+
+
 def _relay_child_line(line: str) -> None:
-    """Relay one line of the background child's ComfyUI output, markup-escaped.
+    """Relay one line of the background child's ComfyUI output, verbatim.
 
-    ``print`` in this module is the Rich-backed ``rprint``, which parses its
-    argument as markup. ComfyUI's raw output is full of square brackets (log
-    levels, ``[1/4]`` step counters, tqdm bars, quoted paths in tracebacks), and
-    unescaped those are read as style tags:
+    This is a *capture* path, not a render path: the child's stdout is
+    ``comfyui_<port>.log`` (see ``launch_and_monitor``), so every byte ComfyUI
+    wrote has to land in the file unchanged for ``comfy logs`` to be worth
+    reading. That rules out ``print`` — in this module that name is the
+    Rich-backed ``rprint``, and routing a line through Rich mangles it three
+    ways:
 
-    - ``Progress: [####  ] 50%`` -> the bracketed run is silently deleted
-    - ``File "[x]"``             -> ``[x]`` is silently deleted
-    - ``... [/red] ...``         -> raises ``rich.errors.MarkupError``
+    - *Markup parsing.* ComfyUI's output is full of square brackets (log
+      levels, ``[1/4]`` step counters, tqdm bars, quoted paths in tracebacks).
+      ``Progress: [####  ] 50%`` loses the bracketed run, and an unbalanced
+      ``[/red]`` raises ``rich.errors.MarkupError``. The raise is the damaging
+      one: it kills the redirector thread, so the log truncates at exactly the
+      moment something is going wrong.
+    - *Wrapping.* ``rich.print`` builds a ``Console`` per call, whose width
+      auto-detects to 80 against the non-tty logfile. Long lines — absolute
+      model paths, traceback frames, tqdm bars — get newlines injected.
+    - *Highlighting and emoji.* The default ``ReprHighlighter`` injects ANSI
+      colour ComfyUI never emitted (Rich honours an inherited ``FORCE_COLOR``),
+      and ``:x:``-style runs get emoji-substituted.
 
-    The raise is the damaging one. It kills the redirector thread, so the child
-    stops relaying ComfyUI's output into ``comfyui_<port>.log`` from that line
-    onward, truncating the log at exactly the moment something is going wrong,
-    which is when ``comfy logs`` is most needed.
+    ``escape()`` only addresses the first, and not exactly: ``render`` rewrites
+    ``\\[`` to ``[`` unconditionally, so ``C:\\[TEMP]\\model.safetensors`` loses
+    a backslash, and a chunk ending in a lone backslash gains one. So write to
+    the stream directly and skip Rich entirely — the same reasoning (and the
+    same ``pretty_stream``) as the raw write ``comfy logs`` uses to replay the
+    file.
 
-    ``escape`` rather than ``sanitize_markup`` because this is a *capture* path,
-    not a render path: the bytes land in a logfile, and any ANSI colour ComfyUI
-    emitted is part of what it genuinely wrote. ``Renderer`` sanitizes on the
-    way back out when ``comfy logs`` displays it. Escaping round-trips exactly
-    (the backslashes are consumed by the markup parser), so the logged text
-    stays byte-identical to ComfyUI's own output.
+    ANSI ComfyUI emitted is preserved because it is part of what ComfyUI
+    genuinely wrote. Sanitizing it is the display path's job:
+    ``background_launch``'s error panel does that (``sanitize_markup``). Note
+    that ``logs()`` deliberately does *not* — it writes the file byte-for-byte,
+    so ``comfy logs`` still replays whatever escapes the file holds.
     """
-    print(escape(line), end="")
+    stream = get_renderer().pretty_stream
+    stream.write(line)
+    # Rich flushed on every print; the logfile is block-buffered, and
+    # `launch_and_monitor` tails it live waiting for the startup marker.
+    stream.flush()
+
+
+def _pump_child_pipe(pick_pipe, stop: threading.Event | None = None) -> None:
+    """Relay one of the background child's pipes until the process exits.
+
+    ``pick_pipe`` is re-called every pass rather than handed a pipe once:
+    ``launch_comfyui`` *reassigns* ``process`` on every reboot, and re-reading
+    is how a rebooted server's output keeps reaching the log.
+
+    The consequence is that there is no terminal condition to break on — an
+    empty read means "the current child's pipe is closed", which is equally the
+    not-started-yet, the exited, and the mid-reboot state. So back off rather
+    than break, and never spin: an unguarded ``readline()`` on a closed pipe
+    returns ``""`` immediately and forever, burning a core for the rest of the
+    run. (Two such threads, both non-daemon, used to do exactly that from the
+    moment the server exited.)
+
+    ``stop`` is the seam that follows from that: production never sets it (the
+    pumps die with the process at ``_hard_exit``), but a caller that needs the
+    thread to actually end — the tests — has no other way to ask.
+    """
+    while stop is None or not stop.is_set():
+        pipe = pick_pipe()
+        line = ""
+        try:
+            if pipe is not None:
+                line = pipe.readline()
+                if line:
+                    _relay_child_line(line)
+        except (ValueError, OSError):
+            # A closed handle — the reboot path swaps the pipe out from under
+            # us, and a torn-down stdout fails the relay's write the same way.
+            # Back off and retry: losing a line beats losing the pump, which
+            # would truncate the log for the rest of the run.
+            line = ""
+        if not line:
+            if stop is None:
+                time.sleep(_REDIRECTOR_IDLE_SLEEP)
+            else:
+                stop.wait(_REDIRECTOR_IDLE_SLEEP)
 
 
 def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
@@ -209,18 +272,19 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
             os.remove(reboot_path)
     else:
         # If running in background mode without using a popen, broken pipe errors may occur when flushing stdout/stderr.
-        def redirector_stderr():
-            while True:
-                if process is not None and process.stderr is not None:
-                    _relay_child_line(process.stderr.readline())
-
-        def redirector_stdout():
-            while True:
-                if process is not None and process.stdout is not None:
-                    _relay_child_line(process.stdout.readline())
-
-        threading.Thread(target=redirector_stderr).start()
-        threading.Thread(target=redirector_stdout).start()
+        # Daemon threads: every exit path here is `_hard_exit` (os._exit), which
+        # kills them regardless, but a `Popen` failure or an early Ctrl-C returns
+        # normally — and non-daemon pumps would hang interpreter shutdown there.
+        threading.Thread(
+            target=_pump_child_pipe,
+            args=(lambda: process.stderr if process is not None else None,),
+            daemon=True,
+        ).start()
+        threading.Thread(
+            target=_pump_child_pipe,
+            args=(lambda: process.stdout if process is not None else None,),
+            daemon=True,
+        ).start()
 
         try:
             while True:
@@ -232,6 +296,10 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
                         text=True,
                         env=new_env,
                         encoding="utf-8",
+                        # ComfyUI and custom nodes can emit non-UTF-8 bytes; a
+                        # strict decode would raise inside the redirector thread
+                        # and truncate the log from that byte onward.
+                        errors="replace",
                         shell=True,  # win32 only
                         creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # win32 only
                     )
@@ -241,6 +309,7 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
                         text=True,
                         env=new_env,
                         encoding="utf-8",
+                        errors="replace",  # see the win32 branch above
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                     )
@@ -396,9 +465,14 @@ def background_launch(extra, frontend_pr=None):
     # Reaching here means the monitor returned without seeing the success line
     # (the success path emits its envelope and _hard_exit(0)s inside the monitor).
     if log is not None:
+        # `log` is ComfyUI's own output, relayed verbatim by `_relay_child_line`
+        # — so it reaches here with its brackets and ANSI intact. `Panel` body
+        # text is markup-parsed, where an unbalanced `[/...]` in the crash output
+        # would raise `MarkupError` while we are reporting the crash. This is the
+        # render path, so neutralize both markup and escape sequences.
         print(
             Panel(
-                "".join(log),
+                sanitize_markup("".join(log)),
                 title="[bold red]Error log during ComfyUI execution[/bold red]",
                 border_style="bright_red",
             )

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -113,6 +113,33 @@ def _emit_launch_success(listen, port, pid) -> None:
         )
 
 
+def _relay_child_line(line: str) -> None:
+    """Relay one line of the background child's ComfyUI output, markup-escaped.
+
+    ``print`` in this module is the Rich-backed ``rprint``, which parses its
+    argument as markup. ComfyUI's raw output is full of square brackets (log
+    levels, ``[1/4]`` step counters, tqdm bars, quoted paths in tracebacks), and
+    unescaped those are read as style tags:
+
+    - ``Progress: [####  ] 50%`` -> the bracketed run is silently deleted
+    - ``File "[x]"``             -> ``[x]`` is silently deleted
+    - ``... [/red] ...``         -> raises ``rich.errors.MarkupError``
+
+    The raise is the damaging one. It kills the redirector thread, so the child
+    stops relaying ComfyUI's output into ``comfyui_<port>.log`` from that line
+    onward, truncating the log at exactly the moment something is going wrong,
+    which is when ``comfy logs`` is most needed.
+
+    ``escape`` rather than ``sanitize_markup`` because this is a *capture* path,
+    not a render path: the bytes land in a logfile, and any ANSI colour ComfyUI
+    emitted is part of what it genuinely wrote. ``Renderer`` sanitizes on the
+    way back out when ``comfy logs`` displays it. Escaping round-trips exactly
+    (the backslashes are consumed by the markup parser), so the logged text
+    stays byte-identical to ComfyUI's own output.
+    """
+    print(escape(line), end="")
+
+
 def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
     reboot_path = None
 
@@ -185,12 +212,12 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
         def redirector_stderr():
             while True:
                 if process is not None and process.stderr is not None:
-                    print(process.stderr.readline(), end="")
+                    _relay_child_line(process.stderr.readline())
 
         def redirector_stdout():
             while True:
                 if process is not None and process.stdout is not None:
-                    print(process.stdout.readline(), end="")
+                    _relay_child_line(process.stdout.readline())
 
         threading.Thread(target=redirector_stderr).start()
         threading.Thread(target=redirector_stdout).start()

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -163,7 +163,19 @@ def _relay_child_line(line: str) -> None:
     stream.flush()
 
 
-def _pump_child_pipe(pick_pipe, stop: threading.Event | None = None) -> None:
+# How long the exit path will wait for the pumps to reach EOF before giving up
+# and exiting anyway. Generous next to the microseconds a drain of an already
+# exited child actually takes, but bounded: a *descendant* that inherited the
+# pipe keeps the write end open, so `readline()` there blocks until that
+# grandchild dies. Shutting down promptly beats waiting on it.
+_DRAIN_DEADLINE = 2.0
+
+
+def _pump_child_pipe(
+    pick_pipe,
+    stop: threading.Event | None = None,
+    drain: threading.Event | None = None,
+) -> None:
     """Relay one of the background child's pipes until the process exits.
 
     ``pick_pipe`` is re-called every pass rather than handed a pipe once:
@@ -178,9 +190,17 @@ def _pump_child_pipe(pick_pipe, stop: threading.Event | None = None) -> None:
     run. (Two such threads, both non-daemon, used to do exactly that from the
     moment the server exited.)
 
-    ``stop`` is the seam that follows from that: production never sets it (the
-    pumps die with the process at ``_hard_exit``), but a caller that needs the
-    thread to actually end — the tests — has no other way to ask.
+    The two events are the seams that follow from that, and they are not the
+    same request:
+
+    - ``stop`` means *give up now*, mid-pipe if need be. Production never sets
+      it; a caller that needs the thread to actually end — the tests — has no
+      other way to ask.
+    - ``drain`` means *the child has exited, so finish the pipe and then end*.
+      Only once a read comes back empty is the pipe genuinely at EOF, and only
+      then does the loop return. That distinction is the whole point: exiting
+      on the flag itself would drop exactly the buffered tail — the last frames
+      of the traceback that killed the server — that the drain exists to save.
     """
     while stop is None or not stop.is_set():
         pipe = pick_pipe()
@@ -194,13 +214,44 @@ def _pump_child_pipe(pick_pipe, stop: threading.Event | None = None) -> None:
             # A closed handle — the reboot path swaps the pipe out from under
             # us, and a torn-down stdout fails the relay's write the same way.
             # Back off and retry: losing a line beats losing the pump, which
-            # would truncate the log for the rest of the run.
+            # would truncate the log for the rest of the run. Under `drain`
+            # there is no retry left to make, and the loop below ends it.
             line = ""
         if not line:
-            if stop is None:
+            if drain is not None and drain.is_set():
+                return
+            # Wait on an event rather than sleep where there is one, so a
+            # `drain` raised mid-backoff is answered now and not up to
+            # `_REDIRECTOR_IDLE_SLEEP` later.
+            waiter = stop if stop is not None else drain
+            if waiter is None:
                 time.sleep(_REDIRECTOR_IDLE_SLEEP)
             else:
-                stop.wait(_REDIRECTOR_IDLE_SLEEP)
+                waiter.wait(_REDIRECTOR_IDLE_SLEEP)
+
+
+def _drain_child_pipes(drain: threading.Event, pumps, deadline: float = _DRAIN_DEADLINE) -> None:
+    """Let the pumps finish the exited child's pipes before the process dies.
+
+    ``process.wait()`` returning only means the child is gone, not that its
+    output has been read: whatever it wrote last is still sitting in the pipe
+    buffer. Every exit below is ``_hard_exit`` (``os._exit``), which takes the
+    daemon pumps with it wherever they are — so without this the tail of the
+    log is lost precisely when it matters most, on the crash whose traceback
+    ``background_launch`` is about to render.
+
+    The race is not theoretical: a pump that happens to be inside its
+    ``_REDIRECTOR_IDLE_SLEEP`` backoff when the child writes its last line and
+    exits has not yet read that line, and the exit path is not obliged to take
+    longer than the backoff to reach ``os._exit``.
+
+    Bounded, and best-effort by construction — the pumps stay daemons, so
+    blowing the deadline costs the tail rather than the shutdown.
+    """
+    drain.set()
+    end = time.monotonic() + deadline
+    for pump in pumps:
+        pump.join(max(0.0, end - time.monotonic()))
 
 
 def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
@@ -275,16 +326,26 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
         # Daemon threads: every exit path here is `_hard_exit` (os._exit), which
         # kills them regardless, but a `Popen` failure or an early Ctrl-C returns
         # normally — and non-daemon pumps would hang interpreter shutdown there.
-        threading.Thread(
-            target=_pump_child_pipe,
-            args=(lambda: process.stderr if process is not None else None,),
-            daemon=True,
-        ).start()
-        threading.Thread(
-            target=_pump_child_pipe,
-            args=(lambda: process.stdout if process is not None else None,),
-            daemon=True,
-        ).start()
+        # Held onto so the exit paths below can drain them first; the reboot
+        # path deliberately does not, since the same pumps carry the restarted
+        # server's output.
+        drain = threading.Event()
+        pumps = [
+            threading.Thread(
+                target=_pump_child_pipe,
+                args=(lambda: process.stderr if process is not None else None,),
+                kwargs={"drain": drain},
+                daemon=True,
+            ),
+            threading.Thread(
+                target=_pump_child_pipe,
+                args=(lambda: process.stdout if process is not None else None,),
+                kwargs={"drain": drain},
+                daemon=True,
+            ),
+        ]
+        for pump in pumps:
+            pump.start()
 
         try:
             while True:
@@ -317,15 +378,26 @@ def launch_comfyui(extra, frontend_pr=None, python=sys.executable):
                 process.wait()
 
                 if reboot_path is None:
+                    # Drain before printing, so our message lands after the
+                    # child's own output rather than in the middle of it.
+                    _drain_child_pipes(drain, pumps)
                     print("[bold red]ComfyUI is not installed.[/bold red]\n")
                     _hard_exit(1)
 
                 if not os.path.exists(reboot_path):
+                    # The server exited for good — this is the path whose tail
+                    # `background_launch` renders as the crash panel.
+                    _drain_child_pipes(drain, pumps)
                     _hard_exit(process.returncode)
 
+                # Reboot: no drain. The pumps keep running and pick the new
+                # `process` up on their next pass.
                 os.remove(reboot_path)
         except KeyboardInterrupt:
             if process is not None:
+                # The child takes the same SIGINT and is on its way out; give
+                # its last words the same bounded chance to reach the log.
+                _drain_child_pipes(drain, pumps)
                 _hard_exit(1)
 
 

--- a/tests/comfy_cli/command/test_launch_log_relay.py
+++ b/tests/comfy_cli/command/test_launch_log_relay.py
@@ -4,19 +4,37 @@
 child pipes ComfyUI's output through `_relay_child_line`, whose writes land in
 `comfyui_<port>.log` (the file `comfy logs` reads back).
 
-That relay prints via the Rich-backed `rprint`, which parses markup. ComfyUI's
-output is dense with square brackets, so before the escape was added a bracketed
-run could be silently swallowed and an unbalanced closing tag raised
-`rich.errors.MarkupError` inside the redirector thread, killing it and
-truncating the logfile from that line onward.
+The relay used to go through the Rich-backed `rprint`, which parses markup,
+word-wraps to an auto-detected 80 columns against the non-tty logfile, and
+highlights. So a bracketed run could be silently swallowed, an unbalanced
+closing tag raised `rich.errors.MarkupError` inside the redirector thread
+(killing it and truncating the logfile from that line onward), and long paths
+grew injected newlines. The relay now writes to the stream directly.
 """
 
 import io
+import threading
+import time
 
 import pytest
-from rich.console import Console
 
 from comfy_cli.command import launch
+from comfy_cli.output.renderer import OutputMode, Renderer
+
+
+@pytest.fixture
+def relay_output(monkeypatch):
+    """Capture what `_relay_child_line` writes, via the real renderer path.
+
+    The relay resolves `get_renderer().pretty_stream`, so overriding that
+    exercises production's stream selection rather than a stand-in print.
+    """
+    buf = io.StringIO()
+    renderer = Renderer(mode=OutputMode.PRETTY)
+    renderer.pretty_stream = buf
+    monkeypatch.setattr(launch, "get_renderer", lambda: renderer)
+    return buf
+
 
 # Lines ComfyUI (or a custom node) realistically emits. Each one is either
 # silently mangled or fatal when passed to a markup-parsing sink unescaped.
@@ -28,65 +46,227 @@ HOSTILE_LINES = [
     "[bold red]not actually styling[/bold red]\n",
     "unbalanced closing tag [/red] mid-line\n",
     "[/]\n",
+    # `escape()` is not a clean inverse of the markup parser: `render` rewrites
+    # `\[` to `[` unconditionally, so an escaped-then-rendered round trip drops
+    # the backslash here.
+    "loading C:\\[TEMP]\\model.safetensors\n",
+    # A chunk ending in a lone backslash gains a second one under `escape()`.
+    "workspace root C:\\models\\",
+    # Rich substitutes emoji for colon syntax; escaping does not touch it.
+    "status :x: failed, :100: done\n",
+    # ANSI is part of what ComfyUI genuinely wrote, so the capture keeps it.
+    "\x1b[32mgreen\x1b[0m 100%\n",
 ]
 
 
 @pytest.mark.parametrize("line", HOSTILE_LINES)
-def test_relay_round_trips_line_verbatim(line, monkeypatch):
-    """Every byte ComfyUI wrote must reach the log unchanged.
+def test_relay_round_trips_line_verbatim(line, relay_output):
+    """Every byte ComfyUI wrote must reach the log unchanged."""
+    launch._relay_child_line(line)
 
-    Escaping is invisible in the output: the markup parser consumes the
-    backslashes, so the rendered text equals the original line.
+    assert relay_output.getvalue() == line
+
+
+def test_relay_does_not_wrap_long_lines(relay_output):
+    """A long line must not gain injected newlines.
+
+    Production reached Rich via `rich.print(file=...)`, which auto-detects width
+    to 80 against the non-tty logfile and word-wraps — so absolute model paths,
+    traceback frames and tqdm bars were silently reflowed in `comfyui_<port>.log`.
     """
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False, width=200)
-    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
+    line = "loading " + "/very/long/model/path" * 20 + " done\n"
+    assert len(line) > 80
 
     launch._relay_child_line(line)
 
-    assert buf.getvalue() == line
+    assert relay_output.getvalue() == line
+    assert relay_output.getvalue().count("\n") == 1
 
 
-def test_relay_does_not_raise_on_unbalanced_markup(monkeypatch):
+def test_relay_does_not_raise_on_unbalanced_markup(relay_output):
     """An unbalanced tag must not kill the redirector thread.
 
     This is the failure that truncated crash logs: `MarkupError` escaping the
     relay stops the child echoing ComfyUI's output for the rest of the run.
     """
-    console = Console(file=io.StringIO(), force_terminal=False, width=200)
-    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
-
-    # Would raise rich.errors.MarkupError without the escape.
     launch._relay_child_line("ComfyUI failed at [/red] during startup\n")
 
-
-def test_relay_preserves_ansi_sequences(monkeypatch):
-    """ANSI is captured verbatim; sanitizing belongs to the render path.
-
-    `_relay_child_line` writes the logfile, so it records what ComfyUI actually
-    emitted. `Renderer` strips escapes when `comfy logs` displays the file.
-    """
-    line = "\x1b[32mgreen\x1b[0m 100%\n"
-    buf = io.StringIO()
-    console = Console(file=buf, force_terminal=False, width=200)
-    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
-
-    launch._relay_child_line(line)
-
-    assert buf.getvalue() == line
+    assert relay_output.getvalue() == "ComfyUI failed at [/red] during startup\n"
 
 
-def test_redirectors_route_through_the_escaping_relay():
+def test_relay_flushes_each_line(monkeypatch):
+    """`launch_and_monitor` tails the logfile live, so writes cannot sit in a buffer."""
+    flushes = []
+
+    class RecordingStream(io.StringIO):
+        def flush(self):
+            flushes.append(self.getvalue())
+
+    renderer = Renderer(mode=OutputMode.PRETTY)
+    renderer.pretty_stream = RecordingStream()
+    monkeypatch.setattr(launch, "get_renderer", lambda: renderer)
+
+    launch._relay_child_line("starting\n")
+
+    assert flushes == ["starting\n"]
+
+
+def test_redirectors_route_through_the_relay():
     """Both redirector threads must use the relay, not a bare `print`.
 
     A future edit reintroducing `print(process.stdout.readline())` would restore
-    the truncation bug without failing any behavioral test above, since the
-    redirectors are nested closures that never run in the suite.
+    the truncation bug without failing any behavioral test above, since nothing
+    else in the suite runs the redirector wiring.
     """
     import inspect
 
     source = inspect.getsource(launch.launch_comfyui)
 
-    assert source.count("_relay_child_line(") == 2
+    assert source.count("_pump_child_pipe,") == 2
+    assert "_relay_child_line(line)" in inspect.getsource(launch._pump_child_pipe)
     assert "print(process.stdout.readline()" not in source
     assert "print(process.stderr.readline()" not in source
+
+
+def test_child_pipes_decode_leniently():
+    """Non-UTF-8 bytes from a custom node must not raise inside the pump.
+
+    Both `Popen` calls in the background branch open text pipes; without
+    `errors="replace"` a single undecodable byte raises `UnicodeDecodeError`
+    in the redirector thread and truncates the log.
+    """
+    import inspect
+
+    source = inspect.getsource(launch.launch_comfyui)
+
+    assert source.count('errors="replace"') == 2
+
+
+class _ClosedPipe:
+    """A pipe whose reads behave like the child's after it exits."""
+
+    def __init__(self):
+        self.reads = 0
+
+    def readline(self):
+        self.reads += 1
+        return ""
+
+
+class _RaisingPipe:
+    """The reboot path swaps the pipe out; the old handle raises on read."""
+
+    def __init__(self):
+        self.reads = 0
+
+    def readline(self):
+        self.reads += 1
+        raise ValueError("readline of closed file")
+
+
+class _UnwritablePipe:
+    """Reads fine; the relay's write is what fails (a torn-down stdout)."""
+
+    def __init__(self):
+        self.reads = 0
+
+    def readline(self):
+        self.reads += 1
+        return "output that cannot be written\n"
+
+
+def _raise_broken_pipe(*_args, **_kwargs):
+    raise BrokenPipeError("stdout is gone")
+
+
+@pytest.fixture
+def run_pump():
+    """Run `_pump_child_pipe` in a thread for `seconds`, then stop and join it.
+
+    The pump loops forever by design, so a test that just starts a daemon thread
+    leaks one that outlives the test — and once the fixtures unwind it writes to
+    the *real* stdout, which is fatal at interpreter shutdown. Always stop it.
+    """
+    stops = []
+
+    def _run(pick_pipe, seconds=0.2):
+        stop = threading.Event()
+        thread = threading.Thread(target=launch._pump_child_pipe, args=(pick_pipe, stop), daemon=True)
+        stops.append((stop, thread))
+        thread.start()
+        time.sleep(seconds)
+        return thread
+
+    yield _run
+
+    for stop, thread in stops:
+        stop.set()
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "pump did not stop"
+
+
+@pytest.mark.parametrize("pipe_factory", [_ClosedPipe, _RaisingPipe, _UnwritablePipe, lambda: None])
+def test_pump_does_not_spin_on_a_dead_pipe(pipe_factory, monkeypatch, relay_output, run_pump):
+    """EOF, a closed handle, a failing write, and not-yet-started all back off.
+
+    The pump cannot break out — `process` is reassigned on every reboot, so an
+    empty read is equally "exited" and "restarting". But an unguarded
+    `readline()` on a closed pipe returns instantly and forever, burning a core.
+    """
+    monkeypatch.setattr(launch, "_REDIRECTOR_IDLE_SLEEP", 0.01)
+    monkeypatch.setattr(relay_output, "write", _raise_broken_pipe)
+    pipe = pipe_factory()
+
+    thread = run_pump(lambda: pipe)
+
+    assert thread.is_alive(), "pump died instead of backing off"
+    # ~20 backoff-paced reads, not the tens of thousands a busy loop manages.
+    if pipe is not None:
+        assert pipe.reads < 200, f"pump spun: {pipe.reads} reads in 0.2s"
+
+
+def test_pump_relays_lines_then_survives_eof(relay_output, run_pump, monkeypatch):
+    """A pump must hand every line to the relay and stay alive past EOF."""
+    monkeypatch.setattr(launch, "_REDIRECTOR_IDLE_SLEEP", 0.01)
+    lines = ["first [1/2]\n", "second [/red]\n"]
+
+    class Pipe:
+        def readline(self):
+            return lines.pop(0) if lines else ""
+
+    pipe = Pipe()
+    thread = run_pump(lambda: pipe)
+
+    assert relay_output.getvalue() == "first [1/2]\nsecond [/red]\n"
+    assert thread.is_alive()
+
+
+def test_pump_picks_up_a_rebooted_process(relay_output, run_pump, monkeypatch):
+    """`process` is reassigned on reboot; the pump must follow it.
+
+    This is why the pump backs off on EOF rather than breaking: the pipe going
+    quiet means "restarting" as often as it means "gone".
+    """
+    monkeypatch.setattr(launch, "_REDIRECTOR_IDLE_SLEEP", 0.01)
+
+    class Pipe:
+        def __init__(self, text):
+            self.lines = [text]
+
+        def readline(self):
+            return self.lines.pop(0) if self.lines else ""
+
+    pipes = [Pipe("before reboot\n"), None, Pipe("after reboot\n")]
+    state = {"i": 0}
+
+    def pick():
+        # Walk to the next pipe once the current one is drained, mimicking the
+        # exit -> no-process -> new-Popen sequence of the reboot path.
+        i = state["i"]
+        if i < len(pipes) - 1 and (pipes[i] is None or not pipes[i].lines):
+            state["i"] = i + 1
+        return pipes[state["i"]]
+
+    run_pump(pick, seconds=0.3)
+
+    assert relay_output.getvalue() == "before reboot\nafter reboot\n"

--- a/tests/comfy_cli/command/test_launch_log_relay.py
+++ b/tests/comfy_cli/command/test_launch_log_relay.py
@@ -1,0 +1,92 @@
+"""Regression tests for the background child's stdout/stderr relay.
+
+`comfy launch --background` re-execs itself with `COMFY_CLI_BACKGROUND` set; that
+child pipes ComfyUI's output through `_relay_child_line`, whose writes land in
+`comfyui_<port>.log` (the file `comfy logs` reads back).
+
+That relay prints via the Rich-backed `rprint`, which parses markup. ComfyUI's
+output is dense with square brackets, so before the escape was added a bracketed
+run could be silently swallowed and an unbalanced closing tag raised
+`rich.errors.MarkupError` inside the redirector thread, killing it and
+truncating the logfile from that line onward.
+"""
+
+import io
+
+import pytest
+from rich.console import Console
+
+from comfy_cli.command import launch
+
+# Lines ComfyUI (or a custom node) realistically emits. Each one is either
+# silently mangled or fatal when passed to a markup-parsing sink unescaped.
+HOSTILE_LINES = [
+    "[INFO] Loading model checkpoint\n",
+    "Progress: [####    ] 50%\n",
+    "got prompt [1/4]\n",
+    'Traceback (most recent call last): File "[x]"\n',
+    "[bold red]not actually styling[/bold red]\n",
+    "unbalanced closing tag [/red] mid-line\n",
+    "[/]\n",
+]
+
+
+@pytest.mark.parametrize("line", HOSTILE_LINES)
+def test_relay_round_trips_line_verbatim(line, monkeypatch):
+    """Every byte ComfyUI wrote must reach the log unchanged.
+
+    Escaping is invisible in the output: the markup parser consumes the
+    backslashes, so the rendered text equals the original line.
+    """
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=200)
+    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
+
+    launch._relay_child_line(line)
+
+    assert buf.getvalue() == line
+
+
+def test_relay_does_not_raise_on_unbalanced_markup(monkeypatch):
+    """An unbalanced tag must not kill the redirector thread.
+
+    This is the failure that truncated crash logs: `MarkupError` escaping the
+    relay stops the child echoing ComfyUI's output for the rest of the run.
+    """
+    console = Console(file=io.StringIO(), force_terminal=False, width=200)
+    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
+
+    # Would raise rich.errors.MarkupError without the escape.
+    launch._relay_child_line("ComfyUI failed at [/red] during startup\n")
+
+
+def test_relay_preserves_ansi_sequences(monkeypatch):
+    """ANSI is captured verbatim; sanitizing belongs to the render path.
+
+    `_relay_child_line` writes the logfile, so it records what ComfyUI actually
+    emitted. `Renderer` strips escapes when `comfy logs` displays the file.
+    """
+    line = "\x1b[32mgreen\x1b[0m 100%\n"
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, width=200)
+    monkeypatch.setattr(launch, "print", lambda *a, **kw: console.print(*a, **kw), raising=False)
+
+    launch._relay_child_line(line)
+
+    assert buf.getvalue() == line
+
+
+def test_redirectors_route_through_the_escaping_relay():
+    """Both redirector threads must use the relay, not a bare `print`.
+
+    A future edit reintroducing `print(process.stdout.readline())` would restore
+    the truncation bug without failing any behavioral test above, since the
+    redirectors are nested closures that never run in the suite.
+    """
+    import inspect
+
+    source = inspect.getsource(launch.launch_comfyui)
+
+    assert source.count("_relay_child_line(") == 2
+    assert "print(process.stdout.readline()" not in source
+    assert "print(process.stderr.readline()" not in source

--- a/tests/comfy_cli/command/test_launch_log_relay.py
+++ b/tests/comfy_cli/command/test_launch_log_relay.py
@@ -270,3 +270,133 @@ def test_pump_picks_up_a_rebooted_process(relay_output, run_pump, monkeypatch):
     run_pump(pick, seconds=0.3)
 
     assert relay_output.getvalue() == "before reboot\nafter reboot\n"
+
+
+class _ListPipe:
+    """A pipe holding a fixed backlog, then EOF — an exited child's buffer."""
+
+    def __init__(self, *lines):
+        self.lines = list(lines)
+
+    def readline(self):
+        return self.lines.pop(0) if self.lines else ""
+
+
+def test_pump_drains_buffered_output_before_ending(relay_output):
+    """`drain` must flush the pipe's backlog, not abandon it.
+
+    `process.wait()` returning means the child is gone, not that its output has
+    been read — the last thing it wrote is still in the pipe buffer. Exiting on
+    the flag itself would drop exactly the crash tail the drain exists to save.
+    """
+    pipe = _ListPipe("loading model\n", "RuntimeError: out of memory\n")
+    drain = threading.Event()
+    drain.set()
+
+    # Returns on its own once the pipe reaches EOF: no thread, no timing.
+    launch._pump_child_pipe(lambda: pipe, drain=drain)
+
+    assert relay_output.getvalue() == "loading model\nRuntimeError: out of memory\n"
+
+
+def test_drain_relays_a_line_written_just_before_child_exit(relay_output, monkeypatch):
+    """The race CodeRabbit flagged: last line written while the pump backs off.
+
+    A pump sitting in its `_REDIRECTOR_IDLE_SLEEP` backoff when the child writes
+    its final traceback and exits has not read that line yet, and nothing
+    obliges the exit path to take longer than the backoff to reach `os._exit`.
+    `_drain_child_pipes` is what closes that window.
+    """
+    monkeypatch.setattr(launch, "_REDIRECTOR_IDLE_SLEEP", 0.05)
+    pipe = _ListPipe()  # empty: the pump starts out backing off, as in the race
+    drain = threading.Event()
+    pump = threading.Thread(target=launch._pump_child_pipe, args=(lambda: pipe,), kwargs={"drain": drain}, daemon=True)
+    pump.start()
+    time.sleep(0.02)  # let it reach the backoff
+
+    pipe.lines.append("RuntimeError: the last thing ComfyUI said\n")
+    launch._drain_child_pipes(drain, [pump])
+
+    assert not pump.is_alive(), "drain returned before the pump finished"
+    assert relay_output.getvalue() == "RuntimeError: the last thing ComfyUI said\n"
+
+
+def test_drain_is_bounded_when_a_pipe_never_reaches_eof():
+    """A descendant holding the pipe open must not block shutdown forever.
+
+    `readline()` only sees EOF once *every* writer closes; a grandchild that
+    inherited the pipe keeps it open past the child's death. The pumps stay
+    daemons precisely so blowing the deadline costs the tail, not the exit.
+    """
+    release = threading.Event()
+
+    class BlockingPipe:
+        def readline(self):
+            release.wait(5)
+            return ""
+
+    drain = threading.Event()
+    pump = threading.Thread(
+        target=launch._pump_child_pipe, args=(lambda: BlockingPipe(),), kwargs={"drain": drain}, daemon=True
+    )
+    pump.start()
+    try:
+        start = time.monotonic()
+        launch._drain_child_pipes(drain, [pump], deadline=0.1)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2, f"drain blocked {elapsed:.1f}s on a pipe that never EOFs"
+        assert pump.is_alive(), "the blocked pump should outlive the bounded wait"
+    finally:
+        release.set()
+        pump.join(timeout=5)
+
+
+def test_drain_deadline_covers_both_pumps():
+    """The deadline is for the whole drain, not per thread.
+
+    Joining each pump with the full timeout would let two stuck pipes take
+    2 x `_DRAIN_DEADLINE` to give up.
+    """
+    release = threading.Event()
+
+    def block():
+        release.wait(5)
+
+    pumps = [threading.Thread(target=block, daemon=True) for _ in range(2)]
+    for pump in pumps:
+        pump.start()
+    try:
+        start = time.monotonic()
+        launch._drain_child_pipes(threading.Event(), pumps, deadline=0.2)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.4, f"deadline applied per-pump, not overall: {elapsed:.2f}s"
+    finally:
+        release.set()
+        for pump in pumps:
+            pump.join(timeout=5)
+
+
+def test_exit_paths_drain_and_the_reboot_path_does_not():
+    """Every `_hard_exit` in the background branch drains; the reboot path must not.
+
+    Draining on reboot would end the pumps mid-run and silence the restarted
+    server, which is the same truncation bug from the other direction — and no
+    behavioral test above covers the wiring.
+    """
+    import inspect
+
+    source = inspect.getsource(launch.launch_comfyui)
+    # The background branch's own opening comment: the foreground branch above
+    # has `else:` and `os.remove(reboot_path)` of its own to be confused with.
+    background = source.split("broken pipe errors may occur", 1)[1]
+
+    # Every `_hard_exit` has a drain between it and the previous one.
+    for i, chunk in enumerate(background.split("_hard_exit(")[:-1]):
+        statements = [ln.strip() for ln in chunk.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+        assert "_drain_child_pipes(drain, pumps)" in statements, f"undrained _hard_exit #{i + 1}"
+
+    # The reboot path continues the loop instead, so the pumps survive it.
+    reboot_step = background.split("os.remove(reboot_path)")[0].rsplit("_hard_exit(", 1)[1]
+    assert "_drain_child_pipes" not in reboot_step

--- a/tests/comfy_cli/command/test_launch_log_relay.py
+++ b/tests/comfy_cli/command/test_launch_log_relay.py
@@ -368,10 +368,13 @@ def test_drain_deadline_covers_both_pumps():
         pump.start()
     try:
         start = time.monotonic()
-        launch._drain_child_pipes(threading.Event(), pumps, deadline=0.2)
+        launch._drain_child_pipes(threading.Event(), pumps, deadline=0.5)
         elapsed = time.monotonic() - start
 
-        assert elapsed < 0.4, f"deadline applied per-pump, not overall: {elapsed:.2f}s"
+        # Shared deadline lands at ~0.5s, per-pump at ~1.0s. The bound sits
+        # between the two rather than on top of the per-pump value, so a loaded
+        # CI runner's scheduling jitter cannot fail a correct implementation.
+        assert elapsed < 0.8, f"deadline applied per-pump, not overall: {elapsed:.2f}s"
     finally:
         release.set()
         for pump in pumps:


### PR DESCRIPTION
## Summary

The background child relays ComfyUI's stdout/stderr through the Rich-backed `rprint`. Rich is a *renderer*, and this is a *capture* path — the child's stdout is `comfyui_<port>.log`, the file `comfy logs` reads back — so everything Rich does to a line is damage here.

Three kinds of damage, all invisible to the user:

| ComfyUI writes | What reached the log |
|---|---|
| `Progress: [####  ] 50%` | `Progress:  50%` (bracketed run parsed as markup, silently deleted) |
| `Traceback ... File "[x]"` | `Traceback ... File ""` (path silently deleted) |
| `... [/red] ...` | nothing further, `rich.errors.MarkupError` raised |
| a 120-char model path | wrapped at 80 columns, newlines injected |
| `status :x: failed` | `status ❌ failed` (emoji substitution) |

The raise is the damaging one. It kills the redirector thread, so the child stops relaying output into `comfyui_<port>.log` from that line onward. The log truncates at exactly the moment something is going wrong, which is precisely when `comfy logs` matters.

The fix is to stop routing the line through Rich at all: `_relay_child_line` writes to `get_renderer().pretty_stream` directly and flushes, which is the same raw-write reasoning (and the same stream) `comfy logs` already uses to replay the file.

## Details

**Why not `escape()`.** An earlier revision of this PR escaped the line and let Rich render it back. That fixes the markup parsing but nothing else — the 80-column wrap and the emoji substitution both survive it — and `escape()` is not a clean inverse of the parser either: `render` rewrites `\[` to `[` unconditionally, so `C:\[TEMP]\model.safetensors` loses a backslash, and a final chunk ending in a lone backslash gains one. Writing raw is exact by construction.

**ANSI is preserved**, deliberately: it is part of what ComfyUI genuinely wrote, and the file is a capture. Sanitizing is the display path's job. `background_launch`'s error `Panel` now does it (`sanitize_markup`) — it renders the captured crash log, and Panel body text is markup-parsed, so an unbalanced `[/...]` in a traceback would have raised `MarkupError` *while reporting the crash*. `logs()` still writes the file byte-for-byte; that's pre-existing and intentional, and the docstring now says so instead of claiming otherwise.

**Redirector loops.** Both pumps are hoisted into one module-level `_pump_child_pipe` and fixed while they are in hand:

- *No more spin.* Neither loop handled EOF: once the child's pipe closed, `readline()` returned `""` immediately and forever, so both non-daemon threads burned a core for the rest of the run. They can't simply `break` — `process` is reassigned on every reboot and re-reading it is how a rebooted server's output keeps reaching the log — so an empty read backs off (`_REDIRECTOR_IDLE_SLEEP`) and retries.
- *No more thread death.* The loop body is wrapped: a closed handle (`ValueError: readline of closed file`, the reboot path) no longer kills the pump, and both `Popen` calls now pass `errors="replace"` so a single non-UTF-8 byte from a custom node can't raise `UnicodeDecodeError` and truncate the log.
- *Daemon threads.* Every exit here is `_hard_exit` (`os._exit`), which kills them regardless — but a `Popen` failure or an early Ctrl-C returns normally, where non-daemon pumps hung interpreter shutdown.

## Tests

`tests/comfy_cli/command/test_launch_log_relay.py` drives the relay through the real renderer (`pretty_stream`) rather than a stand-in print, so it exercises the configuration the background child actually runs with. Coverage: verbatim round-trip of hostile lines (brackets, unbalanced tags, ANSI, `C:\[TEMP]\...`, trailing backslash, `:x:`), no wrapping of a >80-char line, per-line flush, and pump behavior — relays then survives EOF, and does not spin on a closed / raising / not-yet-started pipe.

## ELI5

When you run `comfy launch --background`, the CLI starts ComfyUI as a child process and copies everything ComfyUI prints into a log file. `comfy logs` reads that file back when you want to know what happened.

The copying step was passing ComfyUI's text through a text *formatter* — the thing the CLI uses to draw coloured tables and panels. A formatter's whole job is to change how text looks, which is exactly wrong for making a copy. It treated square brackets as styling instructions (the way `[bold]` means "start bold"), and ComfyUI prints square brackets constantly: `[INFO]`, progress bars, step counters, file paths in error messages. It also folded long lines at 80 characters, and turned things like `:x:` into emoji.

Mostly it quietly deleted the bracketed parts, so the log was subtly wrong. Occasionally it hit a bracket pattern it considered malformed and threw an error, which killed the thread doing the copying — and from that point on nothing more got written to the log. The worst part was the timing: crashes produce tracebacks, tracebacks are full of bracketed paths, so the log was most likely to cut out right when it was the only record of what went wrong.

The fix takes the formatter out of the copying path entirely and writes the text straight through, so the log is a real copy. Two related bugs in the copying threads went with it: they spun at full CPU forever once ComfyUI exited, and a single odd byte could kill them mid-run.

## Credit

The original escaping fix was proposed by @nvdamien in #260, a PR whose main feature (named multi-GPU background sessions) we closed as out of scope. This hunk was the salvageable part and is carried here with co-author credit; review then established that bypassing Rich altogether is the exact form of that fix.
