### PR TITLE
fix(ops): concrete inputs are LWW registers + op-vocabulary amendment v1.2

### DIFF
--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -346,9 +346,16 @@ def _stamp_key(op: dict) -> list:
 
 
 def _lww_gate(workflow: dict, op: dict) -> bool:
-    """True iff this ``set_widget`` should apply under last-writer-wins. A write
-    to a target already claimed by a higher-or-equal stamp is dropped, making the
-    surviving value independent of apply order."""
+    """True iff this op's write should apply under last-writer-wins. A write to a
+    target already claimed by a higher-or-equal stamp is dropped, making the
+    surviving value independent of apply order.
+
+    Gated targets (``_write_target``): ``set_widget``'s ``("widget", …)``, the
+    connect-embedded ``inputcount`` bump that shares a connect's stamp (§8.4),
+    and — since amendment v1.2 — a concrete connect's ``("input", to_node,
+    to_slot)``. The register store is still spelled ``_widget_stamps`` for
+    on-the-wire compatibility with documents written before v1.2; it holds every
+    gated target, not just widgets."""
     prior = workflow.get("_widget_stamps", {}).get(json.dumps(_write_target(op), default=str))
     return prior is None or _stamp_key(op) > list(prior)
 
@@ -1425,11 +1432,17 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
 
 
 def _apply_add_node(workflow: dict, op: dict) -> None:
+    # Node identity is compared as a STRING everywhere in the apply path
+    # (amendment v1.2): ids are legitimately either JSON type, and an exact
+    # ``==`` made ``7`` and ``"7"`` two different nodes.
     nodes = workflow.setdefault("nodes", [])
-    if any(n.get("id") == op["node_id"] for n in nodes):
+    if any(str(n.get("id")) == str(op["node_id"]) for n in nodes):
         return
     nodes.append(copy.deepcopy(op["node"]))
-    workflow["last_node_id"] = max(workflow.get("last_node_id") or 0, op["node_id"])
+    # last_node_id is a max-register over INT ids only; a string id (subgraph
+    # address, historical workflow) is not comparable and never bumps it.
+    if isinstance(op["node_id"], int) and not isinstance(op["node_id"], bool):
+        workflow["last_node_id"] = max(workflow.get("last_node_id") or 0, op["node_id"])
 
 
 def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
@@ -1453,7 +1466,7 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
         _engine._write_widget(target, op["inner_widget"], op["value"], graph, extend=False)
         _lww_commit(workflow, op)
         return
-    node = _find(workflow, op["node_id"])
+    node = _find_by_str(workflow, op["node_id"])
     if node is None:
         return  # target concurrently deleted => no-op (delete wins).
     from comfy_cli.cql import engine as _engine
