### PR TITLE
feat(cli): emit the widget catalog (widget_order + autogrow templates + catalog_version)

### DIFF
--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -989,6 +989,102 @@ def categories_cmd(
 
 
 # ---------------------------------------------------------------------------
+# widget-catalog — the derived name↔index projection the CRDT applier needs
+# ---------------------------------------------------------------------------
+
+
+@app.command(
+    "widget-catalog",
+    help=(
+        "Emit the widget catalog: per-class widget order (plus autogrow/inputcount families) "
+        "with a content-hash catalog_version. The projection of object_info a name<->index "
+        "widget converter needs."
+    ),
+)
+@tracking.track_command("nodes")
+def widget_catalog_cmd(
+    where: Annotated[
+        str | None,
+        typer.Option("--where", show_default=False, help="'cloud' to query Comfy Cloud's catalog; default is local."),
+    ] = None,
+    input_path: Annotated[
+        str | None,
+        typer.Option("--input", show_default=False, help="Path to a local object_info JSON (offline mode)."),
+    ] = None,
+    host: Annotated[str | None, typer.Option(show_default=False)] = None,
+    port: Annotated[int | None, typer.Option(show_default=False)] = None,
+    select: Annotated[
+        str | None,
+        typer.Option(
+            "--select",
+            show_default=False,
+            help="Project the payload: dot path (types.KSampler.widget_order), comma multi-select.",
+        ),
+    ] = None,
+):
+    """Export ``{types: {<class_type>: {widget_order, ...}}}`` + ``catalog_version``.
+
+    A ComfyUI workflow stores widget values POSITIONALLY (``widgets_values``);
+    the CRDT document the cloud agent and the frontend co-edit stores them BY
+    NAME. Converting between the two needs the widget order — which
+    ``cql.engine.Graph`` already computes for every ``set-widget`` in this CLI,
+    including the two shapes a naive projection gets wrong (the synthetic
+    ``control_after_generate`` slot, and dynamic-combo sub-widget expansion).
+    Exporting it from here means there is one implementation of widget order,
+    not one per consumer; see ``comfy_cli.cql.widget_catalog``.
+
+    Offline is the normal case for a server-side host: with
+    ``COMFY_OBJECT_INFO_FILE`` set (or ``--input``) this reads a baked dump and
+    never touches the network or a credential.
+    """
+    from comfy_cli.cql.widget_catalog import build_catalog
+
+    renderer = get_renderer()
+    _stale: dict = {}
+    graph = _get_graph(
+        input_path,
+        host,
+        port,
+        where=where,
+        on_stale=lambda key, err: _stale.update(stale=True, source=key, reason=err),
+    )
+
+    payload = build_catalog(graph)
+
+    if _stale:
+        # A stale catalog is still a usable catalog — the version pins WHICH one
+        # it is, so a consumer that cached a different version re-fetches. Warn,
+        # don't fail: the alternative is no catalog at all.
+        payload["stale"] = True
+        payload["warnings"] = [
+            {
+                "code": "object_info_stale",
+                "message": f"served from cache ({_stale['source']}): {_stale['reason']}",
+            }
+        ]
+
+    if select is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select, command="nodes widget-catalog")
+
+    if renderer.is_pretty():
+        from rich.table import Table
+
+        rprint(f"[bold]{payload['class_count']}[/bold] class(es)  [dim]{payload['catalog_version']}[/dim]")
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("class_type")
+        table.add_column("widgets")
+        table.add_column("widget_order")
+        for class_type, entry in sorted(payload["types"].items()):
+            order = entry["widget_order"]
+            table.add_row(sanitize_markup(class_type), str(len(order)), sanitize_markup(", ".join(order)))
+        renderer.console().print(table)
+
+    renderer.emit(payload, command="nodes widget-catalog")
+
+
+# ---------------------------------------------------------------------------
 # refresh — object_info is fetched live; the annotation data is what's cached
 # ---------------------------------------------------------------------------
 

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -122,6 +122,26 @@ class Port:
         return None
 
     @property
