### PR TITLE
fix(logs): sanitize replayed log output and the launch-failure panel

### DIFF
--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -19,12 +19,13 @@ from rich.markup import escape
 from rich.panel import Panel
 
 from comfy_cli import constants, utils
+from comfy_cli.caller import stream_is_tty
 from comfy_cli.command.custom_nodes.cm_cli_util import find_cm_cli, resolve_manager_gui_mode
 from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import _bracket_host, check_comfy_server_running
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as print  # context-aware print: stderr in JSON mode
-from comfy_cli.output.sanitize import sanitize_markup, sanitize_terminal_stream
+from comfy_cli.output.sanitize import close_open_sgr, sanitize_log_markup, sanitize_terminal_stream
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.workspace_manager import WorkspaceManager, WorkspaceType
 
@@ -373,13 +374,15 @@ def background_launch(extra, frontend_pr=None):
         # Panel content IS parsed as Rich markup, so this sink needs the markup
         # escape as well as the escape-byte strip: an unbalanced '[/red]' in the
         # captured log raised MarkupError from inside the failure handler, and
-        # any other bracketed run was silently deleted. sanitize_markup (not
-        # sanitize_terminal_stream) because of that markup parse — monochrome is
-        # fine in an error panel, and no colour is worth reporting a failed
-        # launch by crashing on the log that explains it.
+        # any other bracketed run was silently deleted. The markup-parsing sink
+        # is why this is not sanitize_terminal_stream — monochrome is fine in an
+        # error panel, and no colour is worth reporting a failed launch by
+        # crashing on the log that explains it. sanitize_log_markup rather than
+        # plain sanitize_markup so a stray '\x1b]' in the capture truncates one
+        # line instead of the whole traceback below it.
         print(
             Panel(
-                sanitize_markup("".join(log)),
+                sanitize_log_markup("".join(log)),
                 title="[bold red]Error log during ComfyUI execution[/bold red]",
                 border_style="bright_red",
             )
@@ -895,14 +898,16 @@ def logs(tail: int = 200, where: str | None = None, port: int | None = None):
         # sequences a terminal would act on (CSI-non-SGR/OSC/DCS/stray C0) while
         # keeping SGR colour, tab/newline/CR — so legitimate logs render unchanged.
         replayed = sanitize_terminal_stream("".join(lines))
-        renderer.pretty_stream.write(replayed)
-        # Keeping SGR means a log that never resets — or ends mid-style — leaves
-        # the user's terminal coloured, in reverse video, or (\x1b[8m) concealing
-        # everything they type next. Close the styles we replayed. Gated on an
-        # SGR actually being present so a log without one is byte-identical to
-        # what this line printed before sanitization existed.
-        if "\x1b[" in replayed:
-            renderer.pretty_stream.write("\x1b[0m")
+        # Keeping SGR means a log line that never resets — or opens \x1b[8m
+        # (conceal) — styles every line replayed after it, and then whatever the
+        # user types next. close_open_sgr closes each line the log left open.
+        # Only for a TTY: there is no terminal state to protect behind
+        # `comfy logs > file` or `| grep`, and adding resets there would put
+        # bytes in the output that the source file never contained.
+        stream = renderer.pretty_stream
+        if stream_is_tty(stream):
+            replayed = close_open_sgr(replayed)
+        stream.write(replayed)
 
     renderer.emit(
         {

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -24,6 +24,7 @@ from comfy_cli.config_manager import ConfigManager
 from comfy_cli.env_checker import _bracket_host, check_comfy_server_running
 from comfy_cli.output import get_renderer
 from comfy_cli.output import rprint as print  # context-aware print: stderr in JSON mode
+from comfy_cli.output.sanitize import sanitize_markup, sanitize_terminal_stream
 from comfy_cli.resolve_python import resolve_workspace_python
 from comfy_cli.workspace_manager import WorkspaceManager, WorkspaceType
 
@@ -369,9 +370,16 @@ def background_launch(extra, frontend_pr=None):
     # Reaching here means the monitor returned without seeing the success line
     # (the success path emits its envelope and _hard_exit(0)s inside the monitor).
     if log is not None:
+        # Panel content IS parsed as Rich markup, so this sink needs the markup
+        # escape as well as the escape-byte strip: an unbalanced '[/red]' in the
+        # captured log raised MarkupError from inside the failure handler, and
+        # any other bracketed run was silently deleted. sanitize_markup (not
+        # sanitize_terminal_stream) because of that markup parse — monochrome is
+        # fine in an error panel, and no colour is worth reporting a failed
+        # launch by crashing on the log that explains it.
         print(
             Panel(
-                "".join(log),
+                sanitize_markup("".join(log)),
                 title="[bold red]Error log during ComfyUI execution[/bold red]",
                 border_style="bright_red",
             )
@@ -882,9 +890,19 @@ def logs(tail: int = 200, where: str | None = None, port: int | None = None):
                 f"{escape(log_path)}, ComfyUI-Manager's unsuffixed log, which does not "
                 f"record which port it served.[/bold yellow]"
             )
-        # Write raw so ComfyUI log text (which can contain '[...]') isn't
-        # reinterpreted as Rich markup, and byte-for-byte matches the file.
-        renderer.pretty_stream.write("".join(lines))
+        # Raw stream write so ComfyUI log text (which can contain '[...]') isn't
+        # reinterpreted as Rich markup; sanitize_terminal_stream strips the escape
+        # sequences a terminal would act on (CSI-non-SGR/OSC/DCS/stray C0) while
+        # keeping SGR colour, tab/newline/CR — so legitimate logs render unchanged.
+        replayed = sanitize_terminal_stream("".join(lines))
+        renderer.pretty_stream.write(replayed)
+        # Keeping SGR means a log that never resets — or ends mid-style — leaves
+        # the user's terminal coloured, in reverse video, or (\x1b[8m) concealing
+        # everything they type next. Close the styles we replayed. Gated on an
+        # SGR actually being present so a log without one is byte-identical to
+        # what this line printed before sanitization existed.
+        if "\x1b[" in replayed:
+            renderer.pretty_stream.write("\x1b[0m")
 
     renderer.emit(
         {

--- a/comfy_cli/output/sanitize.py
+++ b/comfy_cli/output/sanitize.py
@@ -9,8 +9,13 @@ terminal and can clear the screen, rewrite the window title, or repaint earlier
 lines to spoof CLI output.
 
 This module sanitizes **pretty** rendering only. The JSON/NDJSON envelope paths
-must NOT use it: ``json.dumps`` already escapes ``\x1b`` as a ``\u`` escape, and
-stripping there would silently mutate the data agents parse.
+must NOT use it: stripping there would silently mutate the data agents parse,
+and the consumer decodes JSON rather than acting on control sequences. Note the
+envelope is not escape-*free*, though: the renderer dumps with
+``ensure_ascii=False``, which escapes C0 (so ``\x1b`` leaves as a six-character
+``\u`` escape) but emits U+0080-U+009F literally — the 8-bit C1 introducers ``\x9b``/``\x90``/
+``\x9d`` cross it raw. Anything that later renders envelope text to a human
+terminal owes it a trip through ``sanitize_terminal_stream``.
 
 ``Renderer`` is not the only path to the terminal, so applying it there is not
 sufficient on its own. Command modules also call ``rich.print`` directly under
@@ -30,11 +35,13 @@ problem and deliberately out of scope here.
 Two display contracts, one module. ``sanitize`` above is for text the CLI
 *authors* — a message we compose around an untrusted value, where colour is
 ours to add and nothing in the value needs to survive as styling.
-``sanitize_terminal_stream`` is for *replaying a captured stream* back to the
-terminal (``comfy logs``): the bytes were produced by another program that owns
-its own colouring, so SGR and carriage return are kept and only the sequences a
-terminal would *act* on are dropped. Use the narrower one whenever the sink is a
-message rather than a replayed stream. Neither belongs on a JSON path.
+``sanitize_terminal_stream`` and ``sanitize_log_markup`` are for *replaying a
+captured stream* (``comfy logs``, the launch-failure panel): the bytes were
+produced by another program, so they are line-bounded rather than allowed to
+swallow the tail (see ``_STREAM_*`` below), and the stream variant additionally
+keeps SGR and carriage return because that program owns its own colouring. Use
+the narrower ``sanitize`` whenever the sink is a message the CLI composed
+rather than a stream it recorded. None of them belong on a JSON path.
 
 Removing the escape *bytes* is only half the boundary: Rich manufactures new
 ones from markup it finds in a string, so text bound for a markup-interpreting
@@ -50,39 +57,61 @@ from rich.markup import escape as _escape_markup
 
 # One pass over the ANSI escape forms a terminal will act on. Ordered so the
 # multi-character sequences are consumed before the lone-ESC fallback.
-_ESCAPE_SEQUENCE_RE = re.compile(
-    r"""
+#
+# ``{payload}``/``{end}`` are filled in below to give the OSC/DCS/SOS/PM/APC
+# ("string") families their two reach variants — see ``_UNTERMINATED_*``. The
+# template is fed through ``str.format``, so any regex brace quantifier added
+# here (``{2}``, ``{1,3}``) must be doubled.
+_ESCAPE_TEMPLATE = r"""
       \x1b\[ [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 7-bit (ESC [ ...)
     | \x9b   [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]?      # CSI, 8-bit C1 form
-    | \x1b[\]PX^_] .*? (?: \x1b\\ | \x9c | \x07 | \Z )   # OSC/DCS/SOS/PM/APC, 7-bit
-    | [\x90\x98\x9d\x9e\x9f] .*? (?: \x1b\\ | \x9c | \x07 | \Z )  # same, 8-bit C1 form (DCS/SOS/OSC/PM/APC)
+    | \x1b[\]PX^_] {payload} (?: \x1b\\ | \x9c | \x07 {end} )   # OSC/DCS/SOS/PM/APC, 7-bit
+    | [\x90\x98\x9d\x9e\x9f] {payload} (?: \x1b\\ | \x9c | \x07 {end} )  # same, 8-bit C1 form
     | \x1b [\x20-\x2f]* [\x30-\x7e]                      # two-/three-char escapes (ESC ( B, ESC =, ...)
-    """,
-    re.VERBOSE | re.DOTALL,
-)
+"""
+
+# Authored messages: an unterminated introducer runs to the end of the string,
+# which is what the terminal itself would do with it (see ``sanitize``).
+_UNTERMINATED_TO_END = {"payload": r".*?", "end": r"| \Z"}
+# Replayed streams: an unterminated introducer stops at the next newline. A
+# terminal would swallow forward here too, but the bytes are a *recording* of
+# another process — a crash that dumps binary into the log would otherwise
+# delete every remaining line of `comfy logs` with no truncation indicator,
+# while the JSON path still showed them. The introducer and its payload-so-far
+# are still removed, so what survives is inert text either way.
+_UNTERMINATED_TO_NEWLINE = {"payload": r"[^\n]*?", "end": r"| (?=\n) | \Z"}
+
+_ESCAPE_SEQUENCE_RE = re.compile(_ESCAPE_TEMPLATE.format(**_UNTERMINATED_TO_END), re.VERBOSE | re.DOTALL)
 
 # Whatever survives the sweep above: stray C0 (minus tab/newline), DEL, and the
 # C1 block. A lone trailing ESC and an orphaned 8-bit introducer land here.
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
-# Exact-match test for a kept sequence: 7-bit SGR only, parameter bytes
-# restricted to digits/;/: so private-mode or intermediate-byte oddities
-# ending in 'm' are still stripped. 8-bit C1 CSI (\x9b...m) is NOT kept —
-# UTF-8 terminals don't honor it and keeping it buys nothing.
-_SGR_RE = re.compile(r"\x1b\[[0-9;:]*m\Z")
+# 7-bit SGR only, parameter bytes restricted to digits/;/: so private-mode or
+# intermediate-byte oddities ending in 'm' are still stripped. 8-bit C1 CSI
+# (\x9b...m) is NOT kept — UTF-8 terminals don't honor it and keeping it buys
+# nothing. Used as an exact-match test for a kept sequence, and to find the
+# SGRs a replayed line left open (``close_open_sgr``).
+_SGR_RE = re.compile(r"\x1b\[[0-9;:]*m")
+# ...of which these are the ones that close everything again: no parameters, or
+# parameters that are all zero.
+_SGR_RESET_RE = re.compile(r"\x1b\[[0;:]*m")
 
-# ``_ESCAPE_SEQUENCE_RE``'s alternation plus the residual control characters,
-# in one pattern so a single ``.sub()`` pass sees whole escape sequences before
-# the lone-control-char fallback can split them. Keeps tab/newline/CR:
-# tab+newline are layout, and \r only rewrites the line it is on — which its
-# writer already fully controls — while being how tqdm progress lines are
-# genuinely recorded.
-# The leading newline is load-bearing under ``re.VERBOSE``: the borrowed pattern
-# ends in a ``#`` comment, and appending to the same line would make the whole
-# alternative part of that comment — a regex that still compiles and still
-# strips escape sequences, but silently stops stripping lone control bytes.
+# The escape alternation plus the residual control characters, in ONE pattern
+# so a single ``.sub()`` pass sees whole escape sequences before the
+# lone-control-char fallback can split them.
+#
+# The keep-SGR variant also keeps CR: tab+newline are layout, and \r only
+# rewrites the line it is on — which the replaying stream fully owns — while
+# being how tqdm progress lines are genuinely recorded. The strip-all variant
+# drops CR, matching ``sanitize``, because its sink is a Rich Panel whose lines
+# the CLI (not the log) lays out.
 _TERMINAL_STREAM_RE = re.compile(
-    _ESCAPE_SEQUENCE_RE.pattern + "\n" + r"| [\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]",
+    _ESCAPE_TEMPLATE.format(**_UNTERMINATED_TO_NEWLINE) + r"| [\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]",
+    re.VERBOSE | re.DOTALL,
+)
+_LOG_CAPTURE_RE = re.compile(
+    _ESCAPE_TEMPLATE.format(**_UNTERMINATED_TO_NEWLINE) + r"| [\x00-\x08\x0b-\x1f\x7f-\x9f]",
     re.VERBOSE | re.DOTALL,
 )
 
@@ -115,15 +144,74 @@ def sanitize_terminal_stream(text: str) -> str:
       stream owns in full — unlike in ``sanitize``, where a server string would
       be overwriting text the CLI itself printed.
 
+    An unterminated OSC/DCS introducer is bounded at the next newline rather
+    than swallowing the tail the way ``sanitize`` does — the difference between
+    dropping the rest of a one-line message and dropping the rest of the log.
+
     This cannot be layered on top of ``sanitize``: that function's second pass
     sweeps residual control characters, which would eat the ``\\x1b`` of every
     SGR the first pass deliberately kept. Hence the single combined pass here.
 
+    Preserving SGR leaves the *closing* of those styles to the caller — see
+    ``close_open_sgr``, which a TTY sink should apply to the result.
+
     The caller must still pick a sink that does not parse Rich markup — this
     returns log text verbatim, brackets included. For a markup-interpreting
-    sink use ``sanitize_markup`` instead and accept the loss of colour.
+    sink use ``sanitize_log_markup`` instead and accept the loss of colour.
     """
     return _TERMINAL_STREAM_RE.sub(lambda m: m.group(0) if _SGR_RE.fullmatch(m.group(0)) else "", text)
+
+
+def sanitize_log_markup(value: Any) -> str:
+    """``sanitize_markup`` for captured log text, without the tail-swallow.
+
+    The launch-failure Panel parses its content as Rich markup, so captured log
+    text needs the markup escape (an unbalanced ``[/red]`` in the log otherwise
+    raises ``MarkupError`` from inside the failure handler). But the text is a
+    recording, not a message we composed, so it gets the stream sanitizers'
+    line-bounded reach: with plain ``sanitize_markup`` one stray ``\\x1b]`` byte
+    would truncate the panel there and discard exactly the traceback the panel
+    exists to display.
+
+    Colour is dropped rather than preserved as in ``sanitize_terminal_stream``:
+    the sink re-lays-out and re-styles what it is given, so raw SGR bytes would
+    fight the panel's own rendering. Monochrome is fine in an error panel.
+    """
+    text = value if isinstance(value, str) else str(value)
+    return _escape_markup(_LOG_CAPTURE_RE.sub("", text))
+
+
+def close_open_sgr(text: str) -> str:
+    """Append an SGR reset to every line of ``text`` that ends mid-style.
+
+    ``sanitize_terminal_stream`` keeps the log's own colouring, which means the
+    log also decides when it stops. A line that never resets — or that opens
+    ``\\x1b[8m`` (conceal) or a foreground-equals-background pair — otherwise
+    bleeds into everything printed after it: the rest of the replay, and then
+    whatever the user types at the prompt next. Since anyone who can land text
+    in the log can land an SGR in it, that is a way to hide later log lines
+    from a human while the JSON path still shows them.
+
+    Closing per line rather than once at the end is what contains it. The cost
+    is fidelity for a log that opens a style on one line and expects it to hold
+    across the next — rare, because loggers that colour (rich, colorama,
+    ``tqdm``, uvicorn) reset before each newline already.
+
+    Lines already ending in a reset gain nothing, and text with no SGR at all
+    is returned unchanged — so an uncoloured log stays byte-identical.
+    """
+    if "\x1b[" not in text:
+        return text
+    # Split on "\n" only: ``str.splitlines`` would also break on "\r", which is
+    # a within-line repaint here (tqdm), and on the Unicode separators.
+    lines = text.split("\n")
+    for i, line in enumerate(lines):
+        last = None
+        for match in _SGR_RE.finditer(line):
+            last = match.group(0)
+        if last is not None and not _SGR_RESET_RE.fullmatch(last):
+            lines[i] = line + "\x1b[0m"
+    return "\n".join(lines)
 
 
 def sanitize_optional(text: str | None) -> str | None:

--- a/comfy_cli/output/sanitize.py
+++ b/comfy_cli/output/sanitize.py
@@ -27,6 +27,15 @@ lets a message overwrite a line that has already been printed. Non-control
 Unicode is left alone; homoglyph and bidi-override spoofing are a different
 problem and deliberately out of scope here.
 
+Two display contracts, one module. ``sanitize`` above is for text the CLI
+*authors* — a message we compose around an untrusted value, where colour is
+ours to add and nothing in the value needs to survive as styling.
+``sanitize_terminal_stream`` is for *replaying a captured stream* back to the
+terminal (``comfy logs``): the bytes were produced by another program that owns
+its own colouring, so SGR and carriage return are kept and only the sequences a
+terminal would *act* on are dropped. Use the narrower one whenever the sink is a
+message rather than a replayed stream. Neither belongs on a JSON path.
+
 Removing the escape *bytes* is only half the boundary: Rich manufactures new
 ones from markup it finds in a string, so text bound for a markup-interpreting
 sink also needs ``sanitize_markup`` (see its docstring).
@@ -56,6 +65,27 @@ _ESCAPE_SEQUENCE_RE = re.compile(
 # C1 block. A lone trailing ESC and an orphaned 8-bit introducer land here.
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
 
+# Exact-match test for a kept sequence: 7-bit SGR only, parameter bytes
+# restricted to digits/;/: so private-mode or intermediate-byte oddities
+# ending in 'm' are still stripped. 8-bit C1 CSI (\x9b...m) is NOT kept —
+# UTF-8 terminals don't honor it and keeping it buys nothing.
+_SGR_RE = re.compile(r"\x1b\[[0-9;:]*m\Z")
+
+# ``_ESCAPE_SEQUENCE_RE``'s alternation plus the residual control characters,
+# in one pattern so a single ``.sub()`` pass sees whole escape sequences before
+# the lone-control-char fallback can split them. Keeps tab/newline/CR:
+# tab+newline are layout, and \r only rewrites the line it is on — which its
+# writer already fully controls — while being how tqdm progress lines are
+# genuinely recorded.
+# The leading newline is load-bearing under ``re.VERBOSE``: the borrowed pattern
+# ends in a ``#`` comment, and appending to the same line would make the whole
+# alternative part of that comment — a regex that still compiles and still
+# strips escape sequences, but silently stops stripping lone control bytes.
+_TERMINAL_STREAM_RE = re.compile(
+    _ESCAPE_SEQUENCE_RE.pattern + "\n" + r"| [\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]",
+    re.VERBOSE | re.DOTALL,
+)
+
 
 def sanitize(text: str) -> str:
     """Return ``text`` with ANSI escape sequences and control characters removed.
@@ -65,6 +95,35 @@ def sanitize(text: str) -> str:
     the conservative reading, not data loss we could have avoided.
     """
     return _CONTROL_CHAR_RE.sub("", _ESCAPE_SEQUENCE_RE.sub("", text))
+
+
+def sanitize_terminal_stream(text: str) -> str:
+    """``sanitize`` for a captured stream replayed to the terminal, keeping colour.
+
+    Same threat model as ``sanitize`` — CSI cursor/erase sequences, OSC title
+    rewrites, DCS payloads and stray control bytes are all removed — with two
+    deliberate exceptions, because the text being replayed is another program's
+    own output rather than a message we composed:
+
+    * **7-bit SGR is preserved** (``\\x1b[31m``), so a ComfyUI log that coloured
+      its own warnings still reads the way it did on the launching terminal.
+      SGR only restyles subsequent characters; it cannot move the cursor, erase
+      anything, or address the terminal outside the stream.
+    * **Carriage return is preserved**, so a ``tqdm`` progress line recorded in
+      the log renders as one rewritten line instead of a wall of duplicates.
+      ``\\r`` can only repaint the line it is already on, which the replayed
+      stream owns in full — unlike in ``sanitize``, where a server string would
+      be overwriting text the CLI itself printed.
+
+    This cannot be layered on top of ``sanitize``: that function's second pass
+    sweeps residual control characters, which would eat the ``\\x1b`` of every
+    SGR the first pass deliberately kept. Hence the single combined pass here.
+
+    The caller must still pick a sink that does not parse Rich markup — this
+    returns log text verbatim, brackets included. For a markup-interpreting
+    sink use ``sanitize_markup`` instead and accept the loss of colour.
+    """
+    return _TERMINAL_STREAM_RE.sub(lambda m: m.group(0) if _SGR_RE.fullmatch(m.group(0)) else "", text)
 
 
 def sanitize_optional(text: str | None) -> str | None:

--- a/tests/comfy_cli/command/test_launch_background.py
+++ b/tests/comfy_cli/command/test_launch_background.py
@@ -111,6 +111,34 @@ def test_background_launch_error_panel_neutralizes_log_text(
     mock_exit.assert_called_once_with(1)
 
 
+@patch("comfy_cli.command.launch.os._exit")
+@patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
+@patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_error_panel_survives_a_stray_escape_introducer(
+    mock_config_manager, mock_check_running, mock_monitor, mock_exit, pretty_renderer, capsys
+):
+    """A crashed process can dump a bare `\\x1b]` into the captured output. The
+    panel exists to show the traceback under it, so the sanitizer bounds that
+    introducer at its line (`sanitize_log_markup`) instead of letting it eat the
+    rest of the capture the way the authored-message `sanitize` does."""
+    mock_config_manager.return_value.background = None
+    mock_monitor.return_value = [
+        "Traceback (most recent call last):\n",
+        "\x1b]0;stray introducer\n",
+        '  File "node.py", line 42\n',
+        "RuntimeError: boom\n",
+    ]
+
+    launch.background_launch(extra=[])
+
+    out = capsys.readouterr().out
+    assert "RuntimeError: boom" in out
+    assert "node.py" in out
+    assert "\x1b]" not in out
+    mock_exit.assert_called_once_with(1)
+
+
 @patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
 @patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
 @patch("comfy_cli.command.launch.ConfigManager")

--- a/tests/comfy_cli/command/test_launch_background.py
+++ b/tests/comfy_cli/command/test_launch_background.py
@@ -10,7 +10,30 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from comfy_cli.caller import Caller
 from comfy_cli.command import launch
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+
+@pytest.fixture
+def pretty_renderer():
+    """Pin PRETTY mode: under pytest stdout is not a TTY, so the default
+    resolution would pick JSON and never render the failure Panel at all."""
+    reset_renderer_for_testing()
+    r = Renderer.resolve(
+        is_stdout_tty=True,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+    )
+    r.mode = OutputMode.PRETTY
+    set_renderer(r)
+    yield r
+    reset_renderer_for_testing()
 
 
 @patch("comfy_cli.command.launch.os._exit")
@@ -58,6 +81,33 @@ def test_background_launch_surfaces_error_log(mock_config_manager, mock_check_ru
 
     mock_monitor.assert_awaited_once()
     assert mock_print.called
+    mock_exit.assert_called_once_with(1)
+
+
+@patch("comfy_cli.command.launch.os._exit")
+@patch("comfy_cli.command.launch.launch_and_monitor", new_callable=AsyncMock)
+@patch("comfy_cli.command.launch.check_comfy_server_running", return_value=False)
+@patch("comfy_cli.command.launch.ConfigManager")
+def test_background_launch_error_panel_neutralizes_log_text(
+    mock_config_manager, mock_check_running, mock_monitor, mock_exit, pretty_renderer, capsys
+):
+    """The failure Panel parses its content as Rich markup, so the captured log
+    goes through `sanitize_markup`: an unbalanced `[/red]` used to raise
+    MarkupError from inside the failure handler (and any other bracketed run was
+    silently deleted), while escape bytes reached the terminal unfiltered."""
+    mock_config_manager.return_value.background = None
+    mock_monitor.return_value = ["[/red] boom\n", "\x1b[2Jerased\n", "[INFO] tail\n"]
+
+    launch.background_launch(extra=[])
+
+    out = capsys.readouterr().out
+    # No MarkupError escaped, and the bracket text is visible rather than eaten.
+    assert "[/red]" in out
+    assert "[INFO]" in out
+    assert "boom" in out
+    assert "erased" in out
+    # ...with nothing the terminal would act on left in the rendered panel.
+    assert "\x1b[2J" not in out
     mock_exit.assert_called_once_with(1)
 
 

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -286,16 +286,111 @@ def test_logs_pretty_honors_large_tail_past_line_cap(monkeypatch, tmp_path, caps
 
 
 def test_logs_pretty_writes_raw_lines(monkeypatch, tmp_path, capsys):
-    # Default renderer is pretty; log text with '[...]' must not be reinterpreted.
+    # Default renderer is pretty; log text with '[...]' must not be reinterpreted
+    # as Rich markup. Escape bytes ARE stripped (see the sanitization tests
+    # below), so this no longer pins the output byte-for-byte — but every
+    # bracketed run has to survive verbatim, including an unbalanced closer that
+    # would raise MarkupError from a markup-parsing sink.
     log = tmp_path / "comfyui_8188.log"
-    log.write_text("[INFO] hello [world]\nplain\n")
+    log.write_text("[INFO] hello [world]\n[####  ] 50%\n[/red]\nplain\n")
     monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
 
     launch.logs(tail=10)
 
     out = capsys.readouterr().out
     assert "[INFO] hello [world]" in out
+    assert "[####  ] 50%" in out
+    assert "[/red]" in out
     assert "plain" in out
+
+
+# --------------------------------------------------------------------------- #
+# `comfy logs` pretty replay — terminal-control sanitization
+# --------------------------------------------------------------------------- #
+
+
+def _logs_pretty_out(monkeypatch, tmp_path, capsys, contents: str) -> str:
+    """Run pretty-mode ``logs()`` over ``contents`` and return captured stdout."""
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text(contents)
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
+    launch.logs(tail=50)
+    return capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("contents", "banned"),
+    [
+        # OSC 0 retitles the user's terminal window; BEL-terminated form.
+        ("start\x1b]0;evil\x07end\n", "\x1b]"),
+        # ...and the unterminated form, which consumes to end-of-string.
+        ("start\x1b]0;evil\n", "\x1b]"),
+        # CSI erase-display and cursor-up repaint CLI-owned lines above.
+        ("start\x1b[2Jend\n", "\x1b[2J"),
+        ("start\x1b[3Aend\n", "\x1b[3A"),
+        # 8-bit C1 CSI — not honored by UTF-8 terminals, so it is stripped too.
+        ("start\x9b31mend\n", "\x9b"),
+    ],
+)
+def test_logs_pretty_strips_terminal_control_sequences(monkeypatch, tmp_path, capsys, contents, banned):
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, contents)
+
+    assert banned not in out
+    assert "start" in out
+
+
+def test_logs_pretty_preserves_sgr_colour(monkeypatch, tmp_path, capsys):
+    # The reason this is `sanitize_terminal_stream` and not `sanitize`: a
+    # coloured ComfyUI log must still be coloured when replayed.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[31mred\x1b[0m\n")
+
+    assert "\x1b[31mred\x1b[0m" in out
+
+
+def test_logs_pretty_closes_styles_left_open_by_the_log(monkeypatch, tmp_path, capsys):
+    # A log that never resets (or conceals with \x1b[8m) would otherwise leave
+    # the terminal styled for everything the user types next.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[8mconcealed\n")
+
+    assert out.endswith("\x1b[0m")
+
+
+def test_logs_pretty_adds_no_reset_when_the_log_has_no_sgr(monkeypatch, tmp_path, capsys):
+    # The overwhelmingly common case stays byte-identical to the pre-sanitize
+    # output: an uncoloured log gains nothing.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "plain one\nplain two\n")
+
+    assert out == "plain one\nplain two\n"
+
+
+def test_logs_pretty_preserves_progress_lines_and_layout(monkeypatch, tmp_path, capsys):
+    # Tabs and newlines are layout and survive. The '\r' a tqdm progress line is
+    # recorded with survives the sanitizer too (see the unit tests) — but it
+    # never reaches the sanitizer, because `read_log_tail` opens the file in the
+    # default universal-newline mode, which normalizes '\r' to '\n' one layer
+    # up. That is pre-existing reader behavior shared with the JSON envelope, so
+    # this asserts what the pretty path actually prints rather than pinning a
+    # '\r' the display layer never sees.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "50%|##   |\r100%|#####|\ncol1\tcol2\n")
+
+    assert "50%|##   |" in out
+    assert "100%|#####|" in out
+    assert "col1\tcol2\n" in out
+
+
+def test_logs_json_lines_are_byte_faithful(monkeypatch, tmp_path, capsys):
+    # The machine path stays raw: json.dumps already escapes \x1b, and stripping
+    # here would mutate data agents parse.
+    _force_json_renderer()
+    raw = "\x1b]0;evil\x07\x1b[2J\x1b[31mred\x1b[0m\x9b31m\n"
+    log = tmp_path / "comfyui_8188.log"
+    log.write_text(raw)
+    monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
+
+    launch.logs(tail=50)
+
+    env = _envelope(capsys)
+    assert env["data"]["lines"] == [raw]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/comfy_cli/command/test_logs.py
+++ b/tests/comfy_cli/command/test_logs.py
@@ -9,6 +9,7 @@ workspace logfile and records its path.
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import os
 import subprocess
@@ -309,13 +310,36 @@ def test_logs_pretty_writes_raw_lines(monkeypatch, tmp_path, capsys):
 # --------------------------------------------------------------------------- #
 
 
-def _logs_pretty_out(monkeypatch, tmp_path, capsys, contents: str) -> str:
-    """Run pretty-mode ``logs()`` over ``contents`` and return captured stdout."""
+class _TtyStream(io.StringIO):
+    """A pretty sink that claims to be a terminal, for the SGR-reset gate."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+def _logs_pretty_out(monkeypatch, tmp_path, capsys, contents: str, *, tty: bool = False) -> str:
+    """Run pretty-mode ``logs()`` over ``contents`` and return what it printed.
+
+    ``tty=True`` swaps in a sink that reports ``isatty()``, which is what gates
+    the closing SGR resets — under pytest the captured stdout never is one.
+    """
     log = tmp_path / "comfyui_8188.log"
     log.write_text(contents)
     monkeypatch.setattr(launch, "resolve_background_log_path", lambda port=None: (str(log), "recorded"))
+    if not tty:
+        launch.logs(tail=50)
+        return capsys.readouterr().out
+
+    renderer = Renderer.resolve(
+        is_stdout_tty=True,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+    )
+    renderer.mode = OutputMode.PRETTY
+    renderer.pretty_stream = _TtyStream()
+    set_renderer(renderer)
     launch.logs(tail=50)
-    return capsys.readouterr().out
+    return renderer.pretty_stream.getvalue()
 
 
 @pytest.mark.parametrize(
@@ -323,8 +347,13 @@ def _logs_pretty_out(monkeypatch, tmp_path, capsys, contents: str) -> str:
     [
         # OSC 0 retitles the user's terminal window; BEL-terminated form.
         ("start\x1b]0;evil\x07end\n", "\x1b]"),
-        # ...and the unterminated form, which consumes to end-of-string.
-        ("start\x1b]0;evil\n", "\x1b]"),
+        # ...and the unterminated form. A terminal would swallow forward looking
+        # for the terminator; on a *replayed* log that would delete every line
+        # below it, so the sanitizer bounds it at the newline instead — hence
+        # the `end` on the following line, which must survive.
+        ("start\x1b]0;evil\nend\n", "\x1b]"),
+        ("start\x1bPdcs never terminated\nend\n", "\x1bP"),
+        ("start\x9d0;evil\nend\n", "\x9d"),
         # CSI erase-display and cursor-up repaint CLI-owned lines above.
         ("start\x1b[2Jend\n", "\x1b[2J"),
         ("start\x1b[3Aend\n", "\x1b[3A"),
@@ -336,23 +365,40 @@ def test_logs_pretty_strips_terminal_control_sequences(monkeypatch, tmp_path, ca
     out = _logs_pretty_out(monkeypatch, tmp_path, capsys, contents)
 
     assert banned not in out
+    # Text on both sides of the stripped sequence survives: the point is to
+    # remove the bytes the terminal acts on, not to truncate the log there.
     assert "start" in out
+    assert "end" in out
+
+
+def test_logs_pretty_keeps_lines_below_an_unterminated_introducer(monkeypatch, tmp_path, capsys):
+    # The tail-swallow regression in full: a crashed process dumping one stray
+    # introducer must not silently cut the replay short while the JSON path
+    # still shows the rest.
+    contents = "line one\n\x1b]0;truncator\nline two\nline three\n"
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, contents)
+
+    assert "line one" in out
+    assert "line two" in out
+    assert "line three" in out
 
 
 def test_logs_pretty_preserves_sgr_colour(monkeypatch, tmp_path, capsys):
     # The reason this is `sanitize_terminal_stream` and not `sanitize`: a
     # coloured ComfyUI log must still be coloured when replayed.
-    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[31mred\x1b[0m\n")
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[31mred\x1b[0m\n", tty=True)
 
     assert "\x1b[31mred\x1b[0m" in out
 
 
-def test_logs_pretty_closes_styles_left_open_by_the_log(monkeypatch, tmp_path, capsys):
-    # A log that never resets (or conceals with \x1b[8m) would otherwise leave
-    # the terminal styled for everything the user types next.
-    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[8mconcealed\n")
+def test_logs_pretty_closes_styles_per_line(monkeypatch, tmp_path, capsys):
+    # A log line that never resets (or conceals with \x1b[8m) would otherwise
+    # style every line replayed after it — and then whatever the user types
+    # next. Closing at the newline, not just once at the end, is what stops one
+    # planted SGR from hiding the log lines below it.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[8mconcealed\nvisible\n", tty=True)
 
-    assert out.endswith("\x1b[0m")
+    assert out == "\x1b[8mconcealed\x1b[0m\nvisible\n"
 
 
 def test_logs_pretty_adds_no_reset_when_the_log_has_no_sgr(monkeypatch, tmp_path, capsys):
@@ -361,6 +407,15 @@ def test_logs_pretty_adds_no_reset_when_the_log_has_no_sgr(monkeypatch, tmp_path
     out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "plain one\nplain two\n")
 
     assert out == "plain one\nplain two\n"
+
+
+def test_logs_pretty_adds_no_reset_when_the_sink_is_not_a_tty(monkeypatch, tmp_path, capsys):
+    # `comfy logs > file` / `| grep` has no terminal state to protect, so it
+    # must not gain a reset the source file never contained. The log's own SGR
+    # still replays — that byte *was* in the file.
+    out = _logs_pretty_out(monkeypatch, tmp_path, capsys, "\x1b[8mconcealed\n")
+
+    assert out == "\x1b[8mconcealed\n"
 
 
 def test_logs_pretty_preserves_progress_lines_and_layout(monkeypatch, tmp_path, capsys):
@@ -379,8 +434,16 @@ def test_logs_pretty_preserves_progress_lines_and_layout(monkeypatch, tmp_path, 
 
 
 def test_logs_json_lines_are_byte_faithful(monkeypatch, tmp_path, capsys):
-    # The machine path stays raw: json.dumps already escapes \x1b, and stripping
-    # here would mutate data agents parse.
+    # The machine path stays raw: stripping here would mutate the data agents
+    # parse, and the envelope is not a terminal — its consumer decodes JSON
+    # rather than acting on control sequences.
+    #
+    # Note the envelope is *not* escape-free the way the pretty path is. The
+    # renderer dumps with `ensure_ascii=False`, which escapes C0 (so `\x1b`
+    # leaves as a six-character `\u` escape) but emits U+0080-U+009F literally — the 8-bit C1
+    # introducers `\x9b`/`\x90`/`\x9d` therefore cross the envelope raw. That is
+    # deliberate for a machine sink; anything that later renders these lines to
+    # a human terminal owes them a trip through `sanitize_terminal_stream`.
     _force_json_renderer()
     raw = "\x1b]0;evil\x07\x1b[2J\x1b[31mred\x1b[0m\x9b31m\n"
     log = tmp_path / "comfyui_8188.log"

--- a/tests/comfy_cli/output/test_sanitize.py
+++ b/tests/comfy_cli/output/test_sanitize.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import pytest
 
 from comfy_cli.output.sanitize import (
+    close_open_sgr,
     sanitize,
+    sanitize_log_markup,
     sanitize_markup,
     sanitize_optional,
     sanitize_terminal_stream,
@@ -143,12 +145,20 @@ def test_sanitize_markup_stringifies_non_strings():
         # mode do not honor it, so keeping it would only leak bytes.
         ("a\x9b31mb", "ab"),
         ("a\x9b2Jb", "ab"),
-        # OSC/DCS/APC, terminated and unterminated.
+        # OSC/DCS/APC, properly terminated.
         ("a\x1b]0;pwned\x07b", "ab"),
         ("a\x1b]0;pwned\x1b\\b", "ab"),
-        ("before\x1b]0;never terminated", "before"),
         ("a\x1bPq#0;2\x1b\\b", "ab"),
         ("a\x1b_G payload \x1b\\b", "ab"),
+        # ...and unterminated, where this variant differs from ``sanitize``:
+        # the sequence ends at the newline instead of eating the rest of the
+        # log. Everything below the stray introducer survives.
+        ("a\x1b]0;never terminated\nkeep me\n", "a\nkeep me\n"),
+        ("a\x1bPnever terminated\nkeep me\n", "a\nkeep me\n"),
+        ("a\x9d0;never terminated\nkeep me\n", "a\nkeep me\n"),
+        # On the last line there is no newline to stop at, so the tail does go —
+        # the introducer's payload is unknowable and must not be printed.
+        ("before\x1b]0;never terminated", "before"),
         # Two-character escapes / charset designators.
         ("a\x1b(Bb", "ab"),
         ("a\x1b=b", "ab"),
@@ -184,11 +194,108 @@ def test_sanitize_terminal_stream_is_idempotent():
     assert sanitize_terminal_stream(once) == once
 
 
+def test_sanitize_terminal_stream_keeps_the_log_below_a_stray_introducer():
+    # The tail-swallow regression: one unterminated introducer must cost the
+    # line it is on, not every line after it.
+    raw = "line one\n\x1b]0;truncator\nline two\nline three\n"
+    assert sanitize_terminal_stream(raw) == "line one\n\nline two\nline three\n"
+
+
 def test_sanitize_terminal_stream_does_not_split_kept_sequences():
     # The regression the single-pass design exists to prevent: a two-pass
     # implementation (escapes, then a residual control-char sweep) would strip
     # the ESC out of a preserved SGR and leave a bare literal '[31m' on screen.
     assert sanitize_terminal_stream("\x1b[31mred") == "\x1b[31mred"
+
+
+# --------------------------------------------------------------------------- #
+# sanitize_log_markup — captured log into a markup-parsing sink
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Brackets are neutralized rather than parsed — an unbalanced closer
+        # would otherwise raise MarkupError from inside the failure handler.
+        ("[/red] boom", r"\[/red] boom"),
+        # Rich only escapes what it would otherwise parse, so a bracketed run
+        # that is not a tag (the usual log-level prefix) passes through as-is.
+        ("[INFO] tail", "[INFO] tail"),
+        # Escapes go entirely, colour included: the panel does its own styling.
+        ("\x1b[31mred\x1b[0m", "red"),
+        ("a\x1b[2Jb", "ab"),
+        ("a\x9b31mb", "ab"),
+        # CR goes too, unlike the stream variant: the Panel lays out its lines.
+        ("real\rspoofed", "realspoofed"),
+        # Layout survives.
+        ("col1\tcol2\nrow2", "col1\tcol2\nrow2"),
+        ("", ""),
+    ],
+)
+def test_sanitize_log_markup_neutralizes_markup_and_escapes(raw: str, expected: str):
+    assert sanitize_log_markup(raw) == expected
+
+
+def test_sanitize_log_markup_keeps_the_traceback_below_a_stray_introducer():
+    # Why this exists instead of plain ``sanitize_markup``: one stray '\x1b]'
+    # byte in the capture would otherwise truncate the panel there, discarding
+    # exactly the traceback the panel is being printed to show.
+    raw = "Traceback:\n\x1b]0;stray\n  File 'x.py', line 1\nRuntimeError: boom\n"
+    out = sanitize_log_markup(raw)
+
+    assert "RuntimeError: boom" in out
+    assert "x.py" in out
+    assert sanitize_markup(raw) == "Traceback:\n"  # the behavior being avoided
+
+
+def test_sanitize_log_markup_stringifies_non_strings():
+    assert sanitize_log_markup(42) == "42"
+
+
+# --------------------------------------------------------------------------- #
+# close_open_sgr — containing style bleed in a replayed stream
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # A line that leaves a style open is closed at its own newline, so the
+        # style cannot hide or restyle the lines below it.
+        ("\x1b[8mconcealed\nvisible\n", "\x1b[8mconcealed\x1b[0m\nvisible\n"),
+        ("\x1b[31mred\nplain\n", "\x1b[31mred\x1b[0m\nplain\n"),
+        # A line that already resets gains nothing, in any spelling of reset.
+        ("\x1b[31mred\x1b[0m\n", "\x1b[31mred\x1b[0m\n"),
+        ("\x1b[31mred\x1b[m\n", "\x1b[31mred\x1b[m\n"),
+        ("\x1b[31mred\x1b[0;0m\n", "\x1b[31mred\x1b[0;0m\n"),
+        # Only the *last* SGR on a line decides — an early reset followed by a
+        # new colour still leaves the line open.
+        ("\x1b[31ma\x1b[0m b\x1b[32mc\n", "\x1b[31ma\x1b[0m b\x1b[32mc\x1b[0m\n"),
+        # Text with no SGR at all is returned unchanged, byte for byte.
+        ("plain one\nplain two\n", "plain one\nplain two\n"),
+        ("", ""),
+        # An unterminated final line is closed too — there is no newline to
+        # hide behind, and the shell prompt follows it directly.
+        ("\x1b[31mno trailing newline", "\x1b[31mno trailing newline\x1b[0m"),
+        # '\r' is a within-line repaint (tqdm), not a line break: one reset for
+        # the whole progress line, not one per rewrite.
+        ("\x1b[32m50%\r\x1b[32m100%\n", "\x1b[32m50%\r\x1b[32m100%\x1b[0m\n"),
+    ],
+)
+def test_close_open_sgr(raw: str, expected: str):
+    assert close_open_sgr(raw) == expected
+
+
+def test_close_open_sgr_is_idempotent():
+    once = close_open_sgr("\x1b[8ma\nb\n\x1b[31mc")
+    assert close_open_sgr(once) == once
+
+
+def test_close_open_sgr_ignores_non_sgr_escapes():
+    # It runs after ``sanitize_terminal_stream``, so nothing else should be
+    # left — but it must not treat a stray erase sequence as an open style.
+    assert close_open_sgr("\x1b[2Jtext\n") == "\x1b[2Jtext\n"
 
 
 def test_sanitize_value_leaves_container_repr_inert():

--- a/tests/comfy_cli/output/test_sanitize.py
+++ b/tests/comfy_cli/output/test_sanitize.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from comfy_cli.output.sanitize import sanitize, sanitize_markup, sanitize_optional, sanitize_value
+from comfy_cli.output.sanitize import (
+    sanitize,
+    sanitize_markup,
+    sanitize_optional,
+    sanitize_terminal_stream,
+    sanitize_value,
+)
 
 
 @pytest.mark.parametrize(
@@ -114,6 +120,75 @@ def test_sanitize_markup_leaves_markup_free_text_untouched():
 
 def test_sanitize_markup_stringifies_non_strings():
     assert sanitize_markup(42) == "42"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # SGR survives byte-for-byte — that is the whole point of this variant.
+        ("\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"),
+        ("\x1b[mreset-shorthand", "\x1b[mreset-shorthand"),
+        ("\x1b[1;38;2;255;0;0mtruecolor\x1b[0m", "\x1b[1;38;2;255;0;0mtruecolor\x1b[0m"),
+        # Sub-parameter colons (ITU T.416 style) are still SGR.
+        ("\x1b[38:2:255:0:0mcolon", "\x1b[38:2:255:0:0mcolon"),
+        # Everything else a terminal acts on still goes: erase, cursor moves,
+        # scroll region, private modes, and an 'm' final byte reached through
+        # private/intermediate bytes rather than plain SGR.
+        ("job \x1b[2Jevil", "job evil"),
+        ("up\x1b[3Aover", "upover"),
+        ("a\x1b[?25lb", "ab"),
+        ("a\x1b[>1mb", "ab"),
+        ("a\x1b[1 mb", "ab"),
+        # 8-bit C1 CSI is stripped even when it *is* an SGR: terminals in UTF-8
+        # mode do not honor it, so keeping it would only leak bytes.
+        ("a\x9b31mb", "ab"),
+        ("a\x9b2Jb", "ab"),
+        # OSC/DCS/APC, terminated and unterminated.
+        ("a\x1b]0;pwned\x07b", "ab"),
+        ("a\x1b]0;pwned\x1b\\b", "ab"),
+        ("before\x1b]0;never terminated", "before"),
+        ("a\x1bPq#0;2\x1b\\b", "ab"),
+        ("a\x1b_G payload \x1b\\b", "ab"),
+        # Two-character escapes / charset designators.
+        ("a\x1b(Bb", "ab"),
+        ("a\x1b=b", "ab"),
+        # Stray control bytes, including a lone trailing ESC and DEL.
+        ("a\x00b\x07c\x7fd", "abcd"),
+        ("trailing\x1b", "trailing"),
+        ("trailing\x9b", "trailing"),
+        # Layout survives — and unlike ``sanitize``, so does CR: a tqdm line
+        # recorded in the log must replay as one rewritten line.
+        ("col1\tcol2\nrow2", "col1\tcol2\nrow2"),
+        ("50%|#####     |\r100%|##########|\n", "50%|#####     |\r100%|##########|\n"),
+        ("windows\r\nlines", "windows\r\nlines"),
+        # Rich markup is text here — this sink never parses it.
+        ("[INFO] hello [world]", "[INFO] hello [world]"),
+        ("[/red]", "[/red]"),
+        ("", ""),
+        ("héllo · 世界 ✓", "héllo · 世界 ✓"),
+    ],
+)
+def test_sanitize_terminal_stream_keeps_sgr_and_cr(raw: str, expected: str):
+    assert sanitize_terminal_stream(raw) == expected
+
+
+def test_sanitize_terminal_stream_leaves_only_sgr_escapes():
+    payload = "x\x1b[2J\x1b]0;t\x07\x1b[32mgreen\x1b[0m\x1bPz\x1b\\\x9b1m\x7f\x00y"
+    cleaned = sanitize_terminal_stream(payload)
+    assert cleaned == "x\x1b[32mgreen\x1b[0my"
+    assert "\x9b" not in cleaned
+
+
+def test_sanitize_terminal_stream_is_idempotent():
+    once = sanitize_terminal_stream("\x1b[31mred\x1b[0m\x1b[2Jgone\r\n")
+    assert sanitize_terminal_stream(once) == once
+
+
+def test_sanitize_terminal_stream_does_not_split_kept_sequences():
+    # The regression the single-pass design exists to prevent: a two-pass
+    # implementation (escapes, then a residual control-char sweep) would strip
+    # the ESC out of a preserved SGR and leave a bare literal '[31m' on screen.
+    assert sanitize_terminal_stream("\x1b[31mred") == "\x1b[31mred"
 
 
 def test_sanitize_value_leaves_container_repr_inert():


### PR DESCRIPTION
## ELI-5

`comfy logs` used to dump the ComfyUI logfile straight into your terminal. Terminals treat some byte sequences as *commands*, not text — clear the screen, rename the window, move the cursor up and overwrite what's already there. Anything that writes to that logfile (a custom node, a model filename, an error string from a remote server) could therefore make your terminal do things. This strips those command sequences on the way out, while keeping the colour codes, so a coloured log still looks like a coloured log.

The launch-failure error panel had the same problem plus a second one: it runs its content through Rich's markup parser, so a stray `[/red]` in the crash log made the CLI crash *while reporting the crash*, and any other bracketed text was silently deleted.

## What changed

- **New `sanitize_terminal_stream(text)`** in `comfy_cli/output/sanitize.py`. It is the display contract for *replaying a captured stream*, as distinct from `sanitize()`, which is for messages the CLI authors. It removes everything a terminal acts on — non-SGR CSI, OSC, DCS/SOS/PM/APC, the 8-bit C1 forms, stray C0/C1 bytes — but preserves **7-bit SGR** (so no colour regression) and **carriage return**.
- **`comfy logs` pretty branch** (`comfy_cli/command/launch.py`) now writes `sanitize_terminal_stream("".join(lines))`. Still a raw stream write, so log text is never reinterpreted as Rich markup.
- **Launch-failure panel** now renders `sanitize_markup("".join(log))`. That sink parses markup, so it needs the markup escape too; monochrome is the right trade in an error panel.
- The JSON/NDJSON envelope emit is untouched and stays byte-faithful — `json.dumps` already escapes `\x1b`, and stripping there would mutate data agents parse.

## Why one pass and not two

`sanitize()` runs an escape-sequence pass then a residual-control-character pass. Layering the new behaviour on top of it cannot work: the second pass would eat the `\x1b` byte of every SGR the first pass deliberately kept, leaving a literal `[31m` on screen. So `sanitize_terminal_stream` makes a single `.sub()` over a combined pattern with a keep-SGR callback, and `_SGR_RE` restricts the kept form to 7-bit `ESC [ <digits/;/:> m` — private-mode and intermediate-byte oddities that merely *end* in `m` are still stripped, and 8-bit C1 SGR is stripped because UTF-8 terminals do not honour it anyway.

## Judgment calls (flagging these explicitly)

1. **One addition beyond the spec: a trailing SGR reset.** Preserving SGR means a log that never resets — or that ends mid-style, or opens `\x1b[8m` (conceal) — leaves the *user's* terminal styled for everything they type next. After the replay, the pretty branch writes `\x1b[0m`, gated on an SGR actually being present so an ordinary uncoloured log stays byte-identical to what this line printed before. Two tests pin both halves of that gate. Happy to drop it if reviewers would rather keep the diff strictly to the sanitizer.
2. **Carriage return is preserved by the sanitizer but never reaches it from `comfy logs`.** `read_log_tail` opens the logfile in Python's default universal-newline mode, which normalizes `\r` to `\n` one layer up — so a recorded tqdm progress line is already split before display. That is pre-existing reader behaviour shared with the JSON envelope, so this PR does not change it; the CR-preserving behaviour is covered by unit tests on the helper directly, and the `logs()`-level test asserts what the pretty path actually prints rather than pinning a `\r` the display layer never sees. Worth a separate look if the flattened progress output is considered a bug.
3. **`comfy_cli/output/__init__.py` was not touched.** The package re-exports the renderer and rich-compat symbols but not the sanitize ones, so there was no existing sanitize export pattern to match; callers import from `comfy_cli.output.sanitize` directly, as the existing ones do.
4. **Out of scope by design:** the capture-side relay is untouched — capture stays byte-faithful, display sanitizes.

## Tests

New coverage:
- Unit tests for `sanitize_terminal_stream` in `tests/comfy_cli/output/test_sanitize.py` — SGR (basic, truecolor, colon sub-params, bare reset) survives byte-for-byte; erase/cursor/private-mode/intermediate-byte CSI, terminated and unterminated OSC, DCS/APC, two-char escapes, 8-bit C1 CSI, stray control bytes and a lone trailing ESC are all stripped; tab/newline/CR survive; idempotence; and an explicit regression test for the split-SGR failure the single-pass design exists to prevent.
- Pretty-mode `logs()` tests — OSC title-set (terminated and unterminated), `\x1b[2J`, `\x1b[3A` and 8-bit `\x9b31m` are not replayed; an SGR run survives byte-for-byte; the reset is added only when an SGR is present; tabs/newlines survive; bracketed text (`[INFO]`, `[####  ] 50%`, `[/red]`) survives verbatim and raises nothing.
- JSON-mode test asserting the envelope `lines` are byte-identical to the file with escape bytes present.
- Failure-panel regression test driving `background_launch` with a log containing `[/red]` and `\x1b[2J` — no `MarkupError`, no escape bytes in the output, bracket text visible.

The only existing test adjusted is `test_logs_pretty_writes_raw_lines`: it keeps (and extends) its bracket assertions and no longer implies the output is byte-for-byte identical to the file.

**Verification run:** `ruff check` and `ruff format --check` are clean on every touched file. `pytest` green across `tests/comfy_cli/output` plus every launch/output-adjacent command module (529 passed). The whole-repo `pytest` run is very slow on this machine (~7% in two minutes) and was not run to completion locally — CI runs it on this PR.

**Negative-claim falsification:** not applicable. This change denies no capability — it preserves colour output and adds no throw/deny/dead-end path or "not supported" message; the only user-visible removal is escape sequences the terminal would execute, which is the stated goal.