@@ -1499,15 +1512,21 @@ def _apply_inputcount_bump(workflow: dict, dst: dict, op: dict, graph, widget: s
 
 
 def _apply_connect(workflow: dict, op: dict, graph) -> None:
-    # Totality: either endpoint concurrently deleted => no-op (delete wins), so a
-    # merge consumer can replay a connect and a delete in either order without a
-    # crash or a dangling link. Resolve both before mutating anything.
-    dst = _find(workflow, op["to_node"])
-    src = _find(workflow, op["from_node"])
-    if dst is None or src is None:
+    # Totality: an endpoint concurrently deleted => no crash and no dangling
+    # link, so a merge consumer can replay a connect and a delete in either
+    # order. Resolve the destination before mutating anything; if it is gone the
+    # target slot does not exist and never will (ids are never reused), so there
+    # is no register to claim and delete simply wins.
+    dst = _find_by_str(workflow, op["to_node"])
+    if dst is None:
         return
     grow = op.get("grow")
     if grow is not None:
+        # Autogrow is NOT a shared register: every grow mints its own slot keyed
+        # by ``grow_id``, so two concurrent grows onto one base both survive and
+        # there is nothing to gate (§1.2 / amendment v1.2's carve-out).
+        if _find_by_str(workflow, op["from_node"]) is None:
+            return
         # Autogrow: grow a concrete slot and wire it. Keyed by ``grow_id`` (the
         # link id) so replay is idempotent AND non-clobbering — a concurrent
         # autogrow that minted the same requested name gets its own fresh slot
@@ -1557,11 +1576,32 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
                 _apply_inputcount_bump(workflow, dst, op, graph, inputcount["widget"], inputcount["value"])
     else:
         to_idx = op["to_slot"]
-        # A concrete input holds at most one link. Replacing it must fully retire
-        # the old link (drop the tuple + scrub the old source's out-links).
+        # --- The concrete-input LWW register (op-vocabulary-v1.md amendment v1.2)
+        #
+        # A concrete input holds at most one link, so "who occupies this slot" is
+        # a SCALAR target — ``("input", to_node, to_slot)`` — resolved by exactly
+        # the ``_lww_gate``/``_lww_commit`` pair ``set_widget`` uses. Without the
+        # gate the occupant was decided by ARRIVAL ORDER, and composed with
+        # delete-wins that produced graphs where a link exists in one
+        # interleaving and not in another (found adversarially against the
+        # TypeScript port: cloud PR #6722, FINDING 1).
+        if not _lww_gate(workflow, op):
+            return
+        # Claiming the register is UNCONDITIONAL once the gate passes: the prior
+        # occupant is retired even if this op then turns out to be a delete-wins
+        # no-op below. Deferring the retirement until the link is known to be
+        # installable would reintroduce order dependence — whether the incumbent
+        # survives would depend on whether the concurrent delete of THIS op's
+        # source had arrived yet.
+        _lww_commit(workflow, op)
         prev = dst["inputs"][to_idx].get("link")
         if prev is not None and prev != op["link_id"]:
             _remove_link(workflow, prev)
+    # Source concurrently deleted => the winning connect leaves the input EMPTY
+    # (delete wins over the link, not over the register claim).
+    src = _find_by_str(workflow, op["from_node"])
+    if src is None:
+        return
     link = [op["link_id"], op["from_node"], op["from_slot"], op["to_node"], to_idx, op["link_type"]]
     links = workflow.setdefault("links", [])
     if not any(ln[0] == op["link_id"] for ln in links):
@@ -1593,10 +1633,14 @@ def _remove_link(workflow: dict, link_id: Any) -> None:
 
 
 def _apply_delete_node(workflow: dict, op: dict) -> None:
-    node_id = op["node_id"]
-    workflow["nodes"] = [n for n in workflow.get("nodes") or [] if n.get("id") != node_id]
+    node_id = str(op["node_id"])  # node identity is compared as a string (amendment v1.2)
+    workflow["nodes"] = [n for n in workflow.get("nodes") or [] if str(n.get("id")) != node_id]
     removed = set(op.get("removed_links") or [])
-    kept = [ln for ln in workflow.get("links") or [] if ln[0] not in removed and ln[1] != node_id and ln[3] != node_id]
+    kept = [
+        ln
+        for ln in workflow.get("links") or []
+        if ln[0] not in removed and str(ln[1]) != node_id and str(ln[3]) != node_id
+    ]
     workflow["links"] = kept
     kept_ids = {ln[0] for ln in kept}
     # Scrub dangling references so no input/output points at a gone link.
@@ -1647,6 +1691,17 @@ def _apply_reset_doc(workflow: dict, op: dict) -> None:
 
 
 def _write_target(op: dict) -> tuple:
+    """The conflict/write target of an op — the LWW register it claims.
+
+    NODE IDS ARE NORMALIZED WITH ``str()`` (amendment v1.2). Node ids are
+    legitimately either JSON type — historical workflows carry string ids and
+    subgraph addresses are strings like ``"57:3"`` — while every lookup path
+    resolves them as strings (``_find_by_str``). Building the target from the
+    raw value gave ``7`` and ``"7"`` two different registers for one node, so
+    ``_lww_gate`` never compared them and the pair converged by apply order
+    (adversarial finding, comfy-multi-player PR #6725). Interior writes already
+    normalized their path; every case now matches.
+    """
     kind = op["op"]
     if kind == "set_widget":
         # Subgraph writes target the resolved interior path so the flat promoted
@@ -1654,17 +1709,17 @@ def _write_target(op: dict) -> tuple:
         # same interior widget share one write target (converge, not clobber).
         if op.get("path"):
             return ("widget", tuple(str(s) for s in op["path"]), op["inner_widget"])
-        return ("widget", op["node_id"], op["widget"])
+        return ("widget", str(op["node_id"]), op["widget"])
     if kind in ("add_node", "delete_node"):
-        return ("node", op["node_id"])
+        return ("node", str(op["node_id"]))
     if kind == "connect":
         grow = op.get("grow")
         if grow is not None:
             # Two autogrow connects onto the same base share a target (their
             # relative order in the batch is the sequence decision the merge
             # consumer must make); distinct bases don't collide.
-            return ("input", op["to_node"], "grow", str(grow["name"]).split(".", 1)[0])
-        return ("input", op["to_node"], op["to_slot"])
+            return ("input", str(op["to_node"]), "grow", str(grow["name"]).split(".", 1)[0])
+        return ("input", str(op["to_node"]), op["to_slot"])
     return (kind,)
 
 

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -84,11 +84,14 @@ and optionally `grow` (autogrow slot descriptor: `{name, type, widget?, inputcou
 
 * Idempotency: `op_id` no-op; a link tuple with an already-present `link_id` is
   not appended twice.
-* Conflict: a concrete input holds at most one link — a connect to an occupied
-  input replaces it and fully retires the prior link (`_remove_link`). Two
-  concurrent connects to the same concrete input are an update-vs-update
-  conflict on that input (section 3). Autogrow connects are non-clobbering:
-  each grows a fresh slot keyed by `grow_id` (the link id), so both survive.
+* Conflict: a concrete input holds at most one link, so its occupant is a
+  **scalar LWW register** on the target `("input", to_node, to_slot)`, resolved
+  by `_stamp_key`/`_lww_gate` exactly like a `set_widget` (section 3, and
+  amendment v1.2 for the full rule). The winning connect retires the prior
+  occupant with `_remove_link`; the losing connect is dropped whole — no link
+  tuple, no out-link entry. Autogrow connects are non-clobbering and therefore
+  **not** gated: each grows a fresh slot keyed by `grow_id` (the link id), so
+  both survive.
 * Invalid: type-mismatched slots are rejected at mint time; a link cannot cross
   a subgraph boundary (rejected with the boundary explanation).
 
@@ -196,10 +199,17 @@ for its target. Higher `base_version` wins; ties break by `actor`, then by the
 unique `op_id` — so no two distinct ops ever compare equal, the order is total,
 and the surviving value is independent of apply order.
 
+Gated targets: the `set_widget` rows, the connect-embedded `inputcount` bump
+(8.4), and — since amendment v1.2 — a concrete `connect`'s
+`("input", to_node, to_slot)`. **Node ids in a target are compared as strings**
+(v1.2): ids are legitimately either JSON type, and comparing them raw gave `7`
+and `"7"` two registers for one node.
+
 | Scenario | Ruling | Where in code |
 |----------|--------|---------------|
 | update vs update (same widget) | LWW on `stamp` with `op_id` tiebreak; loser dropped | `_lww_gate` / `_stamp_key` |
-| update vs delete | **delete wins**: `set_widget` to a deleted node is a no-op; `connect` with either endpoint deleted is a no-op; replay never raises on a since-removed target | `_apply_set_widget` (missing node → return), `_apply_connect` (missing endpoint → return) |
+| **concurrent `connect` to the same concrete input** | LWW on `stamp` with `op_id` tiebreak, target `("input", to_node, to_slot)`; the loser is dropped whole (no link tuple, no out-link entry) and the winner retires the prior occupant. Amendment v1.2 — previously **undefined** and decided by arrival order | `_apply_connect` (concrete branch) / `_lww_gate` |
+| update vs delete | **delete wins**: `set_widget` to a deleted node is a no-op; a `connect` whose destination is gone is a no-op; a `connect` whose SOURCE is gone still claims its input register and leaves that input empty (v1.2 — otherwise the incumbent's survival depends on when the delete arrives); replay never raises on a since-removed target | `_apply_set_widget` (missing node → return), `_apply_connect` (missing endpoint → return) |
 | concurrent moves | no `move` op exists in v1 — positions are decided once at `add_node` mint time and frozen into the op; live position editing is frontend view state, out of scope until the FE stable-ID reconciliation (section 6) | `add_node` / `layout.cascade_pos` |
 | edges referencing deleted nodes | the connect no-ops (delete wins); a delete removes incident links and scrubs every dangling input/output reference, so no dangling edge survives either order | `_apply_connect`, `_apply_delete_node` |
 | duplicate entity creation | impossible by construction across writers (random 53-bit `mint_id`, no shared counter); a replayed `add_node` whose `node_id` already exists is a no-op; a re-sent op is dropped by `op_id` | `mint_id`, `_apply_add_node` |
@@ -474,3 +484,126 @@ kinds are minted for a whole-file replacement.
 
 **No change to §§2-7, 8.1-8.7.** Stamping, LWW, abort-remainder, aliases and
 replication semantics are untouched.
+
+## 11. Amendment v1.2 — 2026-08-12 (concrete-input contention; id-type identity)
+
+Two convergence rules that v1 left undefined, both found by **adversarial
+testing against the TypeScript port of this applier** — not by review. The
+Python `apply_op` and the port agreed with each other in every case below,
+which is what made these contract gaps rather than port bugs.
+
+### 11.1 A concrete input is an LWW register
+
+**The rule.** The occupant of a CONCRETE input slot is a scalar target
+`("input", to_node, to_slot)` under exactly the comparison of §3/§8.1 —
+`[base_version, actor, op_id]`, numeric then code-point, `op_id` breaking
+exact ties. `_apply_connect`'s concrete branch now runs `_lww_gate` /
+`_lww_commit` around its write, the same pair `_apply_set_widget` uses.
+
+**The repro** (writer A and writer B, each keeping its own causal order):
+
+```
+A: [add_node 400, connect 400 -> 200.positive]
+B: [connect 300 -> 200.positive, delete_node 300]
+```
+
+Before v1.2, order A-then-B left `200.positive` EMPTY (B's connect displaced
+A's link by arrival, then B's delete retired B's link) while order B-then-A
+left link 9003 in place. Same op set, two legal interleavings, two different
+graphs: one user sees a wired sampler, the other an unwired one.
+
+**The displaced link.** A concrete input holds at most one link, so exactly one
+link record survives per register:
+
+* the **winning** connect fully retires the prior occupant (`_remove_link`:
+  the link tuple plus the old source's out-link entry). The displaced link is
+  deleted, never orphaned and never re-parented to another slot.
+* the **losing** connect is dropped WHOLE — no link tuple, no out-link entry,
+  no slot write. It still consumes its `op_id` (§2): a dropped write is a
+  protocol-level apply, exactly like a losing `set_widget`.
+
+**Composition with delete-wins.** Claiming the register is unconditional once
+the gate passes, and it happens BEFORE the source endpoint is resolved:
+
+* destination node gone → the slot does not exist and never will (ids are
+  never reused), so there is no register and the op is a plain no-op;
+* source node gone → the winning connect still claims the register and clears
+  the input. Deferring the retirement until the link is known to be
+  installable would reintroduce order dependence: whether the incumbent
+  survives would depend on whether the concurrent delete had arrived yet.
+  "Delete wins" therefore means *the new link does not appear*, not *the
+  previous link is preserved*.
+* a stamp outlives the node it names, which is what makes the composed case
+  converge: a later, lower-stamped connect onto that input is still dropped.
+
+**Autogrow is explicitly NOT gated.** An autogrow connect grows a fresh slot
+keyed by `grow_id`, so two concurrent autogrows onto one base never contend:
+both survive (§1.2). Gating `("input", to_node, "grow", base)` would silently
+discard one writer's connection. That target keeps its §3 role as conflict
+*identity* for `detect_conflict`, not as a gate.
+
+**Alternatives considered and rejected.**
+
+1. *Allow multiple links on one concrete input and let the projection pick.*
+   Rejected: it breaks the graph invariant that a concrete input has at most
+   one link, and every downstream consumer (`convert_ui_to_api`, the executor,
+   the frontend) assumes it. It also just relocates the decision into a
+   projection rule that would itself have to be stamp-ordered.
+2. *Reject the later connect (return an error to the second writer).*
+   Rejected: it breaks "nobody's work is rejected" — a merge consumer replays
+   ops that were already accepted from the writer's point of view, and §4's
+   abort-remainder would then discard the remainder of an innocent batch. LWW
+   drops a write silently and locally; rejection propagates.
+3. *Order by receipt (status quo).* Rejected: that is the finding.
+
+**What v1.2 does NOT close** (filed, tested, unchanged):
+
+* `outputs[].links` is appended in arrival order, so two connects out of ONE
+  source into two DIFFERENT inputs record the same set in two different
+  sequences. No link is lost or invented; closing it means canonicalizing a
+  set-valued field in both implementations' projections.
+* An autogrow connect racing a delete of its source leaves the grown slot
+  present in one order and absent in the other — the structural sibling of the
+  gap above, on a target that is deliberately not a register.
+* Two `add_node` ops with the SAME `node_id` and different payloads resolve
+  first-writer-wins by arrival (`("node", node_id)` is reserved but ungated).
+  §1.1 rules this out by construction — `mint_id` draws 53-bit random ids — so
+  it is a property of hand-authored or replayed streams, not of minted ones.
+
+**Batch caveat, now stated.** `apply_specs` stamps every op in one batch with
+the same `base_version`, so two writes to the SAME target inside one batch are
+decided by the `op_id` tiebreak, not by spec order — "last spec wins" does not
+hold. This has been true of `set_widget` since the freeze; v1.2 extends the
+same property to `connect` and names it rather than leaving it implicit.
+
+### 11.2 Write targets compare node ids as strings
+
+`_write_target` built its key from the raw `node_id` / `to_node` while every
+apply-path lookup resolves ids as strings. An op carrying `7` and one carrying
+`"7"` therefore addressed the same node through two different registers: the
+gate never compared them and the pair converged by arrival order. Node ids are
+legitimately either JSON type — historical workflows carry string ids, and
+subgraph-scoped addresses are strings like `"57:3"` (§6) — so this is legal
+traffic, not malformed input. Interior `set_widget` targets already normalized
+their path (`tuple(str(s) for s in path)`) and were unaffected.
+
+**The rule:** every node id in a write target is normalized with `str()`.
+Equivalently: **node identity is compared as a string throughout the apply
+path.** `_apply_add_node`, `_apply_set_widget`, `_apply_connect` and
+`_apply_delete_node` now resolve nodes by string id (`_find_by_str`) so the
+register key and the node it names can never disagree. `last_node_id` stays a
+max-register over INT ids only — a string id is not comparable and never bumps
+it (§8.3).
+
+This changes the BYTES of a stamp key (`["widget", 7, "steps"]` becomes
+`["widget", "7", "steps"]`). Stamp maps are apply-time bookkeeping stripped
+before serialization (`strip_internal`, §2), and the doc-side `__stamps` map
+lives only inside a live document, so the change is not a data migration; a
+document mid-flight across the upgrade loses prior stamp claims for
+numerically-keyed targets and falls back to first-writer-wins for those
+targets until the next write. Downstream repos that pin this document by SHA
+must move the SHA and their applier pin together.
+
+**No change to §§2, 4-7, 8.1-8.8** beyond the §3 table row and the §1.2
+conflict bullet cited above. No op kind was added, removed, or re-scoped;
+`FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS` are untouched.

--- a/tests/comfy_cli/test_connect_lww.py
+++ b/tests/comfy_cli/test_connect_lww.py
@@ -1,0 +1,620 @@
+"""Concrete-input contention: ``connect`` is a stamp-gated LWW register.
+
+Amendment v1.2 of ``docs/op-vocabulary-v1.md``: the occupant of a CONCRETE
+input slot is a scalar target ``("input", to_node, to_slot)`` resolved by the
+same ``[base_version, actor, op_id]`` last-writer-wins comparison
+(``_stamp_key`` / ``_lww_gate``) that already governs ``set_widget``.
+
+Before the amendment only ``set_widget``-family writes passed through
+``_lww_gate``, so a connect onto an occupied input displaced the occupant by
+ARRIVAL ORDER. Composed with delete-wins that escalated from "a different link
+id" to "a link that exists in one interleaving and not in the other". Found by
+adversarial testing against the TypeScript port of this applier (cloud
+PR #6722, FINDING 1), not by review — ``_apply_connect`` and the port behaved
+identically, which is what made it a contract gap rather than a port bug.
+
+The mirror of these tests lives in comfy-multi-player
+``test/connect-lww.test.ts``; the two suites assert the same outcomes for the
+same op sets so the CLI's local application agrees with the document's.
+"""
+
+from __future__ import annotations
+
+import copy
+import itertools
+import random
+from typing import Any
+
+import pytest
+
+from comfy_cli import workflow_ops as ops
+
+AGENT = "agent:th_8f2c:12"
+HUMAN = "human:u_41ab:tab_2"
+
+SAMPLER = 200
+ENCODER = 300
+OTHER_ENCODER = 310
+FRESH = 400
+#: KSampler input index of ``positive`` — the contested concrete slot.
+POSITIVE = 1
+NEGATIVE = 2
+
+
+# ---------------------------------------------------------------------------
+# fixtures — hand-built graphs and ops, applied with graph=None (the connect
+# path needs a catalog only for autogrow templates / inputcount)
+# ---------------------------------------------------------------------------
+
+
+def _encoder(node_id: int, text: str) -> dict[str, Any]:
+    return {
+        "id": node_id,
+        "type": "CLIPTextEncode",
+        "pos": [40, 60],
+        "inputs": [{"name": "clip", "type": "CLIP", "link": None}],
+        "outputs": [{"name": "CONDITIONING", "type": "CONDITIONING", "links": []}],
+        "widgets_values": [text],
+    }
+
+
+def _sampler() -> dict[str, Any]:
+    return {
+        "id": SAMPLER,
+        "type": "KSampler",
+        "pos": [360, 60],
+        "inputs": [
+            {"name": "model", "type": "MODEL", "link": None},
+            {"name": "positive", "type": "CONDITIONING", "link": None},
+            {"name": "negative", "type": "CONDITIONING", "link": None},
+            {"name": "latent_image", "type": "LATENT", "link": None},
+        ],
+        "outputs": [{"name": "LATENT", "type": "LATENT", "links": []}],
+        "widgets_values": [0, "fixed", 20, 8.0, "euler", "simple", 1.0],
+    }
+
+
+def _base() -> dict[str, Any]:
+    """``200.positive`` is EMPTY — the FINDING's own base."""
+    return {
+        "last_node_id": 400,
+        "last_link_id": 0,
+        "nodes": [_encoder(ENCODER, "the human's prompt"), _sampler()],
+        "links": [],
+        "groups": [],
+    }
+
+
+def _wired_base() -> dict[str, Any]:
+    """``200.positive`` already holds link 9000 from node 310 — the displacement case."""
+    incumbent = _encoder(OTHER_ENCODER, "the incumbent")
+    incumbent["outputs"][0]["links"] = [9000]
+    sampler = _sampler()
+    sampler["inputs"][POSITIVE]["link"] = 9000
+    return {
+        "last_node_id": 400,
+        "last_link_id": 9000,
+        "nodes": [_encoder(ENCODER, "the human's prompt"), incumbent, sampler],
+        "links": [[9000, OTHER_ENCODER, 0, SAMPLER, POSITIVE, "CONDITIONING"]],
+        "groups": [],
+    }
+
+
+def _op_id(tag: str) -> str:
+    """32 lowercase hex (§8.2) — load-bearing: it is the final LWW tiebreak."""
+    return (tag + "0" * 32)[:32]
+
+
+def _connect(
+    tag: str,
+    actor: str,
+    base_version: int,
+    link_id: int,
+    from_node: int,
+    to_node: int = SAMPLER,
+    to_slot: int = POSITIVE,
+) -> dict[str, Any]:
+    return {
+        "op": "connect",
+        "op_id": _op_id(tag),
+        "actor": actor,
+        "base_version": base_version,
+        "stamp": [base_version, actor],
+        "link_id": link_id,
+        "from_node": from_node,
+        "from_slot": 0,
+        "to_node": to_node,
+        "to_slot": to_slot,
+        "link_type": "CONDITIONING",
+    }
+
+
+def _add_encoder(tag: str, actor: str, base_version: int, node_id: int, text: str) -> dict[str, Any]:
+    return {
+        "op": "add_node",
+        "op_id": _op_id(tag),
+        "actor": actor,
+        "base_version": base_version,
+        "stamp": [base_version, actor],
+        "node_id": node_id,
+        "class_type": "CLIPTextEncode",
+        "pos": [40, 300],
+        "node": _encoder(node_id, text),
+    }
+
+
+def _delete(tag: str, actor: str, base_version: int, node_id: int, removed: list[int]) -> dict[str, Any]:
+    return {
+        "op": "delete_node",
+        "op_id": _op_id(tag),
+        "actor": actor,
+        "base_version": base_version,
+        "stamp": [base_version, actor],
+        "node_id": node_id,
+        "removed_links": removed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# permutation harness
+# ---------------------------------------------------------------------------
+
+
+def _interleavings(a: list[dict], b: list[dict]) -> list[list[dict]]:
+    """Every order-preserving interleaving of two causal sequences."""
+    out: list[list[dict]] = []
+    n, m = len(a), len(b)
+    for positions in itertools.combinations(range(n + m), n):
+        order: list[dict] = []
+        ia = ib = 0
+        for k in range(n + m):
+            if k in positions:
+                order.append(a[ia])
+                ia += 1
+            else:
+                order.append(b[ib])
+                ib += 1
+        out.append(order)
+    return out
+
+
+def _comparable(workflow: dict) -> dict:
+    """``canonical`` plus a sort of every ``outputs[].links``.
+
+    SEPARATE KNOWN GAP, deliberately not closed by amendment v1.2: an output
+    port's ``links`` list is appended in ARRIVAL ORDER, so two concurrent
+    connects out of one source node into two DIFFERENT inputs record the same
+    set in two different orders. No link is lost or invented; closing it means
+    canonicalizing a set-valued field in both implementations' projections,
+    which is its own contract change. ``test_known_gap_out_links_order`` keeps
+    it a tested fact; sorting here keeps the register tests measuring the
+    register.
+    """
+    w = ops.canonical(workflow)
+    for node in w.get("nodes") or []:
+        for out in node.get("outputs") or []:
+            if isinstance(out.get("links"), list):
+                out["links"] = sorted(out["links"], key=str)
+    return w
+
+
+def _run(base: dict, order: list[dict]) -> dict:
+    wf = copy.deepcopy(base)
+    for op in order:
+        wf = ops.apply_op(wf, op, None)
+    return wf
+
+
+def _tags(order: list[dict]) -> str:
+    return ",".join(op["op_id"].rstrip("0") for op in order)
+
+
+def _expect_convergent(base: dict, writer_a: list[dict], writer_b: list[dict]) -> dict:
+    """Assert every interleaving converges; return the agreed workflow."""
+    orders = _interleavings(writer_a, writer_b)
+    assert len(orders) > 1
+    want = None
+    agreed = None
+    for order in orders:
+        wf = _run(base, order)
+        got = _comparable(wf)
+        if want is None:
+            want, agreed = got, wf
+            continue
+        assert got == want, f"interleaving [{_tags(order)}] diverged"
+    return agreed
+
+
+def _input_link(wf: dict, node_id: int = SAMPLER, slot: int = POSITIVE) -> Any:
+    node = next(n for n in wf["nodes"] if n["id"] == node_id)
+    return node["inputs"][slot]["link"]
+
+
+def _link_ids(wf: dict) -> list[Any]:
+    return sorted(ln[0] for ln in wf.get("links") or [])
+
+
+# ---------------------------------------------------------------------------
+# 1. the FINDING's own repro
+# ---------------------------------------------------------------------------
+
+
+def _writer_a(base_version: int) -> list[dict]:
+    """Mint a fresh encoder, wire it into 200.positive."""
+    return [
+        _add_encoder("a1", AGENT, base_version, FRESH, "replacement"),
+        _connect("a2", AGENT, base_version, 9003, FRESH),
+    ]
+
+
+def _writer_b(base_version: int) -> list[dict]:
+    """Wire the EXISTING encoder into the same input, then delete it."""
+    return [
+        _connect("b1", HUMAN, base_version, 9004, ENCODER),
+        _delete("b2", HUMAN, base_version, ENCODER, [9004]),
+    ]
+
+
+def test_finding1_repro_agent_holds_the_register():
+    """Order A-then-B used to leave ``positive`` empty while B-then-A left link
+    9003 in place. With the register gate the agent's higher stamp owns the
+    input in all six interleavings and the human's link never lands."""
+    wf = _expect_convergent(_base(), _writer_a(9), _writer_b(5))
+    assert _input_link(wf) == 9003
+    assert _link_ids(wf) == [9003]
+    assert 9004 not in _link_ids(wf)
+
+
+def test_finding1_repro_human_holds_the_register():
+    """The mirror polarity: the human's connect wins the register in every
+    order and its own delete then retires the winning link, so ``positive`` is
+    deterministically EMPTY and neither link survives."""
+    wf = _expect_convergent(_base(), _writer_a(5), _writer_b(9))
+    assert _input_link(wf) is None
+    assert _link_ids(wf) == []
+    assert any(n["id"] == FRESH for n in wf["nodes"])  # the node still exists
+
+
+def test_finding1_repro_tie_breaks_by_actor():
+    """Same base_version: ``agent:...`` < ``human:...`` by code point, so the
+    human wins on actor alone — no op_id tiebreak needed."""
+    wf = _expect_convergent(_base(), _writer_a(5), _writer_b(5))
+    assert _input_link(wf) is None
+    assert _link_ids(wf) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. the register rule stated directly
+# ---------------------------------------------------------------------------
+
+
+def test_higher_stamp_owns_the_input_whichever_connect_arrives_last():
+    agent_connect = _connect("c1", AGENT, 5, 9101, ENCODER)
+    human_add = _add_encoder("c2", HUMAN, 9, FRESH, "rival")
+    human_connect = _connect("c3", HUMAN, 9, 9102, FRESH)
+
+    human_last = _run(_base(), [agent_connect, human_add, human_connect])
+    agent_last = _run(_base(), [human_add, human_connect, agent_connect])
+
+    assert _input_link(human_last) == 9102
+    assert _input_link(agent_last) == 9102
+    assert _comparable(human_last) == _comparable(agent_last)
+    # The losing connect contributes NO link record in either order.
+    assert _link_ids(human_last) == [9102]
+    assert _link_ids(agent_last) == [9102]
+
+
+def test_losing_connect_neither_displaces_nor_leaves_a_link():
+    winner = _connect("d1", HUMAN, 9, 9201, ENCODER)
+    loser = _connect("d2", AGENT, 5, 9202, OTHER_ENCODER)
+    wf = _run(_wired_base(), [winner, loser])
+    assert _input_link(wf) == 9201
+    assert _link_ids(wf) == [9201]
+    # The loser's source output must not advertise a link that does not exist.
+    src = next(n for n in wf["nodes"] if n["id"] == OTHER_ENCODER)
+    assert src["outputs"][0]["links"] == []
+
+
+def test_distinct_inputs_on_one_node_are_independent_registers():
+    a = _connect("e1", AGENT, 5, 9301, ENCODER, to_slot=POSITIVE)
+    b = _connect("e2", HUMAN, 9, 9302, OTHER_ENCODER, to_slot=NEGATIVE)
+    wf = _expect_convergent(_wired_base(), [a], [b])
+    assert _input_link(wf, slot=POSITIVE) == 9301
+    assert _input_link(wf, slot=NEGATIVE) == 9302
+
+
+# ---------------------------------------------------------------------------
+# 3. composition with delete-wins
+# ---------------------------------------------------------------------------
+
+
+def test_winning_connect_with_a_deleted_source_still_clears_the_input():
+    """The second divergence the ungated path carried, independent of
+    two-writer contention: connect-first retired the incumbent and then lost
+    its own link to the delete (input empty), while delete-first made the
+    connect a silent no-op and left the incumbent in place. Claiming the
+    register is now unconditional, so both orders end empty."""
+    writer_a = [_connect("f1", AGENT, 9, 9401, ENCODER)]
+    writer_b = [_delete("f2", HUMAN, 5, ENCODER, [])]
+    wf = _expect_convergent(_wired_base(), writer_a, writer_b)
+    assert _input_link(wf) is None
+    assert _link_ids(wf) == []
+
+
+def test_losing_connect_with_a_deleted_source_leaves_the_winner_untouched():
+    writer_a = [
+        _connect("g1", AGENT, 5, 9501, ENCODER),
+        _delete("g2", AGENT, 5, ENCODER, [9501]),
+    ]
+    writer_b = [_connect("g3", HUMAN, 9, 9502, OTHER_ENCODER)]
+    wf = _expect_convergent(_wired_base(), writer_a, writer_b)
+    assert _input_link(wf) == 9502
+    assert _link_ids(wf) == [9502]
+
+
+def test_deleting_the_destination_wins_over_any_connect():
+    writer_a = [_connect("h1", AGENT, 9, 9601, ENCODER)]
+    writer_b = [_delete("h2", HUMAN, 5, SAMPLER, [9000])]
+    wf = _expect_convergent(_wired_base(), writer_a, writer_b)
+    assert all(n["id"] != SAMPLER for n in wf["nodes"])
+    assert _link_ids(wf) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. autogrow stays UNGATED (the amendment's explicit carve-out)
+# ---------------------------------------------------------------------------
+
+
+def _autogrow_base() -> dict[str, Any]:
+    def loader(node_id: int) -> dict[str, Any]:
+        return {
+            "id": node_id,
+            "type": "LoadImage",
+            "pos": [0, 0],
+            "inputs": [],
+            "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+            "widgets_values": [],
+        }
+
+    return {
+        "last_node_id": 700,
+        "last_link_id": 0,
+        "nodes": [
+            loader(500),
+            loader(510),
+            {
+                "id": 700,
+                "type": "BatchImagesNode",
+                "pos": [0, 0],
+                "inputs": [{"name": "images.image0", "type": "IMAGE", "link": None}],
+                "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+                "widgets_values": [],
+            },
+        ],
+        "links": [],
+        "groups": [],
+    }
+
+
+def _grow_connect(tag: str, actor: str, base_version: int, link_id: int, from_node: int) -> dict[str, Any]:
+    op = _connect(tag, actor, base_version, link_id, from_node, to_node=700, to_slot=None)
+    op["link_type"] = "IMAGE"
+    op["grow"] = {"name": "images.image0", "type": "IMAGE"}
+    return op
+
+
+def test_concurrent_autogrows_are_not_a_shared_register():
+    """Autogrow connects mint their own slot keyed by ``grow_id``, so two
+    writers never contend for one register and BOTH links survive — gating
+    them on ``("input", to_node, "grow", base)`` would silently drop one."""
+    a = _grow_connect("i1", AGENT, 5, 9701, 500)
+    b = _grow_connect("i2", HUMAN, 9, 9702, 510)
+    forward = _run(_autogrow_base(), [a, b])
+    reverse = _run(_autogrow_base(), [b, a])
+    assert _link_ids(forward) == [9701, 9702]
+    assert _link_ids(reverse) == [9701, 9702]
+    assert _comparable(forward) == _comparable(reverse)
+
+
+# ---------------------------------------------------------------------------
+# 5. generated interleavings — breadth over the hand-picked cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", list(range(1, 13)))
+def test_generated_two_writer_streams_converge(seed: int):
+    rng = random.Random(seed)
+    bv_a = rng.choice([3, 5, 7, 9])
+    bv_b = rng.choice([3, 5, 7, 9])
+    src_a = rng.choice([ENCODER, OTHER_ENCODER, FRESH])
+    src_b = rng.choice([ENCODER, OTHER_ENCODER])
+    slot_a = rng.choice([POSITIVE, NEGATIVE])
+    slot_b = rng.choice([POSITIVE, NEGATIVE])
+
+    writer_a = [
+        _add_encoder("j1", AGENT, bv_a, FRESH, "generated"),
+        _connect("j2", AGENT, bv_a, 9801, src_a, to_slot=slot_a),
+    ]
+    writer_b = [_connect("j3", HUMAN, bv_b, 9802, src_b, to_slot=slot_b)]
+    if rng.random() < 0.5:
+        writer_b.append(_delete("j4", HUMAN, bv_b, src_b, [9802]))
+
+    _expect_convergent(_wired_base(), writer_a, writer_b)
+
+
+# ---------------------------------------------------------------------------
+# 6. the caveats, pinned honestly
+# ---------------------------------------------------------------------------
+
+
+def test_same_batch_connects_resolve_by_op_id_not_batch_position():
+    """``apply_specs`` stamps every op in a batch with the SAME base_version,
+    so a same-target pair inside one batch is decided by the op_id tiebreak,
+    not by spec order. Convergence holds — "last spec wins" does not. This has
+    been true of ``set_widget`` since the freeze; amendment v1.2 extends the
+    same property to ``connect`` and says so."""
+    first = _connect("k1", AGENT, 5, 9901, ENCODER)
+    second = _connect("k0", AGENT, 5, 9902, OTHER_ENCODER)
+    wf = _run(_base(), [first, second])
+    # "k0…" < "k1…" by code point, so the FIRST spec wins despite arriving first.
+    assert _input_link(wf) == 9901
+    assert _link_ids(wf) == [9901]
+
+
+def test_known_gap_out_links_order():
+    """KNOWN GAP amendment v1.2 does NOT close: ``outputs[].links`` is appended
+    in arrival order, so two connects out of one source into two DIFFERENT
+    inputs record the same SET in two different sequences. Filed, not fixed:
+    closing it canonicalizes a set-valued projection field in both
+    implementations."""
+    a = _connect("l1", AGENT, 5, 9001, ENCODER, to_slot=POSITIVE)
+    b = _connect("l2", HUMAN, 9, 9002, ENCODER, to_slot=NEGATIVE)
+
+    def out_links(order: list[dict]) -> list[Any]:
+        wf = _run(_base(), order)
+        return next(n for n in wf["nodes"] if n["id"] == ENCODER)["outputs"][0]["links"]
+
+    assert out_links([a, b]) == [9001, 9002]
+    assert out_links([b, a]) == [9002, 9001]
+    # …and the SET is convergent, which is the part v1.2 guarantees.
+    assert sorted(out_links([a, b])) == sorted(out_links([b, a]))
+
+
+def test_known_gap_autogrow_racing_a_delete_of_its_source():
+    """KNOWN GAP amendment v1.2 does NOT close: an autogrow connect grows a
+    STRUCTURAL slot rather than writing a register, so racing a delete of its
+    source leaves the grown slot present in one order and absent in the other.
+    Filed as the autogrow-shaped sibling of FINDING 1."""
+    grow = _grow_connect("m1", AGENT, 5, 9701, 500)
+    delete = _delete("m2", HUMAN, 9, 500, [9701])
+
+    def slots(order: list[dict]) -> list[str]:
+        wf = _run(_autogrow_base(), order)
+        return [i["name"] for i in next(n for n in wf["nodes"] if n["id"] == 700)["inputs"]]
+
+    assert slots([grow, delete]) == ["images.image0", "images.image1"]
+    assert slots([delete, grow]) == ["images.image0"]
+
+
+# ---------------------------------------------------------------------------
+# 7. stamp-target identity is node-id-TYPE independent
+#
+# FINDING (adversarial, comfy-multi-player PR #6725): ``_write_target`` built
+# the register key from the RAW ``node_id`` while every lookup resolves ids as
+# strings, so an op carrying ``7`` and one carrying ``"7"`` addressed the same
+# node through two different registers — ``_lww_gate`` never compared them and
+# the pair converged by apply order. ``NodeId`` is legitimately either JSON
+# type (historical string ids; subgraph addresses like ``"57:3"``), so this is
+# legal traffic, not malformed input. Interior writes already normalized their
+# path and survived the attack; amendment v1.2 makes every case match them.
+# ---------------------------------------------------------------------------
+
+
+def _ksampler_graph():
+    """A one-node catalog whose KSampler widget order matches ``_sampler()``:
+    seed, control_after_generate, steps, cfg, sampler_name, scheduler, denoise.
+    ``set_widget`` needs a graph to resolve widget NAME -> positional index;
+    the connect path does not, which is why the rest of this file passes None."""
+    from comfy_cli.cql.engine import Graph
+
+    return Graph.from_object_info(
+        {
+            "KSampler": {
+                "input": {
+                    "required": {
+                        "model": "MODEL",
+                        "positive": "CONDITIONING",
+                        "negative": "CONDITIONING",
+                        "latent_image": "LATENT",
+                        "seed": ["INT", {"default": 0, "control_after_generate": True}],
+                        "steps": ["INT", {"default": 20}],
+                        "cfg": ["FLOAT", {"default": 8.0}],
+                        "sampler_name": [["euler", "euler_ancestral"]],
+                        "scheduler": [["normal", "karras"]],
+                        "denoise": ["FLOAT", {"default": 1.0}],
+                    }
+                },
+                "input_order": {
+                    "required": [
+                        "model",
+                        "positive",
+                        "negative",
+                        "latent_image",
+                        "seed",
+                        "steps",
+                        "cfg",
+                        "sampler_name",
+                        "scheduler",
+                        "denoise",
+                    ]
+                },
+                "output": ["LATENT"],
+                "output_name": ["LATENT"],
+                "category": "sampling",
+                "display_name": "KSampler",
+                "python_module": "nodes",
+            }
+        }
+    )
+
+
+def _run_with_graph(base: dict, order: list[dict]) -> dict:
+    wf = copy.deepcopy(base)
+    g = _ksampler_graph()
+    for op in order:
+        wf = ops.apply_op(wf, op, g)
+    return wf
+
+
+def _set_steps(tag: str, actor: str, base_version: int, node_id: Any, value: int) -> dict[str, Any]:
+    return {
+        "op": "set_widget",
+        "op_id": _op_id(tag),
+        "actor": actor,
+        "base_version": base_version,
+        "stamp": [base_version, actor],
+        "node_id": node_id,
+        "widget": "steps",
+        "value": value,
+    }
+
+
+def _steps(wf: dict) -> Any:
+    node = next(n for n in wf["nodes"] if str(n["id"]) == str(SAMPLER))
+    # KSampler widget order: seed, control_after_generate, steps, ...
+    return node["widgets_values"][2]
+
+
+def test_write_target_normalizes_node_id_type():
+    assert ops._write_target(_set_steps("n1", AGENT, 5, SAMPLER, 111)) == ops._write_target(
+        _set_steps("n2", HUMAN, 9, str(SAMPLER), 999)
+    )
+    assert ops._write_target(_connect("n3", AGENT, 5, 1, ENCODER, to_node=SAMPLER)) == ops._write_target(
+        _connect("n4", HUMAN, 9, 2, ENCODER, to_node=str(SAMPLER))
+    )
+    assert ops._write_target(_delete("n5", AGENT, 5, SAMPLER, [])) == ops._write_target(
+        _delete("n6", AGENT, 5, str(SAMPLER), [])
+    )
+
+
+def test_set_widget_mixed_id_types_converge():
+    numeric = _set_steps("o1", AGENT, 5, SAMPLER, 111)
+    stringy = _set_steps("o2", HUMAN, 9, str(SAMPLER), 999)
+    assert _steps(_run_with_graph(_base(), [numeric, stringy])) == 999
+    assert _steps(_run_with_graph(_base(), [stringy, numeric])) == 999
+    # …and the lower stamp loses whichever id type it carries.
+    wins = _set_steps("o3", HUMAN, 9, SAMPLER, 111)
+    loses = _set_steps("o4", AGENT, 5, str(SAMPLER), 999)
+    assert _steps(_run_with_graph(_base(), [wins, loses])) == 111
+    assert _steps(_run_with_graph(_base(), [loses, wins])) == 111
+
+
+def test_connect_mixed_to_node_types_share_one_register():
+    numeric = _connect("p1", AGENT, 5, 501, ENCODER, to_node=SAMPLER)
+    stringy = _connect("p2", HUMAN, 9, 502, OTHER_ENCODER, to_node=str(SAMPLER))
+    forward = _run(_wired_base(), [numeric, stringy])
+    reverse = _run(_wired_base(), [stringy, numeric])
+    assert _input_link(forward) == 502
+    assert _input_link(reverse) == 502
+    assert _link_ids(forward) == [502]
+    assert _link_ids(reverse) == [502]


### PR DESCRIPTION
## The finding

**Found by adversarial testing, not by review.** The cloud-side suite (`services/agent/internal/dochost/adversarial_crdt_test.go`, cloud PR #6722, FINDING 1) drives every order-preserving interleaving of two writers' causal sequences through the REAL applier. It caught schema §2.5 claiming a property the code did not have.

Only `set_widget`-family writes were `__stamps`-gated. A `connect` to an already-occupied concrete input displaced the occupant by **arrival order**. Composed with delete-wins, that escalates from "a different link id" to "a link that exists in one interleaving and not in the other":

```
writer A: [add_node 400, connect 400 → 200.positive]
writer B: [connect 300 → 200.positive, delete_node 300]
```

* **A-then-B**: B's connect displaces A's link, then B's delete retires B's link → `200.positive` is **EMPTY**.
* **B-then-A**: A's connect displaces B's link, and the delete of 300 does not touch a link 300 is not an endpoint of → `200.positive` holds **link 9003**.

Both are legal interleavings of two writers who each kept their own causal order. One user sees a wired sampler, the other an unwired one, from the same op set. comfy-cli's `apply_op` behaved identically, so this is a gap in the **op contract**, not a port bug — which is why it is fixed in both implementations and both written contracts in lockstep.

A second finding of the same class (adversarial PR #6725) rides along: `writeTarget` built its key from the RAW `node_id` while the applier resolved nodes with `String(node_id)`, so `7` and `"7"` addressed one node through two registers and converged by arrival order.

## The rule

**The occupant of a concrete input slot is a scalar LWW register on `("input", String(to_node), to_slot)`**, gated by exactly the comparison the vocabulary already pins (§8.1: sequence compare over `[base_version, actor, op_id]`, numeric then Unicode code point, `op_id` breaking exact ties) — the same gate `set_widget` uses.

**What happens to the displaced link.** Exactly one link record survives per register:

* the **winning** connect fully retires the prior occupant (`removeLink`: the link tuple plus the old source's out-link entry). The displaced link is **deleted** — never orphaned, never re-parented to another slot;
* the **losing** connect is dropped **whole** — no link tuple, no slot write, no out-link entry — and still consumes its `op_id`, exactly like a losing `set_widget` (a dropped write is a protocol-level apply, not a rejection).

**Composition with delete-wins.** The register claim is unconditional once the gate passes, and happens BEFORE the source endpoint is resolved:

* destination gone → the slot does not exist and never will (ids are never reused) → plain no-op, no stamp;
* source gone → the winning connect still claims the register and **clears the input**. Deferring the retirement until the link is known installable would reintroduce order dependence: whether the incumbent survives would depend on whether the concurrent delete had arrived yet. "Delete wins" therefore means *the new link does not appear*, not *the previous link is preserved*. This closes a second divergence the ungated path carried, independent of two-writer contention.
* A stamp outlives the node it names — that is what makes the composed case converge, because a later, lower-stamped connect is still dropped.

**Autogrow is explicitly NOT gated.** An autogrow connect grows a fresh slot keyed by `grow_id`, so two concurrent autogrows never contend; both survive (vocabulary §1.2). Gating `("input", to_node, "grow", base)` would silently discard one writer's connection. That target keeps its role as conflict *identity* for `detect_conflict`, not as a gate.

### Alternatives considered and dismissed

1. **Allow multiple links on one concrete input and let projection pick.** Rejected: it breaks the graph invariant that a concrete input has at most one link, which every downstream consumer (`convert_ui_to_api`, the executor, the frontend) assumes. It also merely relocates the decision into a projection rule that would itself have to be stamp-ordered.
2. **Reject the later connect.** Rejected: it breaks "nobody's work is rejected". A merge consumer replays ops already accepted from the writer's point of view, and vocabulary §4's abort-remainder would then discard the remainder of an innocent batch. LWW drops a write silently and locally; rejection propagates.
3. **Order by receipt (status quo).** Rejected: that is the finding.

## Evidence

**CLI:** `pytest tests/comfy_cli/test_connect_lww.py` — **28 passed**. `tests/comfy_cli/test_op_vocabulary_contract.py` (the doc↔code contract test) — **7 passed**, so amendment v1.2 keeps the frozen table in sync. Targeted op suites (`test_workflow_edit.py`, `test_connect_null_output_links.py`, `test_connect_union_types.py`, `test_reset_doc_op.py`, `test_workflow_apply_rollback.py`, `test_templates_fetch_emit_ops.py`, `test_ack_flag.py`) — **137 passed**. Full `tests/comfy_cli` — 4602 passed; the 29 failures (`test_jobs.py`, `test_host_port.py`, `test_onboarding.py`) reproduce identically with `workflow_ops.py` reverted to the base commit, i.e. pre-existing/environmental, not from this change. `ruff check` + `ruff format --check` clean.

**Applier twin** (Comfy-Org/comfy-multi-player#5): `npm run build && npm test && npm run check:purity` — 92 green, plus 4 mutation checks.

`tests/comfy_cli/test_connect_lww.py` mirrors comfy-multi-player's `test/connect-lww.test.ts` **op-for-op**, so the CLI's local application and the document's are asserted to reach the same outcomes for the same op sets: the exact repro in all 6 interleavings at both stamp polarities and on the actor tiebreak; the register rule stated directly; delete-wins composition; autogrow non-clobbering; **12 generated two-writer streams** (seeded RNG); the mixed-type node-id vectors; and pinning tests for the three gaps v1.2 deliberately does NOT close.

Written **RED first**: 13 of the new tests failed against the pre-change `_apply_connect`, 2 more against the pre-change `_write_target`.

## What this does NOT close (filed, tested, unchanged)

Schema §2.5 now names these as carve-outs instead of implying convergence, and each is pinned by a test that starts failing the day it is closed:

1. **`outputs[].links` ordering** — a set projected as an ordered array, appended in arrival order. Two connects out of ONE source into two DIFFERENT inputs project the same set in two sequences. Closing it canonicalizes a set-valued projection field and invalidates recorded fixture finals (several carry unsorted out-links today).
2. **Autogrow racing a delete of its source** — the grown slot is present in one order, absent in the other. The structural sibling of this finding, on a target that is deliberately not a register.
3. **`add_node` id collision** — same `node_id`, different payloads, first-writer-wins by arrival. Vocabulary §1.1 rules this out by construction (`mint_id` draws 53-bit random ids), so it is a property of hand-authored or replayed streams only.

## The amendment

`docs/op-vocabulary-v1.md` gains **§11 — Amendment v1.2** (the doc already carries the v1.1 amendment mechanism from §9), plus two edits to frozen sections it supersedes:

* §1.2's `connect` conflict bullet now states the register, the displaced link, and the autogrow carve-out;
* §3's concurrency-semantics table gains a **`concurrent connect to the same concrete input`** row — no longer undefined — and its update-vs-delete row now distinguishes destination-deleted from source-deleted.

The amendment also states the **batch caveat** that was previously implicit: `apply_specs` stamps every op in one batch with the same `base_version`, so two writes to the same target inside one batch are decided by the `op_id` tiebreak, not by spec order. This has been true of `set_widget` since the freeze; v1.2 extends it to `connect` and names it. Pinned by `test_same_batch_connects_resolve_by_op_id_not_batch_position`.

`tests/comfy_cli/test_op_vocabulary_contract.py` (doc ↔ `FROZEN_OPS` ↔ dispatch tables) stays green: no op kind was added, removed, or re-scoped.

**Compatibility note.** §11.2 changes the BYTES of a stamp key (`["widget", 7, "steps"]` → `["widget", "7", "steps"]`). Stamp maps are apply-time bookkeeping stripped before serialization (`strip_internal`), so this is not a data migration — but a document mid-flight across the upgrade loses prior claims for numerically-keyed targets and falls back to first-writer-wins on those until the next write.

## Cross-repo

* applier — Comfy-Org/comfy-multi-player#5 (schema Amendment A1 cites this doc by SHA `1201b676275ce7e9b5cdb90f135b6e115ba9df10`)
* cloud pin + the flipped adversarial test — Comfy-Org/cloud#6732

Pin order: **applier first** (it is the document's authority), **CLI second**.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