+    def autogrow_element_template(self) -> dict | None:
+        """The element-naming template a caller should USE for this autogrow
+        input — never None for an autogrow port.
+
+        Identical to :attr:`autogrow_template` when object_info ships one;
+        otherwise the historical pluralization fallback (``images`` → prefix
+        ``image``) that ``workflow_ops._autogrow_elem_name`` applies when the
+        schema is silent. Exporters need the *effective* answer: a consumer
+        holding only the exported catalog has no object_info to fall back to,
+        and omitting the entry would tell it the input does not autogrow at all.
+        """
+        if not self.is_autogrow:
+            return None
+        declared = self.autogrow_template
+        if declared is not None:
+            return declared
+        stem = self.name[:-1] if self.name.endswith("s") else self.name
+        return {"prefix": stem}
+
+    @property
     def is_upload_backed(self) -> bool:
         """This COMBO's options are the server's *installed input files*, so the
         catalog snapshot is not authoritative for it.

--- a/comfy_cli/cql/widget_catalog.py
+++ b/comfy_cli/cql/widget_catalog.py
@@ -1,0 +1,119 @@
+"""The widget catalog: a derived projection of ``object_info`` that says, per
+node class, **which widgets exist and in what positional order**.
+
+WHY IT EXISTS. A ComfyUI workflow stores widget values POSITIONALLY, in each
+node's ``widgets_values`` array. The CRDT document the cloud agent and the
+frontend co-edit stores them BY NAME, because an index is not a stable identity
+across a schema change (add one widget to a class and every later index moves).
+Something has to convert between the two, in both directions, and that
+something needs exactly one fact per class: the widget order.
+
+That fact is already computed here — :meth:`cql.engine.Graph.widget_order` is
+what every edit primitive in this CLI resolves ``set-widget <id>.<name>``
+against, including the two shapes a naive projection gets wrong:
+
+* ``control_after_generate`` — a synthetic widget the frontend injects after a
+  seed. It occupies a real ``widgets_values`` slot and is in no ``input_order``.
+* ``COMFY_DYNAMICCOMBO_V3`` — one declared selector that expands into
+  key-dependent sub-widgets (``model`` → ``model``, ``model.resolution``).
+
+So the catalog is exported from here rather than recomputed by each consumer:
+a second implementation of widget order is a second answer, and the two would
+diverge silently — as a wrong index, i.e. a widget value written into the wrong
+field of the user's canvas.
+
+WHAT IT IS NOT. It is not ``object_info``. It carries no types, no defaults, no
+enum choices, no descriptions — only what a name↔index converter needs. That
+keeps it small enough to hand to a sidecar on every call.
+
+SHAPE (``envelope/1`` ``data`` of ``comfy nodes widget-catalog``)::
+
+    {
+      "catalog_version": "sha256:<64 hex>",
+      "class_count": 1234,
+      "types": {
+        "KSampler": {"widget_order": ["seed", "control_after_generate", ...]},
+        "BatchImagesNode": {
+          "widget_order": [],
+          "autogrow_templates": {"images": {"prefix": "image"}}
+        },
+        "ImageBatchMulti": {
+          "widget_order": ["inputcount"],
+          "inputcount": {"widget": "inputcount", "elements": ["image"]}
+        }
+      }
+    }
+
+``catalog_version`` is the SHA-256 of the canonical JSON encoding of ``types``
+alone (sorted keys, no whitespace, UTF-8), prefixed ``sha256:``. It excludes
+itself and ``class_count`` so a consumer that stored only the catalog can
+recompute and verify the pin it was given. Identical ``object_info`` in ⇒
+identical version out, regardless of key iteration order; any change to any
+class's widget order or grow family moves it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+CATALOG_VERSION_PREFIX = "sha256:"
+
+
+def build_types(graph) -> dict[str, dict[str, Any]]:
+    """The ``types`` map: one entry per class the graph knows, in class order.
+
+    Every class gets an entry, including widget-less ones (``VAEDecode`` →
+    ``{"widget_order": []}``). A missing entry and an empty order are different
+    statements — "I have never heard of this class" vs. "this class has no
+    widgets" — and a converter must be able to tell them apart.
+    """
+    # Imported inside the function: workflow_ops sits above cql in the import
+    # graph (it consumes cql.engine), so a module-level import here would make
+    # the dependency circular.
+    from comfy_cli.workflow_ops import INPUTCOUNT_WIDGET, inputcount_family_elements
+
+    types: dict[str, dict[str, Any]] = {}
+    for m in graph.all_nodes():
+        entry: dict[str, Any] = {"widget_order": list(graph.widget_order(m.id))}
+
+        # V3 autogrow (COMFY_AUTOGROW_V3): one declared input, one wire slot per
+        # connection (`images` → `images.image0`, `images.image1`, …). The
+        # effective template is used, so a schema that ships none still tells the
+        # consumer the input grows (see Port.autogrow_element_template).
+        autogrow = {p.name: p.autogrow_element_template for p in m.inputs if p.is_autogrow}
+        if autogrow:
+            entry["autogrow_templates"] = autogrow
+
+        # kijai `inputcount` family (ImageBatchMulti, JoinStringMulti, …): NOT
+        # autogrow-typed — fixed `{elem}_N` inputs plus an INT `inputcount`
+        # widget the node reads at runtime. Growing a slot means bumping that
+        # widget, which is a widget write, so the converter has to know.
+        elements = inputcount_family_elements(graph, m.id)
+        if elements:
+            entry["inputcount"] = {"widget": INPUTCOUNT_WIDGET, "elements": elements}
+
+        types[m.id] = entry
+    return types
+
+
+def catalog_version(types: dict[str, Any]) -> str:
+    """``sha256:<hex>`` over the canonical JSON encoding of ``types``.
+
+    Canonical = sorted keys, no insignificant whitespace, non-ASCII kept
+    verbatim. Deterministic for identical input on any platform and any Python
+    build, which is what makes it usable as a consumer-side cache key.
+    """
+    canonical = json.dumps(types, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return CATALOG_VERSION_PREFIX + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_catalog(graph) -> dict[str, Any]:
+    """The full emitted payload — ``types`` plus its pin and cardinality."""
+    types = build_types(graph)
+    return {
+        "catalog_version": catalog_version(types),
+        "class_count": len(types),
+        "types": types,
+    }

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -51,6 +51,10 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy nodes types": "nodes",
     "comfy nodes categories": "nodes",
     "comfy nodes refresh": "nodes",
+    # The widget catalog gets its OWN schema, not `nodes`: `nodes.json` declares
+    # `types` as an array of connection-type names (`nodes types`), and the
+    # catalog's `types` is a class_type→entry map. Same key, different contract.
+    "comfy nodes widget-catalog": "widget_catalog",
     # workflow editing
     "comfy workflow slots": "workflow",
     "comfy workflow set-slot": "workflow",

--- a/comfy_cli/schemas/widget_catalog.json
+++ b/comfy_cli/schemas/widget_catalog.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "comfy nodes widget-catalog",
+  "description": "The widget catalog: a derived projection of object_info giving, per node class, the positional order of its widgets (plus the grow families that mint slots). It is what a name<->index widget converter needs — notably the CRDT applier, which stores widget values by NAME while the workflow JSON stores them POSITIONALLY in widgets_values. It is NOT object_info: no types, defaults, enum choices, or descriptions.",
+  "type": "object",
+  "properties": {
+    "catalog_version": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "SHA-256 of the canonical JSON encoding of `types` alone (sorted keys, no whitespace, UTF-8), prefixed 'sha256:'. Excludes itself and class_count, so a consumer holding only the catalog can recompute it. Deterministic for identical object_info regardless of key order; any change to any class's widget order or grow family moves it. Consumers pin and cache on this."
+    },
+    "class_count": {
+      "type": "integer",
+      "description": "Number of entries in `types`. Redundant with the map's size; present so a consumer can sanity-check a truncated transfer without walking the map."
+    },
+    "types": {
+      "type": "object",
+      "description": "One entry per node class the loaded environment knows. EVERY class is present, including widget-less ones: a missing entry ('unknown class') and an empty widget_order ('no widgets') are different statements and a converter must distinguish them.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "widget_order": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Widget names in the exact positional order of the node's widgets_values array — index i in this list IS index i in widgets_values. Includes the synthetic 'control_after_generate' slot the frontend injects after a seed, and dynamic-combo sub-widgets flattened as '<selector>.<sub>'. Computed by cql.engine.Graph.widget_order, the same call every set-widget in this CLI resolves against."
+          },
+          "autogrow_templates": {
+            "type": "object",
+            "description": "Present only for classes with a COMFY_AUTOGROW_V3 input: base input name -> element-naming template. The schema's own template when object_info ships one, else the pluralization fallback the edit path applies ('images' -> prefix 'image'), so a consumer holding only the catalog can name grown slots without object_info.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "prefix": {
+                  "type": "string",
+                  "description": "Grown slots are '<base>.<prefix><N>', N from 0. Mutually exclusive with 'names'."
+                },
+                "names": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "Verbatim element names by index; past the end, growth continues as '<names[-1]><N>'. Mutually exclusive with 'prefix'."
+                }
+              }
+            }
+          },
+          "inputcount": {
+            "type": "object",
+            "description": "Present only for the kijai 'inputcount' family (ImageBatchMulti, JoinStringMulti, ...). NOT autogrow: the schema declares fixed '<elem>_N' inputs plus an INT widget the node reads at runtime, so bare 1-based '<elem>_N' keys are the wire address and growing one also means WRITING that widget.",
+            "properties": {
+              "widget": { "type": "string", "description": "The widget to bump when a slot is grown (always 'inputcount')." },
+              "elements": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Element bases with a '<elem>_1' input, sorted (e.g. ['image'])."
+              }
+            },
+            "required": ["widget", "elements"]
+          }
+        },
+        "required": ["widget_order"]
+      }
+    },
+    "stale": {
+      "type": "boolean",
+      "description": "True when object_info came from the on-disk cache because the server/session was unreachable. The catalog is still usable — catalog_version identifies WHICH snapshot it is — so this is a warning, not an error."
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "Non-fatal advisories; carries the 'object_info_stale' entry when stale is true."
+    }
+  },
+  "required": ["catalog_version", "class_count", "types"]
+}

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1543,6 +1543,32 @@ def _resolve_input_slot(node: dict, graph, slot: Any) -> int:
 
 _INPUTCOUNT_KEY_RE = re.compile(r"^(.+)_(\d+)$")
 
