### PR TITLE
fix(distribution): close the five the machine review left open

### DIFF
--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -696,7 +696,11 @@ def plan_create(definition: dict, resolver=resolve_model_source) -> dict:
             for key in ("gitRef", "commit"):
                 if n.get(key):
                     entry[key] = n[key]
-        elif n.get("registryVersion") and n.get("id"):
+        elif n.get("registryVersion"):
+            # A hand-written node often names the pack once. scan writes id and
+            # name the same for a registry pack, and the builder prefers id then
+            # name, so the name is the id when no other is given.
+            entry["id"] = n.get("id") or n["name"]
             entry["registryVersion"] = n["registryVersion"]
         elif n.get("blobId"):
             entry["blobId"] = n["blobId"]
@@ -1127,7 +1131,6 @@ def _create_execute(
     name: str,
     builder_url: str | None,
     models_dir: str | None,
-    repair: bool = False,
 ) -> None:
     """The live --execute path: auth, resolve, upload, create, cut. Maps every
     failure class to a single error envelope + exit(1)."""
@@ -1556,7 +1559,11 @@ def from_snapshot_cmd(
     path = Path(from_).expanduser()
     try:
         snapshot = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        # `null`, a list and a bare scalar all parse. Caught here so the caller
+        # gets the error envelope rather than an AttributeError from the wrapper.
+        if not isinstance(snapshot, dict):
+            raise ValueError(f"expected a JSON object, got {type(snapshot).__name__}")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
         renderer.error(
             code="build_definition_invalid",
             message=f"could not read {path}: {e}",
@@ -1599,7 +1606,7 @@ def blob_upload_cmd(
     file_path = Path(path).expanduser()
     if not file_path.is_file():
         renderer.error(
-            code="build_models_dir_missing",
+            code="build_definition_invalid",
             message=f"no file at {file_path}",
             details={"path": str(file_path)},
         )

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -86,7 +86,12 @@ _SENSITIVE_SUFFIXES = ("_token", "_api_key", "_secret", "_password")
 # are verbatim user content — like `changelog`, we keep the presence but never
 # ship the text. Sensitive values become "<redacted>" (the key is kept so we can
 # still tell the option was supplied).
-_SENSITIVE_EXACT = frozenset({"api_key", "key", "token", "password", "secret", "changelog", "prompt", "set_overrides"})
+# `from_` is the `--from` path: a local filesystem path naming the user's home
+# directory and their install layout, with no analytics value beyond having been
+# supplied.
+_SENSITIVE_EXACT = frozenset(
+    {"api_key", "key", "token", "password", "secret", "changelog", "prompt", "set_overrides", "from_"}
+)
 
 
 def _is_sensitive(name: str) -> bool:

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1510,3 +1510,35 @@ def test_distribution_alias_hidden_from_root_help():
     assert proc.returncode == 0
     assert "build" in proc.stdout
     assert "distribution" not in proc.stdout
+# --- review follow-ups --------------------------------------------------------
+
+
+def test_plan_create_reads_a_registry_pin_that_names_the_pack_once():
+    """A hand-written node often gives the name and the version and no separate id.
+    `update` read that as a builder source while `create` routed it to an upload it
+    then refused, so the two commands disagreed about the same file."""
+    plan = distribution.plan_create({"customNodes": [{"name": "comfyui-kjnodes", "registryVersion": "1.4.9"}]})
+    assert plan["definition"]["customNodes"][0] == {
+        "name": "comfyui-kjnodes",
+        "id": "comfyui-kjnodes",
+        "registryVersion": "1.4.9",
+    }
+    assert plan["upload_count"] == 0
+
+
+@pytest.mark.parametrize("payload", ["null", "[]", '"a string"', "42"])
+def test_from_snapshot_refuses_json_that_is_not_an_object(tmp_path, payload):
+    """`json.loads` accepts all of these, and the wrapper would raise AttributeError
+    instead of the error envelope a caller can read."""
+    f = tmp_path / "export.json"
+    f.write_text(payload, encoding="utf-8")
+    with pytest.raises(typer.Exit):
+        distribution.from_snapshot_cmd(from_=str(f), name="demo")
+
+
+def test_the_from_path_is_not_shipped_as_telemetry():
+    """`--from` is a local path naming the user's home directory and install layout."""
+    from comfy_cli.tracking import filter_command_kwargs
+
+    out = filter_command_kwargs({"from_": "/Users/someone/ComfyUI-Installs/private/definition.json"})
+    assert out["from_"] == "<redacted>"

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1527,18 +1527,26 @@ def test_plan_create_reads_a_registry_pin_that_names_the_pack_once():
 
 
 @pytest.mark.parametrize("payload", ["null", "[]", '"a string"', "42"])
-def test_from_snapshot_refuses_json_that_is_not_an_object(tmp_path, payload):
+def test_from_snapshot_refuses_json_that_is_not_an_object(tmp_path, capsys, payload):
     """`json.loads` accepts all of these, and the wrapper would raise AttributeError
-    instead of the error envelope a caller can read."""
+    instead of the error envelope a caller can read. The code is the contract, so
+    assert it rather than the exit."""
     f = tmp_path / "export.json"
     f.write_text(payload, encoding="utf-8")
     with pytest.raises(typer.Exit):
         distribution.from_snapshot_cmd(from_=str(f), name="demo")
+    assert "build_definition_invalid" in capsys.readouterr().out
 
 
 def test_the_from_path_is_not_shipped_as_telemetry():
-    """`--from` is a local path naming the user's home directory and install layout."""
+    """`--from` is a local path naming the user's home directory and install layout.
+    Redacting must keep the key, since whether the option was supplied is the part
+    analytics is entitled to."""
     from comfy_cli.tracking import filter_command_kwargs
 
     out = filter_command_kwargs({"from_": "/Users/someone/ComfyUI-Installs/private/definition.json"})
     assert out["from_"] == "<redacted>"
+
+    # Supplied but empty is still supplied; absent is absent.
+    assert filter_command_kwargs({"from_": None})["from_"] is None
+    assert "from_" not in filter_command_kwargs({"name": "demo"})


### PR DESCRIPTION
**TL;DR:** Close the five findings the machine review left open on [#738](https://github.com/Comfy-Org/comfy-cli/pull/738), one of which shipped a local filesystem path as telemetry.

Follows [#738](https://github.com/Comfy-Org/comfy-cli/pull/738), which is merged.

**Why:** #738 merged with five review threads unresolved. Four are small and real; one is a privacy leak that predates the PR and that its new command widened.

**What changed**
* **[comfy-cli] `tracking`**: `--from` is redacted like the other sensitive values. It is a local path naming the user's home directory and their install layout, and its presence is still recorded.
* **[comfy-cli] `plan_create` and `from-snapshot`**: a registry pin naming the pack once is a registry source to both `create` and `update`, which previously disagreed about the same file; and a snapshot file holding `null`, a list or a scalar is refused with the error envelope rather than an `AttributeError`.
* **[comfy-cli] two tidies**: a missing input file no longer reports itself as a missing models directory, and `_create_execute` no longer carries the parameter of a flag that was removed.

**Contradicts:** nothing.

**Validation**
* **Unit**: 317 pass across `test_distribution.py` and the tracking tests, 6 new. The registry-pin case and the telemetry case both fail on `origin/main` and pass here.
* **Not run**: no build was cut for this change, since none of it alters what reaches the builder except the id fallback, which is covered by the unit case.
