### PR TITLE
fix(distribution): make a scanned definition buildable

### DIFF
--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -1160,13 +1160,19 @@ def _create_execute(
         if checked is not None:
             # A pack it could not vouch for is absent from what it returns, and
             # an image quietly missing a pack is worse than a refused create.
-            kept = {n.get("name") for n in checked}
+            # Matched case-insensitively: the importer derives a pack's folder by
+            # lowercasing, so a name it chose to normalise must not read as a pack
+            # it dropped, which would refuse a create the builder was happy with.
+            def _key(name):
+                return (name or "").strip().casefold()
+
+            kept = {_key(n.get("name")) for n in checked}
             # A collision is the importer resolving a conflict the cut would refuse
             # outright, so its definition is the buildable one and stopping would
             # help nobody. Every other absence means the user asked for something
             # that does not exist, which only they can fix.
-            colliding = set(imported_report.get("collidingNodes") or [])
-            missing = [n for n in declared if n not in kept and n not in colliding]
+            colliding = {_key(n) for n in imported_report.get("collidingNodes") or []}
+            missing = [n for n in declared if _key(n) not in kept and _key(n) not in colliding]
             if missing:
                 renderer.error(
                     code="distribution_registry_pin_missing",

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -9,10 +9,11 @@ POC scope: ``scan`` inspects a local ComfyUI install and emits a builder-ready
   gap: a workflow only carries a bare model name (path stripped, no hash), but a
   build needs the placement folder, filename, and a content hash to fetch and
   verify the right file.
-- **custom nodes** — walk ``custom_nodes/`` and record each node's git
-  ``repository`` + commit ``gitRef`` (the builder fetches ``repo@ref``). Nodes
-  with no fetchable upstream are marked ``source: local`` — they must be uploaded
-  as a blob.
+- **custom nodes** — walk ``custom_nodes/`` and record each node's most precise
+  source: a git ``repository`` + commit ``gitRef`` (the builder fetches
+  ``repo@ref``), else the ``id`` + ``registryVersion`` its ``pyproject.toml``
+  declares (the builder fetches the published artifact). Nodes with neither are
+  marked ``source: local`` — they must be uploaded as a blob.
 
 The scan runs entirely on the user's machine — the one place the real files and
 node checkouts exist — and is the agreed compatibility shim for users who won't
@@ -36,6 +37,8 @@ from pathlib import Path
 from typing import Annotated
 
 import requests
+import tomlkit
+import tomlkit.exceptions
 import typer
 
 from comfy_cli import tracking
@@ -175,15 +178,47 @@ def _git_output(repo_path: Path, *args: str) -> str | None:
     return result.stdout.strip() or None
 
 
+def read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
+    """Return ``(registry id, version)`` from a pack's ``pyproject.toml``, or None.
+
+    A pack installed by ``comfy node install`` comes from the Comfy Registry as an
+    archive, so it has no git history at all — but its ``pyproject.toml`` still
+    carries the two fields that name the published version the builder can fetch:
+    ``project.name`` is the registry node id and ``project.version`` its package
+    version. Silent on every failure (absent, unreadable, malformed, missing
+    either field): a pack that cannot answer simply has no registry pin."""
+    try:
+        with open(node_dir / "pyproject.toml", encoding="utf-8-sig") as f:
+            data = tomlkit.load(f)
+    except (OSError, UnicodeDecodeError, tomlkit.exceptions.TOMLKitError):
+        return None
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return None
+    node_id = project.get("name")
+    version = project.get("version")
+    if not isinstance(node_id, str) or not isinstance(version, str):
+        return None
+    node_id, version = node_id.strip(), version.strip()
+    return (node_id, version) if node_id and version else None
+
+
 def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
     """Return one definition entry per custom-node directory, sorted by name.
 
-    Each top-level directory under ``custom_nodes/`` is one node. For a git
-    checkout we record its ``repository`` (origin remote) and ``gitRef`` (HEAD
-    commit) so the builder can fetch ``repo@ref`` reproducibly. A directory that
-    is not a git checkout, or has no fetchable origin, is marked ``source:
-    local`` — it has no upstream and must be uploaded as a blob. Returns an empty
-    list when the folder is absent (a workflow may use no custom nodes)."""
+    Each top-level directory under ``custom_nodes/`` is one node, recorded as the
+    most precise source the builder can rebuild it from:
+
+    - a git checkout with a fetchable origin → ``repository`` + ``gitRef`` (HEAD),
+      which pins an exact commit;
+    - otherwise a published registry version → ``id`` + ``registryVersion`` read
+      from its ``pyproject.toml``, which pins an exact artifact. This is the case
+      for everything ``comfy node install`` writes, since it unpacks archives
+      rather than cloning;
+    - otherwise ``source: local`` — no upstream, so it must be uploaded as a blob.
+
+    Returns an empty list when the folder is absent (a workflow may use no custom
+    nodes)."""
     nodes: list[dict] = []
     if not custom_nodes_root.is_dir():
         return nodes
@@ -195,17 +230,17 @@ def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
         is_git = (entry / ".git").exists()
         repository = _git_output(entry, "remote", "get-url", "origin") if is_git else None
         git_ref = _git_output(entry, "rev-parse", "HEAD") if is_git else None
-        nodes.append(
-            {
-                "name": entry.name,
-                "repository": repository,
-                "gitRef": git_ref,
-                # Fetchable only when we have BOTH a remote and a pinned commit;
-                # a local-only or detached checkout can't be reconstructed from
-                # a repo@ref, so it must be uploaded.
-                "source": "git" if (repository and git_ref) else "local",
-            }
-        )
+        node: dict = {"name": entry.name, "repository": repository, "gitRef": git_ref}
+        if repository and git_ref:
+            node["source"] = "git"
+        else:
+            pin = read_registry_pin(entry)
+            if pin:
+                node["id"], node["registryVersion"] = pin
+                node["source"] = "registry"
+            else:
+                node["source"] = "local"
+        nodes.append(node)
     return nodes
 
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -1577,7 +1577,7 @@ def from_snapshot_cmd(
     renderer.emit(result, command="distribution from-snapshot", changed=True)
 
 
-@app.command("blob-upload", help="Upload a private file and print the blobId a definition can reference.")
+@blob_app.command("upload", help="Upload a private file and print the blobId a definition can reference.")
 @tracking.track_command("distribution")
 def blob_upload_cmd(
     path: Annotated[str, typer.Argument(help="File to upload.")],
@@ -1608,26 +1608,14 @@ def blob_upload_cmd(
     _builder_call(renderer, lambda: client.upload_blob(upload_url, file_path))
     if renderer.is_pretty():
         renderer.success(f"Uploaded {file_path.name} as {blob_id}")
-        renderer.info(f'reference it in a definition as "blobId": "{blob_id}", then `comfy distribution update`')
+        # A model entry needs the hash as well as the id, and the cut refuses one
+        # that is not a real sha256, so both are printed rather than just the id.
+        renderer.info(f'reference it as "blobId": "{blob_id}", "sha256": "{sha256}"')
     renderer.emit(
         {"blobId": blob_id, "kind": kind, "filename": file_path.name, "sha256": sha256, "sizeBytes": size_bytes},
-        command="distribution blob-upload",
+        command="distribution blob upload",
         changed=True,
     )
-
-
-@app.command("blobs", help="List the workspace's uploaded private files.")
-@tracking.track_command("distribution")
-def blobs_cmd(
-    kind: Annotated[str | None, typer.Option("--kind", help="Filter by kind: model or node_zip.")] = None,
-    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
-):
-    renderer = get_renderer()
-    client = _builder_client(renderer, builder_url)
-    blobs = _builder_call(renderer, lambda: client.list_blobs(kind))
-    if renderer.is_pretty():
-        renderer.console().print_json(json.dumps(blobs))
-    renderer.emit({"blobs": blobs}, command="distribution blobs")
 
 
 @app.command("resolve", help="Resolve model filenames to public download candidates (HF/CivitAI).")

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -46,6 +46,7 @@ from comfy_cli._safe_exec import BinaryNotFoundError, resolve_required_binary
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH, SUPPORTED_PT_EXTENSIONS
 from comfy_cli.file_utils import atomic_write_text
 from comfy_cli.output import get_renderer
+from comfy_cli.registry import NodeFetchError, RegistryAPI
 from comfy_cli.workspace_manager import WorkspaceManager
 
 app = typer.Typer(
@@ -444,6 +445,49 @@ def resolve_model_source(model: dict) -> str | None:
     call, so ``plan_create`` stays offline and testable. Injectable, so tests can
     still substitute a fake resolver."""
     return model.get("sourceUri")
+
+
+def registry_knows(api, node_id: str) -> bool | None:
+    """Whether the Comfy Registry has a node under ``node_id``.
+
+    True / False on a definite answer, None when the registry could not be asked
+    (transport, timeout, 5xx). Uses the read-only node endpoint rather than the
+    install one, which records an installation and fires an analytics event on
+    every call — a verification must not look like a install."""
+    try:
+        api.get_node(node_id)
+        return True
+    except NodeFetchError as e:
+        return False if e.status_code == 404 else None
+    except (requests.RequestException, KeyError, ValueError):
+        return None
+
+
+def repair_registry_ids(nodes: list[dict], api) -> list[tuple[str, str]]:
+    """Point a registry-pinned node at an id the registry actually has.
+
+    A pack published from a pull-request preview carries that preview's id in its
+    ``pyproject.toml`` (``pr-was-node-suite-comfyui-47064894``), which no released
+    version exists under: the definition looks right, validates, and dies at
+    freeze. The directory the pack was installed into is named for its real
+    registry id, so it is the candidate to try.
+
+    Only a definite 404 on the declared id plus a definite hit on the directory
+    name rewrites anything; an unreachable registry leaves the definition exactly
+    as the user wrote it. Mutates ``nodes`` in place and returns what it changed,
+    so the caller can say so out loud."""
+    repaired: list[tuple[str, str]] = []
+    for n in nodes:
+        declared = (n.get("id") or "").strip()
+        fallback = (n.get("name") or "").strip()
+        if not n.get("registryVersion") or not declared or fallback == declared:
+            continue
+        if registry_knows(api, declared) is not False:
+            continue
+        if fallback and registry_knows(api, fallback) is True:
+            n["id"] = fallback
+            repaired.append((declared, fallback))
+    return repaired
 
 
 # The builder's POST /v1/models/resolve accepts at most this many filenames/call.
@@ -950,6 +994,11 @@ def _create_execute(renderer, definition: dict, *, name: str, builder_url: str |
             renderer.info(f"Resolved {n} model(s) to public URLs — skipping their upload")
     except (urllib.error.URLError, requests.RequestException, KeyError) as e:
         renderer.warn(f"model resolution unavailable ({e}); all models will be uploaded")
+
+    # A registry id the registry does not have builds nothing, and only says so at
+    # freeze — after the cut is spent. Check it here, where we are already online.
+    for was, now in repair_registry_ids(definition.get("customNodes", []), RegistryAPI()):
+        renderer.warn(f"registry id {was!r} does not exist; using {now!r}, which does")
 
     plan = plan_create(definition)
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -442,8 +442,10 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
     For each model: if the resolver finds a public URL → reference it as
     ``sourceUri`` (no upload); otherwise it's a private blob → goes in the upload
     plan and will be referenced by ``blobId`` once uploaded. For each custom node:
-    a ``git`` node is referenced by ``repository``+``gitRef`` (no upload); a
-    ``local`` node has no upstream → uploaded as a ``node_zip`` blob.
+    ``repository``+``gitRef``, ``id``+``registryVersion`` or ``blobId`` is carried
+    through as-is; only a node naming none of them has no upstream and is uploaded
+    as a ``node_zip`` blob. Every other definition key travels untouched, because
+    a dropped one is not an error the builder reports, just a different build.
 
     Pure and backend-free: it decides *what* would be sent/uploaded without making
     any network call. The ``blobId`` values are filled in later by the upload step;
@@ -476,19 +478,31 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
 
     for j, n in enumerate(definition.get("customNodes", [])):
         entry = {"name": n["name"]}
-        if n.get("source") == "git" and n.get("repository") and n.get("gitRef"):
+        # The builder takes exactly one source per node. Try them most-precise
+        # first: a pinned git checkout reconstructs an exact commit, a registry
+        # version an exact published artifact, a blob is bytes we already hold.
+        # Keyed on the fields themselves rather than the scan's `source` tag, so a
+        # hand-edited definition that names a source without one is honoured too.
+        if n.get("repository") and n.get("gitRef"):
             entry["repository"] = n["repository"]
             entry["gitRef"] = n["gitRef"]
+        elif n.get("registryVersion") and n.get("id"):
+            entry["id"] = n["id"]
+            entry["registryVersion"] = n["registryVersion"]
+        elif n.get("blobId"):
+            entry["blobId"] = n["blobId"]
         else:
             uploads.append({"kind": "node_zip", "name": n["name"], "sizeBytes": 0, "slot": ["customNodes", j]})
         nodes_out.append(entry)
 
     builder_definition: dict = {"models": models_out, "customNodes": nodes_out}
-    # Carry environment fields the scan captured straight through to the builder.
-    if definition.get("baseComfyVersion"):
-        builder_definition["baseComfyVersion"] = definition["baseComfyVersion"]
-    if definition.get("pipDependencies"):
-        builder_definition["pipDependencies"] = definition["pipDependencies"]
+    # Everything else the definition declares goes through untouched. Dropping a
+    # key here does not fail loudly: the builder just applies its own default, so a
+    # base image silently becomes the catalog's current one and an absent policy
+    # seals as allow-all.
+    for key in ("baseComfyVersion", "baseImage", "pipDependencies", "modelPolicy", "partnerNodePolicy"):
+        if definition.get(key):
+            builder_definition[key] = definition[key]
     return {
         "definition": builder_definition,
         "uploads": uploads,

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -551,6 +551,7 @@ def snapshot_from_definition(definition: dict) -> dict:
 # Each entry is (report key, what it means to the reader).
 _REPORT_ADVISORIES = (
     ("notInRegistry", "pinned to something the Comfy Registry does not publish"),
+    ("collidingNodes", "left out: another pack already claimed the folder they install into"),
     ("registryPending", "published but not yet servable; the build will wait or fail on it"),
     ("unresolvedNodes", "named nothing the builder can install from"),
     ("unverifiedPins", "left unchecked because the registry did not answer"),
@@ -568,9 +569,14 @@ def report_advisories(report: dict) -> list[str]:
             "no curated base image matches the scanned Python exactly; the build runs on the closest one, "
             "so a pin resolved against your Python may not resolve against the build's"
         )
+    # The release the importer refused, so the empty version field has a reason.
+    dropped = report.get("droppedComfyVersion")
+    if dropped:
+        lines.append(f"the ComfyUI release {str(dropped)!r} is not a ref the build can use, so none was set")
     for key, meaning in _REPORT_ADVISORIES:
         entries = report.get(key) or []
-        if entries:
+        # Every one of these is a list; a scalar would render one line per character.
+        if entries and isinstance(entries, list | tuple):
             lines.append(f"{len(entries)} {meaning}: {', '.join(str(e) for e in entries[:8])}")
     return lines
 
@@ -1147,18 +1153,24 @@ def _create_execute(
     except (urllib.error.URLError, requests.RequestException, KeyError, ValueError) as e:
         renderer.warn(f"the builder could not read the definition's pins ({e}); they go to the cut unchecked")
     else:
-        for line in report_advisories(imported.get("report") or {}):
+        imported_report = imported.get("report") or {}
+        for line in report_advisories(imported_report):
             renderer.warn(line)
         checked = (imported.get("definition") or {}).get("customNodes")
         if checked is not None:
             # A pack it could not vouch for is absent from what it returns, and
             # an image quietly missing a pack is worse than a refused create.
             kept = {n.get("name") for n in checked}
-            dropped = [n for n in declared if n not in kept]
-            if dropped:
+            # A collision is the importer resolving a conflict the cut would refuse
+            # outright, so its definition is the buildable one and stopping would
+            # help nobody. Every other absence means the user asked for something
+            # that does not exist, which only they can fix.
+            colliding = set(imported_report.get("collidingNodes") or [])
+            missing = [n for n in declared if n not in kept and n not in colliding]
+            if missing:
                 renderer.error(
                     code="distribution_registry_pin_missing",
-                    message="the builder could not resolve these custom nodes: " + ", ".join(sorted(dropped)),
+                    message="the builder could not resolve these custom nodes: " + ", ".join(sorted(missing)),
                     hint="see the advisories above; edit the definition to name a published version, or remove the pack",
                 )
                 raise typer.Exit(code=1)

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -47,7 +47,6 @@ from comfy_cli.command.pack_scan import read_pyproject
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH, SUPPORTED_PT_EXTENSIONS
 from comfy_cli.file_utils import atomic_write_text
 from comfy_cli.output import get_renderer
-from comfy_cli.registry import NodeFetchError, RegistryAPI
 from comfy_cli.registry.api import sanitize_error_body
 from comfy_cli.workspace_manager import WorkspaceManager
 
@@ -499,96 +498,87 @@ def resolve_model_source(model: dict) -> str | None:
     return model.get("sourceUri")
 
 
-def _registry_has_pin(api, node_id: str, version: str) -> bool | None:
-    """Whether the registry has ``version`` of ``node_id`` published.
+def snapshot_from_definition(definition: dict) -> dict:
+    """Wrap a scanned definition as the snapshot envelope the builder reads.
 
-    True / False on a definite answer, None when the registry could not be asked
-    (transport, timeout, 5xx). This is the pair the builder resolves at freeze,
-    not just the node: a node can exist while the version asked for does not, so
-    proving the node alone proves nothing about the build."""
-    try:
-        api.get_node_version(node_id, version)
-        return True
-    except NodeFetchError as e:
-        return False if e.status_code == 404 else None
-    except (requests.RequestException, KeyError, ValueError):
-        return None
+    The builder's importer is the one place that knows what the Comfy Registry
+    actually publishes, which curated base image a Python fits, and how a pin
+    normalizes. It takes a Desktop export, and a scan collects the same facts
+    under different names, so the scan is translated rather than that knowledge
+    being reimplemented here and drifting from it.
 
+    Models have no place in a snapshot and stay with the caller."""
+    nodes = []
+    for n in definition.get("customNodes", []):
+        name = n.get("name") or ""
+        if n.get("registryVersion"):
+            nodes.append(
+                {
+                    "type": "cnr",
+                    "id": n.get("id") or name,
+                    "dirName": name,
+                    "version": n["registryVersion"],
+                    "enabled": True,
+                }
+            )
+        elif n.get("repository"):
+            node = {"type": "git", "id": name, "dirName": name, "url": n["repository"], "enabled": True}
+            if n.get("gitRef"):
+                node["commit"] = n["gitRef"]
+            nodes.append(node)
 
-def verify_registry_pins(nodes: list[dict], api, *, repair: bool = False) -> dict:
-    """Check every registry pin against the registry before a cut is spent on one.
-
-    A pin comes from the pack's own ``pyproject.toml``, which says what the pack
-    calls itself — not that it was ever published, nor that the copy on disk is
-    what was published. Unchecked, a pack that is not in the registry sails past
-    create and dies at freeze, which is the failure this whole command set exists
-    to move earlier.
-
-    For a pin the registry does not have, the install directory's name is a
-    candidate: ``comfy node install`` names the directory after the node id, so a
-    pack whose ``pyproject`` carries a pull-request preview id still sits in a
-    directory named for the real one. But a directory name is not evidence —
-    nothing binds it to the bytes inside, registry ids are first-come, and a pack
-    unpacked from a zip is in whatever directory its author or the user chose. So
-    the candidate is only *used* under ``repair``; otherwise it is reported and
-    the caller decides.
-
-    Returns ``{"repaired": [(from, to)], "unresolved": [(name, id, version,
-    candidate|None)], "unreachable": bool}``. Mutates ``nodes`` in place, and only
-    under ``repair``."""
-    repaired: list[tuple[str, str]] = []
-    unresolved: list[tuple[str, str, str, str | None]] = []
-    for n in nodes:
-        node_id = (n.get("id") or "").strip()
-        version = (n.get("registryVersion") or "").strip()
-        if not node_id or not version:
+    # A freeze is one pin per line; a snapshot is a name -> version map. Anything
+    # that is not a plain `==` pin (a comment, a direct git reference, an extras
+    # marker) has no place in that map, and the importer reports what it drops.
+    pips: dict[str, str] = {}
+    for line in (definition.get("pipDependencies") or "").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "==" not in line:
             continue
-        answer = _registry_has_pin(api, node_id, version)
-        if answer is None:
-            # The registry is not answering. Every later pin would get the same
-            # non-answer, so stop rather than spend a timeout per pack.
-            return {"repaired": repaired, "unresolved": unresolved, "unreachable": True}
-        if answer:
-            continue
-        name = (n.get("name") or "").strip()
-        candidate = name if name and name != node_id and _registry_has_pin(api, name, version) is True else None
-        if candidate and repair:
-            n["id"] = candidate
-            repaired.append((node_id, candidate))
-        else:
-            unresolved.append((name or node_id, node_id, version, candidate))
-    return {"repaired": repaired, "unresolved": unresolved, "unreachable": False}
+        pip_name, _, pip_version = line.partition("==")
+        if pip_name.strip() and pip_version.strip():
+            pips[pip_name.strip()] = pip_version.strip()
+
+    environment = definition.get("environment") or {}
+    return {
+        "type": "comfyui-desktop-2-snapshot",
+        "version": 2,
+        "snapshots": [
+            {
+                "comfyui": {"baseTag": definition.get("baseComfyVersion") or ""},
+                "customNodes": nodes,
+                "pipPackages": pips,
+                "pythonVersion": environment.get("pythonVersion") or "",
+            }
+        ],
+    }
 
 
-# The builder's POST /v1/models/resolve accepts at most this many filenames/call.
-def _unresolved_pin_message(unresolved: list[tuple[str, str, str, str | None]]) -> str:
-    """One line per pack the registry does not have, naming the candidate when the
-    install directory suggests one. The candidate is a suggestion the user accepts
-    with --repair-registry-ids, never something applied on their behalf."""
+# Each entry is (report key, what it means to the reader).
+_REPORT_ADVISORIES = (
+    ("notInRegistry", "pinned to something the Comfy Registry does not publish"),
+    ("registryPending", "published but not yet servable; the build will wait or fail on it"),
+    ("unresolvedNodes", "named nothing the builder can install from"),
+    ("unverifiedPins", "left unchecked because the registry did not answer"),
+    ("skippedPins", "dropped: the build owns these packages"),
+    ("unpinnablePins", "dropped: not a public PyPI release"),
+)
+
+
+def report_advisories(report: dict) -> list[str]:
+    """One line per thing the importer could not carry, in reader's terms."""
     lines = []
-    for name, node_id, version, candidate in unresolved:
-        line = f"  {name}: the registry has no {node_id!r} at version {version}"
-        if candidate:
-            line += f"; the install directory suggests {candidate!r}, which it does have"
-        lines.append(line)
-    tail = (
-        "\nRe-run with --repair-registry-ids to use the suggested ids, or edit the definition."
-        if any(c for *_, c in unresolved)
-        else "\nEdit the definition to name a published version, or remove the pack."
-    )
-    return "these custom nodes are pinned to something the registry cannot serve:\n" + "\n".join(lines) + tail
-
-
-# The registry the BUILDER resolves nodes against, in every environment: its
-# workers hard-code this host. RegistryAPI() would otherwise follow $ENVIRONMENT
-# and check a staging run's ids against a registry the build never calls.
-_REGISTRY_BASE_URL = "https://api.comfy.org"
-
-
-def _registry_client():
-    """The registry the pin check asks. A function for the same reason
-    ``_builder_client`` is one: it is where the remote is chosen."""
-    return RegistryAPI(_REGISTRY_BASE_URL)
+    # Present and false is the finding; absent means the importer did not say.
+    if report.get("pythonSatisfied") is False:
+        lines.append(
+            "no curated base image matches the scanned Python exactly; the build runs on the closest one, "
+            "so a pin resolved against your Python may not resolve against the build's"
+        )
+    for key, meaning in _REPORT_ADVISORIES:
+        entries = report.get(key) or []
+        if entries:
+            lines.append(f"{len(entries)} {meaning}: {', '.join(str(e) for e in entries[:8])}")
+    return lines
 
 
 _RESOLVE_BATCH = 32
@@ -1070,13 +1060,6 @@ def create_cmd(
         str | None,
         typer.Option("--models-dir", help="Models folder, to locate bytes for private-model uploads (--execute)."),
     ] = None,
-    repair_registry_ids: Annotated[
-        bool,
-        typer.Option(
-            "--repair-registry-ids",
-            help="When a pack's declared registry id is not published, use its install directory's name instead.",
-        ),
-    ] = False,
 ):
     renderer = get_renderer()
 
@@ -1106,7 +1089,6 @@ def create_cmd(
             name=name,
             builder_url=builder_url,
             models_dir=models_dir,
-            repair=repair_registry_ids,
         )
         return
 
@@ -1164,19 +1146,33 @@ def _create_execute(
         renderer.warn(f"model resolution unavailable ({e}); all models will be uploaded")
 
     # A pin the registry does not have builds nothing and only says so at freeze,
-    # after the cut is spent. Check here, where we are already online, against the
-    # registry the builder itself resolves against.
-    pins = verify_registry_pins(definition.get("customNodes", []), _registry_client(), repair=repair)
-    if pins["unreachable"]:
-        renderer.warn("could not reach the registry; declared node pins were not checked")
-    for was, now in pins["repaired"]:
-        renderer.warn(f"registry pin {was!r} does not exist; using {now!r}, which does")
-    if pins["unresolved"]:
-        renderer.error(
-            code="distribution_registry_pin_missing",
-            message=_unresolved_pin_message(pins["unresolved"]),
-        )
-        raise typer.Exit(code=1)
+    # after the cut is spent. The builder's own importer already answers that, and
+    # it is the side of the boundary that knows: a second implementation here would
+    # be a second thing to keep in step with the registry. Best effort, because a
+    # builder without the endpoint must still be able to create.
+    declared = [n.get("name") for n in definition.get("customNodes", [])]
+    try:
+        imported = client.resolve_snapshot(snapshot_from_definition(definition))
+    except (urllib.error.URLError, requests.RequestException, KeyError, ValueError) as e:
+        renderer.warn(f"the builder could not read the definition's pins ({e}); they go to the cut unchecked")
+    else:
+        for line in report_advisories(imported.get("report") or {}):
+            renderer.warn(line)
+        checked = (imported.get("definition") or {}).get("customNodes")
+        if checked is not None:
+            # A pack the importer could not vouch for is absent from what it
+            # returns. Building without it silently is the one outcome worse than
+            # failing, since the user gets an image missing what they asked for.
+            kept = {n.get("name") for n in checked}
+            dropped = [n for n in declared if n not in kept]
+            if dropped:
+                renderer.error(
+                    code="distribution_registry_pin_missing",
+                    message="the builder could not resolve these custom nodes: " + ", ".join(sorted(dropped)),
+                    hint="see the advisories above; edit the definition to name a published version, or remove the pack",
+                )
+                raise typer.Exit(code=1)
+            definition["customNodes"] = checked
 
     plan = plan_create(definition)
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -1523,6 +1523,19 @@ def update_cmd(
     renderer.emit(dist, command="distribution update", changed=True)
 
 
+def as_snapshot_envelope(data: dict) -> dict:
+    """Wrap a bare Desktop snapshot in the envelope the importer requires.
+
+    Desktop writes one snapshot per file under `.launcher/snapshots/`, and only
+    its export action wraps them. The importer takes the wrapped shape, so the
+    file a user actually has on disk is refused as not a Desktop export."""
+    if data.get("type") or "snapshots" in data:
+        return data
+    if "customNodes" not in data and "pipPackages" not in data:
+        return data
+    return {"type": "comfyui-desktop-2-snapshot", "version": 2, "snapshots": [data]}
+
+
 @app.command("from-snapshot", help="Create a distribution from a ComfyUI Desktop snapshot export.")
 @tracking.track_command("distribution")
 def from_snapshot_cmd(
@@ -1551,7 +1564,7 @@ def from_snapshot_cmd(
     result = _builder_call(
         renderer,
         lambda: client.create_distribution_from_snapshot(
-            name, snapshot, description=description, base_image_id=base_image
+            name, as_snapshot_envelope(snapshot), description=description, base_image_id=base_image
         ),
     )
     created = result.get("distribution") or {}

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -1523,6 +1523,47 @@ def update_cmd(
     renderer.emit(dist, command="distribution update", changed=True)
 
 
+@app.command("from-snapshot", help="Create a distribution from a ComfyUI Desktop snapshot export.")
+@tracking.track_command("distribution")
+def from_snapshot_cmd(
+    from_: Annotated[str, typer.Option("--from", "-f", help="Path to a Desktop snapshot export JSON.")],
+    name: Annotated[str, typer.Option("--name", help="Name for the new distribution.")],
+    description: Annotated[str | None, typer.Option("--description", help="Optional description.")] = None,
+    base_image: Annotated[
+        str | None,
+        typer.Option("--base-image", help="Build on this base image rather than the one the snapshot's Python picks."),
+    ] = None,
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    path = Path(from_).expanduser()
+    try:
+        snapshot = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        renderer.error(
+            code="distribution_definition_invalid",
+            message=f"could not read {path}: {e}",
+            details={"path": str(path)},
+        )
+        raise typer.Exit(code=1) from e
+
+    client = _builder_client(renderer, builder_url)
+    result = _builder_call(
+        renderer,
+        lambda: client.create_distribution_from_snapshot(
+            name, snapshot, description=description, base_image_id=base_image
+        ),
+    )
+    created = result.get("distribution") or {}
+    distribution_id = created.get("id")
+    if renderer.is_pretty():
+        renderer.success(f"Created distribution {distribution_id} from {path.name}")
+        for line in report_advisories(result.get("report") or {}):
+            renderer.warn(line)
+        renderer.info(f"cut a build with `comfy distribution version create {distribution_id}`")
+    renderer.emit(result, command="distribution from-snapshot", changed=True)
+
+
 @app.command("blob-upload", help="Upload a private file and print the blobId a definition can reference.")
 @tracking.track_command("distribution")
 def blob_upload_cmd(

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -1191,7 +1191,19 @@ def validate_cmd(
     # message + details.body so the caller sees exactly what failed to resolve.
     result = _builder_call(renderer, lambda: client.validate_distribution(distribution_id))
     if renderer.is_pretty():
-        renderer.success("Definition resolves.")
+        # "resolves" was a promise this endpoint never made: it checks the
+        # definition's shape, that a ComfyUI version is pinned, and that each
+        # pinned package and version exists. Whether the set installs together is
+        # only answered by a build, so say what was actually checked.
+        renderer.success("Definition is valid: shape and pin existence checked, not a full resolve.")
+        # Warnings ride alongside ok: true. A ref the builder could not find on
+        # its remote is non-blocking here and fatal at freeze. Printed rather than
+        # left for the reader to spot inside the JSON below.
+        warnings = result.get("warnings") or []
+        if warnings:
+            renderer.warn(f"{len(warnings)} reference(s) the builder could not resolve; a cut will fail on these:")
+            for w in warnings:
+                renderer.warn(f"  {w.get('field', '?')}: {w.get('reason', '')}")
         renderer.console().print_json(json.dumps(result))
     renderer.emit(result, command="distribution validate")
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -276,6 +276,23 @@ def detect_comfy_version(root: Path) -> str | None:
     return None
 
 
+# A bare release number, as `comfyui_version.py` and `/system_stats` report it.
+_BARE_RELEASE_RE = re.compile(r"^\d+(?:\.\d+)+$")
+
+
+def as_comfy_git_ref(version: str) -> str:
+    """Return ``version`` as a ref the builder can actually resolve.
+
+    ``baseComfyVersion`` is resolved with ``git ls-remote`` against upstream
+    ComfyUI, which tags its releases ``vX.Y.Z`` — but every source we detect the
+    version from reports the bare number, so the value we recorded was guaranteed
+    to miss, and a build was the first thing to say so. Only a bare release number
+    is rewritten; a branch, a commit sha, a describe string or an
+    already-prefixed tag is left exactly as given."""
+    v = version.strip()
+    return "v" + v if _BARE_RELEASE_RE.match(v) else v
+
+
 # ComfyUI's default local address; the running server reports its version at
 # /system_stats even when the code dir has no version marker (split layouts).
 DEFAULT_COMFY_URL = "http://127.0.0.1:8188"
@@ -731,6 +748,9 @@ def scan_cmd(
     base_version = comfy_version or (detect_comfy_version(comfy_root) if comfy_root else None)
     if not base_version:
         base_version = detect_comfy_version_from_server(comfy_url or DEFAULT_COMFY_URL)
+    # Whatever named it, the definition records a ref the builder can resolve.
+    if base_version:
+        base_version = as_comfy_git_ref(base_version)
 
     # pip deps: freeze the ComfyUI env (evidence for the resolver, tagged with the
     # source platform). Never guess the interpreter — omit if we can't find it.

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -208,14 +208,9 @@ def _read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
     if not path.is_file():
         return None
     try:
-        # The repo's one pack-pyproject parser, so this agrees with `comfy
-        # outdated` and `comfy node deps` — including PEP 621 `dynamic = [
-        # "version"]`, which a hand-rolled read of `project.version` misses and
-        # which comfy-cli's own publish path resolves.
-        #
-        # Muted: that parser writes advice aimed at someone publishing a pack
-        # ("License should be in one of these two formats"), which is noise once
-        # per pack in a scan of somebody else's install and not actionable there.
+        # The repo's one pack-pyproject parser, which also resolves a PEP 621
+        # `dynamic = ["version"]`. Muted: it writes advice for someone publishing
+        # a pack, which is noise when reading somebody else's install.
         with contextlib.redirect_stderr(io.StringIO()):
             config = read_pyproject(str(path))
     except Exception:
@@ -229,6 +224,23 @@ def _read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
     if not _REGISTRY_ID_RE.match(node_id) or not _REGISTRY_VERSION_RE.match(version):
         return None
     return node_id, version
+
+
+def _identify_node(node_dir: Path) -> dict:
+    """One definition entry for one pack, naming the single source it has."""
+    repository = git_ref = None
+    if (node_dir / ".git").exists():
+        repository = _git_output(node_dir, "remote", "get-url", "origin")
+        git_ref = _git_output(node_dir, "rev-parse", "HEAD")
+    # A repo@ref reconstructs an exact commit, so it wins where both exist.
+    if repository and git_ref:
+        return {"name": node_dir.name, "repository": repository, "gitRef": git_ref, "source": "git"}
+    pin = _read_registry_pin(node_dir)
+    if pin:
+        # The builder takes exactly one source, so a half-git checkout keeps none
+        # of its git fields: an origin without a resolvable HEAD is not fetchable.
+        return {"name": node_dir.name, "id": pin[0], "registryVersion": pin[1], "source": "registry"}
+    return {"name": node_dir.name, "repository": repository, "gitRef": git_ref, "source": "local"}
 
 
 def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
@@ -255,25 +267,7 @@ def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
             continue  # single-file .py nodes aren't buildable units here
         if entry.name.startswith(".") or entry.name == "__pycache__":
             continue
-        is_git = (entry / ".git").exists()
-        repository = _git_output(entry, "remote", "get-url", "origin") if is_git else None
-        git_ref = _git_output(entry, "rev-parse", "HEAD") if is_git else None
-        node: dict = {"name": entry.name, "repository": repository, "gitRef": git_ref}
-        if repository and git_ref:
-            node["source"] = "git"
-        else:
-            pin = _read_registry_pin(entry)
-            if pin:
-                # Exactly one source per node, which the builder enforces. A
-                # half-git checkout (an origin but no resolvable HEAD, or the
-                # reverse) would otherwise carry both and be rejected at validate.
-                node.pop("repository", None)
-                node.pop("gitRef", None)
-                node["id"], node["registryVersion"] = pin
-                node["source"] = "registry"
-            else:
-                node["source"] = "local"
-        nodes.append(node)
+        nodes.append(_identify_node(entry))
     return nodes
 
 
@@ -683,16 +677,12 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
         # so it rides along whatever the source turns out to be.
         if n.get("id"):
             entry["id"] = n["id"]
-        # The builder takes exactly one source per node. Try them most-precise
-        # first: a pinned git checkout reconstructs an exact commit, a registry
-        # version an exact published artifact, a blob is bytes we already hold.
-        # Keyed on the fields themselves rather than the scan's `source` tag, so a
-        # hand-edited definition that names a source without one is honoured too.
+        # Most precise first, and keyed on the fields rather than the scan's
+        # `source` tag, so a hand-written definition is read the same way.
         if n.get("repository"):
             entry["repository"] = n["repository"]
-            # Both optional to the builder, and `commit` lets freeze skip ref
-            # resolution entirely. The website emits repository+commit and no
-            # gitRef, so requiring gitRef here would send it to be uploaded.
+            # The website emits repository+commit and no gitRef, so requiring
+            # gitRef here would send those nodes to be uploaded instead.
             for key in ("gitRef", "commit"):
                 if n.get(key):
                     entry[key] = n[key]
@@ -1145,11 +1135,8 @@ def _create_execute(
     except (urllib.error.URLError, requests.RequestException, KeyError) as e:
         renderer.warn(f"model resolution unavailable ({e}); all models will be uploaded")
 
-    # A pin the registry does not have builds nothing and only says so at freeze,
-    # after the cut is spent. The builder's own importer already answers that, and
-    # it is the side of the boundary that knows: a second implementation here would
-    # be a second thing to keep in step with the registry. Best effort, because a
-    # builder without the endpoint must still be able to create.
+    # The importer is the side of the boundary that knows what the registry
+    # publishes. Best effort: a builder without it leaves the pins to the cut.
     declared = [n.get("name") for n in definition.get("customNodes", [])]
     try:
         imported = client.resolve_snapshot(snapshot_from_definition(definition))
@@ -1160,9 +1147,8 @@ def _create_execute(
             renderer.warn(line)
         checked = (imported.get("definition") or {}).get("customNodes")
         if checked is not None:
-            # A pack the importer could not vouch for is absent from what it
-            # returns. Building without it silently is the one outcome worse than
-            # failing, since the user gets an image missing what they asked for.
+            # A pack it could not vouch for is absent from what it returns, and
+            # an image quietly missing a pack is worse than a refused create.
             kept = {n.get("name") for n in checked}
             dropped = [n for n in declared if n not in kept]
             if dropped:
@@ -1176,10 +1162,8 @@ def _create_execute(
 
     plan = plan_create(definition)
 
-    # An absent policy is not neutral: the version seals as allow-all. The CLI does
-    # not write one on the user's behalf — an invented allow-all is a no-op today
-    # and a pinned posture if the platform default ever changes — but it says so,
-    # because on this path there is no wizard to have said it.
+    # An absent policy seals as allow-all. Said rather than written on the user's
+    # behalf, which would pin a posture nobody chose if the default ever moves.
     missing = [k for k in ("modelPolicy", "partnerNodePolicy") if definition.get(k) is None]
     if missing:
         renderer.warn(
@@ -1424,16 +1408,11 @@ def validate_cmd(
     # message + details.body so the caller sees exactly what failed to resolve.
     result = _builder_call(renderer, lambda: client.validate_distribution(distribution_id))
     if renderer.is_pretty():
-        # "resolves" was a promise this endpoint never made: it checks the
-        # definition's shape, that a ComfyUI version is pinned, and that each
-        # pinned package and version exists. Whether the set installs together is
-        # only answered by a build, so say what was actually checked.
+        # The endpoint checks shape and pin existence. Whether the set installs
+        # together is answered by a build, so the line claims only what it did.
         renderer.success("Definition is valid: shape and pin existence checked, not a full resolve.")
-        # Warnings ride alongside ok: true. A ref the builder could not find on
-        # its remote is non-blocking here and fatal at freeze. Printed rather than
-        # left for the reader to spot inside the JSON below.
-        # The cut itself passes: refs are resolved inside the build, at freeze, so
-        # this is a build failure in waiting rather than a cut failure.
+        # Non-blocking here and fatal at freeze, so they are printed rather than
+        # left to be found in the JSON below. The cut itself still passes.
         warnings = result.get("warnings") if isinstance(result, dict) else None
         warnings = warnings if isinstance(warnings, list) else []
         if warnings:
@@ -1494,11 +1473,8 @@ def update_cmd(
         raise typer.Exit(code=1) from e
     client = _builder_client(renderer, builder_url)
 
-    # A scan definition is not a builder definition: its models carry {sizeBytes,
-    # source} and no sourceUri or blobId, and its nodes name a source the builder
-    # spells differently. Sending the file verbatim means the builder rejects every
-    # model with "must set exactly one of sourceUri or blobId". Map it the same way
-    # create does, so the same file works through either command.
+    # A scan definition names sources the builder does not take verbatim, so it is
+    # mapped the way create maps it and one file works through either command.
     if _is_scan_shaped(definition):
         # Batched, one call per 32 filenames, exactly as create does it. The
         # annotation it leaves is what the default resolver in plan_create reads.

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -47,6 +47,7 @@ from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH, SUPPORTED_PT_EXTENSION
 from comfy_cli.file_utils import atomic_write_text
 from comfy_cli.output import get_renderer
 from comfy_cli.registry import NodeFetchError, RegistryAPI
+from comfy_cli.registry.api import sanitize_error_body
 from comfy_cli.workspace_manager import WorkspaceManager
 
 app = typer.Typer(
@@ -179,15 +180,28 @@ def _git_output(repo_path: Path, *args: str) -> str | None:
     return result.stdout.strip() or None
 
 
-def read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
-    """Return ``(registry id, version)`` from a pack's ``pyproject.toml``, or None.
+# What the two consumers of a pin accept. The builder rejects a registryVersion
+# that is not a package version (definition.go), and a node id is a slug: reading
+# either straight out of a pyproject and sending it on lets a pack put arbitrary
+# text into a registry URL and into the definition.
+_REGISTRY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+_REGISTRY_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
+    """Return the ``(id, version)`` a pack's ``pyproject.toml`` CLAIMS, or None.
 
     A pack installed by ``comfy node install`` comes from the Comfy Registry as an
     archive, so it has no git history at all — but its ``pyproject.toml`` still
-    carries the two fields that name the published version the builder can fetch:
-    ``project.name`` is the registry node id and ``project.version`` its package
-    version. Silent on every failure (absent, unreadable, malformed, missing
-    either field): a pack that cannot answer simply has no registry pin."""
+    carries the two fields that name a published version: ``project.name`` is the
+    registry node id and ``project.version`` its package version.
+
+    This is the pack's own claim about itself, not evidence: the file is written by
+    whoever wrote the pack, so a pin from here is unverified until the registry is
+    asked (see :func:`verify_registry_pins`). Silent on every failure — absent,
+    unreadable, malformed, missing either field, or a value neither the registry
+    nor the builder would accept — because a pack that cannot answer simply has no
+    registry pin, and the scan must not die on one bad neighbour."""
     try:
         with open(node_dir / "pyproject.toml", encoding="utf-8-sig") as f:
             data = tomlkit.load(f)
@@ -201,7 +215,9 @@ def read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
     if not isinstance(node_id, str) or not isinstance(version, str):
         return None
     node_id, version = node_id.strip(), version.strip()
-    return (node_id, version) if node_id and version else None
+    if not _REGISTRY_ID_RE.match(node_id) or not _REGISTRY_VERSION_RE.match(version):
+        return None
+    return node_id, version
 
 
 def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
@@ -235,8 +251,13 @@ def scan_custom_nodes(custom_nodes_root: Path) -> list[dict]:
         if repository and git_ref:
             node["source"] = "git"
         else:
-            pin = read_registry_pin(entry)
+            pin = _read_registry_pin(entry)
             if pin:
+                # Exactly one source per node, which the builder enforces. A
+                # half-git checkout (an origin but no resolvable HEAD, or the
+                # reverse) would otherwise carry both and be rejected at validate.
+                node.pop("repository", None)
+                node.pop("gitRef", None)
                 node["id"], node["registryVersion"] = pin
                 node["source"] = "registry"
             else:
@@ -447,15 +468,15 @@ def resolve_model_source(model: dict) -> str | None:
     return model.get("sourceUri")
 
 
-def registry_knows(api, node_id: str) -> bool | None:
-    """Whether the Comfy Registry has a node under ``node_id``.
+def _registry_has_pin(api, node_id: str, version: str) -> bool | None:
+    """Whether the registry has ``version`` of ``node_id`` published.
 
     True / False on a definite answer, None when the registry could not be asked
-    (transport, timeout, 5xx). Uses the read-only node endpoint rather than the
-    install one, which records an installation and fires an analytics event on
-    every call — a verification must not look like a install."""
+    (transport, timeout, 5xx). This is the pair the builder resolves at freeze,
+    not just the node: a node can exist while the version asked for does not, so
+    proving the node alone proves nothing about the build."""
     try:
-        api.get_node(node_id)
+        api.get_node_version(node_id, version)
         return True
     except NodeFetchError as e:
         return False if e.status_code == 404 else None
@@ -463,34 +484,82 @@ def registry_knows(api, node_id: str) -> bool | None:
         return None
 
 
-def repair_registry_ids(nodes: list[dict], api) -> list[tuple[str, str]]:
-    """Point a registry-pinned node at an id the registry actually has.
+def verify_registry_pins(nodes: list[dict], api, *, repair: bool = False) -> dict:
+    """Check every registry pin against the registry before a cut is spent on one.
 
-    A pack published from a pull-request preview carries that preview's id in its
-    ``pyproject.toml`` (``pr-was-node-suite-comfyui-47064894``), which no released
-    version exists under: the definition looks right, validates, and dies at
-    freeze. The directory the pack was installed into is named for its real
-    registry id, so it is the candidate to try.
+    A pin comes from the pack's own ``pyproject.toml``, which says what the pack
+    calls itself — not that it was ever published, nor that the copy on disk is
+    what was published. Unchecked, a pack that is not in the registry sails past
+    create and dies at freeze, which is the failure this whole command set exists
+    to move earlier.
 
-    Only a definite 404 on the declared id plus a definite hit on the directory
-    name rewrites anything; an unreachable registry leaves the definition exactly
-    as the user wrote it. Mutates ``nodes`` in place and returns what it changed,
-    so the caller can say so out loud."""
+    For a pin the registry does not have, the install directory's name is a
+    candidate: ``comfy node install`` names the directory after the node id, so a
+    pack whose ``pyproject`` carries a pull-request preview id still sits in a
+    directory named for the real one. But a directory name is not evidence —
+    nothing binds it to the bytes inside, registry ids are first-come, and a pack
+    unpacked from a zip is in whatever directory its author or the user chose. So
+    the candidate is only *used* under ``repair``; otherwise it is reported and
+    the caller decides.
+
+    Returns ``{"repaired": [(from, to)], "unresolved": [(name, id, version,
+    candidate|None)], "unreachable": bool}``. Mutates ``nodes`` in place, and only
+    under ``repair``."""
     repaired: list[tuple[str, str]] = []
+    unresolved: list[tuple[str, str, str, str | None]] = []
     for n in nodes:
-        declared = (n.get("id") or "").strip()
-        fallback = (n.get("name") or "").strip()
-        if not n.get("registryVersion") or not declared or fallback == declared:
+        node_id = (n.get("id") or "").strip()
+        version = (n.get("registryVersion") or "").strip()
+        if not node_id or not version:
             continue
-        if registry_knows(api, declared) is not False:
+        answer = _registry_has_pin(api, node_id, version)
+        if answer is None:
+            # The registry is not answering. Every later pin would get the same
+            # non-answer, so stop rather than spend a timeout per pack.
+            return {"repaired": repaired, "unresolved": unresolved, "unreachable": True}
+        if answer:
             continue
-        if fallback and registry_knows(api, fallback) is True:
-            n["id"] = fallback
-            repaired.append((declared, fallback))
-    return repaired
+        name = (n.get("name") or "").strip()
+        candidate = name if name and name != node_id and _registry_has_pin(api, name, version) is True else None
+        if candidate and repair:
+            n["id"] = candidate
+            repaired.append((node_id, candidate))
+        else:
+            unresolved.append((name or node_id, node_id, version, candidate))
+    return {"repaired": repaired, "unresolved": unresolved, "unreachable": False}
 
 
 # The builder's POST /v1/models/resolve accepts at most this many filenames/call.
+def _unresolved_pin_message(unresolved: list[tuple[str, str, str, str | None]]) -> str:
+    """One line per pack the registry does not have, naming the candidate when the
+    install directory suggests one. The candidate is a suggestion the user accepts
+    with --repair-registry-ids, never something applied on their behalf."""
+    lines = []
+    for name, node_id, version, candidate in unresolved:
+        line = f"  {name}: the registry has no {node_id!r} at version {version}"
+        if candidate:
+            line += f"; the install directory suggests {candidate!r}, which it does have"
+        lines.append(line)
+    tail = (
+        "\nRe-run with --repair-registry-ids to use the suggested ids, or edit the definition."
+        if any(c for *_, c in unresolved)
+        else "\nEdit the definition to name a published version, or remove the pack."
+    )
+    return "these custom nodes are pinned to something the registry cannot serve:\n" + "\n".join(lines) + tail
+
+
+# The registry the BUILDER resolves nodes against, in every environment: its
+# workers hard-code this host. RegistryAPI() would otherwise follow $ENVIRONMENT
+# and check a staging run's ids against a registry the build never calls.
+_REGISTRY_BASE_URL = "https://api.comfy.org"
+
+
+def _registry_client():
+    """The registry the pin check asks. A function for the same reason
+    ``_builder_client`` is one: it is where the remote is chosen."""
+    return RegistryAPI(_REGISTRY_BASE_URL)
+
+
 _RESOLVE_BATCH = 32
 
 
@@ -574,16 +643,24 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
 
     for j, n in enumerate(definition.get("customNodes", [])):
         entry = {"name": n["name"]}
+        # `id` is not a source: the builder uses it to name the install directory,
+        # so it rides along whatever the source turns out to be.
+        if n.get("id"):
+            entry["id"] = n["id"]
         # The builder takes exactly one source per node. Try them most-precise
         # first: a pinned git checkout reconstructs an exact commit, a registry
         # version an exact published artifact, a blob is bytes we already hold.
         # Keyed on the fields themselves rather than the scan's `source` tag, so a
         # hand-edited definition that names a source without one is honoured too.
-        if n.get("repository") and n.get("gitRef"):
+        if n.get("repository"):
             entry["repository"] = n["repository"]
-            entry["gitRef"] = n["gitRef"]
+            # Both optional to the builder, and `commit` lets freeze skip ref
+            # resolution entirely. The website emits repository+commit and no
+            # gitRef, so requiring gitRef here would send it to be uploaded.
+            for key in ("gitRef", "commit"):
+                if n.get(key):
+                    entry[key] = n[key]
         elif n.get("registryVersion") and n.get("id"):
-            entry["id"] = n["id"]
             entry["registryVersion"] = n["registryVersion"]
         elif n.get("blobId"):
             entry["blobId"] = n["blobId"]
@@ -592,13 +669,23 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
         nodes_out.append(entry)
 
     builder_definition: dict = {"models": models_out, "customNodes": nodes_out}
-    # Everything else the definition declares goes through untouched. Dropping a
-    # key here does not fail loudly: the builder just applies its own default, so a
-    # base image silently becomes the catalog's current one and an absent policy
-    # seals as allow-all.
-    for key in ("baseComfyVersion", "baseImage", "pipDependencies", "modelPolicy", "partnerNodePolicy"):
+    # Every key the builder's Definition accepts, which is an allowlist rather than
+    # a passthrough: `schema` and `environment` are the scan's own bookkeeping and
+    # stay local. Dropping one of these does not fail loudly — the builder applies
+    # its own default, so a base image silently becomes the catalog's current one.
+    for key in ("baseComfyVersion", "baseImage", "pipDependencies"):
         if definition.get(key):
             builder_definition[key] = definition[key]
+    # A policy is permission-bearing, so absent and empty must not be the same: an
+    # absent policy seals as allow-all, while `{}` is something the user wrote.
+    for key in ("modelPolicy", "partnerNodePolicy"):
+        if definition.get(key) is not None:
+            builder_definition[key] = definition[key]
+    # The ref the builder resolves, not the number every version source reports.
+    # Applied here rather than only in `scan` so a definition written before this
+    # existed does not spend its cut discovering the difference.
+    if builder_definition.get("baseComfyVersion"):
+        builder_definition["baseComfyVersion"] = as_comfy_git_ref(builder_definition["baseComfyVersion"])
     return {
         "definition": builder_definition,
         "uploads": uploads,
@@ -710,11 +797,17 @@ def _render_nodes_table(renderer, nodes: list[dict]) -> None:
     table = Table(title=title)
     table.add_column("node", style="cyan", no_wrap=True)
     table.add_column("source", style="green")
-    table.add_column("repository", style="white")
-    table.add_column("ref", style="dim")
+    table.add_column("from", style="white")
+    table.add_column("pinned to", style="dim")
     for n in nodes:
-        ref = (n["gitRef"][:12] + "…") if n["gitRef"] else "—"
-        table.add_row(n["name"], n["source"], n["repository"] or "—", ref)
+        # One row per node whatever its source, so a registry pin is as visible as
+        # a git one rather than rendering as two dashes.
+        if n.get("registryVersion"):
+            origin, pin = n.get("id") or "—", n["registryVersion"]
+        else:
+            origin = n.get("repository") or "—"
+            pin = (n["gitRef"][:12] + "…") if n.get("gitRef") else "—"
+        table.add_row(n["name"], n["source"], origin, pin)
     renderer.console().print(table)
 
 
@@ -931,6 +1024,13 @@ def create_cmd(
         str | None,
         typer.Option("--models-dir", help="Models folder, to locate bytes for private-model uploads (--execute)."),
     ] = None,
+    repair_registry_ids: Annotated[
+        bool,
+        typer.Option(
+            "--repair-registry-ids",
+            help="When a pack's declared registry id is not published, use its install directory's name instead.",
+        ),
+    ] = False,
 ):
     renderer = get_renderer()
 
@@ -954,23 +1054,37 @@ def create_cmd(
         raise typer.Exit(code=1)
 
     if execute:
-        _create_execute(renderer, definition, name=name, builder_url=builder_url, models_dir=models_dir)
+        _create_execute(
+            renderer,
+            definition,
+            name=name,
+            builder_url=builder_url,
+            models_dir=models_dir,
+            repair=repair_registry_ids,
+        )
         return
 
     # Preview (default): offline plan, no network — so no resolution, everything
     # shows as an upload (the live --execute path resolves first).
     plan = plan_create(definition)
     resolved = sum(1 for m in plan["definition"]["models"] if m.get("sourceUri"))
-    git_nodes = sum(1 for n in plan["definition"]["customNodes"] if n.get("repository"))
+    nodes_out = plan["definition"]["customNodes"]
+    git_nodes = sum(1 for n in nodes_out if n.get("repository"))
+    registry_nodes = sum(1 for n in nodes_out if n.get("registryVersion"))
+    # From the plan, not from the definition: a registry-pinned node has no
+    # repository, and counting it as an upload overstates the one number a user
+    # reads before deciding to spend.
+    node_uploads = sum(1 for u in plan["uploads"] if u["kind"] == "node_zip")
+    model_uploads = plan["upload_count"] - node_uploads
     if renderer.is_pretty():
         renderer.info(f"Distribution '{name}' — preview (no calls made)")
         renderer.print(
             f"  models: {len(plan['definition']['models'])}  "
-            f"({resolved} resolved to URL, {plan['upload_count']} to upload · {_human_size(plan['upload_bytes'])})"
+            f"({resolved} resolved to URL, {model_uploads} to upload · {_human_size(plan['upload_bytes'])})"
         )
         renderer.print(
-            f"  custom nodes: {len(plan['definition']['customNodes'])}  "
-            f"({git_nodes} from git, {len(plan['definition']['customNodes']) - git_nodes} to upload)"
+            f"  custom nodes: {len(nodes_out)}  "
+            f"({git_nodes} from git, {registry_nodes} from the registry, {node_uploads} to upload)"
         )
         renderer.print("\n  Builder definition that would be sent:")
         renderer.console().print_json(json.dumps(plan["definition"]))
@@ -978,7 +1092,15 @@ def create_cmd(
     renderer.emit({"name": name, "plan": plan, "executed": False}, command="distribution create")
 
 
-def _create_execute(renderer, definition: dict, *, name: str, builder_url: str | None, models_dir: str | None) -> None:
+def _create_execute(
+    renderer,
+    definition: dict,
+    *,
+    name: str,
+    builder_url: str | None,
+    models_dir: str | None,
+    repair: bool = False,
+) -> None:
     """The live --execute path: auth, resolve, upload, create, cut. Maps every
     failure class to a single error envelope + exit(1)."""
     import urllib.error
@@ -995,10 +1117,20 @@ def _create_execute(renderer, definition: dict, *, name: str, builder_url: str |
     except (urllib.error.URLError, requests.RequestException, KeyError) as e:
         renderer.warn(f"model resolution unavailable ({e}); all models will be uploaded")
 
-    # A registry id the registry does not have builds nothing, and only says so at
-    # freeze — after the cut is spent. Check it here, where we are already online.
-    for was, now in repair_registry_ids(definition.get("customNodes", []), RegistryAPI()):
-        renderer.warn(f"registry id {was!r} does not exist; using {now!r}, which does")
+    # A pin the registry does not have builds nothing and only says so at freeze,
+    # after the cut is spent. Check here, where we are already online, against the
+    # registry the builder itself resolves against.
+    pins = verify_registry_pins(definition.get("customNodes", []), _registry_client(), repair=repair)
+    if pins["unreachable"]:
+        renderer.warn("could not reach the registry; declared node pins were not checked")
+    for was, now in pins["repaired"]:
+        renderer.warn(f"registry pin {was!r} does not exist; using {now!r}, which does")
+    if pins["unresolved"]:
+        renderer.error(
+            code="distribution_registry_pin_missing",
+            message=_unresolved_pin_message(pins["unresolved"]),
+        )
+        raise typer.Exit(code=1)
 
     plan = plan_create(definition)
 
@@ -1248,11 +1380,20 @@ def validate_cmd(
         # Warnings ride alongside ok: true. A ref the builder could not find on
         # its remote is non-blocking here and fatal at freeze. Printed rather than
         # left for the reader to spot inside the JSON below.
-        warnings = result.get("warnings") or []
+        # The cut itself passes: refs are resolved inside the build, at freeze, so
+        # this is a build failure in waiting rather than a cut failure.
+        warnings = result.get("warnings") if isinstance(result, dict) else None
+        warnings = warnings if isinstance(warnings, list) else []
         if warnings:
-            renderer.warn(f"{len(warnings)} reference(s) the builder could not resolve; a cut will fail on these:")
+            renderer.warn(f"{len(warnings)} reference(s) the builder could not resolve; the build will fail on these:")
             for w in warnings:
-                renderer.warn(f"  {w.get('field', '?')}: {w.get('reason', '')}")
+                # Builder-supplied text, so it goes through the same scrub as any
+                # other remote error body rather than straight at the terminal.
+                if isinstance(w, dict):
+                    field, reason = w.get("field", "?"), w.get("reason", "")
+                else:
+                    field, reason = "?", w
+                renderer.warn(f"  {sanitize_error_body(str(field))}: {sanitize_error_body(str(reason))}")
         renderer.console().print_json(json.dumps(result))
     renderer.emit(result, command="distribution validate")
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -27,7 +27,9 @@ scan/hash logic is kept in pure helpers so it stays unit-testable.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
 import json
 import os
 import re
@@ -37,12 +39,11 @@ from pathlib import Path
 from typing import Annotated
 
 import requests
-import tomlkit
-import tomlkit.exceptions
 import typer
 
 from comfy_cli import tracking
 from comfy_cli._safe_exec import BinaryNotFoundError, resolve_required_binary
+from comfy_cli.command.pack_scan import read_pyproject
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH, SUPPORTED_PT_EXTENSIONS
 from comfy_cli.file_utils import atomic_write_text
 from comfy_cli.output import get_renderer
@@ -202,16 +203,27 @@ def _read_registry_pin(node_dir: Path) -> tuple[str, str] | None:
     unreadable, malformed, missing either field, or a value neither the registry
     nor the builder would accept — because a pack that cannot answer simply has no
     registry pin, and the scan must not die on one bad neighbour."""
+    path = node_dir / "pyproject.toml"
+    # Guarded rather than caught: the shared parser reports an absent file to the
+    # user, and most packs in a scan do not have one.
+    if not path.is_file():
+        return None
     try:
-        with open(node_dir / "pyproject.toml", encoding="utf-8-sig") as f:
-            data = tomlkit.load(f)
-    except (OSError, UnicodeDecodeError, tomlkit.exceptions.TOMLKitError):
+        # The repo's one pack-pyproject parser, so this agrees with `comfy
+        # outdated` and `comfy node deps` — including PEP 621 `dynamic = [
+        # "version"]`, which a hand-rolled read of `project.version` misses and
+        # which comfy-cli's own publish path resolves.
+        #
+        # Muted: that parser writes advice aimed at someone publishing a pack
+        # ("License should be in one of these two formats"), which is noise once
+        # per pack in a scan of somebody else's install and not actionable there.
+        with contextlib.redirect_stderr(io.StringIO()):
+            config = read_pyproject(str(path))
+    except Exception:
         return None
-    project = data.get("project")
-    if not isinstance(project, dict):
+    if config is None:
         return None
-    node_id = project.get("name")
-    version = project.get("version")
+    node_id, version = config.project.name, config.project.version
     if not isinstance(node_id, str) or not isinstance(version, str):
         return None
     node_id, version = node_id.strip(), version.strip()
@@ -385,6 +397,21 @@ def find_comfy_python(comfy_root: Path | None, explicit: str | None) -> Path | N
 _TORCH_RE = re.compile(r"^torch==(\S+)", re.MULTILINE)
 
 
+# userinfo in a direct-reference URL, e.g.
+# `pkg @ git+https://x-access-token:ghp_xxx@github.com/org/private.git@sha`.
+_URL_USERINFO_RE = re.compile(r"(?P<scheme>[a-zA-Z][\w+.-]*://)(?P<userinfo>[^/@\s]+)@")
+
+
+def _redact_freeze_credentials(freeze: str) -> str:
+    """Strip userinfo from any URL in a freeze.
+
+    A freeze can carry direct references to private repositories, and pip writes
+    those with whatever credential was used to install them. The definition is
+    written to disk, POSTed to the builder, and often committed, so a token in it
+    travels a long way from the machine that minted it."""
+    return _URL_USERINFO_RE.sub(lambda m: m.group("scheme") + "***@", freeze)
+
+
 def _freeze_env(python_exe: str) -> str | None:
     """`pip freeze` for a Python env, falling back to `uv pip freeze` when the
     env has no pip module (uv-created venvs, common for ComfyUI). Returns the
@@ -396,13 +423,17 @@ def _freeze_env(python_exe: str) -> str | None:
         attempts.append([resolve_required_binary("uv"), "pip", "freeze", "--python", python_exe])
     except BinaryNotFoundError:
         pass
+    # PYTHONPATH would put whatever it points at into the freeze as an installed
+    # package, so a caller with one set gets phantom pins the builder then tries
+    # to resolve. The freeze must describe the target env and nothing else.
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
     for cmd in attempts:
         try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=60, env=env)
         except (subprocess.SubprocessError, OSError):
             continue
         if r.returncode == 0 and r.stdout.strip():
-            return r.stdout
+            return _redact_freeze_credentials(r.stdout)
     return None
 
 
@@ -599,6 +630,21 @@ def resolve_models_via_builder(models: list[dict], client) -> int:
                 resolved += 1
                 break
     return resolved
+
+
+def _is_scan_shaped(definition: dict) -> bool:
+    """Whether this definition still carries the scan's own vocabulary.
+
+    A definition round-tripped out of the builder already names sources the way
+    the builder does; one straight from `scan` does not. The tell is a member that
+    names no builder source at all, which the builder would reject."""
+    for m in definition.get("models", []):
+        if not m.get("sourceUri") and not m.get("blobId"):
+            return True
+    for n in definition.get("customNodes", []):
+        if not n.get("repository") and not n.get("registryVersion") and not n.get("blobId"):
+            return True
+    return False
 
 
 def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
@@ -1134,6 +1180,16 @@ def _create_execute(
 
     plan = plan_create(definition)
 
+    # An absent policy is not neutral: the version seals as allow-all. The CLI does
+    # not write one on the user's behalf — an invented allow-all is a no-op today
+    # and a pinned posture if the platform default ever changes — but it says so,
+    # because on this path there is no wizard to have said it.
+    missing = [k for k in ("modelPolicy", "partnerNodePolicy") if definition.get(k) is None]
+    if missing:
+        renderer.warn(
+            f"no {' or '.join(missing)} set; this version will be sealed permitting everything in those categories"
+        )
+
     # Locate bytes for private-model uploads: models/<type>/<filename>. Only
     # needed when something actually uploads.
     mroot = Path(models_dir).expanduser() if models_dir else None
@@ -1441,6 +1497,30 @@ def update_cmd(
         renderer.error(code="distribution_definition_invalid", message=str(e), details={"path": from_})
         raise typer.Exit(code=1) from e
     client = _builder_client(renderer, builder_url)
+
+    # A scan definition is not a builder definition: its models carry {sizeBytes,
+    # source} and no sourceUri or blobId, and its nodes name a source the builder
+    # spells differently. Sending the file verbatim means the builder rejects every
+    # model with "must set exactly one of sourceUri or blobId". Map it the same way
+    # create does, so the same file works through either command.
+    if _is_scan_shaped(definition):
+        # Batched, one call per 32 filenames, exactly as create does it. The
+        # annotation it leaves is what the default resolver in plan_create reads.
+        try:
+            resolve_models_via_builder(definition.get("models", []), client)
+        except (requests.RequestException, KeyError, ValueError) as e:
+            renderer.warn(f"model resolution unavailable ({e})")
+        plan = plan_create(definition)
+        if plan["uploads"]:
+            names = ", ".join(sorted(u.get("filename") or u["name"] for u in plan["uploads"]))
+            renderer.error(
+                code="distribution_upload_unavailable",
+                message=f"these need uploading, which update cannot do: {names}",
+                hint="use `comfy distribution create --from ... --execute`, which uploads private blobs",
+            )
+            raise typer.Exit(code=1)
+        definition = plan["definition"]
+
     # The builder guards the save with the updatedAt the caller last saw (optimistic
     # concurrency, meant for the website's read-edit-save). For a CLI that's just
     # last-writer-wins: fetch the current updatedAt and echo it back, else the save

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -654,7 +654,11 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
         if m.get("sha256"):
             entry["sha256"] = m["sha256"]
         uri = resolver(m)
-        if uri:
+        # A blob the caller already holds is a source, so it is neither resolved
+        # nor uploaded again: re-uploading would orphan the bytes it replaced.
+        if m.get("blobId"):
+            entry["blobId"] = m["blobId"]
+        elif uri:
             entry["sourceUri"] = uri
         else:
             # `slot` points at the builder-definition entry this upload fills, so
@@ -1505,6 +1509,59 @@ def update_cmd(
     if renderer.is_pretty():
         renderer.success(f"Updated distribution {distribution_id}")
     renderer.emit(dist, command="distribution update", changed=True)
+
+
+@app.command("blob-upload", help="Upload a private file and print the blobId a definition can reference.")
+@tracking.track_command("distribution")
+def blob_upload_cmd(
+    path: Annotated[str, typer.Argument(help="File to upload.")],
+    kind: Annotated[str, typer.Option("--kind", help="What the file is: model or node_zip.")] = "model",
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    if kind not in ("model", "node_zip"):
+        renderer.error(
+            code="distribution_definition_invalid",
+            message=f"unknown blob kind {kind!r}",
+            hint="use --kind model or --kind node_zip",
+        )
+        raise typer.Exit(code=1)
+    file_path = Path(path).expanduser()
+    if not file_path.is_file():
+        renderer.error(
+            code="distribution_models_dir_missing",
+            message=f"no file at {file_path}",
+            details={"path": str(file_path)},
+        )
+        raise typer.Exit(code=1)
+
+    client = _builder_client(renderer, builder_url)
+    size_bytes = file_path.stat().st_size
+    sha256 = _sha256_file(file_path)
+    blob_id, upload_url = _builder_call(renderer, lambda: client.create_blob(kind, file_path.name, sha256, size_bytes))
+    _builder_call(renderer, lambda: client.upload_blob(upload_url, file_path))
+    if renderer.is_pretty():
+        renderer.success(f"Uploaded {file_path.name} as {blob_id}")
+        renderer.info(f'reference it in a definition as "blobId": "{blob_id}", then `comfy distribution update`')
+    renderer.emit(
+        {"blobId": blob_id, "kind": kind, "filename": file_path.name, "sha256": sha256, "sizeBytes": size_bytes},
+        command="distribution blob-upload",
+        changed=True,
+    )
+
+
+@app.command("blobs", help="List the workspace's uploaded private files.")
+@tracking.track_command("distribution")
+def blobs_cmd(
+    kind: Annotated[str | None, typer.Option("--kind", help="Filter by kind: model or node_zip.")] = None,
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    client = _builder_client(renderer, builder_url)
+    blobs = _builder_call(renderer, lambda: client.list_blobs(kind))
+    if renderer.is_pretty():
+        renderer.console().print_json(json.dumps(blobs))
+    renderer.emit({"blobs": blobs}, command="distribution blobs")
 
 
 @app.command("resolve", help="Resolve model filenames to public download candidates (HF/CivitAI).")

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -50,6 +50,8 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy distribution version manifest": "distribution_version_manifest",
     "comfy distribution artifact download": "distribution_artifact_download",
     "comfy distribution blob list": "distribution_blob_list",
+    "comfy distribution blob upload": "distribution_blob_upload",
+    "comfy distribution from-snapshot": "distribution_from_snapshot",
     "comfy jobs ls": "jobs",
     "comfy jobs status": "jobs",
     "comfy jobs watch": "jobs",

--- a/comfy_cli/distribution_api.py
+++ b/comfy_cli/distribution_api.py
@@ -124,6 +124,15 @@ class BuilderClient:
         r = self._post(("models", "resolve"), {"filenames": filenames})
         return r.get("results", [])
 
+    def resolve_snapshot(self, snapshot: dict) -> dict:
+        """POST /v1/snapshots/resolve — read a captured environment as a definition.
+
+        The builder's importer is the one place that knows what the Comfy Registry
+        actually publishes, which curated base image a Python fits, and how a pin
+        normalizes. Returns ``{definition, report, ...}``; the report names what
+        did not translate rather than leaving it to fail inside a build."""
+        return self._post(("snapshots", "resolve"), {"snapshot": snapshot})
+
     def _get(self, parts: tuple[str, ...], params: dict | None = None, *, max_bytes: int = _MAX_JSON) -> dict:
         url = self.target.url(*parts)
         if params:

--- a/comfy_cli/distribution_api.py
+++ b/comfy_cli/distribution_api.py
@@ -133,6 +133,18 @@ class BuilderClient:
         did not translate rather than leaving it to fail inside a build."""
         return self._post(("snapshots", "resolve"), {"snapshot": snapshot})
 
+    def create_distribution_from_snapshot(
+        self, name: str, snapshot: dict, *, description: str | None = None, base_image_id: str | None = None
+    ) -> dict:
+        """POST /v1/distributions/from-snapshot — read a snapshot and store what it
+        maps to, in one call. Returns ``{distribution, report}``."""
+        body: dict = {"name": name, "snapshot": snapshot}
+        if description:
+            body["description"] = description
+        if base_image_id:
+            body["baseImageId"] = base_image_id
+        return self._post(("distributions", "from-snapshot"), body)
+
     def _get(self, parts: tuple[str, ...], params: dict | None = None, *, max_bytes: int = _MAX_JSON) -> dict:
         url = self.target.url(*parts)
         if params:

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1085,13 +1085,11 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "distribution_registry_pin_missing",
-        "`comfy distribution create --execute` found a custom node pinned to a registry id or version the "
-        "registry does not have. The pin comes from the pack's own `pyproject.toml`, which says what the pack "
-        "calls itself rather than proving it was published, so the build would only discover this at freeze, "
-        "after the cut is spent. The message names each pack, and names the install directory as a candidate "
-        "when the registry does have that one.",
-        "re-run with `--repair-registry-ids` to use the suggested ids, or edit the definition to name a "
-        "published version",
+        "`comfy distribution create --execute` sent the definition to the builder's snapshot importer, which "
+        "could not vouch for one or more custom node pins and returned a definition without them. Creating "
+        "anyway would build an image quietly missing what the user asked for, so create stops. The advisories "
+        "printed above name why each pack could not be carried.",
+        "edit the definition to name a published registry version, or remove the pack",
     ),
     ErrorCode(
         "distribution_delete_needs_confirm",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1084,6 +1084,16 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "re-scan with `--comfy-version <ref>` (a tag, branch, or commit), or add a `baseComfyVersion` to the definition JSON",
     ),
     ErrorCode(
+        "distribution_registry_pin_missing",
+        "`comfy distribution create --execute` found a custom node pinned to a registry id or version the "
+        "registry does not have. The pin comes from the pack's own `pyproject.toml`, which says what the pack "
+        "calls itself rather than proving it was published, so the build would only discover this at freeze, "
+        "after the cut is spent. The message names each pack, and names the install directory as a candidate "
+        "when the registry does have that one.",
+        "re-run with `--repair-registry-ids` to use the suggested ids, or edit the definition to name a "
+        "published version",
+    ),
+    ErrorCode(
         "distribution_delete_needs_confirm",
         "`comfy distribution delete` was run without `--yes` in a non-interactive context (JSON output, an agent, "
         "or a pipe) where there is no TTY to confirm on. Delete is refused rather than blocking on a prompt.",

--- a/comfy_cli/registry/api.py
+++ b/comfy_cli/registry/api.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from urllib.parse import quote
 
 from comfy_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -69,8 +70,11 @@ class NodeFetchError(Exception):
 
 
 class RegistryAPI:
-    def __init__(self):
-        self.base_url = self.determine_base_url()
+    def __init__(self, base_url: str | None = None):
+        # An explicit host pins the check to one registry. Callers that must agree
+        # with another service (the builder resolves nodes against prod in every
+        # environment) pass it rather than following $ENVIRONMENT.
+        self.base_url = base_url or self.determine_base_url()
 
     def determine_base_url(self):
         env = os.getenv("ENVIRONMENT")
@@ -237,6 +241,28 @@ class RegistryAPI:
                 f"Failed to retrieve node: {response.status_code} - {response.text}",
                 status_code=response.status_code,
             )
+
+    def get_node_version(self, node_id, version):
+        """Check that ``version`` of ``node_id`` is published, read-only.
+
+        This is the pair the builder resolves at freeze time: a node can exist
+        while the version asked for does not, so proving the node alone proves
+        nothing about the build. Like ``get_node`` and unlike ``install_node``,
+        this records no installation and fires no analytics event.
+
+        Raises:
+          NodeFetchError: carrying ``status_code``, 404 when the pair is not
+            published and anything else when the registry could not answer.
+        """
+        url = f"{self.base_url}/nodes/{quote(str(node_id), safe='')}/versions/{quote(str(version), safe='')}"
+        # Same rationale as get_node: a stalled registry must not hang callers.
+        response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
+        if response.status_code == 200:
+            return response.json()
+        raise NodeFetchError(
+            f"Failed to retrieve node version: {response.status_code} - {sanitize_error_body(response.text)}",
+            status_code=response.status_code,
+        )
 
 
 def map_node_version(api_node_version):

--- a/comfy_cli/registry/api.py
+++ b/comfy_cli/registry/api.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from urllib.parse import quote
 
 from comfy_cli.http import DEFAULT_HTTP_TIMEOUT
 
@@ -70,11 +69,8 @@ class NodeFetchError(Exception):
 
 
 class RegistryAPI:
-    def __init__(self, base_url: str | None = None):
-        # An explicit host pins the check to one registry. Callers that must agree
-        # with another service (the builder resolves nodes against prod in every
-        # environment) pass it rather than following $ENVIRONMENT.
-        self.base_url = base_url or self.determine_base_url()
+    def __init__(self):
+        self.base_url = self.determine_base_url()
 
     def determine_base_url(self):
         env = os.getenv("ENVIRONMENT")
@@ -241,28 +237,6 @@ class RegistryAPI:
                 f"Failed to retrieve node: {response.status_code} - {response.text}",
                 status_code=response.status_code,
             )
-
-    def get_node_version(self, node_id, version):
-        """Check that ``version`` of ``node_id`` is published, read-only.
-
-        This is the pair the builder resolves at freeze time: a node can exist
-        while the version asked for does not, so proving the node alone proves
-        nothing about the build. Like ``get_node`` and unlike ``install_node``,
-        this records no installation and fires no analytics event.
-
-        Raises:
-          NodeFetchError: carrying ``status_code``, 404 when the pair is not
-            published and anything else when the registry could not answer.
-        """
-        url = f"{self.base_url}/nodes/{quote(str(node_id), safe='')}/versions/{quote(str(version), safe='')}"
-        # Same rationale as get_node: a stalled registry must not hang callers.
-        response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
-        if response.status_code == 200:
-            return response.json()
-        raise NodeFetchError(
-            f"Failed to retrieve node version: {response.status_code} - {sanitize_error_body(response.text)}",
-            status_code=response.status_code,
-        )
 
 
 def map_node_version(api_node_version):

--- a/comfy_cli/schemas/distribution_blob_upload.json
+++ b/comfy_cli/schemas/distribution_blob_upload.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/distribution_blob_upload.json",
+  "title": "comfy distribution blob upload --json data payload",
+  "type": "object",
+  "required": ["blobId", "kind", "filename", "sha256", "sizeBytes"],
+  "additionalProperties": true,
+  "properties": {
+    "blobId": {"type": "string"},
+    "kind": {"type": "string", "enum": ["model", "node_zip"]},
+    "filename": {"type": "string"},
+    "sha256": {"type": "string"},
+    "sizeBytes": {"type": "integer"}
+  }
+}

--- a/comfy_cli/schemas/distribution_from_snapshot.json
+++ b/comfy_cli/schemas/distribution_from_snapshot.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/distribution_from_snapshot.json",
+  "title": "comfy distribution from-snapshot --json data payload",
+  "type": "object",
+  "required": ["distribution"],
+  "additionalProperties": true,
+  "properties": {
+    "distribution": {"type": "object", "additionalProperties": true},
+    "report": {"type": "object", "additionalProperties": true}
+  }
+}

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -15,6 +15,7 @@ import requests
 import typer
 
 from comfy_cli.command import distribution
+from comfy_cli.output import get_renderer
 
 
 @pytest.fixture
@@ -1057,186 +1058,174 @@ def test_validate_does_not_claim_the_definition_resolves(monkeypatch, capsys):
     assert "Definition resolves." not in out
 
 
-# --- create: a pin the registry cannot serve ----------------------------------
+# --- create: the builder reads the pins, not us -------------------------------
 
 
-class _FakeRegistry:
-    """Stands in for RegistryAPI. `known` holds published (id, version) pairs;
-    `unreachable` ids raise a non-404, and `flaky` ids raise the transport error a
-    real timeout produces. Both must be read as "no answer", never as "no node"."""
-
-    def __init__(self, known=(), unreachable=(), flaky=()):
-        self.known = {tuple(k) for k in known}
-        self.unreachable = set(unreachable)
-        self.flaky = set(flaky)
-        self.asked = []
-
-    def get_node_version(self, node_id, version):
-        self.asked.append((node_id, version))
-        if node_id in self.flaky:
-            raise requests.ConnectionError("connection reset")
-        if node_id in self.unreachable:
-            raise distribution.NodeFetchError("registry down", status_code=503)
-        if (node_id, version) not in self.known:
-            raise distribution.NodeFetchError("no such node version", status_code=404)
-        return {"id": node_id, "version": version}
-
-
-WAS_PREVIEW = {
-    "name": "was-node-suite-comfyui",
-    "id": "pr-was-node-suite-comfyui-47064894",
-    "registryVersion": "1.0.1",
-}
-
-
-def test_verify_registry_pins_checks_the_pair_not_just_the_node():
-    """Freeze resolves (id, version). A node that exists at some other version is
-    not a buildable pin, and proving the node alone would pass it through."""
-    nodes = [{"name": "kj", "id": "kj", "registryVersion": "9.9.9"}]
-    api = _FakeRegistry(known=[("kj", "1.4.9")])
-    assert distribution.verify_registry_pins(nodes, api)["unresolved"] == [("kj", "kj", "9.9.9", None)]
-
-
-def test_verify_registry_pins_reports_the_candidate_without_applying_it():
-    """The default is to say what was found. A directory name is not evidence: it
-    is user-controlled and registry ids are first-come, so using it silently could
-    install a stranger's package."""
-    nodes = [dict(WAS_PREVIEW)]
-    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
-    out = distribution.verify_registry_pins(nodes, api)
-    assert out["repaired"] == []
-    assert out["unresolved"] == [
-        ("was-node-suite-comfyui", "pr-was-node-suite-comfyui-47064894", "1.0.1", "was-node-suite-comfyui")
+def test_snapshot_from_definition_maps_each_source_to_its_snapshot_kind():
+    """The importer reads a Desktop export; a scan holds the same facts under other
+    names. Translating is what lets one implementation of registry truth serve both."""
+    snap = distribution.snapshot_from_definition(
+        {
+            "baseComfyVersion": "v0.30.2",
+            "environment": {"pythonVersion": "3.12.7"},
+            "customNodes": [
+                {"name": "was-node-suite-comfyui", "id": "pr-was-47064894", "registryVersion": "1.0.1"},
+                {"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"},
+                {"name": "handmade"},
+            ],
+        }
+    )
+    assert snap["type"] == "comfyui-desktop-2-snapshot"
+    (entry,) = snap["snapshots"]
+    assert entry["comfyui"]["baseTag"] == "v0.30.2"
+    assert entry["pythonVersion"] == "3.12.7"
+    assert entry["customNodes"] == [
+        {
+            "type": "cnr",
+            "id": "pr-was-47064894",
+            "dirName": "was-node-suite-comfyui",
+            "version": "1.0.1",
+            "enabled": True,
+        },
+        {
+            "type": "git",
+            "id": "gitpack",
+            "dirName": "gitpack",
+            "url": "https://github.com/x/gitpack",
+            "commit": "deadbeef",
+            "enabled": True,
+        },
     ]
-    assert nodes[0]["id"] == "pr-was-node-suite-comfyui-47064894"  # untouched
 
 
-def test_verify_registry_pins_applies_the_candidate_only_under_repair():
-    nodes = [dict(WAS_PREVIEW)]
-    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
-    out = distribution.verify_registry_pins(nodes, api, repair=True)
-    assert out["repaired"] == [("pr-was-node-suite-comfyui-47064894", "was-node-suite-comfyui")]
-    assert out["unresolved"] == []
-    assert nodes[0]["id"] == "was-node-suite-comfyui"
+def test_snapshot_from_definition_keeps_only_plain_pins():
+    """A freeze is one pin per line; a snapshot is a map. A comment, a git direct
+    reference and a bare name are not pins and have no key to occupy."""
+    snap = distribution.snapshot_from_definition(
+        {
+            "pipDependencies": (
+                "# captured on Darwin/arm64\n"
+                "numpy==1.26.4\n"
+                "cstr @ git+https://github.com/WASasquatch/cstr@0520c29\n"
+                "torch\n"
+                "\n"
+                "timm==1.0.28\n"
+            )
+        }
+    )
+    assert snap["snapshots"][0]["pipPackages"] == {"numpy": "1.26.4", "timm": "1.0.28"}
 
 
-def test_verify_registry_pins_repair_still_requires_the_candidate_version_to_exist():
-    """Repair rewrites the id and keeps the version. If the released series never
-    had that version, rewriting would only move the failure back to freeze."""
-    nodes = [dict(WAS_PREVIEW)]
-    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.2")])
-    out = distribution.verify_registry_pins(nodes, api, repair=True)
-    assert out["repaired"] == []
-    assert out["unresolved"] == [("was-node-suite-comfyui", "pr-was-node-suite-comfyui-47064894", "1.0.1", None)]
+def test_snapshot_from_definition_carries_no_models():
+    """A snapshot describes an environment. Models are the caller's half and stay
+    with the definition, which is why the importer's answer is merged, not adopted."""
+    snap = distribution.snapshot_from_definition({"models": [{"type": "vae", "filename": "ae.safetensors"}]})
+    assert "models" not in snap["snapshots"][0]
 
 
-@pytest.mark.parametrize("kind", ["unreachable", "flaky"])
-def test_verify_registry_pins_never_rewrites_on_a_non_answer(kind):
-    """A 503 or a dropped connection is not evidence a pin is missing. Treating it
-    as one would corrupt a correct definition every time the registry hiccups."""
-    nodes = [dict(WAS_PREVIEW)]
-    api = _FakeRegistry(**{kind: {"pr-was-node-suite-comfyui-47064894"}})
-    out = distribution.verify_registry_pins(nodes, api, repair=True)
-    assert out["unreachable"] is True
-    assert out["repaired"] == [] and out["unresolved"] == []
-    assert nodes[0]["id"] == "pr-was-node-suite-comfyui-47064894"
+def test_report_advisories_names_every_thing_the_import_could_not_carry():
+    lines = distribution.report_advisories(
+        {"notInRegistry": ["was-node-suite-comfyui"], "unpinnablePins": ["torch"], "pythonSatisfied": True}
+    )
+    assert any("was-node-suite-comfyui" in line and "does not publish" in line for line in lines)
+    assert any("torch" in line and "not a public PyPI release" in line for line in lines)
+    assert len(lines) == 2  # pythonSatisfied True says nothing
 
 
-def test_verify_registry_pins_stops_asking_once_the_registry_stops_answering():
-    """One timeout per pack turns a 40-pack install into a 20-minute hang."""
-    nodes = [dict(WAS_PREVIEW), {"name": "b", "id": "b", "registryVersion": "1.0.0"}]
-    api = _FakeRegistry(unreachable={"pr-was-node-suite-comfyui-47064894", "b"})
-    distribution.verify_registry_pins(nodes, api)
-    assert len(api.asked) == 1
+def test_report_advisories_says_when_no_base_image_matches_the_python():
+    """The scan ran on one Python and the build runs on another, which is how a
+    freeze that resolved locally fails in the build."""
+    (line,) = distribution.report_advisories({"pythonSatisfied": False})
+    assert "closest one" in line
 
 
-def test_verify_registry_pins_ignores_nodes_with_no_registry_pin():
-    api = _FakeRegistry()
-    nodes = [{"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"}]
-    assert distribution.verify_registry_pins(nodes, api)["unresolved"] == []
-    assert api.asked == []
+class _ImportingBuilder:
+    """Stands in for the builder across the whole execute path."""
+
+    def __init__(self, resolved=None, fail=None):
+        self.resolved = resolved
+        self.fail = fail
+        self.created_with = None
+        self.snapshot_seen = None
+
+    def resolve_snapshot(self, snapshot):
+        self.snapshot_seen = snapshot
+        if self.fail:
+            raise self.fail
+        return self.resolved
+
+    def resolve_models(self, filenames):
+        return []
+
+    def create_distribution(self, name, definition, description=None):
+        self.created_with = definition
+        return "dist-1"
+
+    def cut_version(self, distribution_id, targets=None):
+        return ("ver-1", "status-url")
 
 
-def test_verify_registry_pins_checks_a_pack_whose_name_matches_its_id():
-    """The common shape of a self-authored pack. Skipping it because there is
-    nothing to fall back to would leave the pin unverified, which is the case that
-    creates the distribution and then dies at freeze."""
-    nodes = [{"name": "my-inhouse-pack", "id": "my-inhouse-pack", "registryVersion": "0.1.0"}]
-    api = _FakeRegistry()
-    out = distribution.verify_registry_pins(nodes, api)
-    assert api.asked == [("my-inhouse-pack", "0.1.0")]
-    assert out["unresolved"] == [("my-inhouse-pack", "my-inhouse-pack", "0.1.0", None)]
+def _execute(monkeypatch, builder, definition):
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: builder)
+    distribution._create_execute(get_renderer(), definition, name="demo", builder_url=None, models_dir=None)
 
 
-def test_create_execute_stops_before_creating_anything_on_a_bad_pin(monkeypatch, capsys):
-    """The wiring, not the logic: a pin the registry cannot serve must fail here,
-    before a distribution exists, which is the whole point of checking early."""
-    created = []
+def test_create_execute_sends_the_definition_for_reading_and_takes_back_what_it_says(monkeypatch):
+    """The whole point of the call: the id the builder vouched for is the id that
+    gets created, without the CLI holding its own copy of registry truth."""
+    builder = _ImportingBuilder(
+        resolved={
+            "definition": {
+                "customNodes": [{"name": "was", "id": "was-node-suite-comfyui", "registryVersion": "1.0.1"}]
+            },
+            "report": {},
+        }
+    )
+    _execute(
+        monkeypatch,
+        builder,
+        {
+            "baseComfyVersion": "v0.30.2",
+            "models": [],
+            "customNodes": [{"name": "was", "id": "pr-was-47064894", "registryVersion": "1.0.1"}],
+        },
+    )
+    assert builder.snapshot_seen["snapshots"][0]["customNodes"][0]["id"] == "pr-was-47064894"
+    (node,) = builder.created_with["customNodes"]
+    assert node["id"] == "was-node-suite-comfyui"
 
-    class FakeBuilder:
-        def resolve_models(self, *a, **k):
-            return {}
 
-    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeBuilder())
-    monkeypatch.setattr(distribution, "_registry_client", lambda: _FakeRegistry())
-    monkeypatch.setattr(distribution, "execute_create", lambda *a, **k: created.append(a) or {})
-
-    with pytest.raises(typer.Exit) as e:
-        distribution._create_execute(
-            distribution.get_renderer(),
-            {"models": [], "customNodes": [dict(WAS_PREVIEW)], "baseComfyVersion": "v0.30.2"},
-            name="d",
-            builder_url=None,
-            models_dir=None,
+def test_create_execute_refuses_when_the_builder_drops_a_pack(monkeypatch):
+    """A pack the importer could not vouch for is absent from what it returns.
+    Building an image quietly missing what the user asked for is worse than failing."""
+    builder = _ImportingBuilder(resolved={"definition": {"customNodes": []}, "report": {"notInRegistry": ["was"]}})
+    with pytest.raises(typer.Exit):
+        _execute(
+            monkeypatch,
+            builder,
+            {
+                "baseComfyVersion": "v0.30.2",
+                "models": [],
+                "customNodes": [{"name": "was", "id": "nope", "registryVersion": "1.0.1"}],
+            },
         )
-    assert e.value.exit_code == 1
-    assert created == []  # nothing was created, so there is no cut to reclaim
-    assert "pr-was-node-suite-comfyui-47064894" in capsys.readouterr().out
+    assert builder.created_with is None
 
 
-def test_create_execute_passes_the_repaired_id_to_the_builder(monkeypatch):
-    """Under --repair-registry-ids the rewritten id must actually reach the
-    definition that is sent, not just the warning line."""
-    sent = {}
-
-    class FakeBuilder:
-        def resolve_models(self, *a, **k):
-            return {}
-
-    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeBuilder())
-    monkeypatch.setattr(
-        distribution, "_registry_client", lambda: _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
+def test_create_execute_still_creates_when_the_builder_cannot_read_pins(monkeypatch):
+    """An older builder has no importer. The pins go to the cut unchecked, which is
+    where they were checked before this existed; refusing to create would be worse."""
+    builder = _ImportingBuilder(fail=requests.RequestException("404 no such endpoint"))
+    _execute(
+        monkeypatch,
+        builder,
+        {
+            "baseComfyVersion": "v0.30.2",
+            "models": [],
+            "customNodes": [{"name": "was", "id": "pr-was-47064894", "registryVersion": "1.0.1"}],
+        },
     )
-
-    def fake_execute(plan, **kwargs):
-        sent.update(plan["definition"])
-        return {"distributionId": "d1", "versionId": "v1", "uploaded": 0, "statusUrl": "u"}
-
-    monkeypatch.setattr(distribution, "execute_create", fake_execute)
-    distribution._create_execute(
-        distribution.get_renderer(),
-        {"models": [], "customNodes": [dict(WAS_PREVIEW)], "baseComfyVersion": "v0.30.2"},
-        name="d",
-        builder_url=None,
-        models_dir=None,
-        repair=True,
-    )
-    assert sent["customNodes"][0]["id"] == "was-node-suite-comfyui"
-
-
-def test_plan_create_prefers_git_when_a_node_carries_both_sources():
-    """plan_create re-decides precedence from the fields, independently of scan. A
-    commit pins bytes; a package version is resolved later, so git wins."""
-    node = {
-        "name": "dual",
-        "repository": "https://github.com/x/dual",
-        "gitRef": "deadbeef",
-        "id": "dual",
-        "registryVersion": "2.0.0",
-    }
-    entry = distribution.plan_create({"models": [], "customNodes": [node]})["definition"]["customNodes"][0]
-    assert entry["gitRef"] == "deadbeef"
-    assert "registryVersion" not in entry
+    assert builder.created_with["customNodes"][0]["id"] == "pr-was-47064894"
 
 
 # --- the freeze describes the target env, and carries no credential -----------

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -828,3 +828,52 @@ def test_create_command_bad_definition(tmp_path):
     assert proc.returncode == 1
     envelope = json.loads(proc.stdout.strip().splitlines()[-1])
     assert envelope["error"]["code"] == "distribution_definition_invalid"
+
+
+# --- create: the definition survives the trip ---------------------------------
+
+REGISTRY_DEF = {
+    "schema": "distribution-definition/0",
+    "baseComfyVersion": "v0.3.40",
+    "baseImage": "cuda130-py312",
+    "modelPolicy": {"mode": "allowlist", "list": ["ae.safetensors"]},
+    "partnerNodePolicy": {"mode": "blocklist", "list": []},
+    "models": [],
+    "customNodes": [
+        {"name": "comfyui-kjnodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9", "source": "registry"},
+        {"name": "priv", "blobId": "blob-1"},
+        {"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"},
+    ],
+}
+
+
+def test_plan_create_keeps_registry_pins_out_of_the_upload_plan():
+    """A registry-pinned node is a source the builder can resolve, so it travels as
+    (id, registryVersion) rather than becoming an upload `--execute` would refuse."""
+    plan = distribution.plan_create(REGISTRY_DEF)
+    kj = next(n for n in plan["definition"]["customNodes"] if n["name"] == "comfyui-kjnodes")
+    assert kj == {"name": "comfyui-kjnodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9"}
+    assert plan["upload_count"] == 0
+
+
+def test_plan_create_keeps_a_blob_reference():
+    """An already-uploaded node names its blob; re-uploading it would orphan bytes."""
+    priv = next(n for n in distribution.plan_create(REGISTRY_DEF)["definition"]["customNodes"] if n["name"] == "priv")
+    assert priv == {"name": "priv", "blobId": "blob-1"}
+
+
+def test_plan_create_honours_a_hand_written_git_node_with_no_source_tag():
+    """`source` is the scan's own annotation. A definition written by hand names its
+    fields and nothing else, and must not be read as an upload."""
+    g = next(n for n in distribution.plan_create(REGISTRY_DEF)["definition"]["customNodes"] if n["name"] == "gitpack")
+    assert g == {"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"}
+
+
+def test_plan_create_carries_base_image_and_policies():
+    """These reach the builder or they do not exist: an absent baseImage silently
+    becomes the catalog default, and an absent policy seals as allow-all."""
+    d = distribution.plan_create(REGISTRY_DEF)["definition"]
+    assert d["baseImage"] == "cuda130-py312"
+    assert d["modelPolicy"] == {"mode": "allowlist", "list": ["ae.safetensors"]}
+    assert d["partnerNodePolicy"] == {"mode": "blocklist", "list": []}
+    assert d["baseComfyVersion"] == "v0.3.40"

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1237,3 +1237,106 @@ def test_plan_create_prefers_git_when_a_node_carries_both_sources():
     entry = distribution.plan_create({"models": [], "customNodes": [node]})["definition"]["customNodes"][0]
     assert entry["gitRef"] == "deadbeef"
     assert "registryVersion" not in entry
+
+
+# --- the freeze describes the target env, and carries no credential -----------
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "cstr @ git+https://x-access-token:ghp_SECRET@github.com/org/p.git@abc",
+            "cstr @ git+https://***@github.com/org/p.git@abc",
+        ),
+        ("pkg @ https://user:pw@example.com/x.whl", "pkg @ https://***@example.com/x.whl"),
+        # no userinfo: untouched, including the @ that pins a git ref
+        (
+            "ffmpy @ git+https://github.com/WASasquatch/ffmpy.git@f000",
+            "ffmpy @ git+https://github.com/WASasquatch/ffmpy.git@f000",
+        ),
+        ("numpy==1.26.4", "numpy==1.26.4"),
+    ],
+)
+def test_redact_freeze_credentials(line, expected):
+    """A definition is written to disk, POSTed to the builder and often committed,
+    so a token pip recorded in a direct reference travels far from where it was
+    minted."""
+    assert distribution._redact_freeze_credentials(line) == expected
+
+
+def test_freeze_ignores_the_callers_pythonpath(tmp_path, monkeypatch):
+    """PYTHONPATH puts whatever it points at into the freeze as an installed
+    package, and the builder then tries to resolve a pin for a phantom."""
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["env"] = kwargs.get("env") or {}
+
+        class R:
+            returncode = 0
+            stdout = "numpy==1.26.4\n"
+
+        return R()
+
+    monkeypatch.setenv("PYTHONPATH", "/somewhere/else")
+    monkeypatch.setattr(distribution.subprocess, "run", fake_run)
+    assert distribution._freeze_env("/x/bin/python") == "numpy==1.26.4\n"
+    assert "PYTHONPATH" not in seen["env"]
+
+
+# --- update: the same file works through either command -----------------------
+
+
+def test_update_maps_a_scan_definition_instead_of_sending_it_raw(monkeypatch):
+    """`update --from` sent the file verbatim, so a scan definition's models
+    arrived with neither sourceUri nor blobId and the builder rejected every one.
+    The same file must work through create and update alike."""
+    sent = {}
+
+    class FakeClient:
+        def get_distribution(self, did):
+            return {"updatedAt": "t0"}
+
+        def update_distribution(self, did, definition, updated_at):
+            sent.update(definition)
+            return {"id": did}
+
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeClient())
+    monkeypatch.setattr(
+        distribution,
+        "resolve_models_via_builder",
+        lambda models, client: [m.__setitem__("sourceUri", "https://hf.co/x") for m in models] and len(models),
+    )
+    defn = {
+        "models": [{"type": "vae", "filename": "a.safetensors", "sha256": "d", "sizeBytes": 1, "source": "local"}],
+        "customNodes": [{"name": "kj", "id": "kj", "registryVersion": "1.4.9", "source": "registry"}],
+        "baseComfyVersion": "0.30.2",
+    }
+    monkeypatch.setattr(distribution, "_load_definition", lambda p, require_models=False: defn)
+    distribution.update_cmd("d1", from_="ignored.json")
+
+    assert sent["models"][0]["sourceUri"] == "https://hf.co/x"
+    assert "sizeBytes" not in sent["models"][0] and "source" not in sent["models"][0]
+    assert sent["customNodes"][0] == {"name": "kj", "id": "kj", "registryVersion": "1.4.9"}
+    assert sent["baseComfyVersion"] == "v0.30.2"
+
+
+def test_update_refuses_what_it_cannot_upload(monkeypatch):
+    """update has no upload step, so a model with no public source is a clear
+    refusal naming the command that can, not a builder 400."""
+
+    class FakeClient:
+        def get_distribution(self, did):
+            return {"updatedAt": "t0"}
+
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeClient())
+    monkeypatch.setattr(distribution, "resolve_models_via_builder", lambda models, client: 0)
+    defn = {
+        "models": [{"type": "vae", "filename": "private.safetensors", "sha256": "d", "source": "local"}],
+        "customNodes": [],
+    }
+    monkeypatch.setattr(distribution, "_load_definition", lambda p, require_models=False: defn)
+    with pytest.raises(typer.Exit) as e:
+        distribution.update_cmd("d1", from_="ignored.json")
+    assert e.value.exit_code == 1

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -971,3 +971,43 @@ def test_scan_command_writes_a_resolvable_comfy_ref(models_tree, tmp_path):
     )
     assert proc.returncode == 0, proc.stderr
     assert json.loads(out.read_text())["baseComfyVersion"] == "v0.30.2"
+
+
+# --- validate: say what was checked, and surface the warnings -----------------
+
+
+def _run_validate(monkeypatch, capsys, result):
+    """Drive validate_cmd against a stand-in builder, in pretty mode."""
+
+    class FakeClient:
+        def validate_distribution(self, distribution_id):
+            return result
+
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeClient())
+    distribution.validate_cmd("d1")
+    return capsys.readouterr().out
+
+
+def test_validate_prints_the_warnings_beside_the_verdict(monkeypatch, capsys):
+    """A ref the builder cannot find rides alongside `ok: true`. It was reachable
+    only by reading the JSON dump, under a line that said the definition resolved,
+    so the one thing that will fail the cut was the easiest thing to miss."""
+    out = _run_validate(
+        monkeypatch,
+        capsys,
+        {
+            "ok": True,
+            "warnings": [{"field": "baseComfyVersion", "reason": "ref not found in remote advertisement"}],
+        },
+    )
+    assert "baseComfyVersion" in out
+    assert "ref not found in remote advertisement" in out
+    assert "a cut will fail on these" in out
+
+
+def test_validate_does_not_claim_the_definition_resolves(monkeypatch, capsys):
+    """The endpoint checks shape and pin existence; whether the set installs
+    together is only answered by a build."""
+    out = _run_validate(monkeypatch, capsys, {"ok": True})
+    assert "not a full resolve" in out
+    assert "Definition resolves." not in out

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -962,8 +962,17 @@ def test_scan_command_writes_a_resolvable_comfy_ref(models_tree, tmp_path):
     env = {**os.environ, "NO_COLOR": "1", "COMFY_OUTPUT": "json"}
     proc = subprocess.run(
         [
-            sys.executable, "-m", "comfy_cli", "distribution", "scan",
-            "--models-dir", str(models_tree), "--comfy-version", "0.30.2", "-o", str(out),
+            sys.executable,
+            "-m",
+            "comfy_cli",
+            "distribution",
+            "scan",
+            "--models-dir",
+            str(models_tree),
+            "--comfy-version",
+            "0.30.2",
+            "-o",
+            str(out),
         ],
         capture_output=True,
         text=True,

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1353,3 +1353,39 @@ def test_a_definition_naming_only_blobs_goes_through_update_untouched():
             "customNodes": [{"name": "priv", "blobId": "blob-1"}],
         }
     )
+
+
+def test_report_advisories_reads_the_refused_release_as_one_value():
+    """`droppedComfyVersion` is a string where its neighbours are lists. Iterated as
+    a list it renders one entry per character."""
+    (line,) = distribution.report_advisories({"droppedComfyVersion": "v9.9.9"})
+    assert "'v9.9.9'" in line and "6 " not in line
+
+
+def test_report_advisories_names_a_folder_collision():
+    (line,) = distribution.report_advisories({"collidingNodes": ["ComfyUI-Easy-Use"]})
+    assert "already claimed the folder" in line and "ComfyUI-Easy-Use" in line
+
+
+def test_create_execute_proceeds_when_a_pack_was_dropped_for_colliding(monkeypatch):
+    """The importer drops the loser of a folder collision on purpose, and what comes
+    back is the definition the cut accepts. Refusing it would help nobody."""
+    builder = _ImportingBuilder(
+        resolved={
+            "definition": {"customNodes": [{"name": "first", "id": "first", "registryVersion": "1.0.0"}]},
+            "report": {"collidingNodes": ["Second"]},
+        }
+    )
+    _execute(
+        monkeypatch,
+        builder,
+        {
+            "baseComfyVersion": "v0.30.2",
+            "models": [],
+            "customNodes": [
+                {"name": "first", "id": "first", "registryVersion": "1.0.0"},
+                {"name": "Second", "id": "Second", "registryVersion": "1.0.0"},
+            ],
+        },
+    )
+    assert [n["name"] for n in builder.created_with["customNodes"]] == ["first"]

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 
 import pytest
+import requests
+import typer
 
 from comfy_cli.command import distribution
 
@@ -299,10 +301,12 @@ def test_plan_create_maps_to_builder_schema_all_upload():
 
 
 def test_plan_create_carries_environment_fields():
-    """baseComfyVersion / pipDependencies pass straight through to the builder def."""
+    """pipDependencies passes straight through; baseComfyVersion is normalized to a
+    ref the builder can resolve, here rather than only in `scan`, so a definition
+    written before that fix does not spend its cut discovering the difference."""
     definition = {**SCAN_DEF, "baseComfyVersion": "0.3.40", "pipDependencies": "numpy==1.26.0\n"}
     d = distribution.plan_create(definition)["definition"]
-    assert d["baseComfyVersion"] == "0.3.40"
+    assert d["baseComfyVersion"] == "v0.3.40"
     assert d["pipDependencies"] == "numpy==1.26.0\n"
 
 
@@ -894,6 +898,19 @@ def _write_pack(root, name, *, project=None, git=False):
     return d
 
 
+def test_scan_drops_the_git_keys_when_it_records_a_registry_pin(tmp_path, monkeypatch):
+    """Exactly one source per node, which the builder enforces. A half-git checkout
+    (an origin but no resolvable HEAD) would otherwise carry both, which `create`
+    hides by picking one but `update --from` sends verbatim and the builder 400s."""
+    _write_pack(tmp_path, "half", project='[project]\nname = "half"\nversion = "1.0.0"\n', git=True)
+    monkeypatch.setattr(
+        distribution, "_git_output", lambda path, *args: "https://github.com/x/half" if args[0] == "remote" else None
+    )
+    (node,) = distribution.scan_custom_nodes(tmp_path / "custom_nodes")
+    assert node["source"] == "registry"
+    assert node.get("repository") is None and node.get("gitRef") is None
+
+
 def test_scan_reads_the_registry_pin_off_an_archive_install(tmp_path):
     """`comfy node install` unpacks archives, so a pack has no git history at all.
     Its pyproject still names the published version the builder can fetch."""
@@ -928,10 +945,25 @@ def test_scan_prefers_git_over_the_registry_pin(tmp_path, monkeypatch):
     assert "registryVersion" not in node
 
 
-def test_read_registry_pin_is_silent_on_a_broken_pyproject(tmp_path):
-    """A malformed file is a pack without a pin, never a crashed scan."""
-    d = _write_pack(tmp_path, "broken", project="this is not toml [[[")
-    assert distribution.read_registry_pin(d) is None
+@pytest.mark.parametrize(
+    ("body", "why"),
+    [
+        ("this is not toml [[[", "malformed"),
+        ('[project]\nname = "ok"\nversion = 1.0\n', "version is a toml float, not a string"),
+        ('[project]\nname = "ok"\nversion = 2024-01-01\n', "version is a toml date"),
+        ('[project]\nname = ""\nversion = "1.0.0"\n', "empty id"),
+        ('[project]\nname = "ok"\nversion = "1.0"\n', "not a package version; the builder rejects it"),
+        ('[project]\nname = "ok"\nversion = "0.1.0b1"\n', "prerelease is not a package version"),
+        ('[project]\nname = "../../publishers/x"\nversion = "1.0.0"\n', "escapes the registry path"),
+        ('[project]\nname = "ok#frag"\nversion = "1.0.0"\n', "truncates server-side to a different id"),
+        ('project = "hello"\n', "project is not a table"),
+    ],
+)
+def test_read_registry_pin_is_silent_on_anything_it_cannot_trust(tmp_path, body, why):
+    """A pack that cannot answer has no pin. It must never crash the scan, and never
+    hand on a value the registry or the builder would reject."""
+    d = _write_pack(tmp_path, "pack", project=body)
+    assert distribution._read_registry_pin(d) is None, why
 
 
 # --- scan: the ComfyUI pin has to be a ref that resolves ----------------------
@@ -1009,9 +1041,12 @@ def test_validate_prints_the_warnings_beside_the_verdict(monkeypatch, capsys):
             "warnings": [{"field": "baseComfyVersion", "reason": "ref not found in remote advertisement"}],
         },
     )
-    assert "baseComfyVersion" in out
-    assert "ref not found in remote advertisement" in out
-    assert "a cut will fail on these" in out
+    # Assert on the text BEFORE the JSON dump: the dump repeats every one of these
+    # strings, so a whole-output assertion passes even with the warn lines deleted.
+    head = out.split("{", 1)[0]
+    assert "1 reference(s)" in head
+    assert "the build will fail on these" in head
+    assert "baseComfyVersion: ref not found in remote advertisement" in head
 
 
 def test_validate_does_not_claim_the_definition_resolves(monkeypatch, capsys):
@@ -1022,64 +1057,183 @@ def test_validate_does_not_claim_the_definition_resolves(monkeypatch, capsys):
     assert "Definition resolves." not in out
 
 
-# --- create: a registry id the registry does not have -------------------------
+# --- create: a pin the registry cannot serve ----------------------------------
 
 
 class _FakeRegistry:
-    """Answers get_node from a known set; anything else 404s. `unreachable` ids
-    raise a non-404, which must never be read as 'no such node'."""
+    """Stands in for RegistryAPI. `known` holds published (id, version) pairs;
+    `unreachable` ids raise a non-404, and `flaky` ids raise the transport error a
+    real timeout produces. Both must be read as "no answer", never as "no node"."""
 
-    def __init__(self, known, unreachable=()):
-        self.known = set(known)
+    def __init__(self, known=(), unreachable=(), flaky=()):
+        self.known = {tuple(k) for k in known}
         self.unreachable = set(unreachable)
+        self.flaky = set(flaky)
         self.asked = []
 
-    def get_node(self, node_id):
-        self.asked.append(node_id)
+    def get_node_version(self, node_id, version):
+        self.asked.append((node_id, version))
+        if node_id in self.flaky:
+            raise requests.ConnectionError("connection reset")
         if node_id in self.unreachable:
             raise distribution.NodeFetchError("registry down", status_code=503)
-        if node_id not in self.known:
-            raise distribution.NodeFetchError("no such node", status_code=404)
-        return {"id": node_id}
+        if (node_id, version) not in self.known:
+            raise distribution.NodeFetchError("no such node version", status_code=404)
+        return {"id": node_id, "version": version}
 
 
-def test_repair_registry_ids_falls_back_to_the_install_directory():
-    """A pack published from a PR preview carries that preview's id, which no
-    released version exists under. The directory it was installed into is named
-    for the real registry id."""
-    nodes = [{"name": "was-node-suite-comfyui", "id": "pr-was-node-suite-comfyui-47064894", "registryVersion": "1.0.1"}]
-    api = _FakeRegistry(known={"was-node-suite-comfyui"})
-    assert distribution.repair_registry_ids(nodes, api) == [
-        ("pr-was-node-suite-comfyui-47064894", "was-node-suite-comfyui")
+WAS_PREVIEW = {
+    "name": "was-node-suite-comfyui",
+    "id": "pr-was-node-suite-comfyui-47064894",
+    "registryVersion": "1.0.1",
+}
+
+
+def test_verify_registry_pins_checks_the_pair_not_just_the_node():
+    """Freeze resolves (id, version). A node that exists at some other version is
+    not a buildable pin, and proving the node alone would pass it through."""
+    nodes = [{"name": "kj", "id": "kj", "registryVersion": "9.9.9"}]
+    api = _FakeRegistry(known=[("kj", "1.4.9")])
+    assert distribution.verify_registry_pins(nodes, api)["unresolved"] == [("kj", "kj", "9.9.9", None)]
+
+
+def test_verify_registry_pins_reports_the_candidate_without_applying_it():
+    """The default is to say what was found. A directory name is not evidence: it
+    is user-controlled and registry ids are first-come, so using it silently could
+    install a stranger's package."""
+    nodes = [dict(WAS_PREVIEW)]
+    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
+    out = distribution.verify_registry_pins(nodes, api)
+    assert out["repaired"] == []
+    assert out["unresolved"] == [
+        ("was-node-suite-comfyui", "pr-was-node-suite-comfyui-47064894", "1.0.1", "was-node-suite-comfyui")
     ]
+    assert nodes[0]["id"] == "pr-was-node-suite-comfyui-47064894"  # untouched
+
+
+def test_verify_registry_pins_applies_the_candidate_only_under_repair():
+    nodes = [dict(WAS_PREVIEW)]
+    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
+    out = distribution.verify_registry_pins(nodes, api, repair=True)
+    assert out["repaired"] == [("pr-was-node-suite-comfyui-47064894", "was-node-suite-comfyui")]
+    assert out["unresolved"] == []
     assert nodes[0]["id"] == "was-node-suite-comfyui"
 
 
-def test_repair_registry_ids_leaves_a_good_id_alone():
-    nodes = [{"name": "comfyui-kjnodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9"}]
-    api = _FakeRegistry(known={"comfyui-kjnodes"})
-    assert distribution.repair_registry_ids(nodes, api) == []
-    assert api.asked == []  # name equals id: nothing to disambiguate, so nothing is asked
+def test_verify_registry_pins_repair_still_requires_the_candidate_version_to_exist():
+    """Repair rewrites the id and keeps the version. If the released series never
+    had that version, rewriting would only move the failure back to freeze."""
+    nodes = [dict(WAS_PREVIEW)]
+    api = _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.2")])
+    out = distribution.verify_registry_pins(nodes, api, repair=True)
+    assert out["repaired"] == []
+    assert out["unresolved"] == [("was-node-suite-comfyui", "pr-was-node-suite-comfyui-47064894", "1.0.1", None)]
 
 
-def test_repair_registry_ids_does_not_rewrite_on_an_unreachable_registry():
-    """A 503 is not evidence the node is missing. Rewriting on it would corrupt a
-    correct definition whenever the registry hiccups."""
-    nodes = [{"name": "realname", "id": "declared", "registryVersion": "1.0.0"}]
-    api = _FakeRegistry(known={"realname"}, unreachable={"declared"})
-    assert distribution.repair_registry_ids(nodes, api) == []
-    assert nodes[0]["id"] == "declared"
+@pytest.mark.parametrize("kind", ["unreachable", "flaky"])
+def test_verify_registry_pins_never_rewrites_on_a_non_answer(kind):
+    """A 503 or a dropped connection is not evidence a pin is missing. Treating it
+    as one would corrupt a correct definition every time the registry hiccups."""
+    nodes = [dict(WAS_PREVIEW)]
+    api = _FakeRegistry(**{kind: {"pr-was-node-suite-comfyui-47064894"}})
+    out = distribution.verify_registry_pins(nodes, api, repair=True)
+    assert out["unreachable"] is True
+    assert out["repaired"] == [] and out["unresolved"] == []
+    assert nodes[0]["id"] == "pr-was-node-suite-comfyui-47064894"
 
 
-def test_repair_registry_ids_leaves_both_misses_alone():
-    """Nothing to point at: the definition stays as written and the build reports it."""
-    nodes = [{"name": "realname", "id": "declared", "registryVersion": "1.0.0"}]
-    assert distribution.repair_registry_ids(nodes, _FakeRegistry(known=set())) == []
-    assert nodes[0]["id"] == "declared"
+def test_verify_registry_pins_stops_asking_once_the_registry_stops_answering():
+    """One timeout per pack turns a 40-pack install into a 20-minute hang."""
+    nodes = [dict(WAS_PREVIEW), {"name": "b", "id": "b", "registryVersion": "1.0.0"}]
+    api = _FakeRegistry(unreachable={"pr-was-node-suite-comfyui-47064894", "b"})
+    distribution.verify_registry_pins(nodes, api)
+    assert len(api.asked) == 1
 
 
-def test_repair_registry_ids_ignores_nodes_with_no_registry_pin():
+def test_verify_registry_pins_ignores_nodes_with_no_registry_pin():
+    api = _FakeRegistry()
     nodes = [{"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"}]
-    api = _FakeRegistry(known=set())
-    assert distribution.repair_registry_ids(nodes, api) == []
+    assert distribution.verify_registry_pins(nodes, api)["unresolved"] == []
     assert api.asked == []
+
+
+def test_verify_registry_pins_checks_a_pack_whose_name_matches_its_id():
+    """The common shape of a self-authored pack. Skipping it because there is
+    nothing to fall back to would leave the pin unverified, which is the case that
+    creates the distribution and then dies at freeze."""
+    nodes = [{"name": "my-inhouse-pack", "id": "my-inhouse-pack", "registryVersion": "0.1.0"}]
+    api = _FakeRegistry()
+    out = distribution.verify_registry_pins(nodes, api)
+    assert api.asked == [("my-inhouse-pack", "0.1.0")]
+    assert out["unresolved"] == [("my-inhouse-pack", "my-inhouse-pack", "0.1.0", None)]
+
+
+def test_create_execute_stops_before_creating_anything_on_a_bad_pin(monkeypatch, capsys):
+    """The wiring, not the logic: a pin the registry cannot serve must fail here,
+    before a distribution exists, which is the whole point of checking early."""
+    created = []
+
+    class FakeBuilder:
+        def resolve_models(self, *a, **k):
+            return {}
+
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeBuilder())
+    monkeypatch.setattr(distribution, "_registry_client", lambda: _FakeRegistry())
+    monkeypatch.setattr(distribution, "execute_create", lambda *a, **k: created.append(a) or {})
+
+    with pytest.raises(typer.Exit) as e:
+        distribution._create_execute(
+            distribution.get_renderer(),
+            {"models": [], "customNodes": [dict(WAS_PREVIEW)], "baseComfyVersion": "v0.30.2"},
+            name="d",
+            builder_url=None,
+            models_dir=None,
+        )
+    assert e.value.exit_code == 1
+    assert created == []  # nothing was created, so there is no cut to reclaim
+    assert "pr-was-node-suite-comfyui-47064894" in capsys.readouterr().out
+
+
+def test_create_execute_passes_the_repaired_id_to_the_builder(monkeypatch):
+    """Under --repair-registry-ids the rewritten id must actually reach the
+    definition that is sent, not just the warning line."""
+    sent = {}
+
+    class FakeBuilder:
+        def resolve_models(self, *a, **k):
+            return {}
+
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeBuilder())
+    monkeypatch.setattr(
+        distribution, "_registry_client", lambda: _FakeRegistry(known=[("was-node-suite-comfyui", "1.0.1")])
+    )
+
+    def fake_execute(plan, **kwargs):
+        sent.update(plan["definition"])
+        return {"distributionId": "d1", "versionId": "v1", "uploaded": 0, "statusUrl": "u"}
+
+    monkeypatch.setattr(distribution, "execute_create", fake_execute)
+    distribution._create_execute(
+        distribution.get_renderer(),
+        {"models": [], "customNodes": [dict(WAS_PREVIEW)], "baseComfyVersion": "v0.30.2"},
+        name="d",
+        builder_url=None,
+        models_dir=None,
+        repair=True,
+    )
+    assert sent["customNodes"][0]["id"] == "was-node-suite-comfyui"
+
+
+def test_plan_create_prefers_git_when_a_node_carries_both_sources():
+    """plan_create re-decides precedence from the fields, independently of scan. A
+    commit pins bytes; a package version is resolved later, so git wins."""
+    node = {
+        "name": "dual",
+        "repository": "https://github.com/x/dual",
+        "gitRef": "deadbeef",
+        "id": "dual",
+        "registryVersion": "2.0.0",
+    }
+    entry = distribution.plan_create({"models": [], "customNodes": [node]})["definition"]["customNodes"][0]
+    assert entry["gitRef"] == "deadbeef"
+    assert "registryVersion" not in entry

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1020,3 +1020,66 @@ def test_validate_does_not_claim_the_definition_resolves(monkeypatch, capsys):
     out = _run_validate(monkeypatch, capsys, {"ok": True})
     assert "not a full resolve" in out
     assert "Definition resolves." not in out
+
+
+# --- create: a registry id the registry does not have -------------------------
+
+
+class _FakeRegistry:
+    """Answers get_node from a known set; anything else 404s. `unreachable` ids
+    raise a non-404, which must never be read as 'no such node'."""
+
+    def __init__(self, known, unreachable=()):
+        self.known = set(known)
+        self.unreachable = set(unreachable)
+        self.asked = []
+
+    def get_node(self, node_id):
+        self.asked.append(node_id)
+        if node_id in self.unreachable:
+            raise distribution.NodeFetchError("registry down", status_code=503)
+        if node_id not in self.known:
+            raise distribution.NodeFetchError("no such node", status_code=404)
+        return {"id": node_id}
+
+
+def test_repair_registry_ids_falls_back_to_the_install_directory():
+    """A pack published from a PR preview carries that preview's id, which no
+    released version exists under. The directory it was installed into is named
+    for the real registry id."""
+    nodes = [{"name": "was-node-suite-comfyui", "id": "pr-was-node-suite-comfyui-47064894", "registryVersion": "1.0.1"}]
+    api = _FakeRegistry(known={"was-node-suite-comfyui"})
+    assert distribution.repair_registry_ids(nodes, api) == [
+        ("pr-was-node-suite-comfyui-47064894", "was-node-suite-comfyui")
+    ]
+    assert nodes[0]["id"] == "was-node-suite-comfyui"
+
+
+def test_repair_registry_ids_leaves_a_good_id_alone():
+    nodes = [{"name": "comfyui-kjnodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9"}]
+    api = _FakeRegistry(known={"comfyui-kjnodes"})
+    assert distribution.repair_registry_ids(nodes, api) == []
+    assert api.asked == []  # name equals id: nothing to disambiguate, so nothing is asked
+
+
+def test_repair_registry_ids_does_not_rewrite_on_an_unreachable_registry():
+    """A 503 is not evidence the node is missing. Rewriting on it would corrupt a
+    correct definition whenever the registry hiccups."""
+    nodes = [{"name": "realname", "id": "declared", "registryVersion": "1.0.0"}]
+    api = _FakeRegistry(known={"realname"}, unreachable={"declared"})
+    assert distribution.repair_registry_ids(nodes, api) == []
+    assert nodes[0]["id"] == "declared"
+
+
+def test_repair_registry_ids_leaves_both_misses_alone():
+    """Nothing to point at: the definition stays as written and the build reports it."""
+    nodes = [{"name": "realname", "id": "declared", "registryVersion": "1.0.0"}]
+    assert distribution.repair_registry_ids(nodes, _FakeRegistry(known=set())) == []
+    assert nodes[0]["id"] == "declared"
+
+
+def test_repair_registry_ids_ignores_nodes_with_no_registry_pin():
+    nodes = [{"name": "gitpack", "repository": "https://github.com/x/gitpack", "gitRef": "deadbeef"}]
+    api = _FakeRegistry(known=set())
+    assert distribution.repair_registry_ids(nodes, api) == []
+    assert api.asked == []

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -932,3 +932,42 @@ def test_read_registry_pin_is_silent_on_a_broken_pyproject(tmp_path):
     """A malformed file is a pack without a pin, never a crashed scan."""
     d = _write_pack(tmp_path, "broken", project="this is not toml [[[")
     assert distribution.read_registry_pin(d) is None
+
+
+# --- scan: the ComfyUI pin has to be a ref that resolves ----------------------
+
+
+@pytest.mark.parametrize(
+    ("detected", "expected"),
+    [
+        ("0.30.2", "v0.30.2"),  # the packaged marker, the common case
+        ("0.30", "v0.30"),
+        ("v0.30.2", "v0.30.2"),  # already a tag: untouched
+        ("master", "master"),  # a branch
+        ("0.30.2-5-gdeadbee", "0.30.2-5-gdeadbee"),  # git describe output
+        ("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+    ],
+)
+def test_as_comfy_git_ref(detected, expected):
+    """Upstream tags releases `vX.Y.Z` while every version source reports the bare
+    number, so only a bare release number is rewritten."""
+    assert distribution.as_comfy_git_ref(detected) == expected
+
+
+def test_scan_command_writes_a_resolvable_comfy_ref(models_tree, tmp_path):
+    """End-to-end: a bare `--comfy-version` reaches the definition as a tag. The
+    builder resolves this field with git ls-remote, so the bare number it used to
+    record could only ever be discovered by a failed build."""
+    out = tmp_path / "definition.json"
+    env = {**os.environ, "NO_COLOR": "1", "COMFY_OUTPUT": "json"}
+    proc = subprocess.run(
+        [
+            sys.executable, "-m", "comfy_cli", "distribution", "scan",
+            "--models-dir", str(models_tree), "--comfy-version", "0.30.2", "-o", str(out),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert json.loads(out.read_text())["baseComfyVersion"] == "v0.30.2"

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1389,3 +1389,33 @@ def test_create_execute_proceeds_when_a_pack_was_dropped_for_colliding(monkeypat
         },
     )
     assert [n["name"] for n in builder.created_with["customNodes"]] == ["first"]
+
+
+# --- from-snapshot: a Desktop export becomes a distribution in one call -------
+
+
+def test_from_snapshot_reads_the_created_id_and_report_from_their_own_keys(monkeypatch, tmp_path, capsys):
+    """The endpoint answers {distribution, report}, not a distribution carrying its
+    report. Reading the id off the envelope prints `None` and loses every advisory."""
+
+    class FakeClient:
+        def create_distribution_from_snapshot(self, name, snapshot, *, description=None, base_image_id=None):
+            return {
+                "distribution": {"id": "dist-7", "name": name},
+                "report": {"notInRegistry": ["was-node-suite-comfyui"]},
+            }
+
+    snap = tmp_path / "export.json"
+    snap.write_text(json.dumps({"type": "comfyui-desktop-2-snapshot", "snapshots": [{}]}), encoding="utf-8")
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: FakeClient())
+    distribution.from_snapshot_cmd(from_=str(snap), name="demo")
+    out = capsys.readouterr().out
+    assert "dist-7" in out and "None" not in out
+    assert "was-node-suite-comfyui" in out
+
+
+def test_from_snapshot_refuses_a_file_that_is_not_json(tmp_path, capsys):
+    bad = tmp_path / "export.json"
+    bad.write_text("not json at all", encoding="utf-8")
+    with pytest.raises(typer.Exit):
+        distribution.from_snapshot_cmd(from_=str(bad), name="demo")

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1419,3 +1419,17 @@ def test_from_snapshot_refuses_a_file_that_is_not_json(tmp_path, capsys):
     bad.write_text("not json at all", encoding="utf-8")
     with pytest.raises(typer.Exit):
         distribution.from_snapshot_cmd(from_=str(bad), name="demo")
+
+
+def test_as_snapshot_envelope_wraps_the_file_desktop_actually_writes():
+    """Desktop stores one bare snapshot per file under `.launcher/snapshots/` and
+    only its export action wraps them, so the file a user has is refused."""
+    bare = {"comfyui": {"baseTag": "v0.30.2"}, "customNodes": [], "pipPackages": {}, "pythonVersion": "3.12.7"}
+    wrapped = distribution.as_snapshot_envelope(bare)
+    assert wrapped["type"] == "comfyui-desktop-2-snapshot"
+    assert wrapped["snapshots"] == [bare]
+
+
+def test_as_snapshot_envelope_leaves_a_real_export_alone():
+    export = {"type": "comfyui-desktop-2-snapshot", "version": 2, "snapshots": [{"customNodes": []}]}
+    assert distribution.as_snapshot_envelope(export) is export

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1329,3 +1329,27 @@ def test_update_refuses_what_it_cannot_upload(monkeypatch):
     with pytest.raises(typer.Exit) as e:
         distribution.update_cmd("d1", from_="ignored.json")
     assert e.value.exit_code == 1
+
+
+# --- blobs: a private file is uploaded once and referenced by id ---------------
+
+
+def test_plan_create_keeps_a_model_blob_reference():
+    """A model the caller already uploaded names its blob. Re-uploading it would
+    orphan the bytes it replaced and spend the transfer twice."""
+    plan = distribution.plan_create(
+        {"models": [{"type": "vae", "filename": "ae.safetensors", "sha256": "def", "blobId": "blob-9"}]}
+    )
+    assert plan["definition"]["models"][0]["blobId"] == "blob-9"
+    assert plan["upload_count"] == 0
+
+
+def test_a_definition_naming_only_blobs_goes_through_update_untouched():
+    """Every member names a builder source, so update has nothing to map and sends
+    the file as written."""
+    assert not distribution._is_scan_shaped(
+        {
+            "models": [{"type": "vae", "filename": "ae.safetensors", "blobId": "blob-9"}],
+            "customNodes": [{"name": "priv", "blobId": "blob-1"}],
+        }
+    )

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -877,3 +877,58 @@ def test_plan_create_carries_base_image_and_policies():
     assert d["modelPolicy"] == {"mode": "allowlist", "list": ["ae.safetensors"]}
     assert d["partnerNodePolicy"] == {"mode": "blocklist", "list": []}
     assert d["baseComfyVersion"] == "v0.3.40"
+
+
+# --- scan: a registry-installed pack has an upstream --------------------------
+
+
+def _write_pack(root, name, *, project=None, git=False):
+    # Under `custom_nodes/`, not tmp_path itself: autouse fixtures put their own
+    # directories there, and scan reads every directory it is handed as a pack.
+    d = root / "custom_nodes" / name
+    d.mkdir(parents=True)
+    if project is not None:
+        d.joinpath("pyproject.toml").write_text(project, encoding="utf-8")
+    if git:
+        d.joinpath(".git").mkdir()
+    return d
+
+
+def test_scan_reads_the_registry_pin_off_an_archive_install(tmp_path):
+    """`comfy node install` unpacks archives, so a pack has no git history at all.
+    Its pyproject still names the published version the builder can fetch."""
+    _write_pack(tmp_path, "comfyui-kjnodes", project='[project]\nname = "comfyui-kjnodes"\nversion = "1.4.9"\n')
+    (node,) = distribution.scan_custom_nodes(tmp_path / "custom_nodes")
+    assert node["source"] == "registry"
+    assert node["id"] == "comfyui-kjnodes"
+    assert node["registryVersion"] == "1.4.9"
+
+
+def test_scan_keeps_a_pack_local_when_nothing_names_an_upstream(tmp_path):
+    """No git, no usable pyproject: it really must be uploaded."""
+    _write_pack(tmp_path, "handmade")
+    _write_pack(tmp_path, "half", project='[project]\nname = "half"\n')
+    assert {n["name"]: n["source"] for n in distribution.scan_custom_nodes(tmp_path / "custom_nodes")} == {
+        "handmade": "local",
+        "half": "local",
+    }
+
+
+def test_scan_prefers_git_over_the_registry_pin(tmp_path, monkeypatch):
+    """A commit pins bytes exactly; a package version is resolved later. When a pack
+    has both, the more precise one wins."""
+    _write_pack(tmp_path, "dual", project='[project]\nname = "dual"\nversion = "2.0.0"\n', git=True)
+    monkeypatch.setattr(
+        distribution,
+        "_git_output",
+        lambda path, *args: "https://github.com/x/dual" if args[0] == "remote" else "cafebabe",
+    )
+    (node,) = distribution.scan_custom_nodes(tmp_path / "custom_nodes")
+    assert node["source"] == "git"
+    assert "registryVersion" not in node
+
+
+def test_read_registry_pin_is_silent_on_a_broken_pyproject(tmp_path):
+    """A malformed file is a pack without a pin, never a crashed scan."""
+    d = _write_pack(tmp_path, "broken", project="this is not toml [[[")
+    assert distribution.read_registry_pin(d) is None

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1433,3 +1433,27 @@ def test_as_snapshot_envelope_wraps_the_file_desktop_actually_writes():
 def test_as_snapshot_envelope_leaves_a_real_export_alone():
     export = {"type": "comfyui-desktop-2-snapshot", "version": 2, "snapshots": [{"customNodes": []}]}
     assert distribution.as_snapshot_envelope(export) is export
+
+
+def test_create_execute_does_not_read_a_renamed_pack_as_a_dropped_one(monkeypatch):
+    """The importer derives a pack's folder by lowercasing. A name it normalises is
+    still the pack that was sent, and refusing it would stop a create the builder
+    was happy with."""
+    builder = _ImportingBuilder(
+        resolved={
+            "definition": {
+                "customNodes": [{"name": "comfyui-kjnodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9"}]
+            },
+            "report": {},
+        }
+    )
+    _execute(
+        monkeypatch,
+        builder,
+        {
+            "baseComfyVersion": "v0.30.2",
+            "models": [],
+            "customNodes": [{"name": "ComfyUI-KJNodes", "id": "comfyui-kjnodes", "registryVersion": "1.4.9"}],
+        },
+    )
+    assert builder.created_with is not None


### PR DESCRIPTION
**TL;DR:** Turn a scanned ComfyUI install into a definition the builder can build, and reach the rest of comfy-builder's snapshot importer: ask it about registry pins, create straight from a Desktop export, and upload a private file without creating a distribution around it.

No Linear ticket: this came out of [Feature 3, a local install becomes a distribution that builds](https://app.notion.com/p/comfy-org/Feature-3-a-local-install-becomes-a-distribution-that-builds-3c26d73d365081fd8353d532eb56ca00) and builds on [BE-8193 Move Desktop snapshot import into comfy-builder](https://linear.app/comfyorg/issue/BE-8193/move-desktop-snapshot-import-into-comfy-builder-add-a-create)

**Why:** `comfy node install` unpacks registry archives rather than cloning, so `scan` found no git checkout, called every pack private, and `create --execute` refuses to upload a custom node. The install path we ship and the build path we ship could not meet, and four paid builds went on learning things knowable offline.

**What changed**
* **[comfy-cli] `scan`**: identifies a pack by the registry pin its `pyproject.toml` carries when there is no git checkout, records a ComfyUI ref that resolves, and gives each pack exactly one source.
* **[comfy-cli] `create` and `update`**: carry the definition they were given rather than a five-key reduction of it, send it to comfy-builder's snapshot importer for the pins, and stop rather than creating a distribution missing a pack it could not vouch for.
* **[comfy-cli] `validate` and three new commands**: `validate` claims only shape and pin existence and prints the ref-miss warnings that sat unread under a green line; `from-snapshot` posts a Desktop export to the importer's create endpoint, which nothing reached before; `blob upload` joins the `blob list` that already existed, exposing an upload that only ever lived inside `create`.

**Contradicts:** the design doc calls the scan output the strongest input to pinning; on the default install path it was the weakest.

**Validation**
* **Unit**: `tests/comfy_cli/command/test_distribution.py` collects 97 and passes, up from 47 on `origin/main`. The full suite runs 5,037 passed locally. Every added case was run against the unpatched code first and failed there.
* **Development environment, end to end**: staging builder and the live registry, driven through the real CLI on a six-pack install. Five packs verified, `was-node-suite-comfyui` reported `notInRegistry` and withheld, torch skipped as build-owned, `cuda130-py312` picked, and the cut reached `ready` with `deployable: true`. Separately a 2 MB private file was uploaded, listed, named in a definition and accepted by `update` with no distribution created; and `from-snapshot` created a distribution from the same install's export in one call, printing the import's advisories. Staging rows cleaned up afterwards.
* **Development environment, unchanged path**: a git-sourced pack round-trips with repository and commit intact beside a registry pack, and a definition naming only public sources goes through `update` untouched.
* **Development environment, the new report fields**: staging, once comfy-builder shipped, returns `collidingNodes` and `droppedComfyVersion` for a colliding fixture; the CLI prints both advisories, keeps the winner and creates rather than refusing. A `node_zip` blob and a private model blob each cut to `ready` and `deployable: true`, and the build log shows ComfyUI loading `custom_nodes/comfy-cli-probe-node`.
* **Not run**: nothing on this change. One slice of the local suite was OOM-killed and is being rerun file by file; `test_onboarding.py::test_first_run_nudges_then_marks_and_stays_quiet` fails identically on a clean `origin/main` worktree and only inside its slice, so it is order-dependent and pre-existing.




