### PR TITLE
fix(utils): apply the stdlib data filter on both tarball extraction paths

### DIFF
--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -169,31 +169,47 @@ def extract_tarball(
     shutil.rmtree(extractPath, ignore_errors=True)
     shutil.rmtree(outPath, ignore_errors=True)
 
+    # Both extraction paths below use the stdlib "data" filter so a member with an
+    # absolute path or a `../` traversal is rejected instead of being written
+    # wherever it points (CVE-2007-4559).
+    #
+    # This used to be skipped because of https://github.com/python/cpython/issues/107845,
+    # where data_filter resolved symlink targets against the destination root rather
+    # than against the directory holding the link, and so falsely raised
+    # LinkOutsideDestinationError on valid archives. That was a false-rejection bug,
+    # never an escape, and it was fixed in 3.10.13 / 3.11.5 / 3.12.0rc2 (2023-08-24).
+    # The only affected releases in our range are 3.10.12 and 3.11.4 — and since
+    # `extractall(filter=...)` does not exist before 3.10.12 at all, that is the whole
+    # window. On those two, the worst case is a loud error rather than a silent escape.
     if not show_progress:
         with tarfile.open(inPath) as tar:
-            tar.extractall(filter=None)
+            tar.extractall(filter="data")
         shutil.move(extractPath, outPath)
         return
 
     fileSize = inPath.stat().st_size
 
-    _size = 0
-
     with _tarball_progress("extracting tarball...", fileSize) as (barProg, barTask, pathProg, pathTask):
 
-        def _filter(tinfo: tarfile.TarInfo, _path: PathLike):
-            nonlocal _size
-            pathProg.update(pathTask, description=tinfo.path)
-            barProg.advance(barTask, _size)
-            _size = tinfo.size
+        def _reporting_members(tar: tarfile.TarFile):
+            """Yield every member, driving the progress bars as we go.
 
-            # TODO: ideally we'd use data_filter here, but it's busted: https://github.com/python/cpython/issues/107845
-            # return tarfile.data_filter(tinfo, _path)
-            return tinfo
+            Progress reporting used to ride on the ``filter`` argument, which
+            meant the extraction filter had to be a custom callable that
+            returned members unmodified — silently disabling the CVE-2007-4559
+            checks. The two concerns are separable: ``members`` drives the UI
+            and ``filter`` stays the stdlib ``"data"`` filter.
+            """
+            size = 0
+            for tinfo in tar:
+                pathProg.update(pathTask, description=tinfo.path)
+                barProg.advance(barTask, size)
+                size = tinfo.size
+                yield tinfo
+            barProg.advance(barTask, size)
 
         with tarfile.open(inPath) as tar:
-            tar.extractall(filter=_filter)
-        barProg.advance(barTask, _size)
+            tar.extractall(members=_reporting_members(tar), filter="data")
         pathProg.update(pathTask, description="")
 
     shutil.move(extractPath, outPath)

--- a/tests/comfy_cli/test_utils.py
+++ b/tests/comfy_cli/test_utils.py
@@ -1,4 +1,5 @@
 import io
+import tarfile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -82,3 +83,79 @@ class TestTarballRoundTrip:
 
         assert (dest / "hello.txt").read_text() == "hello world"
         assert (dest / "sub" / "nested.txt").read_text() == "nested content"
+
+
+def _write_member(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+    tinfo = tarfile.TarInfo(name)
+    tinfo.size = len(data)
+    tar.addfile(tinfo, io.BytesIO(data))
+
+
+def _write_symlink(tar: tarfile.TarFile, name: str, target: str) -> None:
+    tinfo = tarfile.TarInfo(name)
+    tinfo.type = tarfile.SYMTYPE
+    tinfo.linkname = target
+    tar.addfile(tinfo)
+
+
+class TestExtractTarballFiltering:
+    """Regression tests for CVE-2007-4559 (see issue #725).
+
+    ``extract_tarball`` extracts into the current working directory, so a member
+    named ``../evil.txt`` lands one level above it unless the stdlib ``data``
+    filter rejects the archive.
+    """
+
+    @staticmethod
+    def _traversal_tarball(workdir):
+        tarball = workdir / "payload.tgz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _write_member(tar, "payload/keep.txt", b"benign")
+            _write_member(tar, "../evil.txt", b"pwned")
+        return tarball
+
+    @pytest.mark.parametrize("show_progress", [False, True])
+    def test_rejects_path_traversal_member(self, tmp_path, monkeypatch, show_progress):
+        """Both extraction paths must refuse to write outside the destination."""
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+
+        tarball = self._traversal_tarball(workdir)
+        escaped = tmp_path / "evil.txt"
+
+        rejection = None
+        with patch("comfy_cli.utils.Live"):
+            try:
+                extract_tarball(tarball, workdir / "out", show_progress=show_progress)
+            except tarfile.FilterError as exc:
+                rejection = exc
+
+        assert not escaped.exists(), f"traversal member escaped the extraction directory: {escaped}"
+        assert rejection is not None, "the traversal member was extracted instead of being rejected"
+
+    @pytest.mark.parametrize("show_progress", [False, True])
+    def test_allows_internal_symlinks(self, tmp_path, monkeypatch, show_progress):
+        """Control: the filter must not reject the layout real payloads use.
+
+        python-build-standalone tarballs (the only thing ``StandalonePython``
+        extracts) are full of relative symlinks such as ``bin/python3 ->
+        python3.12``. Those stay inside the destination and must survive.
+        """
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        monkeypatch.chdir(workdir)
+
+        tarball = workdir / "python.tgz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _write_member(tar, "python/bin/python3.12", b"#!/bin/sh\n")
+            _write_symlink(tar, "python/bin/python3", "python3.12")
+            _write_symlink(tar, "python/bin/python", "python3")
+
+        dest = workdir / "out"
+        with patch("comfy_cli.utils.Live"):
+            extract_tarball(tarball, dest, show_progress=show_progress)
+
+        assert (dest / "bin" / "python3.12").read_bytes() == b"#!/bin/sh\n"
+        assert (dest / "bin" / "python3").is_symlink()
+        assert (dest / "bin" / "python").is_symlink()


### PR DESCRIPTION
Closes #725

## The problem

`extract_tarball()` bypassed Python's tarball extraction filter on **both** of its paths:

- non-progress path: `tar.extractall(filter=None)`
- progress path: a custom `_filter` that updated the progress bar and then `return tinfo` unmodified

So a member named `../evil.txt` or `/etc/evil` was written wherever it pointed — the CVE-2007-4559 class. It is reachable from caller-supplied input: `StandalonePython.FromTarball(fpath)` takes an arbitrary path, and `FromDistro()` downloads from a configurable `asset_url_prefix`.

## The crux: is cpython#107845 still a problem?

The filter was disabled deliberately, not by accident. The code carried:

```python
# TODO: ideally we'd use data_filter here, but it's busted: https://github.com/python/cpython/issues/107845
```

That TODO is now stale. What the bug actually was:

`data_filter` resolved a **symlink's** target against the destination root rather than against the directory containing the link. `TarInfo.linkname` is relative to the link's own directory for symlinks but relative to the archive root for hardlinks, and PEP 706's original implementation used the hardlink rule for both. Result: `LinkOutsideDestinationError` raised on perfectly valid archives.

Two things follow, and both matter here:

1. **It was a false-rejection bug, never an escape.** The buggy target was `realpath(dest/linkname)`; the correct one is `realpath(dest/dirname(name)/linkname)`. `dirname(name)` is always inside `dest` (the member name itself is checked earlier), so the buggy computation starts strictly shallower and can only reject *more* than the correct one — never accept a link that actually escapes. Upstream carries no security label and no CVE; the NEWS entry says it "will no longer **reject some valid** tarballs".
2. **It is fixed on every version we support.** Fixed by [cpython#107846](https://github.com/python/cpython/pull/107846) and backported to every live branch, all released 2023-08-24:

| Branch | First fixed release |
| --- | --- |
| 3.10 | **3.10.13** |
| 3.11 | **3.11.5** |
| 3.12 | **3.12.0rc2** → all 3.12.x finals are clean |
| 3.13+ | clean from 3.13.0a1 |

The affected set was exactly the releases that *introduced* the filter: 3.8.17, 3.9.17, 3.10.12, 3.11.4, plus 3.12.0b1–rc1.

`requires-python = ">=3.10"`, and CI runs 3.10 (pytest/build) and 3.12 (mac/windows/GPU). Intersecting that with the affected set leaves exactly **3.10.12 and 3.11.4** — two patch releases superseded three years ago. And since `extractall(filter=...)` does not exist *at all* before 3.10.12, the existing code already could not run below that line, so that two-release window is the entire residual exposure. On those two the worst case is a loud `LinkOutsideDestinationError`, not a silent escape — it fails closed.

So: **use `data_filter` directly, no version gate.** The `pypa/build`-style version gate is the wrong trade here, because its fallback branch reverts to *unfiltered* extraction on precisely those versions — reintroducing the hole this PR closes, to dodge a bug that only ever produced a loud error.

## The fix

The progress bar and the safety decision were conflated in one callback. They are separable concerns:

- non-progress path → `tar.extractall(filter="data")`
- progress path → `tar.extractall(members=_reporting_members(tar), filter="data")`, where the generator drives the two progress bars while yielding members

`members` drives the UI; `filter` stays the literal `"data"` filter. Using the string literal rather than `filter=tarfile.data_filter` also clears ruff's `S202` — `ruff check --select S202 comfy_cli` now passes clean across the package, which the callable form would not have.

## Tests

`TestExtractTarballFiltering` in `tests/comfy_cli/test_utils.py`, parametrised over both `show_progress` values so neither path can regress. The malicious tarball is built in-test; no binary fixture.

- `test_rejects_path_traversal_member` — a tarball carrying `../evil.txt` must not write outside the extraction directory, and must be rejected.
- `test_allows_internal_symlinks` — the control. python-build-standalone tarballs (the only thing `StandalonePython` extracts) are full of relative symlinks like `bin/python3 -> python3.12`. Those stay inside the destination and must still extract. This is the case cpython#107845 would have broken.

Verified the regression test genuinely fails against the unfixed code, on both paths:

```
FAILED tests/comfy_cli/test_utils.py::TestExtractTarballFiltering::test_rejects_path_traversal_member[False]
FAILED tests/comfy_cli/test_utils.py::TestExtractTarballFiltering::test_rejects_path_traversal_member[True]

E  AssertionError: traversal member escaped the extraction directory:
E    /tmp/pytest-of-c_byrne/pytest-76/test_rejects_path_traversal_me1/evil.txt
E  assert not True
```

With the fix, `tests/comfy_cli/test_utils.py` is 8 passed, and `tests/comfy_cli/test_standalone.py` (the caller) is 11 passed / 3 skipped.

## Notes for the reviewer

- **#511 also touches `comfy_cli/utils.py`**, but only to make `requests` a lazy import inside `download_url`. It does not touch `extract_tarball`, so these should not conflict.
- Scope note: `filter="data"` is not an absolute guarantee on an unpatched interpreter — there is a separate, later cluster of filter-bypass bugs ([cpython#135034](https://github.com/python/cpython/issues/135034), CVE-2025-4517 / 4330 / 4138 / 4435, fixed June 2025). That is an argument for keeping interpreters current, not against this change: filtered extraction is strictly better than the `filter=None` it replaces.