+INPUTCOUNT_WIDGET = "inputcount"
+
+
+def inputcount_family_elements(graph, node_type: str) -> list[str]:
+    """The element bases of ``node_type``'s kijai ``inputcount`` family, sorted
+    — ``["image"]`` for ImageBatchMulti, ``[]`` for anything that isn't one.
+
+    Both detection signals must be present (see
+    :func:`_inputcount_family_match`, which is defined in terms of this): a
+    required INT widget named exactly ``inputcount``, PLUS at least one
+    ``{elem}_1`` sibling input. Exposed (not private) because the family is a
+    *class-level* property of the schema, and exporters — ``nodes
+    widget-catalog``, which ships this to the CRDT applier — need to ask about
+    a class without first inventing a slot name to probe with.
+
+    Returns ``[]`` when ``graph`` is unavailable (offline edit) or the class
+    isn't in the catalog."""
+    if graph is None:
+        return []
+    schema = graph.node(node_type)
+    if schema is None:
+        return []
+    if not any(p.name == INPUTCOUNT_WIDGET and p.type == "INT" and not p.is_link for p in schema.inputs):
+        return []
+    return sorted({p.name[: -len("_1")] for p in schema.inputs if p.name.endswith("_1")})
+
 
 def _inputcount_family_match(graph, node_type: str, slot: str) -> tuple[str, int] | None:
     """Detect a kijai ``inputcount``-family numbered key (e.g. ``image_3`` on
@@ -1566,19 +1592,13 @@ def _inputcount_family_match(graph, node_type: str, slot: str) -> tuple[str, int
     isn't shaped ``{elem}_<N>``, or the node's schema doesn't carry both
     signals."""
     m = _INPUTCOUNT_KEY_RE.fullmatch(slot)
