### PR TITLE
feat(distribution): upload a private file without creating a distribution

### DIFF
--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -654,7 +654,11 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
         if m.get("sha256"):
             entry["sha256"] = m["sha256"]
         uri = resolver(m)
-        if uri:
+        # A blob the caller already holds is a source, so it is neither resolved
+        # nor uploaded again: re-uploading would orphan the bytes it replaced.
+        if m.get("blobId"):
+            entry["blobId"] = m["blobId"]
+        elif uri:
             entry["sourceUri"] = uri
         else:
             # `slot` points at the builder-definition entry this upload fills, so
@@ -1505,6 +1509,59 @@ def update_cmd(
     if renderer.is_pretty():
         renderer.success(f"Updated distribution {distribution_id}")
     renderer.emit(dist, command="distribution update", changed=True)
+
+
+@app.command("blob-upload", help="Upload a private file and print the blobId a definition can reference.")
+@tracking.track_command("distribution")
+def blob_upload_cmd(
+    path: Annotated[str, typer.Argument(help="File to upload.")],
+    kind: Annotated[str, typer.Option("--kind", help="What the file is: model or node_zip.")] = "model",
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    if kind not in ("model", "node_zip"):
+        renderer.error(
+            code="distribution_definition_invalid",
+            message=f"unknown blob kind {kind!r}",
+            hint="use --kind model or --kind node_zip",
+        )
+        raise typer.Exit(code=1)
+    file_path = Path(path).expanduser()
+    if not file_path.is_file():
+        renderer.error(
+            code="distribution_models_dir_missing",
+            message=f"no file at {file_path}",
+            details={"path": str(file_path)},
+        )
+        raise typer.Exit(code=1)
+
+    client = _builder_client(renderer, builder_url)
+    size_bytes = file_path.stat().st_size
+    sha256 = _sha256_file(file_path)
+    blob_id, upload_url = _builder_call(renderer, lambda: client.create_blob(kind, file_path.name, sha256, size_bytes))
+    _builder_call(renderer, lambda: client.upload_blob(upload_url, file_path))
+    if renderer.is_pretty():
+        renderer.success(f"Uploaded {file_path.name} as {blob_id}")
+        renderer.info(f'reference it in a definition as "blobId": "{blob_id}", then `comfy distribution update`')
+    renderer.emit(
+        {"blobId": blob_id, "kind": kind, "filename": file_path.name, "sha256": sha256, "sizeBytes": size_bytes},
+        command="distribution blob-upload",
+        changed=True,
+    )
+
+
+@app.command("blobs", help="List the workspace's uploaded private files.")
+@tracking.track_command("distribution")
+def blobs_cmd(
+    kind: Annotated[str | None, typer.Option("--kind", help="Filter by kind: model or node_zip.")] = None,
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    client = _builder_client(renderer, builder_url)
+    blobs = _builder_call(renderer, lambda: client.list_blobs(kind))
+    if renderer.is_pretty():
+        renderer.console().print_json(json.dumps(blobs))
+    renderer.emit({"blobs": blobs}, command="distribution blobs")
 
 
 @app.command("resolve", help="Resolve model filenames to public download candidates (HF/CivitAI).")

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1329,3 +1329,27 @@ def test_update_refuses_what_it_cannot_upload(monkeypatch):
     with pytest.raises(typer.Exit) as e:
         distribution.update_cmd("d1", from_="ignored.json")
     assert e.value.exit_code == 1
+
+
+# --- blobs: a private file is uploaded once and referenced by id ---------------
+
+
+def test_plan_create_keeps_a_model_blob_reference():
+    """A model the caller already uploaded names its blob. Re-uploading it would
+    orphan the bytes it replaced and spend the transfer twice."""
+    plan = distribution.plan_create(
+        {"models": [{"type": "vae", "filename": "ae.safetensors", "sha256": "def", "blobId": "blob-9"}]}
+    )
+    assert plan["definition"]["models"][0]["blobId"] == "blob-9"
+    assert plan["upload_count"] == 0
+
+
+def test_a_definition_naming_only_blobs_goes_through_update_untouched():
+    """Every member names a builder source, so update has nothing to map and sends
+    the file as written."""
+    assert not distribution._is_scan_shaped(
+        {
+            "models": [{"type": "vae", "filename": "ae.safetensors", "blobId": "blob-9"}],
+            "customNodes": [{"name": "priv", "blobId": "blob-1"}],
+        }
+    )


### PR DESCRIPTION
**TL;DR:** Add `blob-upload` and `blobs`, so a private model or pack can be uploaded once and referenced from a definition, instead of only ever reaching the builder inside a fresh `create`.

Stacked on [#738 make a scanned definition buildable](https://github.com/Comfy-Org/comfy-cli/pull/738) · Notion: [Feature 3, a local install becomes a distribution that builds](https://app.notion.com/p/comfy-org/Feature-3-a-local-install-becomes-a-distribution-that-builds-3c26d73d365081fd8353d532eb56ca00)

**Why:** the builder has accepted a `blobId` on a model or a node all along and the client has had `create_blob`, `upload_blob` and `list_blobs`, but nothing exposed them. The upload was welded inside `create`, so adding one private model to a distribution that already exists meant creating a second distribution and abandoning the first with its id and its history.

**What changed**
* **[comfy-cli] `blob-upload` and `blobs`**: hash a file, mint the presigned PUT, stream the bytes and print the `blobId` a definition can name; list what the workspace already holds so an id is found rather than uploaded twice.
* **[comfy-cli] `plan_create`**: carries a model's `blobId` as it already carried a node's, since dropping it turned a hand-referenced model back into an upload of bytes the workspace was already storing.

**Contradicts:** nothing.

**Validation**
* **Unit**: 90 pass in `tests/comfy_cli/command/test_distribution.py`, 2 new. The model-blob case fails on the base branch and passes here.
* **Development environment, end to end**: staging builder, driven through the real CLI. A 2 MB file uploaded as `f67400e9`, listed by `blobs`, named in a definition and sent with `update`; reading the distribution back shows the private model carrying that blobId beside three public models carrying `sourceUri`, and no distribution was created.
* **Development environment, unchanged path**: a definition naming only public sources still goes through `update` untouched.
* **Not run**: a build cut from a definition naming a blob, so the bytes were stored and referenced but never installed; and `--kind node_zip`, which the builder stores but no build path unpacks yet.
