### PR TITLE
feat(nodes): include is_api_node in `nodes ls` and `nodes search` rows

### DIFF
--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -284,6 +284,9 @@ def ls_cmd(
                 "display_name": m.display_name,
                 "output_types": m.output_types(),
                 "output_node": m.is_output_node,
+                # Paid partner-API node vs free open-weights node. JSON only —
+                # the pretty table is deliberately left unchanged.
+                "is_api_node": m.is_api_node,
             }
             for m in nodes
         ],
@@ -553,6 +556,10 @@ def search_cmd(
                 "display_name": m.display_name,
                 "description": m.description,
                 "output_types": m.output_types(),
+                # Paid partner-API node vs free open-weights node — two nodes can
+                # share a display name and differ only here (MiniMax H3). JSON
+                # only; the pretty table is deliberately left unchanged.
+                "is_api_node": m.is_api_node,
                 **({"close_match": True} if close_match else {}),
             }
             for m in matched

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -350,6 +350,11 @@ comfy --json nodes ls --produces VIDEO --exclude-deprecated --limit 10
 comfy --json nodes ls --pack core --produces MASK --limit 5
 ```
 
+Every `nodes ls` and `nodes search` row carries `is_api_node` — `true` for a paid
+partner-API node, `false` for a free open-weights one. Two nodes can share a
+display name and differ only in this flag, so read it off the row instead of
+running `nodes show` per candidate.
+
 If no local server is running and you're not signed into cloud, pass
 `--input <object_info.json>` to query against a saved dump.
 

--- a/tests/comfy_cli/command/test_nodes_introspect.py
+++ b/tests/comfy_cli/command/test_nodes_introspect.py
@@ -458,6 +458,87 @@ class TestSearch:
         assert "KSampler" in [r["name"] for r in env["data"]["rows"]]
 
 
+class TestIsApiNodeRows:
+    """`is_api_node` on `nodes ls` / `nodes search` rows.
+
+    The twin-family trap: a paid partner-API node and a free open-weights one can
+    carry the same display name, so an agent picking off a search row needs the
+    flag inline rather than a follow-up `nodes show` per candidate.
+    """
+
+    @pytest.fixture
+    def patched_loader(self, monkeypatch: pytest.MonkeyPatch):
+        from comfy_cli.cql.engine import Graph
+
+        info = {
+            # Paid partner-API twin: object_info carries `api_node: true`.
+            "MinimaxHailuo03ReferenceNode": {
+                "input": {"required": {}},
+                "output": ["VIDEO"],
+                "output_name": ["VIDEO"],
+                "category": "partner/video",
+                "display_name": "MiniMax H3 Reference to Video",
+                "description": "Generate video from a reference image.",
+                "output_node": False,
+                "api_node": True,
+                "python_module": "comfy_api_nodes",
+            },
+            # Free open-weights twin: no `api_node` key at all.
+            "MiniMaxH3ReferenceToVideo": {
+                "input": {"required": {}},
+                "output": ["VIDEO"],
+                "output_name": ["VIDEO"],
+                "category": "video",
+                "display_name": "MiniMax H3 Reference to Video",
+                "description": "Generate video from a reference image.",
+                "output_node": False,
+                "python_module": "nodes",
+            },
+        }
+        graph = Graph.from_object_info(info)
+        monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: graph)
+
+    def test_ls_rows_carry_the_flag(self, patched_loader, capsys):
+        env = _run(["ls"], capsys)
+        flags = {r["name"]: r["is_api_node"] for r in env["data"]["rows"]}
+        assert flags == {
+            "MinimaxHailuo03ReferenceNode": True,
+            "MiniMaxH3ReferenceToVideo": False,
+        }
+
+    def test_search_rows_carry_the_flag(self, patched_loader, capsys):
+        """Both twins match the same query and are told apart only by the flag."""
+        env = _run(["search", "MiniMax H3 Reference to Video"], capsys)
+        flags = {r["name"]: r["is_api_node"] for r in env["data"]["rows"]}
+        assert flags == {
+            "MinimaxHailuo03ReferenceNode": True,
+            "MiniMaxH3ReferenceToVideo": False,
+        }
+
+    def test_missing_api_node_key_is_false_not_absent(self, patched_loader, capsys):
+        """A node whose object_info entry omits `api_node` reports `false`; a
+        caller must never have to distinguish "free" from "field missing"."""
+        for args in (["ls"], ["search", "MiniMaxH3ReferenceToVideo"]):
+            env = _run(args, capsys)
+            row = next(r for r in env["data"]["rows"] if r["name"] == "MiniMaxH3ReferenceToVideo")
+            assert row["is_api_node"] is False
+
+    def test_close_match_fallback_rows_carry_the_flag(self, patched_loader, capsys):
+        """The typo path builds its rows from the same projection, so the flag
+        must survive there too."""
+        env = _run(["search", "MinimaxHailou03ReferenceNode"], capsys)
+        rows = env["data"]["rows"]
+        assert rows and all(r["close_match"] is True for r in rows)
+        assert next(r for r in rows if r["name"] == "MinimaxHailuo03ReferenceNode")["is_api_node"] is True
+
+    def test_api_only_filter_is_unchanged(self, patched_loader, capsys):
+        """Additive change: `--api-only` still selects exactly the API nodes."""
+        env = _run(["ls", "--api-only"], capsys)
+        rows = env["data"]["rows"]
+        assert [r["name"] for r in rows] == ["MinimaxHailuo03ReferenceNode"]
+        assert rows[0]["is_api_node"] is True
+
+
 class TestPath:
     """`comfy nodes path` — the envelope an agent plans a graph off (BE-6857)."""
 


### PR DESCRIPTION
## ELI-5

Some ComfyUI nodes are free (they run open weights locally); others are paid partner-API nodes that call an external provider and cost money. `comfy nodes show` already tells you which is which, but `comfy nodes ls` and `comfy nodes search` did not — so an agent scanning search results had to run a second `nodes show` call per candidate just to find out whether picking a node would spend money. This adds one boolean, `is_api_node`, to every `ls` and `search` row so the answer is right there in the result you already have.

## What changed

- `comfy_cli/command/nodes.py` — `"is_api_node": m.is_api_node` added to the row dict in `ls_cmd` and in `search_cmd`. The value comes from `Morphism.is_api_node`, which the CQL engine already parses out of object_info's `api_node` flag and already emits from `morphism_to_dict` (what `nodes show` renders).
- `comfy_cli/skills/comfy/SKILL.md` — a short note in the Nodes section telling agents the flag is on the row, so they stop doing a `nodes show` per candidate. No existing doc enumerated the row field list, so there was nothing else to update.
- `tests/comfy_cli/command/test_nodes_introspect.py` — a new `TestIsApiNodeRows` class following the file's existing fake-`object_info` fixture pattern.

**JSON only.** The pretty rich tables in `ls` and `search` are untouched — no new column — so interactive terminal output is byte-for-byte what it was. The JSON payload is what scripts and MCP wrappers consume, and that is where the field lands.

**Additive only.** No row field is renamed or removed. The close-match ("did you mean…") fallback rows carry the field too, since they are built from the same projection. `--api-only` on `ls` is unchanged — it already filtered on this same model field, and a test now pins that.

`comfy_cli/schemas/nodes.json` types `rows` as a bare array with no per-item schema, so no schema change was required.

## Why the flag matters

Two node classes can share a display name and differ only in whether they are paid. The known case is a partner-API "MiniMax H3 Reference to Video" node and a free open-weights node with the identical display name — indistinguishable in a search row before this change. The new tests model exactly that pair: same `display_name`, one entry with `api_node: true`, one with the key absent entirely.

## Verification

Lint/format with the CI-pinned ruff (`ruff==0.15.15`, per `.github/workflows/ruff_check.yml`): `ruff check .` → all checks passed; `ruff format --diff .` → 283 files already formatted. (Heads-up for anyone reproducing locally: an older ruff in a stale venv reports 19 pre-existing findings in files this PR does not touch — use the pinned version.)

Targeted tests green — `tests/comfy_cli/command/test_nodes_introspect.py`, `test_nodes_cli.py`, `tests/comfy_cli/cql/`, `test_pretty_print_sanitize.py`: **412 passed**. New coverage: the flag on `ls` rows, on `search` rows, `false` (not missing) when object_info omits `api_node`, the flag surviving the close-match fallback path, and `--api-only` still selecting exactly the API nodes.

Beyond the hand-rolled fixtures, I ran the shipped commands end-to-end against a **real captured object_info** already in the repo (`tests/comfy_cli/fixtures/nodes_path_object_info.json`, which contains a genuine partner node, `ByteDanceImageNode` with `api_node: true`):

- `nodes ls --input …` → `ByteDanceImageNode` `is_api_node: true`; the other 11 nodes `false`.
- `nodes search ByteDance --input …` and `nodes search image --input …` → same, correct per row.
- `nodes search BiteDanceImageNode --input …` (typo → close-match fallback) → row carries both `close_match: true` and `is_api_node: true`.

**Full-suite caveat:** the repo's whole `pytest` run exceeded the time budget I had for this change and was still going when I opened this PR, so I am not claiming it green from a local run — CI is the gate on that. Everything I did run is reported above.

## Unexercised artifacts / judgment calls

- **The two specific node classes** that motivated this (`MinimaxHailuo03ReferenceNode` and its free twin `MiniMaxH3ReferenceToVideo`) were **not** exercised by name: neither appears in any object_info fixture or bundled catalog in this repo, and I had no live ComfyUI instance with partner-API nodes loaded to query. What I verified instead is the mechanism they exemplify — a real partner-API node from a real captured object_info (above), plus a fixture pair reproducing their exact shape (shared display name, one `api_node: true`, one with the key absent). Anyone with a live catalog can confirm in one call: `comfy --json nodes search "MiniMax H3 Reference to Video"` and read `is_api_node` off the two rows.
- **`nodes upstream` / `nodes downstream` rows still omit the flag.** Those projections were deliberately out of scope here; this PR changes only `ls` and `search`. Worth a separate look if agents plan graphs off those rows.
- The SKILL.md paragraph is a small addition beyond the letter of the request (no existing docstring or help text enumerated the row fields, so there was no field list to update). It seemed strictly better than shipping a field no agent-facing doc mentions — easy to drop if you'd rather keep the doc untouched.
- No spend/consent code path is touched anywhere in this diff.