-    if not m or graph is None:
+    if not m:
         return None
     elem, n_str = m.group(1), m.group(2)
     n = int(n_str)
     if n < 1:
         return None
-    schema = graph.node(node_type)
-    if schema is None:
-        return None
-    has_inputcount = any(p.name == "inputcount" and p.type == "INT" and not p.is_link for p in schema.inputs)
-    if not has_inputcount:
-        return None
-    if not any(p.name == f"{elem}_1" for p in schema.inputs):
+    if elem not in inputcount_family_elements(graph, node_type):
         return None
     return elem, n
 

--- a/tests/comfy_cli/command/test_nodes_widget_catalog.py
+++ b/tests/comfy_cli/command/test_nodes_widget_catalog.py
@@ -1,0 +1,357 @@
+"""Tests for ``comfy nodes widget-catalog`` (the widget-catalog producer).
+
+WHY THIS COMMAND EXISTS: the CRDT doc host (cloud ``services/agent/dochost``)
+and the applier (``@comfyorg/comfy-multi-player``) convert between the CRDT
+doc's NAME-keyed widget maps and the workflow JSON's POSITIONAL
+``widgets_values`` array. That conversion needs one derived projection of
+``object_info`` — ``{types: {<class_type>: {widget_order, autogrow_templates}}}``
+— and the widget order it needs is exactly what ``cql.engine.Graph`` already
+computes for every edit primitive in this CLI. Emitting it here (rather than
+recomputing it in Go) keeps a single source of ComfyUI widget semantics.
+
+THE CONTRACT IS THE ENGINE: for every class, ``types[c].widget_order`` must be
+byte-identical to ``Graph.widget_order(c)``. If those two ever diverge, the
+applier writes a widget value into the wrong index and the user's canvas
+silently corrupts — so the tests below assert equality against the engine
+itself, never against a hand-written expectation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Fixture object_info — one class per interesting widget-order shape.
+# ---------------------------------------------------------------------------
+
+
+def _object_info() -> dict[str, Any]:
+    return {
+        # control_after_generate: the engine injects a synthetic widget right
+        # after the seed, so a naive "list the non-link inputs" projection
+        # mis-indexes every widget after it.
+        "KSampler": {
+            "input": {
+                "required": {
+                    "model": ["MODEL"],
+                    "seed": ["INT", {"default": 0, "control_after_generate": True}],
+                    "steps": ["INT", {"default": 20}],
+                    "cfg": ["FLOAT", {"default": 8.0}],
+                    "sampler_name": [["euler", "dpmpp_2m"]],
+                    "denoise": ["FLOAT", {"default": 1.0}],
+                }
+            },
+            "input_order": {"required": ["model", "seed", "steps", "cfg", "sampler_name", "denoise"]},
+            "output": ["LATENT"],
+            "output_name": ["LATENT"],
+            "category": "sampling",
+            "display_name": "KSampler",
+            "python_module": "nodes",
+        },
+        "CLIPTextEncode": {
+            "input": {"required": {"text": ["STRING", {"multiline": True}], "clip": ["CLIP"]}},
+            "input_order": {"required": ["text", "clip"]},
+            "output": ["CONDITIONING"],
+            "output_name": ["CONDITIONING"],
+            "category": "conditioning",
+            "display_name": "CLIP Text Encode",
+            "python_module": "nodes",
+        },
+        # Zero widgets — a real, load-bearing state. The applier must be able to
+        # tell "this class has no widgets" from "this class is unknown".
+        "VAEDecode": {
+            "input": {"required": {"samples": ["LATENT"], "vae": ["VAE"]}},
+            "input_order": {"required": ["samples", "vae"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "latent",
+            "display_name": "VAE Decode",
+            "python_module": "nodes",
+        },
+        # V3 autogrow WITH a schema-declared naming template.
+        "BatchImagesNode": {
+            "input": {
+                "required": {
+                    "images": ["COMFY_AUTOGROW_V3", {"template": {"prefix": "image", "min": 1, "max": 50}}],
+                }
+            },
+            "input_order": {"required": ["images"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "image",
+            "display_name": "Batch Images",
+            "python_module": "nodes",
+        },
+        # V3 autogrow with NO template — the catalog must still say the input is
+        # autogrow, falling back to the same pluralization the edit path uses.
+        "UntemplatedGrowNode": {
+            "input": {"required": {"masks": ["COMFY_AUTOGROW_V3"]}},
+            "input_order": {"required": ["masks"]},
+            "output": ["MASK"],
+            "output_name": ["MASK"],
+            "category": "mask",
+            "display_name": "Untemplated Grow",
+            "python_module": "nodes",
+        },
+        # kijai `inputcount` family: NOT autogrow-typed; fixed `{elem}_N` inputs
+        # plus an INT `inputcount` widget the node reads at runtime.
+        "ImageBatchMulti": {
+            "input": {
+                "required": {
+                    "inputcount": ["INT", {"default": 2, "min": 2, "max": 1000}],
+                    "image_1": ["IMAGE"],
+                    "image_2": ["IMAGE"],
+                }
+            },
+            "input_order": {"required": ["inputcount", "image_1", "image_2"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "image",
+            "display_name": "Image Batch Multi",
+            "python_module": "custom_nodes.KJNodes",
+        },
+        # Dynamic combo: the selector expands key-dependent sub-widgets, and the
+        # catalog must carry the expanded order (model, model.resolution, seed).
+        "DynNode": {
+            "input": {
+                "required": {
+                    "model": [
+                        "COMFY_DYNAMICCOMBO_V3",
+                        {
+                            "options": [
+                                {"key": "a", "inputs": {"required": {"resolution": ["INT", {"default": 512}]}}},
+                                {"key": "b", "inputs": {"required": {}}},
+                            ]
+                        },
+                    ],
+                    "seed": ["INT", {"default": 0}],
+                }
+            },
+            "input_order": {"required": ["model", "seed"]},
+            "output": ["IMAGE"],
+            "output_name": ["IMAGE"],
+            "category": "api node",
+            "display_name": "Dyn Node",
+            "python_module": "nodes",
+        },
+    }
+
+
+def _graph(data: dict[str, Any] | None = None) -> Graph:
+    return Graph.from_object_info(data if data is not None else _object_info())
+
+
+@pytest.fixture
+def patched_loader(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    _force_json_renderer()
+    runner = CliRunner()
+    result = runner.invoke(nodes_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+# ---------------------------------------------------------------------------
+# widget_order — graded against the engine, class by class
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetOrder:
+    def test_every_class_matches_the_engine(self, patched_loader, capsys):
+        env = _run(["widget-catalog"], capsys)
+        assert env["ok"] is True
+        types = env["data"]["types"]
+        graph = _graph()
+        assert set(types) == {m.id for m in graph.all_nodes()}
+        for class_type, entry in types.items():
+            assert entry["widget_order"] == graph.widget_order(class_type), class_type
+
+    def test_control_after_generate_is_in_the_order(self, patched_loader, capsys):
+        """The synthetic widget the frontend injects after a seed occupies a
+        real `widgets_values` slot — omitting it shifts every later index."""
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["KSampler"]["widget_order"] == [
+            "seed",
+            "control_after_generate",
+            "steps",
+            "cfg",
+            "sampler_name",
+            "denoise",
+        ]
+
+    def test_link_only_class_keeps_an_empty_order(self, patched_loader, capsys):
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["VAEDecode"]["widget_order"] == []
+        assert "VAEDecode" in types, "a widget-less class must still be present, not dropped"
+
+    def test_dynamic_combo_sub_widgets_expand(self, patched_loader, capsys):
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["DynNode"]["widget_order"] == ["model", "model.resolution", "seed"]
+
+
+# ---------------------------------------------------------------------------
+# autogrow / inputcount families
+# ---------------------------------------------------------------------------
+
+
+class TestGrowFamilies:
+    def test_schema_declared_autogrow_template(self, patched_loader, capsys):
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["BatchImagesNode"]["autogrow_templates"] == {"images": {"prefix": "image"}}
+
+    def test_untemplated_autogrow_falls_back_to_the_edit_paths_naming(self, patched_loader, capsys):
+        """No template in object_info still means "this input autogrows" — the
+        catalog says so, using the same singularization `_autogrow_elem_name`
+        applies when the schema is silent."""
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["UntemplatedGrowNode"]["autogrow_templates"] == {"masks": {"prefix": "mask"}}
+
+    def test_non_growing_class_carries_no_template_key(self, patched_loader, capsys):
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert "autogrow_templates" not in types["KSampler"]
+
+    def test_inputcount_family_is_reported(self, patched_loader, capsys):
+        types = _run(["widget-catalog"], capsys)["data"]["types"]
+        assert types["ImageBatchMulti"]["inputcount"] == {"widget": "inputcount", "elements": ["image"]}
+        assert "inputcount" not in types["BatchImagesNode"], "autogrow is a different family"
+
+
+# ---------------------------------------------------------------------------
+# catalog_version
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogVersion:
+    def test_stable_across_runs_for_identical_input(self, patched_loader, capsys):
+        first = _run(["widget-catalog"], capsys)["data"]
+        second = _run(["widget-catalog"], capsys)["data"]
+        assert first == second
+        assert first["catalog_version"] == second["catalog_version"]
+        assert first["catalog_version"].startswith("sha256:")
+        assert len(first["catalog_version"]) == len("sha256:") + 64
+
+    def test_changes_when_the_input_changes(self, monkeypatch, capsys):
+        base = _object_info()
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph(base))
+        before = _run(["widget-catalog"], capsys)["data"]["catalog_version"]
+
+        drifted = _object_info()
+        # One extra widget on one class — the smallest change that must move the
+        # version, because it moves every later widget's index.
+        drifted["KSampler"]["input"]["required"]["scheduler"] = [["normal", "karras"]]
+        drifted["KSampler"]["input_order"]["required"].insert(4, "scheduler")
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph(drifted))
+        after = _run(["widget-catalog"], capsys)["data"]["catalog_version"]
+
+        assert after != before
+
+    def test_version_is_independent_of_class_iteration_order(self, monkeypatch, capsys):
+        """Reordering object_info's keys is not a catalog change — a pin that
+        flapped on dict order would be useless as a cache key."""
+        base = _object_info()
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph(base))
+        before = _run(["widget-catalog"], capsys)["data"]["catalog_version"]
+
+        shuffled = dict(reversed(list(_object_info().items())))
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph(shuffled))
+        after = _run(["widget-catalog"], capsys)["data"]["catalog_version"]
+
+        assert after == before
+
+    def test_version_excludes_itself_and_the_class_count(self, patched_loader, capsys):
+        """The hash covers the `types` map only, so a consumer can recompute it
+        from the catalog it stored without carrying the envelope metadata."""
+        import hashlib
+
+        data = _run(["widget-catalog"], capsys)["data"]
+        canonical = json.dumps(data["types"], sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        assert data["catalog_version"] == "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert data["class_count"] == len(data["types"])
+
+
+# ---------------------------------------------------------------------------
+# offline + projection
+# ---------------------------------------------------------------------------
+
+
+class TestOfflineAndSelect:
+    def test_offline_via_input_dump(self, tmp_path, capsys):
+        dump = tmp_path / "object_info.json"
+        dump.write_text(json.dumps(_object_info()), encoding="utf-8")
+        env = _run(["widget-catalog", "--input", str(dump)], capsys)
+        assert env["ok"] is True
+        assert env["data"]["types"]["KSampler"]["widget_order"][0] == "seed"
+
+    def test_offline_via_comfy_object_info_file_env(self, tmp_path, monkeypatch, capsys):
+        """The hermetic path the agent's sandbox uses: no --input, no server, no
+        credential — just the baked dump every other object_info consumer reads."""
+        dump = tmp_path / "object_info.json"
+        dump.write_text(json.dumps(_object_info()), encoding="utf-8")
+        monkeypatch.setenv("COMFY_OBJECT_INFO_FILE", str(dump))
+        monkeypatch.setattr(
+            "comfy_cli.cql.engine._load_from_target",
+            lambda **_: (_ for _ in ()).throw(AssertionError("must not touch the network")),
+        )
+        env = _run(["widget-catalog"], capsys)
+        assert env["ok"] is True
+        assert env["data"]["types"]["BatchImagesNode"]["autogrow_templates"] == {"images": {"prefix": "image"}}
+
+    def test_select_projects_the_payload(self, patched_loader, capsys):
+        env = _run(["widget-catalog", "--select", "catalog_version"], capsys)
+        assert env["ok"] is True
+        assert isinstance(env["data"], str) and env["data"].startswith("sha256:")
+
+
+class TestSchemaContract:
+    def test_payload_validates_against_the_registered_schema(self, patched_loader, capsys):
+        """`comfy discover` hands agents this schema; the payload has to match it."""
+        import jsonschema
+
+        from comfy_cli.discovery import COMMAND_SCHEMAS
+
+        assert COMMAND_SCHEMAS["comfy nodes widget-catalog"] == "widget_catalog"
+        schema = json.loads(
+            (Path(nodes_cmd.__file__).resolve().parents[1] / "schemas" / "widget_catalog.json").read_text()
+        )
+        jsonschema.Draft202012Validator.check_schema(schema)
+        jsonschema.Draft202012Validator(schema).validate(_run(["widget-catalog"], capsys)["data"])


### PR DESCRIPTION
## The gap

The cloud CRDT write path (cloud PR #6620 doc host, #6672 loop rewiring) needs a **widget catalog**:

```json
{"types": {"<class_type>": {"widget_order": ["seed", "control_after_generate", ...],
                            "autogrow_templates": {"images": {"prefix": "image"}}}}}
```

A ComfyUI workflow stores widget values **positionally**, in each node's `widgets_values` array. The CRDT document the cloud agent and the frontend co-edit stores them **by name**, because an index is not a stable identity across a schema change. The applier (`@comfyorg/comfy-multi-player`) converts between the two, in both directions, and needs exactly one fact per class to do it: the widget order.

**Nothing in any repo produced it.** The only instance was a hand-vendored 10-class test fixture (`services/agent/internal/dochost/testdata/catalog.json`), whose own comment says it was "exported from the prod object_info via `cql.engine.Graph`" — but that export step was never committed anywhere. So `AGENT_CRDT_MODE=on` could not start a deployed image, and the CRDT flag flip was blocked on a missing producer.

## Why the CLI owns the computation

`Graph.widget_order` is what **every `workflow set-widget` in this CLI already resolves against**. It handles the two shapes a naive "list the non-link inputs" projection gets wrong:

* **`control_after_generate`** — a synthetic widget the frontend injects after a seed. It occupies a real `widgets_values` slot and appears in no `input_order`.
* **`COMFY_DYNAMICCOMBO_V3`** — one declared selector that expands into key-dependent sub-widgets (`model` → `model`, `model.resolution`).

The new command **imports** that; it does not restate it. Reimplementing widget order in Go would be a second answer to the same question, and the divergence would not surface as an error — it would surface as a widget value written into the wrong index of someone's canvas. The repo's own layering rule says the CLI is the single source of ComfyUI semantics, so the CLI emits the catalog.

## The command

`comfy nodes widget-catalog` — filed under `nodes` because that group is "introspect ComfyUI node classes", and the catalog is a whole-catalog projection of exactly that. It shares the group's `--where` / `--input` / `--host` / `--port` graph resolution and its `--select` projection.

`envelope/1`, `data`:

```json
{
  "catalog_version": "sha256:ac63f025...",
  "class_count": 3625,
  "types": {
    "KSampler":        {"widget_order": ["seed","control_after_generate","steps","cfg","sampler_name","scheduler","denoise"]},
    "VAEDecode":       {"widget_order": []},
    "BatchImagesNode": {"widget_order": [], "autogrow_templates": {"images": {"prefix": "image"}}},
    "ImageBatchMulti": {"widget_order": ["inputcount"], "inputcount": {"widget": "inputcount", "elements": ["image"]}}
  }
}
```

Every class gets an entry, including widget-less ones: a missing entry ("unknown class") and an empty `widget_order` ("no widgets") are different statements and a converter must distinguish them.

**Offline by construction.** It routes through the existing loader, so `COMFY_OBJECT_INFO_FILE` (or `--input`) resolves the schema from a baked dump with no network fetch and no cloud credential — the path a server-side host runs it on.

## The `catalog_version` contract

`sha256:<hex>` over the **canonical JSON encoding of the `types` map alone** — sorted keys, no insignificant whitespace, UTF-8, non-ASCII kept verbatim.

* It **excludes itself** and `class_count`, so a consumer that stored only the catalog can recompute the pin it was handed and verify it.
* Identical `object_info` in ⇒ identical version out, **regardless of key iteration order** (a pin that flapped on dict order would be useless as a cache key).
* Any change to any class's widget order or grow family moves it.

Consumers pin and cache on this.

## Grow families

A consumer holding only the catalog has no `object_info` to fall back to, so the catalog states the *effective* answer:

* **`autogrow_templates`** — an entry for every `COMFY_AUTOGROW_V3` input: the schema's own template when `object_info` ships one, else the same singularization `_autogrow_elem_name` falls back to. New `Port.autogrow_element_template` holds that rule in one place. Omitting the entry would tell the consumer the input does not autogrow at all.
* **`inputcount`** — the kijai `*Multi` family (`ImageBatchMulti`, `JoinStringMulti`, …), which is *not* autogrow-typed: fixed `{elem}_N` inputs plus an INT widget the node reads at runtime, so growing a slot also means *writing* a widget. Detection is factored out of `_inputcount_family_match` into a public `inputcount_family_elements`, and the slot-level matcher now calls it — the slot-level and class-level answers cannot drift.

## Verification

* `uv run pytest tests/comfy_cli/command/test_nodes_widget_catalog.py -q` → **16 passed**.
* `uv run pytest tests/comfy_cli -q -k "catalog or engine or discovery or error_code or envelope_schema or workflow_edit or inputcount"` → **331 passed, 2 skipped**.
* Full `tests/comfy_cli` → 4562 passed / 30 failed; **all 30 fail identically on the base branch** (local-environment tests: `test_logs`, `test_jobs`, `test_host_port`, `test_onboarding`, `test_run_json`, `test_restore_snapshot_fast_deps`).
* `ruff format --check` clean; `ruff check` on the touched files clean (the repo's 17 pre-existing `UP038` findings are unchanged).
* **Against the real prod `object_info`** (3625 classes, 344 KB emitted): the output reproduces the hand-vendored cloud fixture `services/agent/internal/dochost/testdata/catalog.json` **exactly** — all 10 classes, `widget_order` and `autogrow_templates` alike.

The tests grade the emitted order **against the engine, class by class** (`entry["widget_order"] == graph.widget_order(class_type)`) rather than against hand-written expectations, so the producer and the edit path cannot drift.

## Registration

* `COMMAND_SCHEMAS["comfy nodes widget-catalog"] = "widget_catalog"` — its own schema, not `nodes`: `nodes.json` declares `types` as an *array* of connection-type names (`nodes types`), and the catalog's `types` is a class_type→entry *map*. Same key, different contract.
* New `comfy_cli/schemas/widget_catalog.json`, and the emitted payload is validated against it in the tests.
* **No new error codes** — the existing `cql_no_graph` covers the only failure the command can raise.

## Base

Branched off `kishore/v1-p2-integration` so it composes with the rest of the V1 stack; the cloud side pins a new `kishore/v1-p3-integration` SHA that includes it.

Unblocks the CRDT flag flip: cloud PR **feat(agent): acquire the widget catalog from the CLI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)