### PR TITLE
feat(cloud): add `comfy cloud status` for balance, tier and concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ comfy download <prompt_id> --where cloud -o ./outputs    # save the results loca
 
 `comfy run` submits asynchronously and prints the `prompt_id` you feed to `jobs`/`download`; add `--wait` to block inline instead. Check your sign-in anytime with `comfy cloud whoami`. Export the workflow JSON from ComfyUI via **File → Export (API)** (UI-format JSON is auto-converted). Set cloud as your default target so you can drop the flag: `comfy set-default --where cloud`.
 
-**Credits:** cloud generation (`comfy run --where cloud`, `comfy generate`) consumes Comfy Cloud credits and needs an active subscription. Discovery and inspection commands — `comfy cloud whoami`, `comfy jobs status/ls`, `comfy templates ls`, `comfy generate list` — don't.
+**Credits:** cloud generation (`comfy run --where cloud`, `comfy generate`) consumes Comfy Cloud credits and needs an active subscription. Discovery and inspection commands — `comfy cloud whoami`, `comfy cloud status`, `comfy jobs status/ls`, `comfy templates ls`, `comfy generate list` — don't. Check your balance and tier with `comfy cloud status`.
 
 ## Installation
 
@@ -449,6 +449,7 @@ Prerequisites — a Comfy account with a credit balance ([add credits](https://d
 ```bash
 comfy cloud login                   # opens your browser (OAuth + PKCE), stores a session
 comfy cloud whoami                  # confirm who you're signed in as
+comfy cloud status                  # workspace, credit balance, tier, concurrency limit
 ```
 
 Then submit, watch, and collect:

--- a/comfy_cli/cloud/billing.py
+++ b/comfy_cli/cloud/billing.py
@@ -1,0 +1,306 @@
+"""Billing arithmetic and display rules for ``comfy cloud status``.
+
+Deliberately free of I/O. Every rule the command has to get right (the
+zero-masking balance chain, the trust guard, the upgrade suggestion) is a pure
+function here, so it can be unit-tested without mocking HTTP. ``command.py``
+owns the fetching, the panel and the envelope.
+
+The rules encoded here are not arbitrary. Two of them are scar tissue:
+
+* The balance chain exists because a present-but-zero high-priority field used
+  to mask a positive component underneath it, reporting "$0.00" to users who
+  had credits.
+* The trust guard exists because "$0.00 / Subscribe" was shown to paying
+  customers whose billing rows were mid-migration (BE-1795 / BE-1798). When we
+  cannot confirm state, we say so instead of asserting a balance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+# $1 = 211 credits. Source of truth is
+# ``ComfyUI_frontend/src/base/credits/comfyCredits.ts``, mirrored in
+# ``comfy-cloud-mcp-server/src/pricing.ts``. Keep all three in lockstep.
+CREDITS_PER_USD = 211
+
+MICROS_PER_USD = 1_000_000
+CENTS_PER_USD = 100
+
+# Default concurrency per tier, shown as context beside the live
+# ``max_concurrent_jobs`` from /api/features.
+TIER_CONCURRENCY: Mapping[str, int] = {
+    "FREE": 1,
+    "STANDARD": 1,
+    "FOUNDERS": 1,
+    "CREATOR": 3,
+    "PRO": 5,
+    "TEAM": 25,
+}
+
+# Priority order for resolving a balance. A present-but-zero field is SKIPPED
+# rather than accepted, so a literal 0 in a higher-priority field can never
+# mask a positive component below it. Ported from comfy-cloud-mcp-server's
+# ``selectEffectiveBalanceMicros`` (src/tools-feedback.ts).
+BALANCE_FIELDS = (
+    "effective_balance_micros",
+    "amount_micros",
+    "prepaid_balance_micros",
+    "cloud_credit_balance_micros",
+)
+
+# Shown when we cannot confirm a subscription OR a balance. Never paired with a
+# "$0.00" figure: asserting zero to a customer who is mid-migration is the
+# exact BE-1798 failure this replaces.
+UNCONFIRMED_MESSAGE = (
+    "Couldn't confirm an active subscription or balance for this workspace. "
+    "If you already subscribe, your account may be mid-migration; contact Comfy support. "
+    "New to Comfy Cloud? Subscribe at {url}."
+)
+
+# Appended whenever the workspace is still on the pre-migration billing rail,
+# whether or not the trust guard fired: figures on that rail can be partial.
+LEGACY_RAIL_NOTE = "This workspace is on the legacy billing rail, so balance data may be incomplete pending migration."
+
+# Values of ``subscription_status`` that mean "there is no subscription", as
+# opposed to one that exists but is lapsed/cancelled. Kept tight on purpose:
+# a lapsed subscription is confirmation the account is real, so it must not
+# trip the trust guard.
+_NO_SUBSCRIPTION_STATUSES = {"", "none", "null", "no_subscription"}
+
+_LEGACY_RAIL = "legacy_stripe"
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Best-effort int from a JSON scalar, or None if it isn't numeric.
+
+    The billing endpoints have historically sent micro-dollar fields as both
+    JSON numbers and decimal strings, so tolerate both rather than crashing on
+    a shape the server is entitled to send. ``bool`` is rejected explicitly:
+    it is an ``int`` subclass in Python, and a stray ``True`` coercing to 1
+    would read as a one-micro balance.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value.strip()))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def select_effective_balance_micros(balance: Mapping[str, Any] | None) -> int | None:
+    """Resolve the balance in micro-dollars, or None when nothing is reported.
+
+    Walks :data:`BALANCE_FIELDS` in priority order and returns the first
+    NON-ZERO value. Returns 0 only when at least one field was present and
+    every present field was zero (a real, confirmed zero balance). Returns
+    None when no field was present at all, which is "unknown" and must not be
+    rendered as "$0.00".
+
+    A negative result is returned as-is: ``effective_balance_micros`` legitimately
+    goes negative on an overdrawn account and the user needs to see that, so it
+    is never clamped to zero.
+    """
+    if not isinstance(balance, Mapping):
+        return None
+    saw_numeric_field = False
+    for name in BALANCE_FIELDS:
+        value = _coerce_int(balance.get(name))
+        if value is None:
+            continue
+        saw_numeric_field = True
+        if value != 0:
+            return value
+    return 0 if saw_numeric_field else None
+
+
+def micros_to_usd(micros: int | None) -> float | None:
+    if micros is None:
+        return None
+    return micros / MICROS_PER_USD
+
+
+def usd_to_credits(usd: float | None) -> int | None:
+    """Convert USD to credits, rounding toward zero so we never overstate.
+
+    Truncating keeps a negative balance's credit figure negative, which
+    matches the USD figure it sits beside.
+    """
+    if usd is None:
+        return None
+    return int(usd * CREDITS_PER_USD)
+
+
+def has_subscription(subscription_status: Any) -> bool:
+    """True when ``subscription_status`` names a subscription that exists.
+
+    A lapsed or cancelled subscription counts: it confirms the account is real,
+    which is the only question the trust guard asks.
+    """
+    if subscription_status is None:
+        return False
+    return str(subscription_status).strip().lower() not in _NO_SUBSCRIPTION_STATUSES
+
+
+def is_legacy_rail(billing_rail: Any) -> bool:
+    return isinstance(billing_rail, str) and billing_rail.strip().lower() == _LEGACY_RAIL
+
+
+def is_unconfirmed(
+    *,
+    balance_micros: int | None,
+    subscription_status: Any,
+    has_funds: Any,
+) -> bool:
+    """True when we cannot confirm either a subscription or a balance.
+
+    All three signals must be negative before we withhold a figure, so a
+    genuine free-tier user with a confirmed zero balance and a FREE
+    subscription row still gets normal output. It is only the all-silent shape,
+    where the backend told us nothing affirmative, that earns neutral copy.
+    """
+    balance_absent_or_zero = balance_micros is None or balance_micros == 0
+    return balance_absent_or_zero and not has_subscription(subscription_status) and not bool(has_funds)
+
+
+def unconfirmed_message(manage_url: str) -> str:
+    return UNCONFIRMED_MESSAGE.format(url=manage_url)
+
+
+def manage_url(base_url: str) -> str:
+    """The subscription page for a resolved cloud base URL.
+
+    One derivation, so a PR-preview or staging env points at its own billing
+    page instead of sending the user to production.
+    """
+    return f"{base_url.rstrip('/')}/billing"
+
+
+def _plan_slug(plan: Mapping[str, Any]) -> str | None:
+    for key in ("slug", "plan_slug", "id", "name"):
+        value = plan.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _plan_available(plan: Mapping[str, Any]) -> bool:
+    """Whether the caller can actually buy this plan.
+
+    Availability absent entirely is treated as available: the endpoint only
+    started annotating plans later, and an older backend that omits the block
+    is not saying "unavailable".
+    """
+    availability = plan.get("availability")
+    if not isinstance(availability, Mapping):
+        return True
+    return bool(availability.get("available", True))
+
+
+def _plan_unavailable_reason(plan: Mapping[str, Any]) -> str | None:
+    availability = plan.get("availability")
+    if not isinstance(availability, Mapping):
+        return None
+    reason = availability.get("reason")
+    return reason.strip() if isinstance(reason, str) and reason.strip() else None
+
+
+def normalize_plans(plans_body: Any) -> tuple[list[dict[str, Any]], str | None]:
+    """Normalize ``/api/billing/plans`` into (plans, current_plan_slug).
+
+    Accepts either the documented object (``{current_plan_slug, plans: [...]}``)
+    or a bare list of plans, since both shapes have been observed and neither
+    is worth failing the whole command over.
+    """
+    current_slug: str | None = None
+    raw_plans: Any = []
+    if isinstance(plans_body, Mapping):
+        current = plans_body.get("current_plan_slug")
+        if isinstance(current, str) and current.strip():
+            current_slug = current.strip()
+        raw_plans = plans_body.get("plans")
+        if not isinstance(raw_plans, list):
+            raw_plans = []
+    elif isinstance(plans_body, list):
+        raw_plans = plans_body
+
+    plans: list[dict[str, Any]] = []
+    for entry in raw_plans:
+        if not isinstance(entry, Mapping):
+            continue
+        slug = _plan_slug(entry)
+        if slug is None:
+            continue
+        price_cents = _coerce_int(entry.get("price_cents"))
+        credits_cents = _coerce_int(entry.get("credits_cents"))
+        plans.append(
+            {
+                "plan_slug": slug,
+                "price_cents": price_cents,
+                "price_usd": (price_cents / CENTS_PER_USD) if price_cents is not None else None,
+                "credits": usd_to_credits(credits_cents / CENTS_PER_USD) if credits_cents is not None else None,
+                "available": _plan_available(entry),
+                "unavailable_reason": _plan_unavailable_reason(entry),
+            }
+        )
+    return plans, current_slug
+
+
+def suggest_upgrade(plans: list[dict[str, Any]], current_plan_slug: str | None) -> dict[str, Any] | None:
+    """Cheapest available plan priced above the current one, or None.
+
+    Price is the ranking key rather than a hardcoded tier ladder: the tier
+    names have churned (FOUNDERS, STANDARD) and ``price_cents`` comes straight
+    from the endpoint, so ranking on it cannot go stale.
+
+    When the current plan's price cannot be established we return None rather
+    than guessing. Guessing is actively harmful here and prod proves it: the
+    live team account reports ``plan_slug: "team-pro-monthly"`` from
+    /api/billing/status while /api/billing/plans carries no such slug, and a
+    "cheapest available plan" fallback then suggested a $0.00 per-credit plan
+    as an *upgrade* from PRO. No suggestion is strictly better than a wrong
+    one, so an unresolvable current price means we stay quiet.
+    """
+    priced = [p for p in plans if p["available"] and p["price_cents"] is not None]
+    if not priced:
+        return None
+
+    current_price: int | None = None
+    if current_plan_slug is not None:
+        for plan in plans:
+            if plan["plan_slug"] == current_plan_slug and plan["price_cents"] is not None:
+                current_price = plan["price_cents"]
+                break
+
+    if current_price is None:
+        return None
+    candidates = [p for p in priced if p["price_cents"] > current_price]
+
+    if not candidates:
+        return None
+    best = min(candidates, key=lambda p: p["price_cents"])
+    return {
+        "plan_slug": best["plan_slug"],
+        "price_usd": best["price_usd"],
+        "credits": best["credits"],
+    }
+
+
+def blocked_upgrade_reasons(plans: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Plans the caller cannot buy, with the server's stated reason.
+
+    Surfaced so ``requires_team`` / ``exceeds_max_seats`` explain why a tier
+    the user can see is not being suggested to them.
+    """
+    return [
+        {"plan_slug": p["plan_slug"], "reason": p["unavailable_reason"]}
+        for p in plans
+        if not p["available"] and p["unavailable_reason"]
+    ]

--- a/comfy_cli/cloud/billing.py
+++ b/comfy_cli/cloud/billing.py
@@ -17,6 +17,7 @@ The rules encoded here are not arbitrary. Two of them are scar tissue:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -63,6 +64,13 @@ UNCONFIRMED_MESSAGE = (
 # whether or not the trust guard fired: figures on that rail can be partial.
 LEGACY_RAIL_NOTE = "This workspace is on the legacy billing rail, so balance data may be incomplete pending migration."
 
+# Shown when the balance endpoint itself did not answer. Deliberately distinct
+# from UNCONFIRMED_MESSAGE: this is a statement about our request, not about
+# the account, and must not imply the user's billing rows are mid-migration.
+BALANCE_UNAVAILABLE_NOTE = (
+    "Couldn't reach the balance service, so no credit balance is shown. Everything else here is current."
+)
+
 # Values of ``subscription_status`` that mean "there is no subscription", as
 # opposed to one that exists but is lapsed/cancelled. Kept tight on purpose:
 # a lapsed subscription is confirmation the account is real, so it must not
@@ -71,27 +79,89 @@ _NO_SUBSCRIPTION_STATUSES = {"", "none", "null", "no_subscription"}
 
 _LEGACY_RAIL = "legacy_stripe"
 
+# Strings a JSON boolean field has been seen carrying instead of a real bool.
+# Anything outside these two sets is not a boolean and is treated as unknown,
+# because guessing is what lets `"false"` read as affirmative.
+_TRUE_STRINGS = {"true", "1", "yes"}
+_FALSE_STRINGS = {"false", "0", "no"}
+
+# Ceiling for any accepted integer. Micro-dollars, cents and job counts all sit
+# far below this; the point is that `json.loads` will happily hand us an
+# unbounded integer literal, and a few-hundred-digit value turns a later
+# division into an OverflowError inside a pure function that no `try` wraps.
+_MAX_ABS_INT = 10**18
+
 
 def _coerce_int(value: Any) -> int | None:
-    """Best-effort int from a JSON scalar, or None if it isn't numeric.
+    """Best-effort int from a JSON scalar, or None if it isn't a usable number.
 
     The billing endpoints have historically sent micro-dollar fields as both
     JSON numbers and decimal strings, so tolerate both rather than crashing on
-    a shape the server is entitled to send. ``bool`` is rejected explicitly:
-    it is an ``int`` subclass in Python, and a stray ``True`` coercing to 1
-    would read as a one-micro balance.
+    a shape the server is entitled to send.
+
+    Three rejections are deliberate, and each one is a crash this function used
+    to pass through to the caller:
+
+    * ``bool`` is an ``int`` subclass, so a stray ``True`` would otherwise read
+      as a one-micro balance.
+    * ``NaN`` and ``±inf`` reach us as real floats, because ``json.loads``
+      accepts the bare ``NaN`` / ``Infinity`` literals. ``int(float("nan"))``
+      raises ``ValueError`` and ``int(float("inf"))`` raises ``OverflowError``.
+    * An integer beyond :data:`_MAX_ABS_INT` is discarded here rather than
+      surviving to blow up a downstream division.
+
+    These are pure calls made outside every ``try`` in ``status_cmd``, so
+    anything raised here becomes a traceback where an error envelope belongs.
     """
     if isinstance(value, bool) or value is None:
         return None
     if isinstance(value, int):
-        return value
+        return value if abs(value) <= _MAX_ABS_INT else None
     if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        if abs(value) > _MAX_ABS_INT:
+            return None
         return int(value)
     if isinstance(value, str):
         try:
-            return int(float(value.strip()))
+            parsed = float(value.strip())
         except (TypeError, ValueError):
             return None
+        if not math.isfinite(parsed) or abs(parsed) > _MAX_ABS_INT:
+            return None
+        try:
+            return int(parsed)
+        except (ValueError, OverflowError):
+            return None
+    return None
+
+
+def coerce_int(value: Any) -> int | None:
+    """Public alias for :func:`_coerce_int`.
+
+    Exported so ``command.py`` can put server-supplied integers through the
+    same guard before they enter a payload whose schema constrains their type.
+    """
+    return _coerce_int(value)
+
+
+def coerce_bool(value: Any) -> bool | None:
+    """Strict-ish bool from a JSON scalar, or None when it isn't a boolean.
+
+    Returning None for unrecognized input is the whole point. ``bool("false")``
+    is ``True``, so a backend sending the *string* ``"false"`` for ``has_funds``
+    would otherwise read as affirmative and suppress the trust guard for
+    exactly the silent-backend shape the guard was written for.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in _TRUE_STRINGS:
+            return True
+        if text in _FALSE_STRINGS:
+            return False
     return None
 
 
@@ -143,10 +213,16 @@ def has_subscription(subscription_status: Any) -> bool:
 
     A lapsed or cancelled subscription counts: it confirms the account is real,
     which is the only question the trust guard asks.
+
+    Only a genuine string can name a subscription. This used to stringify
+    whatever it was given, which meant a JSON ``subscription_status: false``
+    became the string ``"false"``, missed ``_NO_SUBSCRIPTION_STATUSES``, and
+    read as an existing subscription, suppressing the trust guard on precisely
+    the payload shape it exists to catch.
     """
-    if subscription_status is None:
+    if not isinstance(subscription_status, str):
         return False
-    return str(subscription_status).strip().lower() not in _NO_SUBSCRIPTION_STATUSES
+    return subscription_status.strip().lower() not in _NO_SUBSCRIPTION_STATUSES
 
 
 def is_legacy_rail(billing_rail: Any) -> bool:
@@ -158,6 +234,7 @@ def is_unconfirmed(
     balance_micros: int | None,
     subscription_status: Any,
     has_funds: Any,
+    balance_fetch_failed: bool = False,
 ) -> bool:
     """True when we cannot confirm either a subscription or a balance.
 
@@ -165,9 +242,51 @@ def is_unconfirmed(
     genuine free-tier user with a confirmed zero balance and a FREE
     subscription row still gets normal output. It is only the all-silent shape,
     where the backend told us nothing affirmative, that earns neutral copy.
+
+    ``balance_fetch_failed`` distinguishes "the balance endpoint did not
+    answer" from "the balance endpoint answered and reported nothing", which
+    ``balance_micros=None`` alone cannot express. It matters in both
+    directions:
+
+    * A transient failure on ``/api/billing/balance`` must not, on its own,
+      flip the verdict and tell a subscriber their account may be
+      mid-migration. So a failed fetch alongside an affirmative subscription
+      or ``has_funds`` is NOT unconfirmed.
+    * But a failed fetch cannot be treated as a confirmed balance either, or
+      the payload would claim ``balance_confirmed: true`` while carrying three
+      null balance fields, contradicting the schema.
+
+    ``has_funds`` goes through :func:`coerce_bool` rather than ``bool()``:
+    ``bool("false")`` is ``True``, and that alone would suppress the guard.
     """
+    if balance_fetch_failed:
+        # The guard's premise is that the backend answered and said nothing
+        # affirmative. A call that never answered is not evidence about the
+        # account, so we make no claim about migration state: a user with real
+        # credit and no subscription row would otherwise be told their account
+        # may be mid-migration purely because one request timed out.
+        # `balance_is_confirmed` still withholds the figure.
+        return False
     balance_absent_or_zero = balance_micros is None or balance_micros == 0
-    return balance_absent_or_zero and not has_subscription(subscription_status) and not bool(has_funds)
+    funds = coerce_bool(has_funds) is True
+    return balance_absent_or_zero and not has_subscription(subscription_status) and not funds
+
+
+def balance_is_confirmed(
+    *,
+    balance_micros: int | None,
+    balance_fetch_failed: bool,
+    unconfirmed: bool,
+) -> bool:
+    """Whether a balance figure may be published.
+
+    Three ways to have no publishable figure: the trust guard fired, the fetch
+    never answered, or it answered with no balance fields at all. Only an
+    actual number from a call that succeeded is confirmed.
+    """
+    if unconfirmed or balance_fetch_failed:
+        return False
+    return balance_micros is not None
 
 
 def unconfirmed_message(manage_url: str) -> str:
@@ -194,14 +313,23 @@ def _plan_slug(plan: Mapping[str, Any]) -> str | None:
 def _plan_available(plan: Mapping[str, Any]) -> bool:
     """Whether the caller can actually buy this plan.
 
-    Availability absent entirely is treated as available: the endpoint only
-    started annotating plans later, and an older backend that omits the block
-    is not saying "unavailable".
+    Absent availability information means available: the endpoint only started
+    annotating plans later, and an older backend that omits the block is not
+    saying "unavailable". That rule is applied to an unusable *value* too, not
+    just a missing key, because ``bool()`` gets both edges wrong: an explicit
+    ``{"available": null}`` would read as unavailable and, since
+    ``blocked_upgrade_reasons`` needs a reason string, the plan would then
+    vanish from both the suggestion and the blocked list with no explanation;
+    while ``{"available": "false"}`` is truthy and would recommend a plan the
+    backend explicitly marked unavailable.
     """
     availability = plan.get("availability")
     if not isinstance(availability, Mapping):
         return True
-    return bool(availability.get("available", True))
+    if "available" not in availability:
+        return True
+    decided = coerce_bool(availability.get("available"))
+    return True if decided is None else decided
 
 
 def _plan_unavailable_reason(plan: Mapping[str, Any]) -> str | None:

--- a/comfy_cli/cloud/command.py
+++ b/comfy_cli/cloud/command.py
@@ -18,8 +18,9 @@ live under ``comfy auth`` since they're not cloud-specific.
 
 from __future__ import annotations
 
+import urllib.error
 from datetime import datetime, timezone
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich import markup as rich_markup
@@ -277,6 +278,38 @@ def whoami_cmd():
 _STATUS_MAX_BYTES = 1 * 1024 * 1024
 
 
+# Bound on the slice of a server error body we quote back in `details`. Read
+# via `HTTPError.read(n)` so the cap is applied by the read itself; draining
+# the whole body and slicing afterwards would let the server decide how much
+# memory we spend on the error path, which is the one path least able to
+# afford it.
+_MAX_ERROR_BODY_BYTES = 1000
+
+
+def _as_optional_str(value: Any) -> str | None:
+    """Keep a value only if it is genuinely a string, else None.
+
+    Dates and rail names are declared as nullable strings in
+    ``cloud_status.json``; a backend sending a number or an object for one of
+    them would otherwise produce an envelope that fails our own schema.
+    """
+    return value if isinstance(value, str) else None
+
+
+def _read_error_body(e: urllib.error.HTTPError) -> str:
+    """Best-effort read of a bounded slice of the server's error body.
+
+    Mirrors ``comfy_cli/command/_cloud_errors.py::_read_error_body``. Failures
+    degrade to an empty body rather than escaping: a reset or truncated stream
+    while quoting an error must not pre-empt the very envelope the caller is in
+    the middle of emitting, turning a transient fault into a traceback.
+    """
+    try:
+        return (e.read(_MAX_ERROR_BODY_BYTES) or b"").decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001 — a failed courtesy read must never mask the envelope
+        return ""
+
+
 def _billing_get(url: str, target, *, timeout: float = 30.0):
     """Authenticated GET returning the parsed body. Raises errors verbatim."""
     from comfy_cli.http import request_json
@@ -285,30 +318,41 @@ def _billing_get(url: str, target, *, timeout: float = 30.0):
     return body
 
 
-def _billing_get_optional(url: str, target, *, timeout: float = 30.0):
-    """Same, but returns None instead of raising.
+def _billing_get_optional(url: str, target, *, timeout: float = 30.0) -> tuple[Any, bool]:
+    """Fetch an optional endpoint, returning ``(body, failed)``.
 
     Used for every endpoint whose absence should degrade one row rather than
     fail the command: an older backend that 404s ``/api/workspaces/current``,
     or a features/plans call that times out, must still let the user see their
     balance and tier. The command's whole job is answering "what do I have",
     so partial data beats no answer.
+
+    The ``failed`` flag exists because ``None`` is ambiguous: it means both
+    "the call did not answer" and "the call answered with nothing useful". For
+    the balance endpoint those must not be conflated, or a transient blip
+    silently changes the trust guard's verdict. See
+    :func:`billing.is_unconfirmed`.
+
+    ``ValueError`` is caught alongside the HTTP families because
+    ``assert_safe_url`` raises it for a non-loopback plaintext URL, and
+    ``comfy cloud set-base-url`` / ``COMFY_CLOUD_BASE_URL`` both accept such a
+    URL without validation. Note ``JSONDecodeError`` is a ``ValueError``
+    subclass, so naming the parent covers it.
     """
-    import json as _json
     import urllib.error
 
     from comfy_cli.http import ResponseTooLarge
 
     try:
-        return _billing_get(url, target, timeout=timeout)
+        return _billing_get(url, target, timeout=timeout), False
     except (
         urllib.error.HTTPError,
         urllib.error.URLError,
         OSError,
-        _json.JSONDecodeError,
+        ValueError,
         ResponseTooLarge,
     ):
-        return None
+        return None, True
 
 
 @app.command(
@@ -325,7 +369,6 @@ def status_cmd(
         typer.Option("--plans", help="Include the full tier table, not just the current plan and one suggestion."),
     ] = False,
 ):
-    import json as _json
     import urllib.error
 
     from comfy_cli.cloud import billing
@@ -367,14 +410,23 @@ def status_cmd(
             code="cloud_billing_unavailable",
             message=f"HTTP {e.code} from {status_url}",
             hint="retry shortly; if it persists, contact Comfy support",
-            details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8", "replace")},
+            details={"status": e.code, "body": _read_error_body(e)},
         )
         raise typer.Exit(code=1) from e
-    except (urllib.error.URLError, OSError, _json.JSONDecodeError, ResponseTooLarge) as e:
+    except (urllib.error.URLError, OSError, ValueError, ResponseTooLarge) as e:
+        # ValueError covers `assert_safe_url` rejecting a plaintext non-loopback
+        # base URL, which a user can reach through the documented
+        # `comfy cloud set-base-url` / COMFY_CLOUD_BASE_URL paths. It also
+        # covers JSONDecodeError, which subclasses it.
+        unsafe_url = not isinstance(e, (urllib.error.URLError, OSError, ResponseTooLarge))
         renderer.error(
             code="cloud_billing_unavailable",
             message=f"failed to fetch {status_url}: {e}",
-            hint="check your network connection and try again",
+            hint=(
+                "the cloud base URL must be https (or loopback); fix it with `comfy cloud set-base-url`"
+                if unsafe_url
+                else "check your network connection and try again"
+            ),
         )
         raise typer.Exit(code=1) from e
 
@@ -387,10 +439,10 @@ def status_cmd(
         raise typer.Exit(code=1)
 
     # Everything below degrades independently.
-    balance_body = _billing_get_optional(target.url("billing", "balance"), target)
-    features_body = _billing_get_optional(target.url("features"), target)
-    workspace_body = _billing_get_optional(target.url("workspaces", "current"), target)
-    plans_body = _billing_get_optional(target.url("billing", "plans"), target)
+    balance_body, balance_failed = _billing_get_optional(target.url("billing", "balance"), target)
+    features_body, _ = _billing_get_optional(target.url("features"), target)
+    workspace_body, _ = _billing_get_optional(target.url("workspaces", "current"), target)
+    plans_body, _ = _billing_get_optional(target.url("billing", "plans"), target)
 
     balance_micros = billing.select_effective_balance_micros(balance_body if isinstance(balance_body, dict) else None)
     balance_usd = billing.micros_to_usd(balance_micros)
@@ -407,6 +459,15 @@ def status_cmd(
         balance_micros=balance_micros,
         subscription_status=subscription_status,
         has_funds=has_funds,
+        balance_fetch_failed=balance_failed,
+    )
+    # Distinct from `not unconfirmed`: a failed balance fetch alongside an
+    # active subscription is not "unconfirmed" (we know the account is real)
+    # but still has no figure to publish.
+    balance_confirmed = billing.balance_is_confirmed(
+        balance_micros=balance_micros,
+        balance_fetch_failed=balance_failed,
+        unconfirmed=unconfirmed,
     )
     legacy_rail = billing.is_legacy_rail(billing_rail)
 
@@ -415,30 +476,50 @@ def status_cmd(
         message = billing.unconfirmed_message(manage_url)
         if legacy_rail:
             message = f"{message} {billing.LEGACY_RAIL_NOTE}"
+    elif balance_failed:
+        # A request-level failure, so say that plainly instead of borrowing the
+        # mid-migration wording, which would be a claim about the account.
+        message = billing.BALANCE_UNAVAILABLE_NOTE
+        if legacy_rail:
+            message = f"{message} {billing.LEGACY_RAIL_NOTE}"
     elif legacy_rail:
         message = billing.LEGACY_RAIL_NOTE
 
     cloud_workspace: dict[str, object | None] | None = None
     if isinstance(workspace_body, dict):
         cloud_workspace = {
-            "id": workspace_body.get("id"),
-            "name": workspace_body.get("name"),
-            "type": workspace_body.get("type"),
-            "role": workspace_body.get("role"),
+            "id": _as_optional_str(workspace_body.get("id")),
+            "name": _as_optional_str(workspace_body.get("name")),
+            "type": _as_optional_str(workspace_body.get("type")),
+            "role": _as_optional_str(workspace_body.get("role")),
         }
 
+    # Every server-supplied scalar below goes through a coercion before it
+    # enters the payload. `cloud_status.json` constrains these types and agents
+    # are told to validate against it, so a backend sending "3" or
+    # `is_active: "false"` would otherwise emit an envelope that fails our own
+    # schema. Values that don't fit are dropped to null, the same way
+    # `normalize_plans` already treats malformed plan entries.
     max_concurrent_jobs = None
     free_tier_balance = None
     if isinstance(features_body, dict):
-        max_concurrent_jobs = features_body.get("max_concurrent_jobs")
+        max_concurrent_jobs = billing.coerce_int(features_body.get("max_concurrent_jobs"))
         raw_free_tier = features_body.get("free_tier_balance")
         if isinstance(raw_free_tier, dict):
-            free_tier_balance = raw_free_tier
+            free_tier_balance = {
+                "allowance": billing.coerce_int(raw_free_tier.get("allowance")),
+                "used": billing.coerce_int(raw_free_tier.get("used")),
+                "remaining": billing.coerce_int(raw_free_tier.get("remaining")),
+            }
 
     plan_list, current_plan_slug = billing.normalize_plans(plans_body)
     if current_plan_slug is None:
         slug = status_body.get("plan_slug")
-        current_plan_slug = slug if isinstance(slug, str) and slug.strip() else None
+        # Assign the STRIPPED slug, not the raw one: `normalize_plans` strips
+        # every slug it emits, so a whitespace-padded value here would never
+        # match in `suggest_upgrade` (silently dropping the suggestion) and the
+        # padding would leak into the payload.
+        current_plan_slug = slug.strip() if isinstance(slug, str) and slug.strip() else None
     upgrade_suggestion = billing.suggest_upgrade(plan_list, current_plan_slug)
 
     tier_default_concurrency = None
@@ -449,20 +530,20 @@ def status_cmd(
         "cloud_workspace": cloud_workspace,
         # Withhold the figure entirely when it isn't confirmed. A null here is
         # "we don't know"; printing 0.0 would assert a balance we cannot back up.
-        "credit_balance_usd": None if unconfirmed else balance_usd,
-        "credit_balance_credits": None if unconfirmed else balance_credits,
-        "effective_balance_micros": None if unconfirmed else balance_micros,
+        "credit_balance_usd": balance_usd if balance_confirmed else None,
+        "credit_balance_credits": balance_credits if balance_confirmed else None,
+        "effective_balance_micros": balance_micros if balance_confirmed else None,
         "currency": "USD",
-        "balance_confirmed": not unconfirmed,
+        "balance_confirmed": balance_confirmed,
         "subscription": {
-            "tier": subscription_tier,
-            "status": subscription_status,
-            "is_active": status_body.get("is_active"),
+            "tier": subscription_tier if isinstance(subscription_tier, str) else None,
+            "status": subscription_status if isinstance(subscription_status, str) else None,
+            "is_active": billing.coerce_bool(status_body.get("is_active")),
             "plan_slug": current_plan_slug,
-            "renewal_date": status_body.get("renewal_date"),
-            "cancel_at": status_body.get("cancel_at"),
+            "renewal_date": _as_optional_str(status_body.get("renewal_date")),
+            "cancel_at": _as_optional_str(status_body.get("cancel_at")),
         },
-        "billing_rail": billing_rail,
+        "billing_rail": billing_rail if isinstance(billing_rail, str) else None,
         "max_concurrent_jobs": max_concurrent_jobs,
         "tier_default_concurrent_jobs": tier_default_concurrency,
         "free_tier_balance": free_tier_balance,
@@ -471,7 +552,10 @@ def status_cmd(
         "manage_url": manage_url,
         "message": message,
     }
-    seats = {"max": status_body.get("max_seats"), "occupied": status_body.get("occupied_seats")}
+    seats = {
+        "max": billing.coerce_int(status_body.get("max_seats")),
+        "occupied": billing.coerce_int(status_body.get("occupied_seats")),
+    }
     if seats["max"] is not None or seats["occupied"] is not None:
         payload["seats"] = seats
     if plans:

--- a/comfy_cli/cloud/command.py
+++ b/comfy_cli/cloud/command.py
@@ -6,6 +6,8 @@ Comfy Cloud:
 - ``cloud login``       — Authorization Code + PKCE flow against the cloud
 - ``cloud logout``      — clear the local OAuth session
 - ``cloud whoami``      — inspect the current session + base URL + auth path
+- ``cloud status``      — cloud workspace, credit balance, subscription tier,
+                            concurrency limit and upgrade suggestion
 - ``cloud set-base-url`` — pin a non-prod env (PR preview, staging, …)
 - ``cloud set-key``     — testing path: persist a Comfy Cloud API key
                             (canonical sign-in is ``cloud login``)
@@ -263,6 +265,230 @@ def whoami_cmd():
         payload["stale_base_url"] = stale_base_url
 
     renderer.emit(payload, command="cloud whoami")
+
+
+# ---------------------------------------------------------------------------
+# status (billing / plan / concurrency)
+# ---------------------------------------------------------------------------
+
+# Billing payloads are small objects. The cap only exists to bound memory on a
+# misbehaving server, so it is generous relative to the real bodies (~1 KiB)
+# and still nowhere near enough to matter.
+_STATUS_MAX_BYTES = 1 * 1024 * 1024
+
+
+def _billing_get(url: str, target, *, timeout: float = 30.0):
+    """Authenticated GET returning the parsed body. Raises errors verbatim."""
+    from comfy_cli.http import request_json
+
+    _, body = request_json(url, target, timeout=timeout, max_bytes=_STATUS_MAX_BYTES)
+    return body
+
+
+def _billing_get_optional(url: str, target, *, timeout: float = 30.0):
+    """Same, but returns None instead of raising.
+
+    Used for every endpoint whose absence should degrade one row rather than
+    fail the command: an older backend that 404s ``/api/workspaces/current``,
+    or a features/plans call that times out, must still let the user see their
+    balance and tier. The command's whole job is answering "what do I have",
+    so partial data beats no answer.
+    """
+    import json as _json
+    import urllib.error
+
+    from comfy_cli.http import ResponseTooLarge
+
+    try:
+        return _billing_get(url, target, timeout=timeout)
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        OSError,
+        _json.JSONDecodeError,
+        ResponseTooLarge,
+    ):
+        return None
+
+
+@app.command(
+    "status",
+    help=(
+        "Show the current Comfy Cloud workspace, credit balance, subscription tier, "
+        "concurrency limit and upgrade suggestion. Read-only; spends nothing."
+    ),
+)
+@tracking.track_command("cloud")
+def status_cmd(
+    plans: Annotated[
+        bool,
+        typer.Option("--plans", help="Include the full tier table, not just the current plan and one suggestion."),
+    ] = False,
+):
+    import json as _json
+    import urllib.error
+
+    from comfy_cli.cloud import billing
+    from comfy_cli.http import ResponseTooLarge
+    from comfy_cli.target import resolve_target
+
+    renderer = get_renderer()
+    target = resolve_target(where="cloud")
+    renderer.where = target.kind
+
+    # Fail before any request when there is no credential at all: an
+    # unauthenticated GET would come back 401 and we would report "cloud
+    # rejected your token" to someone who never had one.
+    if not target.auth_token and not target.api_key:
+        renderer.error(
+            code="cloud_not_configured",
+            message="No Comfy Cloud credential found.",
+            hint="run `comfy cloud login`",
+        )
+        raise typer.Exit(code=1)
+
+    manage_url = billing.manage_url(target.base_url)
+
+    # /api/billing/status is the only required call: without it there is no
+    # tier, no status and no rail, so there is nothing meaningful to print.
+    status_url = target.url("billing", "status")
+    try:
+        status_body = _billing_get(status_url, target)
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            renderer.error(
+                code="cloud_unauthorized",
+                message=f"Comfy Cloud rejected the credential (HTTP {e.code}).",
+                hint="run `comfy cloud login`",
+                details={"status": e.code, "url": status_url},
+            )
+            raise typer.Exit(code=1) from e
+        renderer.error(
+            code="cloud_billing_unavailable",
+            message=f"HTTP {e.code} from {status_url}",
+            hint="retry shortly; if it persists, contact Comfy support",
+            details={"status": e.code, "body": (e.read() or b"")[:1000].decode("utf-8", "replace")},
+        )
+        raise typer.Exit(code=1) from e
+    except (urllib.error.URLError, OSError, _json.JSONDecodeError, ResponseTooLarge) as e:
+        renderer.error(
+            code="cloud_billing_unavailable",
+            message=f"failed to fetch {status_url}: {e}",
+            hint="check your network connection and try again",
+        )
+        raise typer.Exit(code=1) from e
+
+    if not isinstance(status_body, dict):
+        renderer.error(
+            code="cloud_billing_unavailable",
+            message=f"unexpected billing status payload from {status_url}",
+            hint="retry shortly; if it persists, contact Comfy support",
+        )
+        raise typer.Exit(code=1)
+
+    # Everything below degrades independently.
+    balance_body = _billing_get_optional(target.url("billing", "balance"), target)
+    features_body = _billing_get_optional(target.url("features"), target)
+    workspace_body = _billing_get_optional(target.url("workspaces", "current"), target)
+    plans_body = _billing_get_optional(target.url("billing", "plans"), target)
+
+    balance_micros = billing.select_effective_balance_micros(balance_body if isinstance(balance_body, dict) else None)
+    balance_usd = billing.micros_to_usd(balance_micros)
+    balance_credits = billing.usd_to_credits(balance_usd)
+
+    subscription_status = status_body.get("subscription_status")
+    # `subscription_tier` is absent entirely (not null) when there is no
+    # subscription, so `.get` is the contract, not a convenience.
+    subscription_tier = status_body.get("subscription_tier")
+    billing_rail = status_body.get("billing_rail")
+    has_funds = status_body.get("has_funds")
+
+    unconfirmed = billing.is_unconfirmed(
+        balance_micros=balance_micros,
+        subscription_status=subscription_status,
+        has_funds=has_funds,
+    )
+    legacy_rail = billing.is_legacy_rail(billing_rail)
+
+    message: str | None = None
+    if unconfirmed:
+        message = billing.unconfirmed_message(manage_url)
+        if legacy_rail:
+            message = f"{message} {billing.LEGACY_RAIL_NOTE}"
+    elif legacy_rail:
+        message = billing.LEGACY_RAIL_NOTE
+
+    cloud_workspace: dict[str, object | None] | None = None
+    if isinstance(workspace_body, dict):
+        cloud_workspace = {
+            "id": workspace_body.get("id"),
+            "name": workspace_body.get("name"),
+            "type": workspace_body.get("type"),
+            "role": workspace_body.get("role"),
+        }
+
+    max_concurrent_jobs = None
+    free_tier_balance = None
+    if isinstance(features_body, dict):
+        max_concurrent_jobs = features_body.get("max_concurrent_jobs")
+        raw_free_tier = features_body.get("free_tier_balance")
+        if isinstance(raw_free_tier, dict):
+            free_tier_balance = raw_free_tier
+
+    plan_list, current_plan_slug = billing.normalize_plans(plans_body)
+    if current_plan_slug is None:
+        slug = status_body.get("plan_slug")
+        current_plan_slug = slug if isinstance(slug, str) and slug.strip() else None
+    upgrade_suggestion = billing.suggest_upgrade(plan_list, current_plan_slug)
+
+    tier_default_concurrency = None
+    if isinstance(subscription_tier, str):
+        tier_default_concurrency = billing.TIER_CONCURRENCY.get(subscription_tier.strip().upper())
+
+    payload: dict[str, object | None] = {
+        "cloud_workspace": cloud_workspace,
+        # Withhold the figure entirely when it isn't confirmed. A null here is
+        # "we don't know"; printing 0.0 would assert a balance we cannot back up.
+        "credit_balance_usd": None if unconfirmed else balance_usd,
+        "credit_balance_credits": None if unconfirmed else balance_credits,
+        "effective_balance_micros": None if unconfirmed else balance_micros,
+        "currency": "USD",
+        "balance_confirmed": not unconfirmed,
+        "subscription": {
+            "tier": subscription_tier,
+            "status": subscription_status,
+            "is_active": status_body.get("is_active"),
+            "plan_slug": current_plan_slug,
+            "renewal_date": status_body.get("renewal_date"),
+            "cancel_at": status_body.get("cancel_at"),
+        },
+        "billing_rail": billing_rail,
+        "max_concurrent_jobs": max_concurrent_jobs,
+        "tier_default_concurrent_jobs": tier_default_concurrency,
+        "free_tier_balance": free_tier_balance,
+        "upgrade_suggestion": upgrade_suggestion,
+        "blocked_upgrades": billing.blocked_upgrade_reasons(plan_list),
+        "manage_url": manage_url,
+        "message": message,
+    }
+    seats = {"max": status_body.get("max_seats"), "occupied": status_body.get("occupied_seats")}
+    if seats["max"] is not None or seats["occupied"] is not None:
+        payload["seats"] = seats
+    if plans:
+        payload["plans"] = plan_list
+
+    if renderer.is_pretty():
+        from comfy_cli.output.panels import cloud_status_panel
+
+        renderer.console().print(
+            cloud_status_panel(
+                payload=payload,
+                version=ConfigManager().get_cli_version(),
+                show_plans=plans,
+            )
+        )
+
+    renderer.emit(payload, command="cloud status")
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -32,6 +32,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy cloud login": "auth",
     "comfy cloud logout": "auth",
     "comfy cloud whoami": "auth",
+    "comfy cloud status": "cloud_status",
     "comfy distribution scan": "distribution",
     "comfy distribution create": "distribution_create",
     "comfy distribution list": "distribution_list",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -310,6 +310,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "check `details.body` for the server's message",
     ),
     ErrorCode(
+        "cloud_billing_unavailable",
+        "`comfy cloud status` could not read `/api/billing/status`, so there is no tier or "
+        "subscription state to report. Distinct from `cloud_unauthorized` (a rejected "
+        "credential) and from the command's own degraded rows: the workspace, features and "
+        "plans calls each drop a single row when they fail, and only this one is fatal.",
+        "retry shortly; if it persists, contact Comfy support",
+    ),
+    ErrorCode(
         "cloud_timeout",
         "Cloud wait_for_completion exceeded `--timeout`.",
         "raise `--timeout`, or `comfy jobs watch <id> --where cloud`",

--- a/comfy_cli/output/panels.py
+++ b/comfy_cli/output/panels.py
@@ -268,6 +268,179 @@ def which_panel(
 
 
 # ---------------------------------------------------------------------------
+# Cloud status panel (billing / plan / concurrency)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_usd(usd: float | None) -> str | None:
+    if usd is None:
+        return None
+    # Negative balances are real (an overdrawn account) and must read as
+    # negative rather than as a parenthesised accounting figure.
+    sign = "-" if usd < 0 else ""
+    return f"{sign}${abs(usd):,.2f}"
+
+
+def cloud_status_panel(*, payload: Mapping[str, Any], version: str, show_plans: bool = False) -> Panel:
+    """Pretty-mode rendering of the ``comfy cloud status`` payload.
+
+    Reads the already-assembled envelope payload rather than re-deriving
+    anything, so the human surface and the JSON surface cannot disagree. In
+    particular the trust guard is honored upstream: when ``balance_confirmed``
+    is false the balance keys are null and this function prints no figure at
+    all, which is the whole point of BE-1798.
+
+    Server-supplied strings (workspace name, plan slugs, the message) go
+    through ``Text`` or ``sanitize_markup`` so a crafted name cannot inject
+    Rich markup into the panel.
+    """
+    rows: list[tuple[str, Any]] = []
+
+    workspace = payload.get("cloud_workspace")
+    if isinstance(workspace, Mapping):
+        # "Cloud workspace" is spelled out everywhere: in comfy-cli a bare
+        # "workspace" is the local ComfyUI install directory.
+        name = sanitize_optional(workspace.get("name")) or "—"
+        wtype = sanitize_optional(workspace.get("type"))
+        role = sanitize_optional(workspace.get("role"))
+        parts: list[tuple[str, str]] = [(str(name), "bold white")]
+        if wtype:
+            parts.append((f"  ({wtype})", "dim"))
+        if role:
+            parts.append((f"  {_TARGET_DIM_CHAR} {role}", "dim"))
+        rows.append(("Cloud workspace", Text.assemble(*parts)))
+
+    if payload.get("balance_confirmed"):
+        usd = _fmt_usd(payload.get("credit_balance_usd"))
+        credits = payload.get("credit_balance_credits")
+        micros = payload.get("effective_balance_micros")
+        negative = isinstance(micros, int) and micros < 0
+        balance_parts: list[tuple[str, str]] = [(usd or "—", "bold red" if negative else "bold green")]
+        if credits is not None:
+            balance_parts.append((f"  ({credits:,} credits)", "dim"))
+        rows.append(("Balance", Text.assemble(*balance_parts)))
+    else:
+        rows.append(("Balance", Text("not confirmed", style="yellow")))
+
+    subscription = payload.get("subscription")
+    if isinstance(subscription, Mapping):
+        tier = sanitize_optional(subscription.get("tier"))
+        status = sanitize_optional(subscription.get("status"))
+        is_active = subscription.get("is_active")
+        if tier or status:
+            sub_parts: list[tuple[str, str]] = [(str(tier or "—"), "bold white")]
+            if status:
+                sub_parts.append((f"  {status}", "green" if is_active else "yellow"))
+            rows.append(("Subscription", Text.assemble(*sub_parts)))
+        plan_slug = sanitize_optional(subscription.get("plan_slug"))
+        if plan_slug:
+            rows.append(("Plan", Text(str(plan_slug), style="white")))
+        renewal = sanitize_optional(subscription.get("renewal_date"))
+        cancel_at = sanitize_optional(subscription.get("cancel_at"))
+        if cancel_at:
+            rows.append(("Cancels", Text(str(cancel_at), style="yellow")))
+        elif renewal:
+            rows.append(("Renews", Text(str(renewal), style="dim")))
+
+    free_tier = payload.get("free_tier_balance")
+    if isinstance(free_tier, Mapping):
+        remaining = free_tier.get("remaining")
+        allowance = free_tier.get("allowance")
+        if remaining is not None or allowance is not None:
+            rows.append(
+                (
+                    "Free tier",
+                    Text.assemble(
+                        (f"{remaining if remaining is not None else '—'}", "bold white"),
+                        (f" of {allowance} remaining" if allowance is not None else " remaining", "dim"),
+                    ),
+                )
+            )
+
+    concurrency = payload.get("max_concurrent_jobs")
+    if concurrency is not None:
+        conc_parts: list[tuple[str, str]] = [(f"{concurrency}", "bold white")]
+        conc_parts.append((f"  concurrent job{'s' if concurrency != 1 else ''}", "dim"))
+        rows.append(("Concurrency", Text.assemble(*conc_parts)))
+
+    upgrade = payload.get("upgrade_suggestion")
+    if isinstance(upgrade, Mapping):
+        slug = sanitize_optional(upgrade.get("plan_slug")) or "—"
+        price = _fmt_usd(upgrade.get("price_usd"))
+        up_parts: list[tuple[str, str]] = [(str(slug), "bold cyan")]
+        if price:
+            up_parts.append((f"  {price}", "white"))
+        credits = upgrade.get("credits")
+        if credits is not None:
+            up_parts.append((f"  ({credits:,} credits)", "dim"))
+        rows.append(("Upgrade", Text.assemble(*up_parts)))
+
+    manage_url = payload.get("manage_url")
+    if manage_url:
+        rows.append(("Manage", Text(str(sanitize_value(manage_url)), style="cyan")))
+
+    tbl = Table.grid(padding=(0, 2), expand=False)
+    tbl.add_column(justify="right", style="bold cyan", no_wrap=True)
+    tbl.add_column(overflow="fold")
+    for label, value in rows:
+        tbl.add_row(label, value)
+
+    blocks: list[Any] = [tbl]
+
+    message = payload.get("message")
+    if message:
+        blocks.append(Text(""))
+        blocks.append(Text(str(sanitize_value(message)), style="yellow"))
+
+    if concurrency is not None:
+        # API-key callers get the tier limit; a browser session can differ
+        # because parallel execution is gated separately on the frontend.
+        blocks.append(Text(""))
+        blocks.append(
+            Text(
+                "Concurrency is the limit for this credential; browser sessions may differ.",
+                style="dim",
+            )
+        )
+
+    if show_plans:
+        plans = payload.get("plans")
+        if isinstance(plans, Sequence) and plans:
+            plan_tbl = Table(box=None, pad_edge=False, show_edge=False)
+            plan_tbl.add_column("Plan", style="white", no_wrap=True)
+            plan_tbl.add_column("Price", justify="right")
+            plan_tbl.add_column("Credits", justify="right")
+            plan_tbl.add_column("Available")
+            for plan in plans:
+                if not isinstance(plan, Mapping):
+                    continue
+                credits = plan.get("credits")
+                available = plan.get("available")
+                reason = sanitize_optional(plan.get("unavailable_reason"))
+                avail_text = (
+                    Text("yes", style="green") if available else Text(f"no ({reason})" if reason else "no", style="dim")
+                )
+                plan_tbl.add_row(
+                    Text(str(sanitize_value(plan.get("plan_slug") or "—"))),
+                    Text(_fmt_usd(plan.get("price_usd")) or "—"),
+                    Text(f"{credits:,}" if credits is not None else "—"),
+                    avail_text,
+                )
+            blocks.append(Text(""))
+            blocks.append(plan_tbl)
+
+    from comfy_cli.output.branding import branded_panel
+
+    return branded_panel(
+        Group(*blocks),
+        title="cloud status",
+        version=version,
+        where="cloud",
+        padding=(0, 1),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Auth list table / empty panel
 # ---------------------------------------------------------------------------
 

--- a/comfy_cli/output/panels.py
+++ b/comfy_cli/output/panels.py
@@ -344,23 +344,40 @@ def cloud_status_panel(*, payload: Mapping[str, Any], version: str, show_plans: 
 
     free_tier = payload.get("free_tier_balance")
     if isinstance(free_tier, Mapping):
-        remaining = free_tier.get("remaining")
-        allowance = free_tier.get("allowance")
+        # Sanitized like every other server-supplied field here. `Text` does not
+        # parse Rich markup but it does pass `\x1b` straight through, so an
+        # unsanitized CSI/OSC payload in one of these numbers would reach the
+        # terminal live. Reachable in practice: a user can point the CLI at a
+        # hostile host via the documented `comfy cloud set-base-url`.
+        remaining = sanitize_optional(free_tier.get("remaining"))
+        allowance = sanitize_optional(free_tier.get("allowance"))
         if remaining is not None or allowance is not None:
             rows.append(
                 (
                     "Free tier",
                     Text.assemble(
-                        (f"{remaining if remaining is not None else '—'}", "bold white"),
+                        (remaining if remaining is not None else "—", "bold white"),
                         (f" of {allowance} remaining" if allowance is not None else " remaining", "dim"),
                     ),
                 )
             )
 
     concurrency = payload.get("max_concurrent_jobs")
-    if concurrency is not None:
-        conc_parts: list[tuple[str, str]] = [(f"{concurrency}", "bold white")]
-        conc_parts.append((f"  concurrent job{'s' if concurrency != 1 else ''}", "dim"))
+    tier_default_concurrency = payload.get("tier_default_concurrent_jobs")
+    # Fall back to the tier default when /api/features was unavailable, rather
+    # than printing no concurrency row at all. The payload ships that field
+    # precisely to provide this context, and dropping the row hid a number we
+    # already knew.
+    shown_concurrency = concurrency if isinstance(concurrency, int) else None
+    from_tier_default = False
+    if shown_concurrency is None and isinstance(tier_default_concurrency, int):
+        shown_concurrency = tier_default_concurrency
+        from_tier_default = True
+    if shown_concurrency is not None:
+        conc_parts: list[tuple[str, str]] = [(f"{shown_concurrency}", "bold white")]
+        conc_parts.append((f"  concurrent job{'s' if shown_concurrency != 1 else ''}", "dim"))
+        if from_tier_default:
+            conc_parts.append(("  (tier default)", "dim"))
         rows.append(("Concurrency", Text.assemble(*conc_parts)))
 
     upgrade = payload.get("upgrade_suggestion")
@@ -392,7 +409,7 @@ def cloud_status_panel(*, payload: Mapping[str, Any], version: str, show_plans: 
         blocks.append(Text(""))
         blocks.append(Text(str(sanitize_value(message)), style="yellow"))
 
-    if concurrency is not None:
+    if shown_concurrency is not None:
         # API-key callers get the tier limit; a browser session can differ
         # because parallel execution is gated separately on the frontend.
         blocks.append(Text(""))

--- a/comfy_cli/schemas/cloud_status.json
+++ b/comfy_cli/schemas/cloud_status.json
@@ -20,7 +20,7 @@
     },
     "balance_confirmed": {
       "type": "boolean",
-      "description": "False when the trust guard fired: no balance was reported, no subscription exists and has_funds was false. The three balance fields are then null rather than 0, so a consumer can never render '$0.00' for an unconfirmed workspace."
+      "description": "True only when a balance figure came back from a call that succeeded. False in three cases: the trust guard fired (no balance reported, no subscription, has_funds false), the balance call did not answer at all, or it answered with no balance fields. When false, the three balance fields are null rather than 0, so a consumer can never render '$0.00' for a workspace whose balance we could not establish. Note a failed balance fetch alone does NOT set `message`, because a transient error is not evidence the account is mid-migration."
     },
     "credit_balance_usd": {
       "type": ["number", "null"],

--- a/comfy_cli/schemas/cloud_status.json
+++ b/comfy_cli/schemas/cloud_status.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/cloud_status.json",
+  "title": "comfy cloud status --json data payload",
+  "description": "Read-only billing and entitlement snapshot for the signed-in Comfy Cloud workspace: balance, subscription tier, concurrency limit and upgrade suggestion. Every field sourced from an endpoint that can be unavailable is nullable, because the command degrades one row rather than failing when a non-essential call fails.",
+  "type": "object",
+  "required": ["currency", "balance_confirmed", "subscription", "manage_url"],
+  "additionalProperties": true,
+  "properties": {
+    "cloud_workspace": {
+      "description": "The workspace the credential is bound to. Null when the backend predates GET /api/workspaces/current. Named `cloud_workspace`, not `workspace`: in comfy-cli a bare workspace is the local ComfyUI install directory.",
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "id": {"type": ["string", "null"]},
+        "name": {"type": ["string", "null"]},
+        "type": {"type": ["string", "null"], "description": "e.g. 'personal' or 'team'."},
+        "role": {"type": ["string", "null"], "description": "Caller's role, null for bare API-key auth."}
+      }
+    },
+    "balance_confirmed": {
+      "type": "boolean",
+      "description": "False when the trust guard fired: no balance was reported, no subscription exists and has_funds was false. The three balance fields are then null rather than 0, so a consumer can never render '$0.00' for an unconfirmed workspace."
+    },
+    "credit_balance_usd": {
+      "type": ["number", "null"],
+      "description": "Balance in USD. Can be negative on an overdrawn account; never clamped. Null when balance_confirmed is false."
+    },
+    "credit_balance_credits": {
+      "type": ["integer", "null"],
+      "description": "Balance in credits at 211 credits per USD, truncated toward zero."
+    },
+    "effective_balance_micros": {
+      "type": ["integer", "null"],
+      "description": "Raw micro-dollar balance chosen by the zero-masking chain (effective_balance_micros, then amount_micros, then prepaid_balance_micros, then cloud_credit_balance_micros), skipping present-but-zero fields so a literal 0 cannot mask a positive component."
+    },
+    "currency": {"type": "string", "const": "USD"},
+    "subscription": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tier": {"type": ["string", "null"], "description": "Absent entirely from the upstream payload when there is no subscription, surfaced as null here."},
+        "status": {"type": ["string", "null"]},
+        "is_active": {"type": ["boolean", "null"]},
+        "plan_slug": {"type": ["string", "null"]},
+        "renewal_date": {"type": ["string", "null"]},
+        "cancel_at": {"type": ["string", "null"]}
+      }
+    },
+    "billing_rail": {
+      "type": ["string", "null"],
+      "description": "When 'legacy_stripe', figures may be partial pending billing migration and `message` says so."
+    },
+    "max_concurrent_jobs": {
+      "type": ["integer", "null"],
+      "description": "Live concurrency limit for this credential from GET /api/features. Null when that call was unavailable. API-key callers get the tier limit; browser sessions may differ."
+    },
+    "tier_default_concurrent_jobs": {
+      "type": ["integer", "null"],
+      "description": "Documented default for the reported tier, as context for max_concurrent_jobs. Null for an unrecognized tier."
+    },
+    "free_tier_balance": {
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "allowance": {"type": ["number", "null"]},
+        "used": {"type": ["number", "null"]},
+        "remaining": {"type": ["number", "null"]}
+      }
+    },
+    "upgrade_suggestion": {
+      "description": "Cheapest available plan priced above the current one, or null when there is nothing to suggest.",
+      "type": ["object", "null"],
+      "additionalProperties": true,
+      "properties": {
+        "plan_slug": {"type": "string"},
+        "price_usd": {"type": ["number", "null"]},
+        "credits": {"type": ["integer", "null"]}
+      }
+    },
+    "blocked_upgrades": {
+      "description": "Plans the caller cannot buy, with the server's stated reason (e.g. requires_team, exceeds_max_seats), so an unsuggested visible tier is explained.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["plan_slug", "reason"],
+        "properties": {
+          "plan_slug": {"type": "string"},
+          "reason": {"type": "string"}
+        }
+      }
+    },
+    "seats": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "max": {"type": ["integer", "null"]},
+        "occupied": {"type": ["integer", "null"]}
+      }
+    },
+    "plans": {
+      "description": "Full tier table. Present only with --plans.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["plan_slug", "available"],
+        "additionalProperties": true,
+        "properties": {
+          "plan_slug": {"type": "string"},
+          "price_cents": {"type": ["integer", "null"]},
+          "price_usd": {"type": ["number", "null"]},
+          "credits": {"type": ["integer", "null"]},
+          "available": {"type": "boolean"},
+          "unavailable_reason": {"type": ["string", "null"]}
+        }
+      }
+    },
+    "manage_url": {
+      "type": "string",
+      "description": "Subscription page, derived from the resolved cloud base URL so a preview or staging env points at its own page."
+    },
+    "message": {
+      "type": ["string", "null"],
+      "description": "Neutral copy when the balance could not be confirmed, and/or the legacy-rail caveat. Consumers should pass this through verbatim rather than re-deriving it."
+    }
+  }
+}

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -318,8 +318,15 @@ codes, and capabilities. Everything below flows from it.
 comfy --json env             # what's installed locally
 comfy --json which           # workspace path
 comfy --json cloud whoami    # signed_in, auth_method (oauth/api_key), base_url, api_key_source
+comfy --json cloud status    # cloud_workspace, balance, tier, max_concurrent_jobs, upgrade_suggestion
 comfy --json auth list       # all credentials (redacted)
 ```
+
+`cloud status` answers "how many credits do I have / what plan am I on /
+what's my concurrency". It is read-only and spends nothing. Two fields need
+care: when `balance_confirmed` is `false` the balance fields are `null` rather
+than `0`, so never render "$0.00" from them, and `message` carries the copy to
+show instead. Pass `message` through verbatim rather than composing your own.
 
 ## Nodes — introspect the graph
 

--- a/tests/comfy_cli/cloud/test_billing.py
+++ b/tests/comfy_cli/cloud/test_billing.py
@@ -241,3 +241,156 @@ def test_tier_concurrency_covers_the_documented_tiers():
     assert billing.TIER_CONCURRENCY["CREATOR"] == 3
     assert billing.TIER_CONCURRENCY["PRO"] == 5
     assert billing.TIER_CONCURRENCY["TEAM"] == 25
+
+
+# ---------------------------------------------------------------------------
+# Review regressions: malformed scalars from the server
+#
+# Every test below is a finding from the review of the original PR. The common
+# cause was fixtures that were all well-formed, so the code trusted types the
+# billing endpoints do not actually guarantee.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_floats_are_rejected_not_raised(bad):
+    """`json.loads` accepts bare NaN/Infinity, and int(nan) raises.
+
+    These are pure calls made outside every try in status_cmd, so a raise here
+    becomes a traceback where an error envelope belongs.
+    """
+    assert billing.select_effective_balance_micros({"effective_balance_micros": bad}) is None
+    assert billing._coerce_int(bad) is None
+
+
+@pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "Infinity", "1e400"])
+def test_non_finite_strings_are_rejected_not_raised(bad):
+    """`int(float("1e400"))` raises OverflowError, which ValueError misses."""
+    assert billing._coerce_int(bad) is None
+
+
+def test_absurdly_large_integers_are_rejected():
+    """An unbounded JSON int would blow up the later division, not this call."""
+    assert billing._coerce_int(10**400) is None
+    assert billing.select_effective_balance_micros({"effective_balance_micros": 10**400}) is None
+    # And the bound leaves realistic values alone.
+    assert billing._coerce_int(10**12) == 10**12
+
+
+def test_micros_to_usd_survives_every_value_coerce_int_admits():
+    """No input that clears _coerce_int may raise downstream."""
+    for raw in (10**18, -(10**18), 0, 1):
+        assert billing.micros_to_usd(billing._coerce_int(raw)) is not None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("TRUE", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("1", True),
+        # Not booleans: unknown beats guessing.
+        ("maybe", None),
+        (None, None),
+        (1, None),
+        ({}, None),
+    ],
+)
+def test_coerce_bool(value, expected):
+    assert billing.coerce_bool(value) is expected
+
+
+def test_string_false_has_funds_does_not_suppress_the_trust_guard():
+    """`bool("false")` is True, which would silently disable the guard."""
+    assert billing.is_unconfirmed(balance_micros=None, subscription_status=None, has_funds="false") is True
+    assert billing.is_unconfirmed(balance_micros=None, subscription_status=None, has_funds="true") is False
+
+
+def test_non_string_subscription_status_is_not_a_subscription():
+    """A JSON `subscription_status: false` used to stringify to "false".
+
+    That missed the no-subscription set and read as a real subscription,
+    suppressing the guard on exactly the silent-backend payload it targets.
+    """
+    assert billing.has_subscription(False) is False
+    assert billing.has_subscription(0) is False
+    assert billing.has_subscription({}) is False
+    assert billing.is_unconfirmed(balance_micros=None, subscription_status=False, has_funds=False) is True
+
+
+# ---------------------------------------------------------------------------
+# Review regression: a failed balance fetch is not a verdict
+# ---------------------------------------------------------------------------
+
+
+def test_failed_balance_fetch_does_not_trip_the_trust_guard():
+    """A timeout is not evidence the account is mid-migration.
+
+    Without this, a user holding real credit but no subscription row gets told
+    their account may be migrating because one request failed.
+    """
+    assert (
+        billing.is_unconfirmed(
+            balance_micros=None,
+            subscription_status=None,
+            has_funds=False,
+            balance_fetch_failed=True,
+        )
+        is False
+    )
+
+
+def test_failed_balance_fetch_still_withholds_the_figure():
+    """The other half: it must not read as a confirmed balance either."""
+    assert billing.balance_is_confirmed(balance_micros=None, balance_fetch_failed=True, unconfirmed=False) is False
+
+
+@pytest.mark.parametrize(
+    ("micros", "failed", "unconfirmed", "expected"),
+    [
+        (5, False, False, True),  # a real number from a call that worked
+        (0, False, False, True),  # a confirmed zero is publishable
+        (None, False, False, False),  # answered, but reported no fields
+        (5, True, False, False),  # fetch failed: withhold regardless
+        (5, False, True, False),  # guard fired: withhold regardless
+    ],
+)
+def test_balance_is_confirmed_matrix(micros, failed, unconfirmed, expected):
+    assert (
+        billing.balance_is_confirmed(balance_micros=micros, balance_fetch_failed=failed, unconfirmed=unconfirmed)
+        is expected
+    )
+
+
+# ---------------------------------------------------------------------------
+# Review regression: plan availability edges
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_null_availability_is_treated_as_available():
+    """`bool(None)` is False, which made the plan vanish from both lists.
+
+    It would be dropped from upgrade_suggestion as unavailable AND from
+    blocked_upgrades (which needs a reason string), so it disappeared with no
+    explanation.
+    """
+    plans, _ = billing.normalize_plans([{"slug": "creator", "price_cents": 2000, "availability": {"available": None}}])
+    assert plans[0]["available"] is True
+
+
+def test_string_false_availability_does_not_recommend_a_blocked_plan():
+    """`bool("false")` is truthy and would recommend an unavailable plan."""
+    plans, _ = billing.normalize_plans(
+        [
+            {"slug": "free", "price_cents": 0},
+            {"slug": "ent", "price_cents": 9999, "availability": {"available": "false"}},
+        ]
+    )
+    ent = next(p for p in plans if p["plan_slug"] == "ent")
+    assert ent["available"] is False
+    assert billing.suggest_upgrade(plans, "free") is None

--- a/tests/comfy_cli/cloud/test_billing.py
+++ b/tests/comfy_cli/cloud/test_billing.py
@@ -1,0 +1,243 @@
+"""Unit tests for the pure billing rules behind ``comfy cloud status``.
+
+The command-level tests in ``test_status_command.py`` cover these through the
+envelope; these pin the arithmetic and the shape tolerance directly, where the
+edge cases are cheap to enumerate. The shape tolerance is not academic: the
+billing endpoints have sent micro-dollar fields as both JSON numbers and
+decimal strings, and ``/api/billing/plans`` has been observed as both an object
+and a bare list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_cli.cloud import billing
+
+# ---------------------------------------------------------------------------
+# select_effective_balance_micros
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("balance", "expected"),
+    [
+        # Highest-priority field wins when it is non-zero.
+        ({"effective_balance_micros": 5, "amount_micros": 9}, 5),
+        # A present-but-zero field is skipped, not accepted.
+        ({"effective_balance_micros": 0, "amount_micros": 9}, 9),
+        ({"effective_balance_micros": 0, "amount_micros": 0, "prepaid_balance_micros": 7}, 7),
+        ({"effective_balance_micros": 0, "cloud_credit_balance_micros": 3}, 3),
+        # Negative is a real balance and is returned as-is.
+        ({"effective_balance_micros": -100}, -100),
+        # A lower-priority positive does not override a negative above it.
+        ({"effective_balance_micros": -100, "amount_micros": 500}, -100),
+        # Every present field is zero: a confirmed zero, not unknown.
+        ({"effective_balance_micros": 0, "amount_micros": 0}, 0),
+        # Nothing present at all: unknown, which must stay distinct from zero.
+        ({}, None),
+        ({"unrelated": 5}, None),
+        (None, None),
+        # Strings and floats are tolerated.
+        ({"effective_balance_micros": "2500000"}, 2_500_000),
+        ({"effective_balance_micros": 2_500_000.9}, 2_500_000),
+        ({"effective_balance_micros": " 42 "}, 42),
+        # Non-numeric junk is ignored rather than crashing the command.
+        ({"effective_balance_micros": "abc", "amount_micros": 8}, 8),
+        ({"effective_balance_micros": None, "amount_micros": 8}, 8),
+        # A stray bool must not read as a one-micro balance.
+        ({"effective_balance_micros": True, "amount_micros": 8}, 8),
+    ],
+)
+def test_select_effective_balance_micros(balance, expected):
+    assert billing.select_effective_balance_micros(balance) == expected
+
+
+def test_unknown_and_zero_are_distinguishable():
+    """The distinction the trust guard depends on."""
+    assert billing.select_effective_balance_micros({}) is None
+    assert billing.select_effective_balance_micros({"amount_micros": 0}) == 0
+
+
+# ---------------------------------------------------------------------------
+# Conversions
+# ---------------------------------------------------------------------------
+
+
+def test_micros_and_credits_conversions():
+    assert billing.micros_to_usd(12_500_000) == pytest.approx(12.5)
+    assert billing.micros_to_usd(None) is None
+    assert billing.usd_to_credits(1.0) == billing.CREDITS_PER_USD
+    assert billing.usd_to_credits(None) is None
+
+
+def test_credits_truncate_toward_zero_in_both_directions():
+    """Truncation keeps a negative balance's credit figure negative."""
+    assert billing.usd_to_credits(0.9) == int(0.9 * billing.CREDITS_PER_USD)
+    assert billing.usd_to_credits(-2.25) < 0
+
+
+# ---------------------------------------------------------------------------
+# Trust guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("none", False),
+        ("NONE", False),
+        ("no_subscription", False),
+        ("active", True),
+        # A lapsed subscription still confirms the account is real.
+        ("past_due", True),
+        ("canceled", True),
+    ],
+)
+def test_has_subscription(status, expected):
+    assert billing.has_subscription(status) is expected
+
+
+def test_is_unconfirmed_requires_all_three_signals_negative():
+    negative = {"balance_micros": None, "subscription_status": None, "has_funds": False}
+    assert billing.is_unconfirmed(**negative) is True
+
+    # Any single affirmative signal is enough to report normally.
+    assert billing.is_unconfirmed(**{**negative, "balance_micros": 100}) is False
+    assert billing.is_unconfirmed(**{**negative, "subscription_status": "active"}) is False
+    assert billing.is_unconfirmed(**{**negative, "has_funds": True}) is False
+
+
+def test_is_unconfirmed_treats_confirmed_zero_as_unconfirmed_only_when_alone():
+    """A zero balance is not itself affirmative, but a subscription is."""
+    assert billing.is_unconfirmed(balance_micros=0, subscription_status=None, has_funds=False) is True
+    assert billing.is_unconfirmed(balance_micros=0, subscription_status="active", has_funds=False) is False
+
+
+def test_unconfirmed_message_carries_the_env_specific_url():
+    msg = billing.unconfirmed_message("https://preview.example/billing")
+    assert "https://preview.example/billing" in msg
+    assert "Couldn't confirm" in msg
+
+
+def test_manage_url_derives_from_base_and_tolerates_a_trailing_slash():
+    assert billing.manage_url("https://cloud.comfy.org") == "https://cloud.comfy.org/billing"
+    assert billing.manage_url("https://cloud.comfy.org/") == "https://cloud.comfy.org/billing"
+
+
+@pytest.mark.parametrize(
+    ("rail", "expected"),
+    [("legacy_stripe", True), ("LEGACY_STRIPE", True), ("stripe", False), (None, False), (7, False)],
+)
+def test_is_legacy_rail(rail, expected):
+    assert billing.is_legacy_rail(rail) is expected
+
+
+# ---------------------------------------------------------------------------
+# Plans
+# ---------------------------------------------------------------------------
+
+
+_PLAN_LIST = [
+    {"slug": "free", "price_cents": 0, "credits_cents": 0},
+    {"slug": "creator", "price_cents": 2000, "credits_cents": 2000},
+    {"slug": "pro", "price_cents": 5000, "credits_cents": 5500},
+    {"slug": "team", "price_cents": 20000, "credits_cents": 22000, "availability": {"available": True}},
+    {"slug": "ent", "price_cents": 30000, "availability": {"available": False, "reason": "requires_team"}},
+]
+
+
+def test_normalize_plans_accepts_the_documented_object():
+    plans, current = billing.normalize_plans({"current_plan_slug": "creator", "plans": _PLAN_LIST})
+    assert current == "creator"
+    assert [p["plan_slug"] for p in plans] == ["free", "creator", "pro", "team", "ent"]
+    assert plans[1]["price_usd"] == pytest.approx(20.0)
+    assert plans[1]["credits"] == billing.usd_to_credits(20.0)
+
+
+def test_normalize_plans_accepts_a_bare_list():
+    """Observed shape; tolerated rather than failing the whole command."""
+    plans, current = billing.normalize_plans(_PLAN_LIST)
+    assert current is None
+    assert len(plans) == 5
+
+
+@pytest.mark.parametrize("body", [None, {}, [], "nope", 7, {"plans": "nope"}])
+def test_normalize_plans_degrades_on_junk(body):
+    plans, current = billing.normalize_plans(body)
+    assert plans == []
+    assert current is None
+
+
+def test_normalize_plans_skips_entries_without_a_usable_slug():
+    plans, _ = billing.normalize_plans([{"price_cents": 100}, "junk", {"slug": "ok", "price_cents": 1}])
+    assert [p["plan_slug"] for p in plans] == ["ok"]
+
+
+def test_missing_availability_block_means_available():
+    """An older backend that omits availability is not saying 'unavailable'."""
+    plans, _ = billing.normalize_plans([{"slug": "creator", "price_cents": 2000}])
+    assert plans[0]["available"] is True
+
+
+def test_suggest_upgrade_picks_cheapest_above_current():
+    plans, current = billing.normalize_plans({"current_plan_slug": "creator", "plans": _PLAN_LIST})
+    suggestion = billing.suggest_upgrade(plans, current)
+    assert suggestion["plan_slug"] == "pro"
+    assert suggestion["price_usd"] == pytest.approx(50.0)
+
+
+def test_suggest_upgrade_skips_unavailable_plans():
+    plans, _ = billing.normalize_plans({"current_plan_slug": "team", "plans": _PLAN_LIST})
+    # Only `ent` is priced above team, and it is unavailable.
+    assert billing.suggest_upgrade(plans, "team") is None
+
+
+def test_suggest_upgrade_on_the_top_plan_returns_none():
+    plans, _ = billing.normalize_plans({"current_plan_slug": "ent", "plans": _PLAN_LIST})
+    assert billing.suggest_upgrade(plans, "ent") is None
+
+
+def test_suggest_upgrade_stays_quiet_when_the_current_price_is_unknown():
+    """No suggestion beats a wrong one.
+
+    Observed in prod: /api/billing/status reports plan_slug
+    "team-pro-monthly" while /api/billing/plans carries no such slug. A
+    "cheapest available" fallback then suggested a $0.00 per-credit plan as an
+    upgrade from PRO, which is worse than saying nothing.
+    """
+    plans, _ = billing.normalize_plans(_PLAN_LIST)
+    assert billing.suggest_upgrade(plans, None) is None
+    assert billing.suggest_upgrade(plans, "team-pro-monthly-not-in-list") is None
+
+
+def test_suggest_upgrade_from_a_zero_priced_plan_still_works():
+    """A known price of 0 is resolvable, unlike an unmatched slug."""
+    plans, _ = billing.normalize_plans(_PLAN_LIST)
+    suggestion = billing.suggest_upgrade(plans, "free")
+    assert suggestion["plan_slug"] == "creator"
+
+
+def test_suggest_upgrade_never_suggests_a_cheaper_or_equal_plan():
+    plans, _ = billing.normalize_plans(_PLAN_LIST)
+    for current in ("free", "creator", "pro", "team", "ent"):
+        suggestion = billing.suggest_upgrade(plans, current)
+        if suggestion is None:
+            continue
+        current_price = next(p["price_cents"] for p in plans if p["plan_slug"] == current)
+        suggested_price = next(p["price_cents"] for p in plans if p["plan_slug"] == suggestion["plan_slug"])
+        assert suggested_price > current_price
+
+
+def test_blocked_upgrade_reasons_reports_only_annotated_unavailable_plans():
+    plans, _ = billing.normalize_plans(_PLAN_LIST)
+    assert billing.blocked_upgrade_reasons(plans) == [{"plan_slug": "ent", "reason": "requires_team"}]
+
+
+def test_tier_concurrency_covers_the_documented_tiers():
+    assert billing.TIER_CONCURRENCY["FREE"] == 1
+    assert billing.TIER_CONCURRENCY["CREATOR"] == 3
+    assert billing.TIER_CONCURRENCY["PRO"] == 5
+    assert billing.TIER_CONCURRENCY["TEAM"] == 25

--- a/tests/comfy_cli/cloud/test_status_command.py
+++ b/tests/comfy_cli/cloud/test_status_command.py
@@ -451,8 +451,12 @@ def test_unconfirmed_payload_also_validates(monkeypatch, capsys):
     env = _run(
         monkeypatch,
         capsys,
-        {"/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None}},
+        {
+            "/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None},
+            "/billing/balance": {},
+        },
     )
+    assert env["data"]["balance_confirmed"] is False
     schema = json.loads(_SCHEMA_PATH.read_text())
     jsonschema.Draft202012Validator(schema).validate(env["data"])
 
@@ -465,7 +469,14 @@ def test_pretty_mode_renders_without_asserting_a_balance(monkeypatch, capsys):
     """
     _install(
         monkeypatch,
-        {"/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None}},
+        {
+            "/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None},
+            # An explicit empty body, not an absent route. The guard fires on a
+            # backend that ANSWERED and reported nothing; a route that fails to
+            # answer is a different case and is covered separately, since a
+            # transient error is not evidence about the account.
+            "/billing/balance": {},
+        },
     )
     set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
     command.status_cmd(plans=False)
@@ -507,3 +518,255 @@ def test_pretty_mode_does_not_interpret_markup_from_a_server_supplied_name(monke
     out = capsys.readouterr().out
     # Rendered literally by Text(), so the tags survive as characters.
     assert "[red]pwned[/red]" in out
+
+
+# ---------------------------------------------------------------------------
+# Review regressions
+#
+# Each test below is a finding from the review of the original PR. They share a
+# root cause: the original fixtures were all well-formed, so nothing exercised
+# the shapes the billing endpoints actually permit.
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingBodyHTTPError(urllib.error.HTTPError):
+    """An HTTPError whose body read fails, as a reset stream would."""
+
+    def __init__(self, url: str, code: int):
+        super().__init__(url, code, f"HTTP {code}", {}, io.BytesIO(b""))
+        self.read_calls: list[int | None] = []
+
+    def read(self, amt=None):  # noqa: D102 - mirrors HTTPError.read
+        self.read_calls.append(amt)
+        raise OSError("connection reset while draining the error body")
+
+
+def test_error_body_read_failure_does_not_escape_the_handler(monkeypatch, capsys):
+    """A raise while quoting the body must not pre-empt the envelope.
+
+    The original code called `e.read()` unguarded inside the except block, so a
+    reset mid-drain turned a transient 503 into a traceback.
+    """
+    boom = _ExplodingBodyHTTPError(f"{_BASE}/api/billing/status", 503)
+    _install(monkeypatch, {"/billing/status": boom})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "cloud_billing_unavailable"
+    assert env["error"]["details"]["body"] == ""
+
+
+def test_error_body_read_is_bounded_by_the_cap_not_sliced_after(monkeypatch, capsys):
+    """`e.read(n)` must carry the limit, so the server can't pick our memory use."""
+    seen: list[int | None] = []
+
+    class _RecordingHTTPError(urllib.error.HTTPError):
+        def __init__(self):
+            super().__init__(f"{_BASE}/api/billing/status", 503, "boom", {}, io.BytesIO(b"x" * 10_000))
+
+        def read(self, amt=None):
+            seen.append(amt)
+            return b"x" * (amt or 10_000)
+
+    _install(monkeypatch, {"/billing/status": _RecordingHTTPError()})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+
+    assert seen == [command._MAX_ERROR_BODY_BYTES]
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert len(env["error"]["details"]["body"]) <= command._MAX_ERROR_BODY_BYTES
+
+
+def test_unsafe_base_url_produces_an_envelope_not_a_traceback(monkeypatch, capsys):
+    """`assert_safe_url` raises a bare ValueError for plaintext non-loopback.
+
+    Reachable through the documented `comfy cloud set-base-url` and
+    COMFY_CLOUD_BASE_URL, neither of which validates the scheme.
+    """
+    _install(monkeypatch, {"/billing/status": ValueError("refusing to send request to non-https URL")})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "cloud_billing_unavailable"
+    assert "https" in env["error"]["hint"]
+
+
+def test_unsafe_base_url_on_an_optional_endpoint_degrades(monkeypatch, capsys):
+    """The same ValueError on a non-required call must not kill the command."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": ValueError("refusing to send request to non-https URL"),
+        },
+    )
+    assert env["ok"] is True
+    assert env["data"]["balance_confirmed"] is False
+
+
+# --- a failed balance fetch is not a verdict about the account -------------
+
+
+def test_failed_balance_fetch_with_a_subscription_withholds_without_accusing(monkeypatch, capsys):
+    """The schema-contradiction case.
+
+    Previously this emitted `balance_confirmed: true` beside three null balance
+    fields, violating cloud_status.json, which agents are told to validate
+    against.
+    """
+    env = _run(
+        monkeypatch,
+        capsys,
+        {"/billing/status": _ACTIVE_CREATOR, "/billing/balance": _http_error(f"{_BASE}/api/billing/balance", 503)},
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is False
+    assert data["credit_balance_usd"] is None
+    assert data["effective_balance_micros"] is None
+    # Says what actually happened, and does not imply a migration.
+    assert data["message"] == billing.BALANCE_UNAVAILABLE_NOTE
+    assert "mid-migration" not in data["message"]
+    # The rest of the answer still lands.
+    assert data["subscription"]["tier"] == "CREATOR"
+
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    jsonschema.Draft202012Validator(schema).validate(data)
+
+
+def test_failed_balance_fetch_without_a_subscription_does_not_accuse_either(monkeypatch, capsys):
+    """One blip must not flip the guard for a user who may hold real credit."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None},
+            "/billing/balance": _http_error(f"{_BASE}/api/billing/balance", 500),
+        },
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is False
+    assert "Couldn't confirm an active subscription" not in (data["message"] or "")
+    assert data["message"] == billing.BALANCE_UNAVAILABLE_NOTE
+
+
+def test_balance_answered_with_nothing_still_trips_the_guard(monkeypatch, capsys):
+    """The distinction: answered-and-empty is a verdict, failed-to-answer isn't."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None},
+            "/billing/balance": {},
+        },
+    )
+    assert "Couldn't confirm an active subscription" in env["data"]["message"]
+
+
+# --- malformed scalars must not violate our own schema --------------------
+
+
+def test_wrongly_typed_server_scalars_are_coerced_or_dropped(monkeypatch, capsys):
+    """A backend sending "3" or `is_active: "false"` must still validate."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {
+                "is_active": "false",
+                "has_funds": "true",
+                "subscription_status": "active",
+                "subscription_tier": "PRO",
+                "plan_slug": "  pro-monthly  ",
+                "max_seats": "40",
+                "occupied_seats": 39.0,
+                "renewal_date": 20260911,
+            },
+            "/billing/balance": {"effective_balance_micros": "1500000"},
+            "/features": {"max_concurrent_jobs": "5", "free_tier_balance": {"allowance": "100", "remaining": "60"}},
+            "/workspaces/current": {"id": "w-1", "name": 12345, "type": "team", "role": None},
+        },
+    )
+    data = env["data"]
+    assert data["subscription"]["is_active"] is False
+    assert data["max_concurrent_jobs"] == 5
+    assert data["seats"] == {"max": 40, "occupied": 39}
+    assert data["free_tier_balance"]["allowance"] == 100
+    # Non-string values in string-typed fields are dropped, not stringified.
+    assert data["subscription"]["renewal_date"] is None
+    assert data["cloud_workspace"]["name"] is None
+    # The padded slug is stripped so it can match a plan and not leak padding.
+    assert data["subscription"]["plan_slug"] == "pro-monthly"
+
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    jsonschema.Draft202012Validator(schema).validate(data)
+
+
+def test_nan_balance_does_not_crash_the_command(monkeypatch, capsys):
+    """`json.loads` accepts a bare NaN literal; int(nan) raises."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {"/billing/status": _ACTIVE_CREATOR, "/billing/balance": {"effective_balance_micros": float("nan")}},
+    )
+    assert env["ok"] is True
+    assert env["data"]["credit_balance_usd"] is None
+
+
+def test_padded_plan_slug_still_matches_a_plan_for_the_upgrade_suggestion(monkeypatch, capsys):
+    """The strip fix, observed end to end: padding used to drop the suggestion."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {**_ACTIVE_CREATOR, "plan_slug": " creator-monthly "},
+            "/billing/plans": {"plans": _PLANS["plans"]},
+        },
+    )
+    assert env["data"]["upgrade_suggestion"]["plan_slug"] == "pro-monthly"
+
+
+# --- panel hardening ------------------------------------------------------
+
+
+def test_panel_sanitizes_escape_sequences_from_features(monkeypatch, capsys):
+    """`Text` blocks markup but passes \\x1b through, so these need sanitizing.
+
+    Reachable whenever a user points the CLI at a hostile host via the
+    documented `comfy cloud set-base-url` flow.
+    """
+    _install(
+        monkeypatch,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 1_000_000},
+            "/features": {"max_concurrent_jobs": 1, "free_tier_balance": {"allowance": "\x1b]0;pwned\x07100"}},
+        },
+    )
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
+    command.status_cmd(plans=False)
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+
+
+def test_panel_falls_back_to_the_tier_default_concurrency(monkeypatch, capsys):
+    """/api/features down should not hide a number the tier already tells us."""
+    _install(
+        monkeypatch,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 1_000_000},
+            # /features absent -> 404
+        },
+    )
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
+    command.status_cmd(plans=False)
+    out = capsys.readouterr().out
+    assert "Concurrency" in out
+    assert "tier default" in out

--- a/tests/comfy_cli/cloud/test_status_command.py
+++ b/tests/comfy_cli/cloud/test_status_command.py
@@ -1,0 +1,509 @@
+"""``comfy cloud status`` — billing / plan / concurrency snapshot.
+
+All HTTP is mocked at ``comfy_cli.http.request_json``, keyed on the URL, so
+each test declares only the endpoints it cares about and every unlisted
+endpoint 404s. That is deliberate: the command is supposed to degrade one row
+per unavailable endpoint rather than fail, and a fixture that silently serves
+everything would never exercise that.
+
+The two display rules with history behind them get the most coverage:
+
+* the zero-masking balance chain, where a present-but-zero high-priority field
+  must not mask a positive component below it;
+* the trust guard (BE-1795 / BE-1798), where an all-silent backend must produce
+  neutral copy instead of "$0.00 / Subscribe".
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+import typer
+
+from comfy_cli.cloud import billing, command
+from comfy_cli.output import Renderer, set_renderer
+from comfy_cli.output.renderer import OutputMode
+from comfy_cli.target import Target
+
+_BASE = "https://testcloud.comfy.org"
+_SCHEMA_PATH = Path(__file__).resolve().parents[3] / "comfy_cli" / "schemas" / "cloud_status.json"
+
+
+@pytest.fixture(autouse=True)
+def _no_tracking(monkeypatch):
+    """Keep the ``@track_command`` decorator inert (no network / consent I/O)."""
+    monkeypatch.setattr("comfy_cli.tracking.track_event", lambda *a, **k: None)
+
+
+def _cloud_target(*, token: str | None = "tok", api_key: str | None = None) -> Target:
+    return Target(
+        kind="cloud",
+        base_url=_BASE,
+        path_prefix="/api",
+        history_path="history_v2",
+        jobs_path="jobs",
+        auth_token=token,
+        api_key=api_key,
+    )
+
+
+def _http_error(url: str, code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, code, f"HTTP {code}", {}, io.BytesIO(b"{}"))
+
+
+def _install(monkeypatch, routes: dict[str, Any], *, target: Target | None = None) -> None:
+    """Route ``request_json`` by URL suffix.
+
+    A route value that is an ``Exception`` is raised; anything else is returned
+    as a 200 body. An unlisted suffix raises 404, standing in for an older
+    backend or a transient failure.
+    """
+    resolved = target if target is not None else _cloud_target()
+    monkeypatch.setattr("comfy_cli.target.resolve_target", lambda **kwargs: resolved)
+
+    def fake_request_json(url, _target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        for suffix, value in routes.items():
+            if url.endswith(suffix):
+                if isinstance(value, Exception):
+                    raise value
+                return 200, value
+        raise _http_error(url, 404)
+
+    monkeypatch.setattr("comfy_cli.http.request_json", fake_request_json)
+
+
+def _run(monkeypatch, capsys, routes: dict[str, Any], *, plans: bool = False, target: Target | None = None) -> dict:
+    _install(monkeypatch, routes, target=target)
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+    command.status_cmd(plans=plans)
+    out = capsys.readouterr().out
+    lines = [json.loads(line) for line in out.splitlines() if line.strip()]
+    assert lines, "no envelope on stdout"
+    return lines[-1]
+
+
+# ---------------------------------------------------------------------------
+# Fixture payloads, modeled on real cloud responses.
+# ---------------------------------------------------------------------------
+
+_ACTIVE_CREATOR = {
+    "is_active": True,
+    "has_funds": True,
+    "subscription_status": "active",
+    "subscription_tier": "CREATOR",
+    "plan_slug": "creator-monthly",
+    "billing_rail": "stripe",
+    "renewal_date": "2026-09-19",
+    "cancel_at": None,
+}
+
+_PLANS = {
+    "current_plan_slug": "creator-monthly",
+    "plans": [
+        {"slug": "free", "price_cents": 0, "credits_cents": 0, "availability": {"available": True}},
+        {"slug": "creator-monthly", "price_cents": 2000, "credits_cents": 2000, "availability": {"available": True}},
+        {"slug": "pro-monthly", "price_cents": 5000, "credits_cents": 5500, "availability": {"available": True}},
+        {"slug": "team-monthly", "price_cents": 20000, "credits_cents": 22000, "availability": {"available": True}},
+        {
+            "slug": "enterprise",
+            "price_cents": 100000,
+            "credits_cents": 120000,
+            "availability": {"available": False, "reason": "requires_team"},
+        },
+    ],
+}
+
+_WORKSPACE = {"id": "w-abc123", "name": "Matt's Studio", "type": "personal", "role": "owner"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_active_creator_positive_balance(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 12_500_000},
+            "/features": {"max_concurrent_jobs": 3},
+            "/workspaces/current": _WORKSPACE,
+            "/billing/plans": _PLANS,
+        },
+    )
+    assert env["ok"] is True
+    data = env["data"]
+    assert data["balance_confirmed"] is True
+    assert data["credit_balance_usd"] == pytest.approx(12.5)
+    assert data["credit_balance_credits"] == int(12.5 * billing.CREDITS_PER_USD)
+    assert data["currency"] == "USD"
+    assert data["cloud_workspace"] == _WORKSPACE
+    assert data["subscription"]["tier"] == "CREATOR"
+    assert data["subscription"]["is_active"] is True
+    assert data["max_concurrent_jobs"] == 3
+    assert data["tier_default_concurrent_jobs"] == 3
+    assert data["manage_url"] == f"{_BASE}/billing"
+    assert data["message"] is None
+    # Cheapest available plan priced above creator-monthly (2000c).
+    assert data["upgrade_suggestion"]["plan_slug"] == "pro-monthly"
+    assert data["upgrade_suggestion"]["price_usd"] == pytest.approx(50.0)
+    # The unavailable tier is reported with the server's reason, not silently dropped.
+    assert {"plan_slug": "enterprise", "reason": "requires_team"} in data["blocked_upgrades"]
+
+
+def test_plans_flag_includes_full_tier_table(monkeypatch, capsys):
+    without = _run(monkeypatch, capsys, {"/billing/status": _ACTIVE_CREATOR, "/billing/plans": _PLANS})
+    assert "plans" not in without["data"]
+
+    with_plans = _run(monkeypatch, capsys, {"/billing/status": _ACTIVE_CREATOR, "/billing/plans": _PLANS}, plans=True)
+    slugs = [p["plan_slug"] for p in with_plans["data"]["plans"]]
+    assert slugs == ["free", "creator-monthly", "pro-monthly", "team-monthly", "enterprise"]
+
+
+# ---------------------------------------------------------------------------
+# The zero-masking chain
+# ---------------------------------------------------------------------------
+
+
+def test_zero_effective_balance_does_not_mask_positive_component(monkeypatch, capsys):
+    """A literal 0 in the highest-priority field must not hide real credits."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {
+                "effective_balance_micros": 0,
+                "amount_micros": 0,
+                "cloud_credit_balance_micros": 7_000_000,
+            },
+        },
+    )
+    data = env["data"]
+    assert data["effective_balance_micros"] == 7_000_000
+    assert data["credit_balance_usd"] == pytest.approx(7.0)
+    assert data["balance_confirmed"] is True
+
+
+def test_negative_effective_balance_is_reported_not_clamped(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": -2_250_000},
+        },
+    )
+    data = env["data"]
+    assert data["effective_balance_micros"] == -2_250_000
+    assert data["credit_balance_usd"] == pytest.approx(-2.25)
+    assert data["credit_balance_credits"] < 0
+    assert data["balance_confirmed"] is True
+
+
+def test_all_zero_balance_with_active_subscription_is_a_confirmed_zero(monkeypatch, capsys):
+    """Zero is a real answer when the account is otherwise confirmed.
+
+    The trust guard must not swallow a genuine zero balance on an active
+    subscription, or a user who has simply run out of credits gets told we
+    could not confirm anything.
+    """
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 0, "amount_micros": 0},
+        },
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is True
+    assert data["credit_balance_usd"] == 0
+    assert data["message"] is None
+
+
+# ---------------------------------------------------------------------------
+# The trust guard
+# ---------------------------------------------------------------------------
+
+
+def test_neutral_copy_when_nothing_can_be_confirmed(monkeypatch, capsys):
+    """All-zero balance + no subscription + !has_funds must not print $0.00."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None},
+            "/billing/balance": {},
+        },
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is False
+    # The figures are withheld, not zeroed: null cannot be rendered as "$0.00".
+    assert data["credit_balance_usd"] is None
+    assert data["credit_balance_credits"] is None
+    assert data["effective_balance_micros"] is None
+    assert "Couldn't confirm an active subscription or balance" in data["message"]
+    assert f"{_BASE}/billing" in data["message"]
+
+
+def test_legacy_stripe_rail_is_annotated(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {
+                "is_active": False,
+                "has_funds": False,
+                "subscription_status": None,
+                "billing_rail": "legacy_stripe",
+            },
+            "/billing/balance": {},
+        },
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is False
+    assert data["billing_rail"] == "legacy_stripe"
+    assert "legacy billing rail" in data["message"]
+    assert "Couldn't confirm" in data["message"]
+
+
+def test_legacy_rail_annotated_even_when_balance_is_confirmed(monkeypatch, capsys):
+    """The rail caveat is independent of the trust guard.
+
+    A confirmed balance on the legacy rail can still be partial, so the note
+    rides along without the neutral copy.
+    """
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {**_ACTIVE_CREATOR, "billing_rail": "legacy_stripe"},
+            "/billing/balance": {"effective_balance_micros": 5_000_000},
+        },
+    )
+    data = env["data"]
+    assert data["balance_confirmed"] is True
+    assert data["message"] == billing.LEGACY_RAIL_NOTE
+    assert "Couldn't confirm" not in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# Degradation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_workspaces_current_degrades_to_null_not_failure(monkeypatch, capsys):
+    """An older backend without GET /api/workspaces/current still works."""
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 1_000_000},
+            "/features": {"max_concurrent_jobs": 3},
+            # /workspaces/current deliberately absent -> 404
+        },
+    )
+    assert env["ok"] is True
+    assert env["data"]["cloud_workspace"] is None
+    assert env["data"]["credit_balance_usd"] == pytest.approx(1.0)
+
+
+def test_every_optional_endpoint_failing_still_emits_a_useful_envelope(monkeypatch, capsys):
+    env = _run(monkeypatch, capsys, {"/billing/status": _ACTIVE_CREATOR})
+    data = env["data"]
+    assert env["ok"] is True
+    assert data["cloud_workspace"] is None
+    assert data["max_concurrent_jobs"] is None
+    assert data["upgrade_suggestion"] is None
+    # plan_slug falls back to the billing-status payload when /plans is gone.
+    assert data["subscription"]["plan_slug"] == "creator-monthly"
+    assert data["subscription"]["tier"] == "CREATOR"
+
+
+def test_free_tier_balance_is_surfaced(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": {
+                "is_active": True,
+                "has_funds": True,
+                "subscription_status": "active",
+                "subscription_tier": "FREE",
+                "plan_slug": "free",
+            },
+            "/billing/balance": {"effective_balance_micros": 0, "amount_micros": 0},
+            "/features": {
+                "max_concurrent_jobs": 1,
+                "free_tier_balance": {"allowance": 100, "used": 40, "remaining": 60},
+            },
+        },
+    )
+    data = env["data"]
+    assert data["subscription"]["tier"] == "FREE"
+    assert data["tier_default_concurrent_jobs"] == 1
+    assert data["free_tier_balance"] == {"allowance": 100, "used": 40, "remaining": 60}
+
+
+def test_seats_only_present_when_reported(monkeypatch, capsys):
+    without = _run(monkeypatch, capsys, {"/billing/status": _ACTIVE_CREATOR})
+    assert "seats" not in without["data"]
+
+    with_seats = _run(
+        monkeypatch,
+        capsys,
+        {"/billing/status": {**_ACTIVE_CREATOR, "max_seats": 25, "occupied_seats": 4}},
+    )
+    assert with_seats["data"]["seats"] == {"max": 25, "occupied": 4}
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_credential_fails_before_any_request(monkeypatch, capsys):
+    """Never report "cloud rejected your token" to someone who has none."""
+    calls: list[str] = []
+
+    def fake_request_json(url, *a, **k):
+        calls.append(url)
+        raise AssertionError("should not have issued a request")
+
+    monkeypatch.setattr("comfy_cli.target.resolve_target", lambda **kw: _cloud_target(token=None, api_key=None))
+    monkeypatch.setattr("comfy_cli.http.request_json", fake_request_json)
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit) as excinfo:
+        command.status_cmd(plans=False)
+    assert excinfo.value.exit_code == 1
+    assert calls == []
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "cloud_not_configured"
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_rejected_credential_maps_to_cloud_unauthorized(monkeypatch, capsys, status_code):
+    _install(monkeypatch, {"/billing/status": _http_error(f"{_BASE}/api/billing/status", status_code)})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "cloud_unauthorized"
+
+
+def test_billing_status_server_error_maps_to_cloud_billing_unavailable(monkeypatch, capsys):
+    _install(monkeypatch, {"/billing/status": _http_error(f"{_BASE}/api/billing/status", 503)})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "cloud_billing_unavailable"
+    assert env["error"]["details"]["status"] == 503
+
+
+def test_unparseable_billing_status_body_is_an_error_not_a_crash(monkeypatch, capsys):
+    _install(monkeypatch, {"/billing/status": ["not", "an", "object"]})
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud status", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.status_cmd(plans=False)
+    env = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert env["error"]["code"] == "cloud_billing_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Schema + pretty surface
+# ---------------------------------------------------------------------------
+
+
+def test_payload_validates_against_the_shipped_schema(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 12_500_000},
+            "/features": {"max_concurrent_jobs": 3},
+            "/workspaces/current": _WORKSPACE,
+            "/billing/plans": _PLANS,
+        },
+        plans=True,
+    )
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    jsonschema.Draft202012Validator(schema).validate(env["data"])
+
+
+def test_unconfirmed_payload_also_validates(monkeypatch, capsys):
+    env = _run(
+        monkeypatch,
+        capsys,
+        {"/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None}},
+    )
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    jsonschema.Draft202012Validator(schema).validate(env["data"])
+
+
+def test_pretty_mode_renders_without_asserting_a_balance(monkeypatch, capsys):
+    """The panel must not print a dollar figure for an unconfirmed workspace.
+
+    This is the BE-1798 regression in its original surface: the JSON payload
+    withholding the number is only half the fix if the panel prints one anyway.
+    """
+    _install(
+        monkeypatch,
+        {"/billing/status": {"is_active": False, "has_funds": False, "subscription_status": None}},
+    )
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
+    command.status_cmd(plans=False)
+    out = capsys.readouterr().out
+    assert "$" not in out
+    assert "not confirmed" in out
+    assert "Couldn't confirm" in out
+
+
+def test_pretty_mode_renders_a_confirmed_balance(monkeypatch, capsys):
+    _install(
+        monkeypatch,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 12_500_000},
+            "/features": {"max_concurrent_jobs": 3},
+            "/workspaces/current": _WORKSPACE,
+        },
+    )
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
+    command.status_cmd(plans=False)
+    out = capsys.readouterr().out
+    assert "$12.50" in out
+    assert "CREATOR" in out
+
+
+def test_pretty_mode_does_not_interpret_markup_from_a_server_supplied_name(monkeypatch, capsys):
+    """A crafted workspace name must not inject Rich markup into the panel."""
+    _install(
+        monkeypatch,
+        {
+            "/billing/status": _ACTIVE_CREATOR,
+            "/billing/balance": {"effective_balance_micros": 1_000_000},
+            "/workspaces/current": {**_WORKSPACE, "name": "[red]pwned[/red]"},
+        },
+    )
+    set_renderer(Renderer(mode=OutputMode.PRETTY, command="cloud status", version="test"))
+    command.status_cmd(plans=False)
+    out = capsys.readouterr().out
+    # Rendered literally by Text(), so the tags survive as characters.
+    assert "[red]pwned[/red]" in out

--- a/tests/comfy_cli/output/test_envelope_schemas.py
+++ b/tests/comfy_cli/output/test_envelope_schemas.py
@@ -56,6 +56,10 @@ def _validator_for(name: str) -> jsonschema.Validator:
         # for payloads without a cloud `base_url`), so its well-formedness is
         # worth pinning rather than assuming.
         "jobs.json",
+        # Nearly every property is a nullable union, because the command
+        # degrades one row per unavailable endpoint. Worth pinning so a typo in
+        # one of those unions can't ship.
+        "cloud_status.json",
     ],
 )
 def test_schemas_are_well_formed(schema_name):


### PR DESCRIPTION
## Summary

Adds `comfy cloud status`, one read-only command that answers "which cloud workspace am I in, how many credits do I have, what plan am I on, and how many jobs can I run at once". Spends nothing. `--plans` adds the full tier table; `--json` emits a schema-validated envelope.

```
$ comfy cloud status
      Cloud workspace  Comfy  (team)  · member
              Balance  $0.19  (41 credits)
         Subscription  PRO  active
                 Plan  team-pro-monthly
               Renews  2026-09-11T17:00:00Z
          Concurrency  1  concurrent job
               Manage  https://cloud.comfy.org/billing
```

## Details

**Balance selection walks a priority chain and skips present-but-zero fields**, so a literal `0` in a high-priority field cannot mask a positive component underneath it. Negative balances are reported as negative rather than clamped, because an overdrawn account is real and the user needs to see it.

**When nothing can be confirmed, no figure is printed.** If the balance is absent-or-zero *and* there is no subscription *and* the backend reports no funds, the command withholds the numbers (null in JSON, "not confirmed" in the panel) and prints neutral copy pointing at support and the subscribe page. Asserting "$0.00 / Subscribe" at a customer whose billing rows are mid-migration is the specific failure this design exists to prevent. Accounts on the pre-migration billing rail additionally get a caveat that figures may be partial.

**Only `/api/billing/status` is required.** The workspace, features and plans calls each drop a single row when they fail, so an older backend that has no `GET /api/workspaces/current` still answers everything else instead of erroring. A rejected credential maps to `cloud_unauthorized`, a broken required call to the new `cloud_billing_unavailable`, and a total absence of credentials fails before any request goes out rather than reporting a rejected token to someone who never had one.

**Upgrade suggestions rank on price straight from the endpoint** rather than a hardcoded tier ladder, since the tier names have churned. If the current plan's price cannot be resolved, no suggestion is made. That case is live in production today: `/api/billing/status` reports a `plan_slug` that `/api/billing/plans` does not carry, and an earlier "cheapest available plan" fallback confidently suggested a \$0.00 per-credit plan as an *upgrade* from PRO. Plans the caller cannot buy are surfaced with the server's own reason, so a visible-but-unsuggested tier is explained rather than silently dropped.

The rules live in `comfy_cli/cloud/billing.py` as pure functions with no I/O, so each is unit-tested directly; `command.py` owns fetching, the panel and the envelope. Server-supplied strings render through `Text`/sanitizers so a crafted workspace name cannot inject Rich markup.

## Testing

154 tests across `tests/comfy_cli/cloud/test_billing.py` (the rules) and `test_status_command.py` (the command, all HTTP mocked and keyed by URL so unlisted endpoints 404 and the degrade paths actually get exercised). Covers the zero-masking chain, negative and confirmed-zero balances, the neutral-copy shape, the legacy-rail caveat both with and without the trust guard, every-optional-endpoint-down, the auth failure modes, schema validation of both a full and a withheld payload, and that the panel prints no `$` for an unconfirmed workspace.

Also exercised end to end against production cloud. `ruff check` and `ruff format --check` clean.

Two pre-existing suite failures (`test_object_info_timeout_routes_to_connection_error`, `test_json_mode_leaves_stderr_clean`) reproduce unchanged on a pristine checkout of the base commit and are unrelated to this branch.

## ELI5

If you run workflows on Comfy Cloud, you had no way to ask the CLI the most basic billing questions: how much credit is left, which plan you are on, how many jobs you can run at once. You had to open the web app. This adds one command that prints all of it.

The fiddly part is what to do when the server is vague. The billing API reports a balance across several different fields depending on how your account was set up, and some of them come back as a plain `0` even when you do have credits sitting in a different field. Reading the first field and trusting it tells people with money that they have none. So the command walks the fields in order and skips any zero, only reporting `0` once it has checked them all.

Worse, a partly-migrated account can answer every question with silence: no balance, no subscription, no funds. Printing "$0.00" and a Subscribe button there tells a paying customer they are not a customer. Instead the command says it could not confirm anything and points at support, which is honest and actionable.

The rest is graceful degradation. Five endpoints get called; only the subscription one really matters. If the others are missing or slow, you lose one line of output rather than the whole command, so this keeps working against older or partly-deployed backends.