### PR TITLE
feat(knowledge): load the comfy-knowledge bundle and add `comfy knowledge` verbs

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -25,6 +25,7 @@ from comfy_cli.command import install as install_inner
 from comfy_cli.command import (
     jobs as jobs_command,
 )
+from comfy_cli.command import knowledge as knowledge_command
 from comfy_cli.command import (
     nodes as nodes_command,
 )
@@ -2001,6 +2002,11 @@ app.add_typer(
 app.add_typer(custom_nodes.app, name="node", help="Manage custom nodes.")
 app.add_typer(nodes_command.app, name="nodes", help="Introspect ComfyUI node classes (inputs, outputs, categories).")
 app.add_typer(templates_command.app, name="templates", help="Browse the Comfy workflow-template gallery.")
+app.add_typer(
+    knowledge_command.app,
+    name="knowledge",
+    help="Inspect the curated model-knowledge bundle: status, resolve an alias, ranked picks per capability.",
+)
 app.command(
     "run-template",
     help=(

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -1,0 +1,173 @@
+"""``comfy knowledge`` — inspect the curated model-knowledge bundle.
+
+    comfy knowledge status [--refresh]
+    comfy knowledge resolve <alias-or-id>
+    comfy knowledge pick <capability>
+
+Backed by :mod:`comfy_cli.knowledge`. JSON mode is the contract; pretty mode
+is a short courtesy view.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+from typing import Annotated, Any
+
+import typer
+
+from comfy_cli import knowledge, tracking
+from comfy_cli.output import get_renderer, rprint
+from comfy_cli.output.sanitize import sanitize_markup
+
+app = typer.Typer(no_args_is_help=True, help="Inspect the curated model-knowledge bundle.")
+
+
+def _env_context() -> dict[str, Any]:
+    return {
+        "env_file": os.environ.get(knowledge.ENV_FILE, "").strip() or None,
+        "url": os.environ.get(knowledge.ENV_URL, "").strip() or None,
+        "ttl_seconds": knowledge.ttl_seconds(),
+        "cache_path": str(knowledge.cache_paths()[0]),
+    }
+
+
+def _require_bundle(renderer) -> knowledge.Bundle:
+    bundle = knowledge.load_bundle()
+    if bundle is None:
+        renderer.error(
+            code="knowledge_unavailable",
+            message="no knowledge bundle is loaded",
+            hint="set COMFY_KNOWLEDGE_FILE to a knowledge.json, or COMFY_KNOWLEDGE_URL to fetch one; see `comfy knowledge status`",
+        )
+        raise typer.Exit(code=1)
+    return bundle
+
+
+@app.command("status", help="Report which knowledge bundle is loaded, where it came from, and how big it is.")
+@tracking.track_command("knowledge")
+def status_cmd(
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", help="Re-fetch from COMFY_KNOWLEDGE_URL, ignoring the cache TTL."),
+    ] = False,
+):
+    renderer = get_renderer()
+    bundle = knowledge.load_bundle(force_fetch=refresh)
+    if bundle is None:
+        payload: dict[str, Any] = {"loaded": False, "reason": knowledge.last_reason(), **_env_context()}
+    else:
+        payload = {
+            "loaded": True,
+            "source": bundle.source,
+            "stale": bundle.stale,
+            "version": bundle.version,
+            "schema_version": knowledge.SCHEMA_VERSION,
+            "as_of": bundle.as_of,
+            "path": bundle.path,
+            **_env_context(),
+            "counts": {
+                "models": len(bundle.models),
+                "capabilities": len(bundle.capabilities),
+                "aliases": len(bundle.aliases),
+                "deprecations": len(bundle.deprecations),
+            },
+        }
+    if renderer.is_pretty():
+        for key, value in payload.items():
+            if isinstance(value, dict):
+                value = ", ".join(f"{k}={v}" for k, v in value.items())
+            rprint(f"[bold]{key}[/bold]: {sanitize_markup(value)}")
+    renderer.emit(payload, command="knowledge status")
+
+
+@app.command("resolve", help="Resolve a model alias or id (e.g. 'Kling 3.0', minimax-h3) to its knowledge row.")
+@tracking.track_command("knowledge")
+def resolve_cmd(
+    query: Annotated[str, typer.Argument(help="Model alias or id; case- and whitespace-insensitive.")],
+):
+    renderer = get_renderer()
+    bundle = _require_bundle(renderer)
+    q = query.strip().lower()
+    row = knowledge.resolve(bundle, query)
+    if row is None:
+        renderer.error(
+            code="knowledge_unknown_model",
+            message=f"no knowledge row matches {query!r}",
+            hint="run `comfy knowledge status` to confirm a bundle is loaded; try a different alias",
+            details={
+                "query": query,
+                "close_matches": difflib.get_close_matches(q, list(bundle.aliases), n=5, cutoff=0.6),
+            },
+        )
+        raise typer.Exit(code=1)
+    model_id = bundle.aliases[q]
+    payload = {
+        "query": query,
+        "id": model_id,
+        "model": row,
+        "deprecation": bundle.deprecations.get(model_id),
+        "bundle_version": bundle.version,
+        "stale": bundle.stale,
+    }
+    if renderer.is_pretty():
+        status, route = sanitize_markup(row.get("status")), sanitize_markup(row.get("route"))
+        rprint(f"[bold]{sanitize_markup(model_id)}[/bold]  status={status}  route={route}")
+        for line in row.get("best_for") or []:
+            rprint(f"  [green]+[/green] {sanitize_markup(line)}")
+        for pitfall in row.get("pitfalls") or []:
+            text = pitfall.get("text") if isinstance(pitfall, dict) else pitfall
+            rprint(f"  [yellow]![/yellow] {sanitize_markup(text)}")
+    renderer.emit(payload, command="knowledge resolve")
+
+
+@app.command("pick", help="Ranked model picks for a capability (e.g. lipsync, text-to-video).")
+@tracking.track_command("knowledge")
+def pick_cmd(
+    capability: Annotated[str, typer.Argument(help="Capability id; see `details.known` on a miss.")],
+):
+    renderer = get_renderer()
+    bundle = _require_bundle(renderer)
+    cap = knowledge.pick(bundle, capability)
+    if cap is None:
+        renderer.error(
+            code="knowledge_unknown_capability",
+            message=f"no knowledge capability matches {capability!r}",
+            hint="pick one of the listed capabilities",
+            details={"capability": capability, "known": sorted(bundle.capabilities)},
+        )
+        raise typer.Exit(code=1)
+    picks = []
+    for p in cap["picks"]:
+        model_id = p.get("model")
+        row = bundle.models.get(model_id, {}) if isinstance(model_id, str) else {}
+        picks.append(
+            {
+                "rank": p.get("rank"),
+                "model": model_id,
+                "route": p.get("route"),
+                "template": p.get("template"),
+                "caveat": p.get("caveat"),
+                "status": row.get("status"),
+                "superseded_by": row.get("superseded_by"),
+            }
+        )
+    payload = {
+        "capability": capability.strip().lower(),
+        "description": cap.get("description"),
+        "as_of": cap.get("as_of"),
+        "picks": picks,
+        "bundle_version": bundle.version,
+        "stale": bundle.stale,
+    }
+    if renderer.is_pretty():
+        from rich.table import Table
+
+        columns = ("rank", "model", "route", "template", "status", "caveat")
+        tbl = Table(show_header=True, header_style="bold")
+        for col in columns:
+            tbl.add_column(col)
+        for p in picks:
+            tbl.add_row(*(sanitize_markup("" if p[c] is None else p[c]) for c in columns))
+        renderer.console().print(tbl)
+    renderer.emit(payload, command="knowledge pick")

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -24,12 +24,22 @@ app = typer.Typer(no_args_is_help=True, help="Inspect the curated model-knowledg
 
 
 def _env_context() -> dict[str, Any]:
+    url = os.environ.get(knowledge.ENV_URL, "").strip()
     return {
         "env_file": os.environ.get(knowledge.ENV_FILE, "").strip() or None,
-        "url": os.environ.get(knowledge.ENV_URL, "").strip() or None,
+        # Userinfo, query and fragment can carry a token; the path still shows which bundle is configured.
+        "url": tracking._scrub_value(url) if url else None,
         "ttl_seconds": knowledge.ttl_seconds(),
         "cache_path": str(knowledge.cache_paths()[0]),
     }
+
+
+def _items(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
 
 
 def _require_bundle(renderer) -> knowledge.Bundle:
@@ -93,9 +103,9 @@ def resolve_cmd(
 ):
     renderer = get_renderer()
     bundle = _require_bundle(renderer)
-    q = query.strip().lower()
-    row = knowledge.resolve(bundle, query)
-    if row is None:
+    model_id = knowledge.resolve_id(bundle, query)
+    if model_id is None:
+        q = query.strip().lower()
         renderer.error(
             code="knowledge_unknown_model",
             message=f"no knowledge row matches {query!r}",
@@ -106,7 +116,7 @@ def resolve_cmd(
             },
         )
         raise typer.Exit(code=1)
-    model_id = row.get("id") or bundle.aliases.get(q) or bundle.normalized_aliases[knowledge._normalize(q)]
+    row = bundle.models[model_id]
     payload = {
         "query": query,
         "id": model_id,
@@ -118,9 +128,9 @@ def resolve_cmd(
     if renderer.is_pretty():
         status, route = sanitize_markup(row.get("status")), sanitize_markup(row.get("route"))
         rprint(f"[bold]{sanitize_markup(model_id)}[/bold]  status={status}  route={route}")
-        for line in row.get("best_for") or []:
+        for line in _items(row.get("best_for")):
             rprint(f"  [green]+[/green] {sanitize_markup(line)}")
-        for pitfall in row.get("pitfalls") or []:
+        for pitfall in _items(row.get("pitfalls")):
             text = pitfall.get("text") if isinstance(pitfall, dict) else pitfall
             rprint(f"  [yellow]![/yellow] {sanitize_markup(text)}")
     renderer.emit(payload, command="knowledge resolve")
@@ -145,10 +155,11 @@ def pick_cmd(
     picks = []
     for p in cap["picks"]:
         model_id = p.get("model")
-        row = bundle.models.get(model_id, {}) if isinstance(model_id, str) else {}
+        model_id = model_id if isinstance(model_id, str) else None
+        row = bundle.models.get(model_id) or {}
         picks.append(
             {
-                "rank": p.get("rank"),
+                "rank": knowledge.pick_rank(p),
                 "model": model_id,
                 "route": p.get("route"),
                 "template": p.get("template"),
@@ -158,9 +169,9 @@ def pick_cmd(
             }
         )
     payload = {
-        "capability": cap.get("id") or capability.strip().lower(),
-        "description": cap.get("description"),
-        "as_of": cap.get("as_of"),
+        "capability": _text(cap.get("id")) or capability.strip().lower(),
+        "description": _text(cap.get("description")),
+        "as_of": _text(cap.get("as_of")),
         "picks": picks,
         "bundle_version": bundle.version,
         "stale": bundle.stale,

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -84,7 +84,12 @@ def status_cmd(
 @app.command("resolve", help="Resolve a model alias or id (e.g. 'Kling 3.0', minimax-h3) to its knowledge row.")
 @tracking.track_command("knowledge")
 def resolve_cmd(
-    query: Annotated[str, typer.Argument(help="Model alias or id; case- and whitespace-insensitive.")],
+    query: Annotated[
+        str,
+        typer.Argument(
+            help="Model alias or id. Case, spacing, punctuation, and leading zeros are ignored ('Hailuo 3' == 'hailuo-03')."
+        ),
+    ],
 ):
     renderer = get_renderer()
     bundle = _require_bundle(renderer)
@@ -101,7 +106,7 @@ def resolve_cmd(
             },
         )
         raise typer.Exit(code=1)
-    model_id = bundle.aliases[q]
+    model_id = row.get("id") or bundle.aliases.get(q) or bundle.normalized_aliases[knowledge._normalize(q)]
     payload = {
         "query": query,
         "id": model_id,
@@ -153,7 +158,7 @@ def pick_cmd(
             }
         )
     payload = {
-        "capability": capability.strip().lower(),
+        "capability": cap.get("id") or capability.strip().lower(),
         "description": cap.get("description"),
         "as_of": cap.get("as_of"),
         "picks": picks,

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -161,11 +161,11 @@ def pick_cmd(
             {
                 "rank": knowledge.pick_rank(p),
                 "model": model_id,
-                "route": p.get("route"),
-                "template": p.get("template"),
-                "caveat": p.get("caveat"),
-                "status": row.get("status"),
-                "superseded_by": row.get("superseded_by"),
+                "route": _text(p.get("route")),
+                "template": _text(p.get("template")),
+                "caveat": _text(p.get("caveat")),
+                "status": _text(row.get("status")),
+                "superseded_by": _text(row.get("superseded_by")),
             }
         )
     payload = {

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -133,6 +133,10 @@ COMMAND_SCHEMAS: dict[str, str] = {
     # the help tree; agents resolve them through `command_schemas`).
     "comfy generate list": "generate_list",
     "comfy generate schema": "generate_schema",
+    # curated model-knowledge bundle
+    "comfy knowledge status": "knowledge",
+    "comfy knowledge resolve": "knowledge",
+    "comfy knowledge pick": "knowledge",
     # template gallery
     "comfy templates ls": "templates",
     "comfy templates show": "templates",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1105,6 +1105,22 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "or a pipe) where there is no TTY to confirm on. Delete is refused rather than blocking on a prompt.",
         "pass `--yes` to confirm the delete when running non-interactively",
     ),
+    # --- knowledge -----------------------------------------------------------
+    ErrorCode(
+        "knowledge_unavailable",
+        "No knowledge bundle could be loaded (no COMFY_KNOWLEDGE_FILE, no cache, no reachable COMFY_KNOWLEDGE_URL).",
+        "set COMFY_KNOWLEDGE_FILE to a knowledge.json or COMFY_KNOWLEDGE_URL to fetch one; run `comfy knowledge status`",
+    ),
+    ErrorCode(
+        "knowledge_unknown_model",
+        "`comfy knowledge resolve` found no row for the alias or id. `details.close_matches` lists near names.",
+        "try one of `details.close_matches`",
+    ),
+    ErrorCode(
+        "knowledge_unknown_capability",
+        "`comfy knowledge pick` found no capability with that id. `details.known` lists them all.",
+        "pick one of `details.known`",
+    ),
 )
 
 

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -119,7 +119,7 @@ def pick(bundle: Bundle, capability: str) -> dict | None:
 
 def _rank_key(p: dict) -> tuple[int, float]:
     rank = p.get("rank")
-    if isinstance(rank, (int, float)) and not isinstance(rank, bool):
+    if isinstance(rank, int | float) and not isinstance(rank, bool):
         return (0, rank)
     return (1, 0.0)
 

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import time
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -52,6 +53,9 @@ class Bundle:
     aliases: dict[str, str]  # lowercased alias or model id -> model id
     templates: dict[str, list[str]]  # template id -> model ids
     nodes: dict[str, list[str]]  # node class -> model ids
+    # _normalize(alias) -> id; a key two ids would share is left out, so only the exact path decides it.
+    normalized_aliases: dict[str, str] = field(default_factory=dict)
+    normalized_capabilities: dict[str, str] = field(default_factory=dict)
 
 
 # One-element tuple so a memoized ``None`` is distinguishable from "not loaded yet".
@@ -101,13 +105,37 @@ def load_bundle(*, force_fetch: bool = False) -> Bundle | None:
     return bundle
 
 
+def _normalize(s: str) -> str:
+    """Spelling-variant key: "Hailuo 3", "hailuo-03" and "HAILUO 03" all become "hailuo3"."""
+    s = re.sub(r"(?<!\d)0+(?=\d)", "", s.lower())
+    return re.sub(r"[^a-z0-9]", "", s)
+
+
+def _normalized_map(keys: dict[str, str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    for key, target in keys.items():
+        norm = _normalize(key)
+        if out.setdefault(norm, target) != target:
+            ambiguous.add(norm)
+    for norm in ambiguous:
+        del out[norm]
+    return out
+
+
 def resolve(bundle: Bundle, query: str) -> dict | None:
-    model_id = bundle.aliases.get(query.strip().lower())
+    q = query.strip().lower()
+    model_id = bundle.aliases.get(q)
+    if model_id is None:
+        model_id = bundle.normalized_aliases.get(_normalize(q))
     return bundle.models.get(model_id) if model_id is not None else None
 
 
 def pick(bundle: Bundle, capability: str) -> dict | None:
-    cap = bundle.capabilities.get(capability.strip().lower())
+    cap_id = capability.strip().lower()
+    if cap_id not in bundle.capabilities:
+        cap_id = bundle.normalized_capabilities.get(_normalize(cap_id), cap_id)
+    cap = bundle.capabilities.get(cap_id)
     if cap is None:
         return None
     raw_picks = cap.get("picks")
@@ -329,4 +357,6 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
         aliases=aliases,
         templates=templates,
         nodes=nodes,
+        normalized_aliases=_normalized_map(aliases),
+        normalized_capabilities=_normalized_map({cid: cid for cid in capabilities}),
     )

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import time
@@ -87,7 +88,7 @@ def ttl_seconds() -> float:
         ttl = float(raw)
     except ValueError:
         return DEFAULT_TTL_SECONDS
-    return max(ttl, 0.0)
+    return max(ttl, 0.0) if math.isfinite(ttl) else DEFAULT_TTL_SECONDS
 
 
 def load_bundle(*, force_fetch: bool = False) -> Bundle | None:
@@ -123,12 +124,18 @@ def _normalized_map(keys: dict[str, str]) -> dict[str, str]:
     return out
 
 
-def resolve(bundle: Bundle, query: str) -> dict | None:
+def resolve_id(bundle: Bundle, query: str) -> str | None:
+    """Model id for an alias or id; ``None`` unless that id has a row."""
     q = query.strip().lower()
     model_id = bundle.aliases.get(q)
     if model_id is None:
         model_id = bundle.normalized_aliases.get(_normalize(q))
-    return bundle.models.get(model_id) if model_id is not None else None
+    return model_id if model_id in bundle.models else None
+
+
+def resolve(bundle: Bundle, query: str) -> dict | None:
+    model_id = resolve_id(bundle, query)
+    return bundle.models[model_id] if model_id is not None else None
 
 
 def pick(bundle: Bundle, capability: str) -> dict | None:
@@ -145,11 +152,17 @@ def pick(bundle: Bundle, capability: str) -> dict | None:
     return out
 
 
-def _rank_key(p: dict) -> tuple[int, float]:
+def pick_rank(p: dict) -> int | float | None:
+    """The pick's numeric ``rank``; ``None`` when missing or not a number."""
     rank = p.get("rank")
-    if isinstance(rank, int | float) and not isinstance(rank, bool):
-        return (0, rank)
-    return (1, 0.0)
+    if isinstance(rank, bool) or not isinstance(rank, int | float) or not math.isfinite(rank):
+        return None
+    return rank
+
+
+def _rank_key(p: dict) -> tuple[int, float]:
+    rank = pick_rank(p)
+    return (0, rank) if rank is not None else (1, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -165,16 +178,11 @@ def _load(*, force_fetch: bool) -> tuple[Bundle | None, str | None]:
         return bundle, (None if bundle else REASON_ENV_FILE)
 
     knowledge_path, manifest_path = cache_paths()
-    ttl = ttl_seconds()
-    if not force_fetch and ttl > 0:
-        try:
-            age = time.time() - knowledge_path.stat().st_mtime
-        except OSError:
-            age = None
-        if age is not None and 0 <= age < ttl:
-            bundle = _load_file(knowledge_path, manifest_path, source="cache")
-            if bundle is not None:
-                return bundle, None
+    fresh = _cache_is_fresh(knowledge_path)
+    if fresh and not force_fetch:
+        bundle = _load_file(knowledge_path, manifest_path, source="cache")
+        if bundle is not None:
+            return bundle, None
 
     url = os.environ.get(ENV_URL, "").strip()
     if url:
@@ -182,10 +190,22 @@ def _load(*, force_fetch: bool) -> tuple[Bundle | None, str | None]:
         if bundle is not None:
             return bundle, None
 
-    bundle = _load_file(knowledge_path, manifest_path, source="stale-cache", stale=True)
+    source = "cache" if fresh else "stale-cache"
+    bundle = _load_file(knowledge_path, manifest_path, source=source, stale=not fresh)
     if bundle is not None:
         return bundle, None
     return None, (REASON_FETCH_FAILED if url else REASON_NO_URL)
+
+
+def _cache_is_fresh(path: Path) -> bool:
+    ttl = ttl_seconds()
+    if ttl <= 0:
+        return False
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return False
+    return 0 <= age < ttl
 
 
 def _load_file(path: Path, manifest_path: Path, *, source: str, stale: bool = False) -> Bundle | None:
@@ -219,13 +239,13 @@ def _fetch(url: str, knowledge_path: Path, manifest_path: Path) -> Bundle | None
     if data is None:
         return None
     try:
+        # The old manifest's sha256 would reject the new bytes if the manifest
+        # write below fails or a reader lands between the two writes; an absent
+        # manifest only skips the check.
+        manifest_path.unlink(missing_ok=True)
         atomic_write_bytes(knowledge_path, raw)
         if manifest_raw is not None:
             atomic_write_bytes(manifest_path, manifest_raw)
-        else:
-            # A leftover manifest from an earlier fetch would fail the sha check
-            # against the new bytes and make the cache unreadable until the next fetch.
-            manifest_path.unlink(missing_ok=True)
     except OSError:
         pass
     return _index(data, manifest, source="fetch", stale=False, path=str(knowledge_path), mtime=time.time())
@@ -244,6 +264,8 @@ def _http_get(url: str) -> bytes:
         req = urllib.request.Request(url, headers={"User-Agent": "comfy-cli"})
         opened = plain_urlopen(req, timeout=FETCH_TIMEOUT_SECONDS)
     with opened as resp:
+        # plain_urlopen follows redirects; the final hop must stay https too.
+        assert_safe_url(resp.url)
         if resp.status != 200:
             raise RuntimeError(f"knowledge fetch failed: HTTP {resp.status}")
         return read_capped(resp, url, max_bytes=MAX_BUNDLE_BYTES)
@@ -298,14 +320,17 @@ def _append_unique(index: dict[str, list[str]], key: str, model_id: str) -> None
 def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path: str, mtime: float) -> Bundle:
     models = {mid: row for mid, row in data["models"].items() if isinstance(mid, str) and isinstance(row, dict)}
 
+    # Exact ids first so no alias can shadow a model's own id; then the compiled
+    # alias map, which wins over row-level aliases.
     aliases: dict[str, str] = {}
+    for mid in models:
+        aliases.setdefault(mid.lower(), mid)
     compiled = data.get("aliases")
     if isinstance(compiled, dict):
         for alias, mid in compiled.items():
             if isinstance(alias, str) and isinstance(mid, str):
                 aliases.setdefault(alias.lower(), mid)
     for mid, row in models.items():
-        aliases.setdefault(mid.lower(), mid)
         for alias in _str_list(row.get("aliases")):
             aliases.setdefault(alias.lower(), mid)
 

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -1,0 +1,332 @@
+"""Find, validate, and index the compiled comfy-knowledge bundle.
+
+The bundle (``knowledge.json`` + optional ``manifest.json``) is produced by
+``Comfy-Org/comfy-knowledge``. It reaches this process by one of three routes,
+tried in order: an explicit ``COMFY_KNOWLEDGE_FILE``, the per-user cache, or a
+fetch from ``COMFY_KNOWLEDGE_URL``. A missing or broken bundle is a normal
+state: every entry point here returns ``None`` rather than raising, and nothing
+is written to stdout or stderr.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from comfy_cli.cloud import get_base_url
+from comfy_cli.cql.loader import _cache_dir
+from comfy_cli.file_utils import atomic_write_bytes
+from comfy_cli.http import assert_safe_url, authed_urlopen, plain_urlopen, read_capped
+
+SCHEMA_VERSION = 1
+ENV_FILE = "COMFY_KNOWLEDGE_FILE"
+ENV_URL = "COMFY_KNOWLEDGE_URL"
+ENV_TTL = "COMFY_KNOWLEDGE_TTL"
+DEFAULT_TTL_SECONDS = 24 * 60 * 60
+FETCH_TIMEOUT_SECONDS = 10.0
+MAX_BUNDLE_BYTES = 16 * 1024 * 1024
+
+REASON_ENV_FILE = "COMFY_KNOWLEDGE_FILE is set but could not be loaded"
+REASON_NO_URL = "no cache and COMFY_KNOWLEDGE_URL is not set"
+REASON_FETCH_FAILED = "fetch failed and no cached bundle exists"
+
+
+@dataclass(frozen=True)
+class Bundle:
+    version: str
+    source: str  # "env" | "cache" | "fetch" | "stale-cache"
+    stale: bool
+    as_of: str  # ISO-8601 UTC, from the loaded file's mtime
+    path: str
+    models: dict[str, dict]
+    capabilities: dict[str, dict]
+    deprecations: dict[str, dict]  # keyed by id
+    aliases: dict[str, str]  # lowercased alias or model id -> model id
+    templates: dict[str, list[str]]  # template id -> model ids
+    nodes: dict[str, list[str]]  # node class -> model ids
+
+
+# One-element tuple so a memoized ``None`` is distinguishable from "not loaded yet".
+_MEMO: tuple[Bundle | None] | None = None
+_LAST_REASON: str | None = None
+
+
+def _reset_for_testing() -> None:
+    global _MEMO, _LAST_REASON
+    _MEMO = None
+    _LAST_REASON = None
+
+
+def last_reason() -> str | None:
+    """Why the most recent ``load_bundle`` returned ``None``; ``None`` after a hit."""
+    return _LAST_REASON
+
+
+def cache_paths() -> tuple[Path, Path]:
+    base = _cache_dir() / "knowledge"
+    return base / "knowledge.json", base / "manifest.json"
+
+
+def ttl_seconds() -> float:
+    raw = os.environ.get(ENV_TTL)
+    if raw is None or not raw.strip():
+        return DEFAULT_TTL_SECONDS
+    try:
+        ttl = float(raw)
+    except ValueError:
+        return DEFAULT_TTL_SECONDS
+    return max(ttl, 0.0)
+
+
+def load_bundle(*, force_fetch: bool = False) -> Bundle | None:
+    """Return the indexed bundle, or ``None`` when no usable bundle exists.
+
+    Memoized per process; ``force_fetch=True`` re-runs the load and skips the
+    cache TTL gate so a fetch happens whenever ``COMFY_KNOWLEDGE_URL`` is set.
+    """
+    global _MEMO, _LAST_REASON
+    if _MEMO is not None and not force_fetch:
+        return _MEMO[0]
+    bundle, reason = _load(force_fetch=force_fetch)
+    _MEMO = (bundle,)
+    _LAST_REASON = reason
+    return bundle
+
+
+def resolve(bundle: Bundle, query: str) -> dict | None:
+    model_id = bundle.aliases.get(query.strip().lower())
+    return bundle.models.get(model_id) if model_id is not None else None
+
+
+def pick(bundle: Bundle, capability: str) -> dict | None:
+    cap = bundle.capabilities.get(capability.strip().lower())
+    if cap is None:
+        return None
+    raw_picks = cap.get("picks")
+    picks = [p for p in raw_picks if isinstance(p, dict)] if isinstance(raw_picks, list) else []
+    out = dict(cap)
+    out["picks"] = sorted(picks, key=_rank_key)
+    return out
+
+
+def _rank_key(p: dict) -> tuple[int, float]:
+    rank = p.get("rank")
+    if isinstance(rank, (int, float)) and not isinstance(rank, bool):
+        return (0, rank)
+    return (1, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# load order
+# ---------------------------------------------------------------------------
+
+
+def _load(*, force_fetch: bool) -> tuple[Bundle | None, str | None]:
+    env_file = os.environ.get(ENV_FILE, "").strip()
+    if env_file:
+        path = Path(env_file)
+        bundle = _load_file(path, path.parent / "manifest.json", source="env")
+        return bundle, (None if bundle else REASON_ENV_FILE)
+
+    knowledge_path, manifest_path = cache_paths()
+    ttl = ttl_seconds()
+    if not force_fetch and ttl > 0:
+        try:
+            age = time.time() - knowledge_path.stat().st_mtime
+        except OSError:
+            age = None
+        if age is not None and 0 <= age < ttl:
+            bundle = _load_file(knowledge_path, manifest_path, source="cache")
+            if bundle is not None:
+                return bundle, None
+
+    url = os.environ.get(ENV_URL, "").strip()
+    if url:
+        bundle = _fetch(url, knowledge_path, manifest_path)
+        if bundle is not None:
+            return bundle, None
+
+    bundle = _load_file(knowledge_path, manifest_path, source="stale-cache", stale=True)
+    if bundle is not None:
+        return bundle, None
+    return None, (REASON_FETCH_FAILED if url else REASON_NO_URL)
+
+
+def _load_file(path: Path, manifest_path: Path, *, source: str, stale: bool = False) -> Bundle | None:
+    try:
+        raw = path.read_bytes()
+        mtime = path.stat().st_mtime
+    except OSError:
+        return None
+    try:
+        manifest = _parse_manifest(manifest_path.read_bytes())
+    except OSError:
+        manifest = None
+    data = _parse(raw, manifest)
+    if data is None:
+        return None
+    return _index(data, manifest, source=source, stale=stale, path=str(path), mtime=mtime)
+
+
+def _fetch(url: str, knowledge_path: Path, manifest_path: Path) -> Bundle | None:
+    try:
+        assert_safe_url(url)
+        raw = _http_get(url)
+    except Exception:  # noqa: BLE001 — any failure is "fetch failed"; the caller falls back
+        return None
+    try:
+        manifest_raw: bytes | None = _http_get(urllib.parse.urljoin(url, "manifest.json"))
+    except Exception:  # noqa: BLE001 — a missing manifest only disables the sha check
+        manifest_raw = None
+    manifest = _parse_manifest(manifest_raw) if manifest_raw is not None else None
+    data = _parse(raw, manifest)
+    if data is None:
+        return None
+    try:
+        atomic_write_bytes(knowledge_path, raw)
+        if manifest_raw is not None:
+            atomic_write_bytes(manifest_path, manifest_raw)
+        else:
+            # A leftover manifest from an earlier fetch would fail the sha check
+            # against the new bytes and make the cache unreadable until the next fetch.
+            manifest_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    return _index(data, manifest, source="fetch", stale=False, path=str(knowledge_path), mtime=time.time())
+
+
+def _http_get(url: str) -> bytes:
+    """GET ``url`` and return the body; raises on any non-200 or transport error.
+
+    Credentials go only to the cloud base URL; anything else is an anonymous fetch.
+    """
+    if url.startswith(get_base_url().rstrip("/") + "/"):
+        from comfy_cli.target import resolve_target
+
+        opened = authed_urlopen(url, resolve_target(where="cloud"), timeout=FETCH_TIMEOUT_SECONDS)
+    else:
+        req = urllib.request.Request(url, headers={"User-Agent": "comfy-cli"})
+        opened = plain_urlopen(req, timeout=FETCH_TIMEOUT_SECONDS)
+    with opened as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"knowledge fetch failed: HTTP {resp.status}")
+        return read_capped(resp, url, max_bytes=MAX_BUNDLE_BYTES)
+
+
+# ---------------------------------------------------------------------------
+# validation + index
+# ---------------------------------------------------------------------------
+
+
+def _parse_manifest(raw: bytes) -> dict | None:
+    try:
+        manifest = json.loads(raw)
+    except (ValueError, RecursionError):
+        return None
+    return manifest if isinstance(manifest, dict) else None
+
+
+def _parse(raw: bytes, manifest: dict | None) -> dict | None:
+    try:
+        data = json.loads(raw)
+    except (ValueError, RecursionError):
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("models"), dict):
+        return None
+    if manifest is not None:
+        if manifest.get("schema_version") != SCHEMA_VERSION:
+            return None
+        expected = _manifest_sha256(manifest)
+        if expected is not None and expected != hashlib.sha256(raw).hexdigest():
+            return None
+    return data
+
+
+def _manifest_sha256(manifest: dict) -> str | None:
+    files = manifest.get("files")
+    entry = files.get("knowledge.json") if isinstance(files, dict) else None
+    sha = entry.get("sha256") if isinstance(entry, dict) else None
+    return sha if isinstance(sha, str) else None
+
+
+def _str_list(value: Any) -> list[str]:
+    return [x for x in value if isinstance(x, str)] if isinstance(value, list) else []
+
+
+def _append_unique(index: dict[str, list[str]], key: str, model_id: str) -> None:
+    ids = index.setdefault(key, [])
+    if model_id not in ids:
+        ids.append(model_id)
+
+
+def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path: str, mtime: float) -> Bundle:
+    models = {mid: row for mid, row in data["models"].items() if isinstance(mid, str) and isinstance(row, dict)}
+
+    aliases: dict[str, str] = {}
+    compiled = data.get("aliases")
+    if isinstance(compiled, dict):
+        for alias, mid in compiled.items():
+            if isinstance(alias, str) and isinstance(mid, str):
+                aliases.setdefault(alias.lower(), mid)
+    for mid, row in models.items():
+        aliases.setdefault(mid.lower(), mid)
+        for alias in _str_list(row.get("aliases")):
+            aliases.setdefault(alias.lower(), mid)
+
+    caps_raw = data.get("capabilities")
+    capabilities = (
+        {cid: cap for cid, cap in caps_raw.items() if isinstance(cid, str) and isinstance(cap, dict)}
+        if isinstance(caps_raw, dict)
+        else {}
+    )
+    deps_raw = data.get("deprecations")
+    deprecations = (
+        {d["id"]: d for d in deps_raw if isinstance(d, dict) and isinstance(d.get("id"), str)}
+        if isinstance(deps_raw, list)
+        else {}
+    )
+
+    templates: dict[str, list[str]] = {}
+    nodes: dict[str, list[str]] = {}
+    for mid, row in models.items():
+        resolves = row.get("resolves")
+        if isinstance(resolves, dict):
+            for template_id in _str_list(resolves.get("templates")):
+                _append_unique(templates, template_id, mid)
+            for node_class in _str_list(resolves.get("nodes")):
+                _append_unique(nodes, node_class, mid)
+        routing = row.get("routing")
+        if isinstance(routing, list):
+            for rule in routing:
+                if isinstance(rule, dict) and isinstance(rule.get("use"), str):
+                    _append_unique(templates, rule["use"], mid)
+    for cap in capabilities.values():
+        picks = cap.get("picks")
+        if not isinstance(picks, list):
+            continue
+        for p in picks:
+            if isinstance(p, dict) and isinstance(p.get("template"), str) and isinstance(p.get("model"), str):
+                _append_unique(templates, p["template"], p["model"])
+
+    version = manifest.get("version") if manifest is not None else None
+    return Bundle(
+        version=version if isinstance(version, str) else "unknown",
+        source=source,
+        stale=stale,
+        as_of=datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        path=path,
+        models=models,
+        capabilities=capabilities,
+        deprecations=deprecations,
+        aliases=aliases,
+        templates=templates,
+        nodes=nodes,
+    )

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -276,9 +276,31 @@ def _http_get(url: str) -> bytes:
 # ---------------------------------------------------------------------------
 
 
+def _reject_constant(token: str) -> float:
+    raise ValueError(f"non-finite JSON constant: {token}")
+
+
+def _finite_float(token: str) -> float:
+    value = float(token)
+    if not math.isfinite(value):
+        raise ValueError(f"non-finite JSON number: {token}")
+    return value
+
+
+def _loads(raw: bytes) -> Any:
+    """``json.loads``, refusing the values that cannot round-trip back out as JSON.
+
+    ``NaN``/``Infinity`` are literals json accepts, and an overflowing exponent
+    like ``1e400`` becomes ``inf``. Either one re-emitted into an envelope is a
+    bare ``NaN``/``Infinity`` token that a strict consumer refuses, so a bundle
+    carrying one is rejected whole.
+    """
+    return json.loads(raw, parse_constant=_reject_constant, parse_float=_finite_float)
+
+
 def _parse_manifest(raw: bytes) -> dict | None:
     try:
-        manifest = json.loads(raw)
+        manifest = _loads(raw)
     except (ValueError, RecursionError):
         return None
     return manifest if isinstance(manifest, dict) else None
@@ -286,7 +308,7 @@ def _parse_manifest(raw: bytes) -> dict | None:
 
 def _parse(raw: bytes, manifest: dict | None) -> dict | None:
     try:
-        data = json.loads(raw)
+        data = _loads(raw)
     except (ValueError, RecursionError):
         return None
     if not isinstance(data, dict) or not isinstance(data.get("models"), dict):

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "comfy knowledge *",
+  "description": "Output shape for the knowledge-bundle commands (status, resolve, pick). All subcommands share this schema; each field is optional because the payload varies per subcommand.",
+  "type": "object",
+  "properties": {
+    "loaded": { "type": "boolean", "description": "Whether a bundle is loaded (status)." },
+    "reason": { "type": "string", "description": "Why no bundle loaded (status, loaded=false)." },
+    "source": { "type": "string", "description": "env | cache | fetch | stale-cache (status)." },
+    "stale": { "type": "boolean", "description": "True when served from an expired cache after a failed fetch." },
+    "version": { "type": "string", "description": "Bundle version from manifest.json, or 'unknown' (status)." },
+    "schema_version": { "type": "integer", "description": "Bundle schema version the loader accepts (status)." },
+    "as_of": { "type": "string", "description": "ISO-8601 UTC timestamp: file mtime (status) or the capability's as_of (pick)." },
+    "path": { "type": "string", "description": "File the bundle bytes were read from (status)." },
+    "env_file": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_FILE (status)." },
+    "url": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_URL (status)." },
+    "ttl_seconds": { "type": "number", "description": "Cache TTL in effect (status)." },
+    "cache_path": { "type": "string", "description": "Where a fetched bundle is cached (status)." },
+    "counts": {
+      "type": "object",
+      "description": "Row counts per plane (status).",
+      "additionalProperties": { "type": "integer" }
+    },
+    "query": { "type": "string", "description": "The alias or id as given (resolve)." },
+    "id": { "type": "string", "description": "Resolved model id (resolve)." },
+    "model": { "type": "object", "description": "The full model row as shipped in the bundle (resolve)." },
+    "deprecation": { "type": ["object", "null"], "description": "Matching deprecations entry, if any (resolve)." },
+    "bundle_version": { "type": "string", "description": "Bundle version the answer came from (resolve, pick)." },
+    "capability": { "type": "string", "description": "Capability id (pick)." },
+    "description": { "type": "string", "description": "Capability description (pick)." },
+    "picks": {
+      "type": "array",
+      "description": "Ranked picks, rank ascending (pick).",
+      "items": {
+        "type": "object",
+        "properties": {
+          "rank": { "type": "integer" },
+          "model": { "type": "string" },
+          "route": { "type": "string" },
+          "template": { "type": ["string", "null"] },
+          "caveat": { "type": "string" },
+          "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
+          "superseded_by": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." }
+        }
+      }
+    }
+  }
+}

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -10,10 +10,10 @@
     "stale": { "type": "boolean", "description": "True when served from an expired cache after a failed fetch." },
     "version": { "type": "string", "description": "Bundle version from manifest.json, or 'unknown' (status)." },
     "schema_version": { "type": "integer", "description": "Bundle schema version the loader accepts (status)." },
-    "as_of": { "type": "string", "description": "ISO-8601 UTC timestamp: file mtime (status) or the capability's as_of (pick)." },
+    "as_of": { "type": ["string", "null"], "description": "ISO-8601 UTC timestamp: file mtime (status) or the capability's as_of, null when the capability has none (pick)." },
     "path": { "type": "string", "description": "File the bundle bytes were read from (status)." },
     "env_file": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_FILE (status)." },
-    "url": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_URL (status)." },
+    "url": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_URL with userinfo, query and fragment removed (status)." },
     "ttl_seconds": { "type": "number", "description": "Cache TTL in effect (status)." },
     "cache_path": { "type": "string", "description": "Where a fetched bundle is cached (status)." },
     "counts": {
@@ -27,15 +27,15 @@
     "deprecation": { "type": ["object", "null"], "description": "Matching deprecations entry, if any (resolve)." },
     "bundle_version": { "type": "string", "description": "Bundle version the answer came from (resolve, pick)." },
     "capability": { "type": "string", "description": "Capability id (pick)." },
-    "description": { "type": "string", "description": "Capability description (pick)." },
+    "description": { "type": ["string", "null"], "description": "Capability description, null when the capability has none (pick)." },
     "picks": {
       "type": "array",
       "description": "Ranked picks, rank ascending (pick).",
       "items": {
         "type": "object",
         "properties": {
-          "rank": { "type": ["integer", "null"] },
-          "model": { "type": "string" },
+          "rank": { "type": ["number", "null"] },
+          "model": { "type": ["string", "null"] },
           "route": { "type": ["string", "null"] },
           "template": { "type": ["string", "null"] },
           "caveat": { "type": ["string", "null"] },

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -34,11 +34,11 @@
       "items": {
         "type": "object",
         "properties": {
-          "rank": { "type": "integer" },
+          "rank": { "type": ["integer", "null"] },
           "model": { "type": "string" },
-          "route": { "type": "string" },
+          "route": { "type": ["string", "null"] },
           "template": { "type": ["string", "null"] },
-          "caveat": { "type": "string" },
+          "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
           "superseded_by": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." }
         }

--- a/tests/comfy_cli/fixtures/knowledge/knowledge.json
+++ b/tests/comfy_cli/fixtures/knowledge/knowledge.json
@@ -198,7 +198,7 @@
         }
       ],
       "status": "recommended",
-      "tier": "recommendation",
+      "tier": "canon",
       "verified_at": "2026-08-05",
       "visibility": "internal"
     },
@@ -289,7 +289,7 @@
       "route": "partner",
       "status": "deprecated",
       "superseded_by": "sync-3",
-      "tier": "recommendation",
+      "tier": "canon",
       "verified_at": "2026-08-05",
       "visibility": "internal"
     },
@@ -497,7 +497,7 @@
         }
       ],
       "status": "recommended",
-      "tier": "recommendation",
+      "tier": "canon",
       "verified_at": "2026-08-05",
       "visibility": "internal",
       "warnings": [

--- a/tests/comfy_cli/fixtures/knowledge/knowledge.json
+++ b/tests/comfy_cli/fixtures/knowledge/knowledge.json
@@ -198,7 +198,7 @@
         }
       ],
       "status": "recommended",
-      "tier": "guidance",
+      "tier": "recommendation",
       "verified_at": "2026-08-05",
       "visibility": "internal"
     },
@@ -289,7 +289,7 @@
       "route": "partner",
       "status": "deprecated",
       "superseded_by": "sync-3",
-      "tier": "guidance",
+      "tier": "recommendation",
       "verified_at": "2026-08-05",
       "visibility": "internal"
     },
@@ -497,7 +497,7 @@
         }
       ],
       "status": "recommended",
-      "tier": "guidance",
+      "tier": "recommendation",
       "verified_at": "2026-08-05",
       "visibility": "internal",
       "warnings": [

--- a/tests/comfy_cli/fixtures/knowledge/knowledge.json
+++ b/tests/comfy_cli/fixtures/knowledge/knowledge.json
@@ -1,0 +1,511 @@
+{
+  "aliases": {
+    "ACE-Step": "ace-step-1-5",
+    "ACE-Step 1.5": "ace-step-1-5",
+    "ACE-Step 1.5XL Turbo": "ace-step-1-5",
+    "AceStep": "ace-step-1-5",
+    "H3": "minimax-h3",
+    "Hailuo 03": "minimax-h3",
+    "Hailuo H3": "minimax-h3",
+    "Kling": "kling",
+    "Kling 3.0": "kling",
+    "Kling Avatar 2": "kling-avatar-2",
+    "Kling Avatar 2.0": "kling-avatar-2",
+    "Kuaishou Kling": "kling",
+    "MiniMax H3": "minimax-h3",
+    "MiniMax Hailuo 03": "minimax-h3",
+    "Sync 3": "sync-3",
+    "Sync Talking Image": "sync-3",
+    "Sync Video Lip-Sync": "sync-3",
+    "Sync.so": "sync-3"
+  },
+  "capabilities": {
+    "audio-generation": {
+      "as_of": "2026-08-05",
+      "description": "Music, text-to-speech and sound effects. Music and TTS are different fetches; neither is the native audio track that H3 or Seedance emit with a clip.",
+      "id": "audio-generation",
+      "owner": "kishore",
+      "picks": [
+        {
+          "caveat": "The doc's No.1 OSS music pick: full songs with tags plus lyrics, 50+ languages. Docs AIO twin is audio_ace_step_1_5_checkpoint.",
+          "model": "ace-step-1-5",
+          "rank": 1,
+          "route": "oss",
+          "template": "audio_ace_step1_5_xl_turbo"
+        },
+        {
+          "caveat": "The doc's API music pick and cheap (0.5275 credits/sec). Video soundtrack twin: api_sonilo_v2m.",
+          "model": "sonilo",
+          "rank": 2,
+          "route": "partner",
+          "template": "api_sonilo_t2m"
+        },
+        {
+          "caveat": "The doc's OSS TTS pick. Do not fetch TTS-Audio-Suite as the default - it has no official template.",
+          "model": "chatterbox",
+          "rank": 3,
+          "route": "oss",
+          "template": "audio-chatterbox_tts"
+        },
+        {
+          "caveat": "The doc's API TTS pick; sound effects twin api_elevenlabs_text_to_sound_effects.",
+          "model": "elevenlabs",
+          "rank": 4,
+          "route": "partner",
+          "template": "api_elevenlabs_text_to_speech"
+        }
+      ],
+      "verified_at": "2026-08-05"
+    },
+    "lipsync": {
+      "as_of": "2026-08-05",
+      "description": "Three distinct jobs: a still plus audio becomes a talking clip, dubbing existing footage, or generating a clip that talks with no source audio (which is not a lipsync graph at all).",
+      "id": "lipsync",
+      "owner": "kishore",
+      "picks": [
+        {
+          "caveat": "The doc's No.1 OSS pick for still-plus-audio and the hottest official Lip Sync template.",
+          "model": "ltx",
+          "rank": 1,
+          "route": "oss",
+          "template": "video_ltx2_3_ia2v"
+        },
+        {
+          "caveat": "The doc's No.1 for dubbing existing video. Talking-image twin is api_sync_so_talking_image. About 40 credits/sec - warn before long audio.",
+          "model": "sync-3",
+          "rank": 2,
+          "route": "partner",
+          "template": "api_sync_so_lip_sync_video"
+        },
+        {
+          "caveat": "Wan 2.1 full-body dubbing where identity and background hold. Not Wan 2.2.",
+          "model": "infinitetalk",
+          "rank": 3,
+          "route": "oss",
+          "template": "video_wan2_1_infinitetalk"
+        },
+        {
+          "caveat": "Wan 2.2 audio-driven from a still plus a wav; sampler 10 / CFG 6 / uni_pc / simple.",
+          "model": "wan",
+          "rank": 4,
+          "route": "oss",
+          "template": "video_wan2_2_14B_s2v"
+        },
+        {
+          "caveat": "Listed as a candidate, not a default. 15.09 credits/sec.",
+          "model": "heygen-talking-photo",
+          "rank": 5,
+          "route": "partner",
+          "template": "api_heygen_talking_photo"
+        },
+        {
+          "caveat": "Only with a photoreal human subject - Kling lip-sync rejects cartoons, robots and mascots, and rejects any input over 1920px (its own 16:9 i2v emits 1924px).",
+          "model": "kling",
+          "rank": 6,
+          "route": "partner"
+        },
+        {
+          "caveat": "Not a lipsync model - the required first stage when the user has no audio. ElevenLabs (api_elevenlabs_text_to_speech) is the API twin.",
+          "model": "chatterbox",
+          "rank": 7,
+          "route": "oss",
+          "template": "audio-chatterbox_tts"
+        }
+      ],
+      "verified_at": "2026-08-05"
+    }
+  },
+  "deprecations": [
+    {
+      "deprecated_on": "2026-08-05",
+      "id": "kling-avatar-2",
+      "reason": "End-of-life: the source says do not fetch api_kling_avatar2 for new work and use Sync 3 or HeyGen instead. The source gives no EOL date, so the doc's curation date (2026-08-05) is recorded. Source: notion:canvas-craft \u00a73.3 and \u00a74 Lipsync / talking head.",
+      "superseded_by": "sync-3"
+    },
+    {
+      "deprecated_on": "2026-04-26",
+      "id": "sora-2",
+      "reason": "Deprecated 2026-04-26 with the API shutting down 2026-09-24; the source states the agent must never build new workflows on it. Source: notion:canvas-craft \u00a73.3."
+    }
+  ],
+  "future_plane": {
+    "x": 1
+  },
+  "models": {
+    "ace-step-1-5": {
+      "aliases": [
+        "ACE-Step",
+        "ACE-Step 1.5",
+        "ACE-Step 1.5XL Turbo",
+        "AceStep"
+      ],
+      "as_of": "2026-08-05",
+      "best_for": [
+        "full songs from tags plus lyrics, 50+ languages, on the OSS route"
+      ],
+      "corrections": [
+        {
+          "claim": "The template index 'vram' field is fake for the audio templates - do not quote it.",
+          "source": "notion:canvas-craft \u00a74 Audio / music"
+        }
+      ],
+      "id": "ace-step-1-5",
+      "modality": "audio",
+      "not_for": [
+        "talking-head audio unless the user asked for a song",
+        "voice/TTS - use Chatterbox or ElevenLabs"
+      ],
+      "owner": "kishore",
+      "pitfalls": [
+        {
+          "source": "notion:canvas-craft \u00a74 Audio / music",
+          "text": "Do not fetch ACE-Step v1 templates as the 1.5 default."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 Audio / music",
+          "text": "DualCLIP type ace (qwen_0.6b_ace15 plus qwen_4b_ace15) and VAE ace_1.5_vae only - do not put CLIP type ace on a Qwen, Krea or Flux graph, and do not use Seedance to write a song."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "ACE-Step music is not a talking-head audio source unless the user asked for a song."
+        }
+      ],
+      "resolves": {
+        "templates": [
+          "audio_ace_step1_5_xl_turbo",
+          "audio_ace_step_1_5_checkpoint",
+          "audio_ace_step1_5_xl_sft",
+          "audio_minimax_music_3"
+        ]
+      },
+      "route": "oss",
+      "routing": [
+        {
+          "use": "audio_ace_step1_5_xl_turbo",
+          "when": "Everyday OSS music generation"
+        },
+        {
+          "use": "audio_ace_step_1_5_checkpoint",
+          "when": "All-in-one checkpoint twin from the docs"
+        },
+        {
+          "use": "audio_ace_step1_5_xl_sft",
+          "when": "User wants CFG control on the music graph"
+        },
+        {
+          "use": "audio_minimax_music_3",
+          "when": "User named MiniMax Music 3"
+        }
+      ],
+      "status": "recommended",
+      "tier": "guidance",
+      "verified_at": "2026-08-05",
+      "visibility": "internal"
+    },
+    "kling": {
+      "aliases": [
+        "Kling",
+        "Kling 3.0",
+        "Kuaishou Kling"
+      ],
+      "as_of": "2026-08-05",
+      "best_for": [
+        "value at scale, motion control, human performance, native 4K (Kling 3.0)"
+      ],
+      "future_field": true,
+      "id": "kling",
+      "modality": "video",
+      "never_confuse_with": [
+        "kling-avatar-2"
+      ],
+      "not_for": [
+        "lip-sync on any subject that is not a photoreal human",
+        "chaining straight from Kling 16:9 image-to-video into Kling lip-sync without a resize"
+      ],
+      "owner": "kishore",
+      "pitfalls": [
+        {
+          "source": "cloud:services/agent/internal/loop/skills/comfy-cloud/SKILL.md",
+          "text": "Lip-sync needs a real human face. Kling's lip-sync rejects cartoons, robots, mascots and stylized characters with \"The model did not detect a human\". If the subject is not photoreal-human, do not build a lip-sync stage: either make the presenter human, or lay the voice over the clip and say the mouths will not be synced."
+        },
+        {
+          "source": "cloud:services/agent/internal/loop/skills/comfy-cloud/SKILL.md",
+          "text": "A partner model can violate its own sibling's limit: Kling's 16:9 image-to-video returns 1924px and Kling's lip-sync rejects anything over 1920px, so chaining them fails unless you insert a resize. When chaining two partner nodes, probe_media the intermediate against the consumer's documented limits instead of assuming vendor self-consistency."
+        },
+        {
+          "source": "cloud:services/agent/internal/loop/skills/comfy-cloud/SKILL.md",
+          "text": "Required text is required: an empty prompt widget on a partner node (e.g. a first/last-frame video node) passes local validation and is rejected by the vendor at run time, after the credits are spent. Fill every required text field."
+        },
+        {
+          "source": "cloud:services/agent/internal/loop/skills/building/SKILL.md",
+          "text": "Take the node class name from the catalog, not memory - the real class is KlingImage2VideoNode, not the remembered KlingImageToVideoNode."
+        },
+        {
+          "source": "notion:canvas-craft \u00a73.3",
+          "text": "Kling V1.5 / V1.6 / V2.1 / V2.1-Master retire 2026-09-15. Do not build new work on them."
+        },
+        {
+          "source": "notion:canvas-craft \u00a73.3",
+          "text": "Kling Avatar 2.0 is EOL: do not fetch the api_kling_avatar2 template for new work. Use Sync 3 or HeyGen instead."
+        }
+      ],
+      "resolves": {
+        "nodes": [
+          "KlingImage2VideoNode",
+          "KlingLipSyncAudioToVideoNode",
+          "KlingLipSyncTextToVideoNode"
+        ]
+      },
+      "route": "partner",
+      "status": "available",
+      "tier": "law",
+      "verified_at": "2026-08-05",
+      "visibility": "internal",
+      "warnings": [
+        {
+          "source": "notion:canvas-craft \u00a73.3",
+          "text": "The \u00a73.3 partner video tier ordering is drawn from secondary aggregators (the doc marks it with a warning sign) - treat the ranking as soft, not measured."
+        }
+      ]
+    },
+    "kling-avatar-2": {
+      "aliases": [
+        "Kling Avatar 2.0",
+        "Kling Avatar 2"
+      ],
+      "as_of": "2026-08-05",
+      "id": "kling-avatar-2",
+      "modality": "video",
+      "not_for": [
+        "any new work - it is end-of-life"
+      ],
+      "owner": "kishore",
+      "pitfalls": [
+        {
+          "source": "notion:canvas-craft \u00a73.3",
+          "text": "Kling Avatar 2.0 is EOL. Do not fetch the api_kling_avatar2 template for new work - use Sync 3 (api_sync_so_talking_image / api_sync_so_lip_sync_video) or HeyGen."
+        }
+      ],
+      "route": "partner",
+      "status": "deprecated",
+      "superseded_by": "sync-3",
+      "tier": "guidance",
+      "verified_at": "2026-08-05",
+      "visibility": "internal"
+    },
+    "minimax-h3": {
+      "aliases": [
+        "MiniMax H3",
+        "Hailuo 03",
+        "Hailuo H3",
+        "H3",
+        "MiniMax Hailuo 03"
+      ],
+      "as_of": "2026-08-05",
+      "best_for": [
+        "the best OSS video model when the user names none",
+        "video that needs native audio (32 kHz stereo, dialogue/SFX/music, 11 languages)",
+        "2K, up to 15 s, t2v / i2v / FLF / r2v in one family",
+        "character consistency in video via the R2V route"
+      ],
+      "corrections": [
+        {
+          "claim": "The four MiniMax H3 open weights return nothing in search_models even though they load fine via template - absence from model search is not absence from cloud. Verify against templates before declaring the model absent.",
+          "source": "notion:canvas-craft \u00a71.1 Cloud"
+        }
+      ],
+      "id": "minimax-h3",
+      "modality": "video",
+      "never_confuse_with": [
+        "hailuo-02"
+      ],
+      "not_for": [
+        "silent photoreal on a ~24 GB card where Wan 2.2 is the OSS workhorse",
+        "1080p/4K paid delivery, which is the Seedance 2.0 path"
+      ],
+      "owner": "kishore",
+      "pitfalls": [
+        {
+          "source": "notion:canvas-craft \u00a71.0 Shared",
+          "text": "H3 ships in two routes, always both: OSS weights (video_minimax_h3_*) and paid partner nodes (api_minimax_h3_*). Never claim only the API path exists or that there is no free version."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "Both routes' templates share display titles (\"MiniMax H3: Text to Video\"). Disambiguate by internal name, and pass exclude_api=True when the user wants local-only."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "OSS i2v is also FLF: last_frame on MiniMaxH3ImageToVideo is optional and unwired on purpose. Leave it empty for i2v; wire a second LoadImage for first-last-frame."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 First-last-frame",
+          "text": "There is no OSS video_minimax_h3_flf2v file. That filename is API-only (api_minimax_h3_flf2v); searching the OSS index for it is a known dead end."
+        },
+        {
+          "source": "notion:canvas-craft \u00a71.0 Shared",
+          "text": "partner_generate has NO H3 entry - its registry only carries the older minimax/video_generation Hailuo-02 proxy."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "The partner_generate alias 'hailuo' is the older Hailuo family, never H3. Do not mix its params with H3's. But \"Hailuo 03\" does mean H3."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "The API node's enums are NOT the model's limits. OSS accepts any resolution in multiples of 32 up to ~2K and ~15 s on a 17k+5-frame grid at 24fps. A request outside the API presets (e.g. 1000x1000) means offer OSS, not declare it impossible."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "Generation time scales exponentially with pixel count, not linearly. Re-estimate per resolution; never extrapolate linearly."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "Recommend the int8 base model on all GPUs (including 50-series) and the NVFP4 text encoder on all GPUs; the shipped template is the best choice for almost all cards."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "For production work generate at the native ~768p canvas and upscale later rather than sampling large in one pass."
+        },
+        {
+          "source": "notion:canvas-craft \u00a73.2",
+          "text": "Needs ComfyUI >= 0.30.0. Community license. Six official templates: three local, three API."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "A successful local run this session, or the weights already on disk, is proof the free route works. Never subsequently claim it does not exist."
+        }
+      ],
+      "resolves": {
+        "nodes": [
+          "MiniMaxH3ImageToVideo",
+          "MiniMaxH3ReferenceToVideo",
+          "MinimaxHailuo03TextToVideoNode"
+        ],
+        "templates": [
+          "video_minimax_h3_t2v",
+          "video_minimax_h3_i2v",
+          "video_minimax_h3_r2v",
+          "api_minimax_h3_t2v",
+          "api_minimax_h3_flf2v",
+          "api_minimax_h3_r2v"
+        ]
+      },
+      "route": "both",
+      "routing": [
+        {
+          "use": "video_minimax_h3_t2v",
+          "when": "Best OSS video, no model named, text to video"
+        },
+        {
+          "use": "video_minimax_h3_i2v",
+          "when": "Image to video on the OSS route"
+        },
+        {
+          "use": "video_minimax_h3_i2v",
+          "when": "First-last-frame on the OSS route: fetch the i2v graph and wire a second LoadImage to last_frame"
+        },
+        {
+          "use": "video_minimax_h3_r2v",
+          "when": "Character consistency in video (reference to video) on the OSS route"
+        },
+        {
+          "use": "api_minimax_h3_t2v",
+          "when": "Paid/API route, text to video"
+        },
+        {
+          "use": "api_minimax_h3_flf2v",
+          "when": "Paid/API route, first-last-frame (the flf2v filename is API-only)"
+        },
+        {
+          "use": "api_minimax_h3_r2v",
+          "when": "Paid/API route, reference to video"
+        }
+      ],
+      "status": "recommended",
+      "tier": "law",
+      "verified_at": "2026-08-05",
+      "visibility": "internal",
+      "warnings": [
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "Pre-spend: the API route bills 27.16 credits/sec at 768P and 39.22 at 2K (5 s at 768P is about 136 credits). Local is free per run. Rates verified 2026-08-05."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 MiniMax H3",
+          "text": "On local, speed is the constraint, not feasibility: 5 s at 480p is about 9 min on a 3060, about 15 min for 5 s at 16 GB. Quote the estimate so the user chooses informed; do not present slow-local as impossible."
+        }
+      ]
+    },
+    "sync-3": {
+      "aliases": [
+        "Sync 3",
+        "Sync.so",
+        "Sync Talking Image",
+        "Sync Video Lip-Sync"
+      ],
+      "as_of": "2026-08-05",
+      "best_for": [
+        "API talking image: a portrait plus a voiceover, hands and product held still",
+        "dubbing or language-swapping existing footage"
+      ],
+      "id": "sync-3",
+      "modality": "video",
+      "not_for": [
+        "jobs with no source audio - run TTS first, or use H3/Seedance quoted dialogue instead"
+      ],
+      "owner": "kishore",
+      "pitfalls": [
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "Feeding Sync when the user has no audio is a hard fail - run TTS first (Chatterbox locally, ElevenLabs on API), then the lipsync graph."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "For a clip that talks with no source audio, use H3 or Seedance with the spoken lines in double quotes - not a Sync graph."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "Sync seed is cache-only; execute does not put it on the request. Randomize to re-run."
+        },
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "Talking Image output length equals the audio length and the face may be up to 4K. Lip Sync video is max 4K with audio up to 600 s, and sync_mode defaults to bounce."
+        },
+        {
+          "source": "notion:canvas-craft \u00a73 Lipsync / talking head",
+          "text": "There is no official LatentSync template. Do not invent one."
+        }
+      ],
+      "resolves": {
+        "nodes": [
+          "SyncTalkingImageNode",
+          "SyncLipSyncNode"
+        ],
+        "templates": [
+          "api_sync_so_talking_image",
+          "api_sync_so_lip_sync_video"
+        ]
+      },
+      "route": "partner",
+      "routing": [
+        {
+          "use": "api_sync_so_talking_image",
+          "when": "API talking image: still portrait plus a voiceover track"
+        },
+        {
+          "use": "api_sync_so_lip_sync_video",
+          "when": "Dub or language-swap an existing video - the API No.1 for this job"
+        }
+      ],
+      "status": "recommended",
+      "tier": "guidance",
+      "verified_at": "2026-08-05",
+      "visibility": "internal",
+      "warnings": [
+        {
+          "source": "notion:canvas-craft \u00a74 Lipsync / talking head",
+          "text": "Pre-spend: Sync Talking Image and Video Lip-Sync bill about 40.13 credits/sec (5 s is about 201 credits) - expensive versus H3 or Seedance native audio. Warn before long audio. Rates verified 2026-08-05."
+        }
+      ]
+    }
+  }
+}

--- a/tests/comfy_cli/fixtures/knowledge/manifest.json
+++ b/tests/comfy_cli/fixtures/knowledge/manifest.json
@@ -1,0 +1,10 @@
+{
+  "files": {
+    "knowledge.json": {
+      "bytes": 20381,
+      "sha256": "b0fc7adb48c7ea031fa188bd88b066b8d41ef98c31e001589ef5d29df9633d34"
+    }
+  },
+  "schema_version": 1,
+  "version": "0.1.0-fixture"
+}

--- a/tests/comfy_cli/fixtures/knowledge/manifest.json
+++ b/tests/comfy_cli/fixtures/knowledge/manifest.json
@@ -1,8 +1,8 @@
 {
   "files": {
     "knowledge.json": {
-      "bytes": 20399,
-      "sha256": "d0e1f85d7ecd46dff4270c1c76cc4919f0b542d86714d3a04b4c00f476e6627e"
+      "bytes": 20372,
+      "sha256": "097751706b4ef8e08747e23298728237b16d9ba50a264329383f833c8970b116"
     }
   },
   "schema_version": 1,

--- a/tests/comfy_cli/fixtures/knowledge/manifest.json
+++ b/tests/comfy_cli/fixtures/knowledge/manifest.json
@@ -1,8 +1,8 @@
 {
   "files": {
     "knowledge.json": {
-      "bytes": 20381,
-      "sha256": "b0fc7adb48c7ea031fa188bd88b066b8d41ef98c31e001589ef5d29df9633d34"
+      "bytes": 20399,
+      "sha256": "d0e1f85d7ecd46dff4270c1c76cc4919f0b542d86714d3a04b4c00f476e6627e"
     }
   },
   "schema_version": 1,

--- a/tests/comfy_cli/output/test_envelope_schemas.py
+++ b/tests/comfy_cli/output/test_envelope_schemas.py
@@ -60,6 +60,7 @@ def _validator_for(name: str) -> jsonschema.Validator:
         # degrades one row per unavailable endpoint. Worth pinning so a typo in
         # one of those unions can't ship.
         "cloud_status.json",
+        "knowledge.json",
     ],
 )
 def test_schemas_are_well_formed(schema_name):

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import jsonschema
@@ -272,9 +273,12 @@ class TestAuthRouting:
         return _Resp()
 
     def test_cloud_url_uses_authed_opener(self, monkeypatch):
+        import comfy_cli.target
         from comfy_cli.cloud import get_base_url
 
         monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        # The real resolve_target can refresh an OAuth token; keep credential code out of the test.
+        monkeypatch.setattr(comfy_cli.target, "resolve_target", lambda **kw: SimpleNamespace(kind="cloud", **kw))
         seen: dict[str, Any] = {}
 
         def fake_authed(url, target, **kw):

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -15,6 +15,7 @@ with a guard that fails the test if reached.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -30,6 +31,7 @@ from typer.testing import CliRunner
 from comfy_cli import knowledge
 from comfy_cli.caller import Caller
 from comfy_cli.command import knowledge as knowledge_cmd
+from comfy_cli.http import ResponseTooLarge
 from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
 
 FIXTURES = Path(__file__).parent / "fixtures" / "knowledge"
@@ -240,6 +242,45 @@ class TestLoadOrder:
         assert knowledge.ttl_seconds() == 0.0
         monkeypatch.setenv(knowledge.ENV_TTL, "90")
         assert knowledge.ttl_seconds() == 90.0
+        for raw in ("nan", "inf", "-inf", "1e400"):
+            monkeypatch.setenv(knowledge.ENV_TTL, raw)
+            assert knowledge.ttl_seconds() == knowledge.DEFAULT_TTL_SECONDS
+
+    def test_force_fetch_without_a_fetch_keeps_fresh_cache_unstale(self, monkeypatch):
+        _seed_cache()
+        b = knowledge.load_bundle(force_fetch=True)
+        assert b.source == "cache"
+        assert b.stale is False
+        knowledge._reset_for_testing()
+        _fake_http(monkeypatch, knowledge_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        b = knowledge.load_bundle(force_fetch=True)
+        assert b.source == "cache"
+        assert b.stale is False
+
+    def test_cache_survives_failed_manifest_write(self, monkeypatch):
+        _k_path, m_path = _seed_cache(age_seconds=2 * 24 * 3600)
+        new_raw = FIXTURE_KNOWLEDGE.read_bytes() + b"\n"
+        manifest = json.loads(FIXTURE_MANIFEST.read_text())
+        manifest["files"]["knowledge.json"]["sha256"] = hashlib.sha256(new_raw).hexdigest()
+        _fake_http(monkeypatch, knowledge_bytes=new_raw, manifest_bytes=json.dumps(manifest).encode())
+        real_write = knowledge.atomic_write_bytes
+
+        def flaky_write(path, data, **kw):
+            if path.name == "manifest.json":
+                raise OSError("disk full")
+            real_write(path, data, **kw)
+
+        monkeypatch.setattr(knowledge, "atomic_write_bytes", flaky_write)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        assert knowledge.load_bundle().source == "fetch"
+        assert not m_path.exists()
+        knowledge._reset_for_testing()
+        monkeypatch.delenv(knowledge.ENV_URL)
+        b = knowledge.load_bundle()
+        assert b is not None
+        assert b.source == "cache"
+        assert b.version == "unknown"
 
     def test_memo_and_force_fetch(self, monkeypatch):
         _seed_cache()
@@ -257,9 +298,10 @@ class TestLoadOrder:
 
 class TestAuthRouting:
     @staticmethod
-    def _fake_resp(body: bytes):
+    def _fake_resp(body: bytes, final_url: str = "https://example.com/knowledge.json"):
         class _Resp:
             status = 200
+            url = final_url
 
             def __enter__(self):
                 return self
@@ -323,7 +365,14 @@ class TestAuthRouting:
             knowledge._http_get("https://example.com/knowledge.json")
         monkeypatch.setattr(knowledge, "MAX_BUNDLE_BYTES", 4)
         monkeypatch.setattr(knowledge, "plain_urlopen", lambda req, **kw: self._fake_resp(b"x" * 10))
-        with pytest.raises(Exception):
+        with pytest.raises(ResponseTooLarge):
+            knowledge._http_get("https://example.com/knowledge.json")
+
+    def test_plain_fetch_rejects_redirect_to_http(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        resp = self._fake_resp(b"{}", final_url="http://mirror.example/knowledge.json")
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda req, **kw: resp)
+        with pytest.raises(ValueError):
             knowledge._http_get("https://example.com/knowledge.json")
 
 
@@ -391,11 +440,34 @@ class TestIndex:
         assert knowledge.resolve(bundle, "Kling-Avatar-2")["id"] == "kling-avatar-2"
         assert knowledge.resolve(bundle, "nope-xyz") is None
 
-    def test_resolve_accepts_spelling_variants(self, bundle):
-        for query in ("Hailuo 3", "hailuo3", "HAILUO-03", "Mini Max H3", "sync.3"):
-            assert knowledge.resolve(bundle, query)["id"] == "minimax-h3" if "sync" not in query else True
-        assert knowledge.resolve(bundle, "sync.3")["id"] == "sync-3"
-        assert knowledge.resolve(bundle, "klingg") is None
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            ("Hailuo 3", "minimax-h3"),
+            ("hailuo3", "minimax-h3"),
+            ("HAILUO-03", "minimax-h3"),
+            ("Mini Max H3", "minimax-h3"),
+            ("sync.3", "sync-3"),
+            ("klingg", None),
+        ],
+    )
+    def test_resolve_accepts_spelling_variants(self, bundle, query, expected):
+        row = knowledge.resolve(bundle, query)
+        assert (row["id"] if row else None) == expected
+        assert knowledge.resolve_id(bundle, query) == expected
+
+    def test_model_id_beats_colliding_alias(self):
+        data = {"models": {"kling": {"id": "kling"}, "kling-3": {"id": "kling-3"}}, "aliases": {"Kling": "kling-3"}}
+        b = knowledge._index(data, None, source="env", stale=False, path="p", mtime=0.0)
+        assert b.aliases["kling"] == "kling"
+        assert knowledge.resolve(b, "KLING")["id"] == "kling"
+
+    def test_resolve_id_requires_a_row(self):
+        data = {"models": {"a": {"id": "a"}}, "aliases": {"ghost": "missing"}}
+        b = knowledge._index(data, None, source="env", stale=False, path="p", mtime=0.0)
+        assert knowledge.resolve_id(b, "ghost") is None
+        assert knowledge.resolve(b, "ghost") is None
+        assert knowledge.resolve_id(b, " A ") == "a"
 
     def test_normalize(self):
         assert knowledge._normalize("Hailuo 03") == "hailuo3"
@@ -507,6 +579,12 @@ class TestCli:
         assert data["cache_path"].endswith(os.path.join("knowledge", "knowledge.json"))
         _validate(data)
 
+    def test_status_redacts_url_credentials(self, monkeypatch, capsys):
+        monkeypatch.setenv(knowledge.ENV_URL, "https://user:secret@cdn.example/k/knowledge.json?token=abc#frag")
+        _rc, env = _run(["status"], capsys)
+        assert env["data"]["url"] == "https://cdn.example/k/knowledge.json"
+        _validate(env["data"])
+
     def test_status_refresh_forces_fetch(self, monkeypatch, capsys):
         _seed_cache()
         calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
@@ -596,6 +674,30 @@ class TestCli:
         assert env["error"]["code"] == "knowledge_unknown_capability"
         assert env["error"]["details"]["known"] == ["audio-generation", "lipsync"]
 
+    def test_pick_payload_normalizes_rank_and_model(self, tmp_path, monkeypatch, capsys):
+        # Written as text so the bundle can carry 1e400, which json.loads turns into inf.
+        raw = (
+            '{"models": {}, "capabilities": {"c": {"id": "c", "description": ["not", "text"], "as_of": 7, "picks": ['
+            '{"model": "x", "rank": "1"}, {"model": 7, "rank": 2}, {"model": "y", "rank": 1.5}, {"model": "w", "rank": 1e400}'
+            "]}}}"
+        )
+        p = tmp_path / "k.json"
+        p.write_text(raw)
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        rc, env = _run(["pick", "c"], capsys)
+        assert rc == 0
+        got = [(q["model"], q["rank"]) for q in env["data"]["picks"]]
+        assert got == [("y", 1.5), (None, 2), ("x", None), ("w", None)]
+        assert env["data"]["description"] is None and env["data"]["as_of"] is None
+        _validate(env["data"])
+
+    def test_resolve_pretty_tolerates_malformed_row_fields(self, tmp_path, monkeypatch, pretty_no_stdout):
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps({"models": {"m": {"id": "m", "best_for": 5, "pitfalls": "ouch"}}}))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        result = CliRunner().invoke(knowledge_cmd.app, ["resolve", "m"], standalone_mode=False)
+        assert result.exception is None, result.exception
+
     def test_pick_without_bundle(self, capsys):
         rc, env = _run(["pick", "lipsync"], capsys)
         assert rc == 1
@@ -614,8 +716,6 @@ class TestCli:
             assert error_codes.is_registered(code)
 
     def test_fixture_manifest_matches_fixture(self):
-        import hashlib
-
         manifest = json.loads(FIXTURE_MANIFEST.read_text())
         raw = FIXTURE_KNOWLEDGE.read_bytes()
         assert manifest["files"]["knowledge.json"]["sha256"] == hashlib.sha256(raw).hexdigest()

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -684,16 +684,23 @@ class TestCli:
         assert env["error"]["details"]["known"] == ["audio-generation", "lipsync"]
 
     def test_pick_payload_normalizes_rank_and_model(self, tmp_path, monkeypatch, capsys):
-        picks = [{"model": "x", "rank": "1"}, {"model": 7, "rank": 2}, {"model": "y", "rank": 1.5}]
+        picks = [
+            {"model": "x", "rank": "1"},
+            {"model": 7, "rank": 2},
+            {"model": "y", "rank": 1.5, "route": 7, "template": [], "caveat": {}},
+        ]
         cap = {"id": "c", "description": ["not", "text"], "as_of": 7, "picks": picks}
+        models = {"y": {"id": "y", "status": 1, "superseded_by": ["z"]}}
         p = tmp_path / "k.json"
-        p.write_text(json.dumps({"models": {}, "capabilities": {"c": cap}}))
+        p.write_text(json.dumps({"models": models, "capabilities": {"c": cap}}))
         monkeypatch.setenv(knowledge.ENV_FILE, str(p))
         rc, env = _run(["pick", "c"], capsys)
         assert rc == 0
         got = [(q["model"], q["rank"]) for q in env["data"]["picks"]]
         assert got == [("y", 1.5), (None, 2), ("x", None)]
         assert env["data"]["description"] is None and env["data"]["as_of"] is None
+        top = env["data"]["picks"][0]
+        assert [top[k] for k in ("route", "template", "caveat", "status", "superseded_by")] == [None] * 5
         _validate(env["data"])
 
     def test_resolve_pretty_tolerates_malformed_row_fields(self, tmp_path, monkeypatch, pretty_no_stdout):

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -1,0 +1,578 @@
+"""Tests for the comfy-knowledge bundle loader and the ``comfy knowledge`` verbs.
+
+Contract under test:
+  * load order: ``COMFY_KNOWLEDGE_FILE`` (authoritative, never cached) >
+    fresh cache > ``COMFY_KNOWLEDGE_URL`` fetch > stale cache > nothing.
+  * a broken or missing bundle returns ``None``; nothing here raises.
+  * manifest ``schema_version`` and ``sha256`` reject a mismatched bundle.
+  * the index is a tolerant reader: unknown keys/fields are ignored.
+  * the three verbs emit one ``envelope/1`` line whose ``data`` validates
+    against ``comfy_cli/schemas/knowledge.json``.
+
+Network is never touched: an autouse fixture replaces ``knowledge._http_get``
+with a guard that fails the test if reached.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import knowledge
+from comfy_cli.caller import Caller
+from comfy_cli.command import knowledge as knowledge_cmd
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+
+FIXTURES = Path(__file__).parent / "fixtures" / "knowledge"
+FIXTURE_KNOWLEDGE = FIXTURES / "knowledge.json"
+FIXTURE_MANIFEST = FIXTURES / "manifest.json"
+SCHEMA = json.loads((Path(__file__).resolve().parents[2] / "comfy_cli" / "schemas" / "knowledge.json").read_text())
+
+_REAL_HTTP_GET = knowledge._http_get
+
+
+def _network_guard(url: str) -> bytes:
+    raise AssertionError(f"network touched: {url}")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    for var in (knowledge.ENV_FILE, knowledge.ENV_URL, knowledge.ENV_TTL):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(knowledge, "_http_get", _network_guard)
+    knowledge._reset_for_testing()
+    yield
+    knowledge._reset_for_testing()
+
+
+def _env_bundle(tmp_path: Path, monkeypatch, *, manifest: dict | None | str = "fixture") -> Path:
+    """Copy the fixture to a tmp dir and point COMFY_KNOWLEDGE_FILE at it.
+
+    ``manifest``: ``"fixture"`` copies the real one, ``None`` writes none,
+    a dict writes that dict as the sibling manifest.
+    """
+    d = tmp_path / "env"
+    d.mkdir()
+    shutil.copy(FIXTURE_KNOWLEDGE, d / "knowledge.json")
+    if manifest == "fixture":
+        shutil.copy(FIXTURE_MANIFEST, d / "manifest.json")
+    elif manifest is not None:
+        (d / "manifest.json").write_text(json.dumps(manifest))
+    monkeypatch.setenv(knowledge.ENV_FILE, str(d / "knowledge.json"))
+    return d / "knowledge.json"
+
+
+def _seed_cache(age_seconds: float = 0.0) -> tuple[Path, Path]:
+    k_path, m_path = knowledge.cache_paths()
+    k_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(FIXTURE_KNOWLEDGE, k_path)
+    shutil.copy(FIXTURE_MANIFEST, m_path)
+    if age_seconds:
+        stamp = time.time() - age_seconds
+        os.utime(k_path, (stamp, stamp))
+    return k_path, m_path
+
+
+def _fake_http(monkeypatch, *, knowledge_bytes: bytes | None = None, manifest_bytes: bytes | None = None):
+    """Install a fake ``_http_get``; records calls. ``None`` for either body means raise."""
+    calls: list[str] = []
+
+    def fake(url: str) -> bytes:
+        calls.append(url)
+        body = manifest_bytes if url.endswith("manifest.json") else knowledge_bytes
+        if body is None:
+            raise RuntimeError(f"fake fetch failure: {url}")
+        return body
+
+    monkeypatch.setattr(knowledge, "_http_get", fake)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrder:
+    def test_env_file_loads_and_never_fetches(self, tmp_path, monkeypatch):
+        path = _env_bundle(tmp_path, monkeypatch)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        b = knowledge.load_bundle()
+        assert b is not None
+        assert b.source == "env"
+        assert b.stale is False
+        assert b.path == str(path)
+        assert b.version == "0.1.0-fixture"
+        assert knowledge.last_reason() is None
+        assert not knowledge.cache_paths()[0].exists()
+
+    def test_env_file_missing_returns_none_without_fallthrough(self, tmp_path, monkeypatch):
+        _seed_cache()
+        monkeypatch.setenv(knowledge.ENV_FILE, str(tmp_path / "nope.json"))
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        assert knowledge.load_bundle() is None
+        assert knowledge.last_reason() == knowledge.REASON_ENV_FILE
+
+    def test_env_file_rejected_by_manifest_schema_version(self, tmp_path, monkeypatch):
+        _env_bundle(tmp_path, monkeypatch, manifest={"schema_version": 2, "version": "9"})
+        assert knowledge.load_bundle() is None
+        assert knowledge.last_reason() == knowledge.REASON_ENV_FILE
+
+    def test_env_file_rejected_by_manifest_sha(self, tmp_path, monkeypatch):
+        bad = {"schema_version": 1, "version": "x", "files": {"knowledge.json": {"sha256": "00" * 32}}}
+        _env_bundle(tmp_path, monkeypatch, manifest=bad)
+        assert knowledge.load_bundle() is None
+
+    def test_env_file_without_manifest_loads_as_unknown_version(self, tmp_path, monkeypatch):
+        _env_bundle(tmp_path, monkeypatch, manifest=None)
+        b = knowledge.load_bundle()
+        assert b is not None
+        assert b.version == "unknown"
+
+    def test_manifest_without_sha_is_tolerated(self, tmp_path, monkeypatch):
+        _env_bundle(tmp_path, monkeypatch, manifest={"schema_version": 1, "version": "1.2.3", "files": {}})
+        b = knowledge.load_bundle()
+        assert b is not None
+        assert b.version == "1.2.3"
+
+    def test_unparseable_manifest_is_treated_as_absent(self, tmp_path, monkeypatch):
+        path = _env_bundle(tmp_path, monkeypatch, manifest=None)
+        (path.parent / "manifest.json").write_text("not json {")
+        b = knowledge.load_bundle()
+        assert b is not None
+        assert b.version == "unknown"
+
+    def test_env_file_not_a_bundle_returns_none(self, tmp_path, monkeypatch):
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps({"hello": "world"}))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        assert knowledge.load_bundle() is None
+        p.write_text("[1, 2]")
+        knowledge._reset_for_testing()
+        assert knowledge.load_bundle() is None
+
+    def test_fresh_cache_serves_without_fetch(self, monkeypatch):
+        _seed_cache()
+        assert knowledge.load_bundle().source == "cache"
+        knowledge._reset_for_testing()
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        b = knowledge.load_bundle()
+        assert b.source == "cache"
+        assert b.stale is False
+
+    def test_expired_cache_fetches_and_rewrites_cache(self, monkeypatch):
+        k_path, m_path = _seed_cache(age_seconds=2 * 24 * 3600)
+        m_path.unlink()
+        manifest_bytes = FIXTURE_MANIFEST.read_bytes()
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=manifest_bytes)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/k/knowledge.json")
+        b = knowledge.load_bundle()
+        assert b.source == "fetch"
+        assert b.stale is False
+        assert calls == ["https://example.com/k/knowledge.json", "https://example.com/k/manifest.json"]
+        assert time.time() - k_path.stat().st_mtime < 60
+        assert m_path.read_bytes() == manifest_bytes
+
+    def test_fetch_without_manifest_drops_stale_cached_manifest(self, monkeypatch):
+        _k_path, m_path = _seed_cache(age_seconds=2 * 24 * 3600)
+        _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        b = knowledge.load_bundle()
+        assert b.source == "fetch"
+        assert b.version == "unknown"
+        assert not m_path.exists()
+
+    def test_expired_cache_with_failed_fetch_serves_stale(self, monkeypatch):
+        _seed_cache(age_seconds=2 * 24 * 3600)
+        _fake_http(monkeypatch, knowledge_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        b = knowledge.load_bundle()
+        assert b.source == "stale-cache"
+        assert b.stale is True
+
+    def test_fetch_rejecting_validation_falls_back_to_stale(self, monkeypatch):
+        _seed_cache(age_seconds=2 * 24 * 3600)
+        _fake_http(monkeypatch, knowledge_bytes=b'{"models": []}', manifest_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        assert knowledge.load_bundle().source == "stale-cache"
+
+    def test_no_cache_no_url_is_none(self):
+        assert knowledge.load_bundle() is None
+        assert knowledge.last_reason() == knowledge.REASON_NO_URL
+
+    def test_no_cache_failed_fetch_is_none(self, monkeypatch):
+        _fake_http(monkeypatch, knowledge_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        assert knowledge.load_bundle() is None
+        assert knowledge.last_reason() == knowledge.REASON_FETCH_FAILED
+
+    def test_unsafe_url_is_a_fetch_failure(self, monkeypatch):
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes())
+        monkeypatch.setenv(knowledge.ENV_URL, "http://example.com/knowledge.json")
+        assert knowledge.load_bundle() is None
+        assert calls == []
+
+    def test_ttl_zero_always_fetches(self, monkeypatch):
+        _seed_cache()
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        monkeypatch.setenv(knowledge.ENV_TTL, "0")
+        assert knowledge.load_bundle().source == "fetch"
+        assert len(calls) == 2
+
+    def test_ttl_env_parsing(self, monkeypatch):
+        assert knowledge.ttl_seconds() == knowledge.DEFAULT_TTL_SECONDS
+        monkeypatch.setenv(knowledge.ENV_TTL, "  ")
+        assert knowledge.ttl_seconds() == knowledge.DEFAULT_TTL_SECONDS
+        monkeypatch.setenv(knowledge.ENV_TTL, "abc")
+        assert knowledge.ttl_seconds() == knowledge.DEFAULT_TTL_SECONDS
+        monkeypatch.setenv(knowledge.ENV_TTL, "-5")
+        assert knowledge.ttl_seconds() == 0.0
+        monkeypatch.setenv(knowledge.ENV_TTL, "90")
+        assert knowledge.ttl_seconds() == 90.0
+
+    def test_memo_and_force_fetch(self, monkeypatch):
+        _seed_cache()
+        first = knowledge.load_bundle()
+        assert knowledge.load_bundle() is first
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        assert knowledge.load_bundle() is first
+        assert calls == []
+        forced = knowledge.load_bundle(force_fetch=True)
+        assert forced is not first
+        assert forced.source == "fetch"
+        assert knowledge.load_bundle() is forced
+
+
+class TestAuthRouting:
+    @staticmethod
+    def _fake_resp(body: bytes):
+        class _Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self, n: int = -1) -> bytes:
+                return body
+
+        return _Resp()
+
+    def test_cloud_url_uses_authed_opener(self, monkeypatch):
+        from comfy_cli.cloud import get_base_url
+
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        seen: dict[str, Any] = {}
+
+        def fake_authed(url, target, **kw):
+            seen["url"] = url
+            seen["target_kind"] = target.kind
+            return self._fake_resp(b'{"models": {}}')
+
+        monkeypatch.setattr(knowledge, "authed_urlopen", fake_authed)
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda *a, **kw: pytest.fail("plain opener used"))
+        url = f"{get_base_url()}/api/knowledge/knowledge.json"
+        assert knowledge._http_get(url) == b'{"models": {}}'
+        assert seen == {"url": url, "target_kind": "cloud"}
+
+    def test_lookalike_host_does_not_get_credentials(self, monkeypatch):
+        from comfy_cli.cloud import get_base_url
+
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        monkeypatch.setattr(knowledge, "authed_urlopen", lambda *a, **kw: pytest.fail("authed opener used"))
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda req, **kw: self._fake_resp(b"{}"))
+        assert knowledge._http_get(get_base_url() + ".evil.example/knowledge.json") == b"{}"
+
+    def test_other_url_uses_plain_opener(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        seen: dict[str, Any] = {}
+
+        def fake_plain(req, **kw):
+            seen["url"] = req.full_url
+            seen["ua"] = req.get_header("User-agent")
+            return self._fake_resp(b'{"models": {}}')
+
+        monkeypatch.setattr(knowledge, "plain_urlopen", fake_plain)
+        monkeypatch.setattr(knowledge, "authed_urlopen", lambda *a, **kw: pytest.fail("authed opener used"))
+        assert knowledge._http_get("https://example.com/knowledge.json") == b'{"models": {}}'
+        assert seen == {"url": "https://example.com/knowledge.json", "ua": "comfy-cli"}
+
+    def test_non_200_and_oversize_raise(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        resp = self._fake_resp(b"{}")
+        resp.status = 404
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda req, **kw: resp)
+        with pytest.raises(RuntimeError):
+            knowledge._http_get("https://example.com/knowledge.json")
+        monkeypatch.setattr(knowledge, "MAX_BUNDLE_BYTES", 4)
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda req, **kw: self._fake_resp(b"x" * 10))
+        with pytest.raises(Exception):
+            knowledge._http_get("https://example.com/knowledge.json")
+
+
+class TestIndex:
+    @pytest.fixture
+    def bundle(self, tmp_path, monkeypatch) -> knowledge.Bundle:
+        _env_bundle(tmp_path, monkeypatch)
+        b = knowledge.load_bundle()
+        assert b is not None
+        return b
+
+    def test_tolerant_reader(self, bundle, tmp_path, monkeypatch):
+        assert "future_field" in bundle.models["kling"]
+        assert len(bundle.models) == 5
+        knowledge._reset_for_testing()
+        p = tmp_path / "min.json"
+        p.write_text(json.dumps({"models": {"a": {"id": "a"}}, "aliases": {"A1": "a"}}))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        b = knowledge.load_bundle()
+        assert b.capabilities == {}
+        assert b.deprecations == {}
+        assert b.aliases == {"a1": "a", "a": "a"}
+
+    def test_malformed_rows_are_skipped(self, tmp_path, monkeypatch):
+        data = {
+            "models": {
+                "good": {"id": "good", "aliases": ["G", 7], "resolves": "nope", "routing": [{"use": 3}]},
+                "bad": "not a row",
+            },
+            "aliases": {"x": 1, "G2": "good"},
+            "capabilities": {"c": {"picks": "nope"}, "d": 5},
+            "deprecations": [{"id": "good"}, "junk", {"no_id": 1}],
+        }
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps(data))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        b = knowledge.load_bundle()
+        assert set(b.models) == {"good"}
+        assert b.aliases == {"g2": "good", "good": "good", "g": "good"}
+        assert set(b.capabilities) == {"c"}
+        assert set(b.deprecations) == {"good"}
+        assert b.templates == {} and b.nodes == {}
+
+    def test_alias_index(self, bundle):
+        assert bundle.aliases["hailuo 03"] == "minimax-h3"
+        assert bundle.aliases["minimax h3"] == "minimax-h3"
+        assert bundle.aliases["minimax-h3"] == "minimax-h3"
+        assert bundle.aliases["kling"] == "kling"
+        assert bundle.aliases["h3"] == "minimax-h3"
+
+    def test_template_and_node_index(self, bundle):
+        assert bundle.templates["video_minimax_h3_t2v"] == ["minimax-h3"]
+        assert bundle.templates["api_sync_so_lip_sync_video"] == ["sync-3"]
+        # Capability pick template for a model outside the trimmed set still maps.
+        assert bundle.templates["video_ltx2_3_ia2v"] == ["ltx"]
+        assert bundle.nodes["KlingLipSyncAudioToVideoNode"] == ["kling"]
+        assert all(len(v) == len(set(v)) for v in bundle.templates.values())
+
+    def test_deprecations_keyed_by_id(self, bundle):
+        assert bundle.deprecations["kling-avatar-2"]["superseded_by"] == "sync-3"
+        assert set(bundle.deprecations) == {"kling-avatar-2", "sora-2"}
+
+    def test_resolve(self, bundle):
+        assert knowledge.resolve(bundle, "  HAILUO 03 ")["id"] == "minimax-h3"
+        assert knowledge.resolve(bundle, "Kling-Avatar-2")["id"] == "kling-avatar-2"
+        assert knowledge.resolve(bundle, "nope-xyz") is None
+
+    def test_pick(self, bundle):
+        cap = knowledge.pick(bundle, " LIPSYNC ")
+        assert cap is not None
+        assert [p["rank"] for p in cap["picks"]] == [1, 2, 3, 4, 5, 6, 7]
+        assert cap is not bundle.capabilities["lipsync"]
+        assert knowledge.pick(bundle, "nope") is None
+
+    def test_pick_sorts_missing_rank_last(self):
+        b = knowledge._index(
+            {
+                "models": {},
+                "capabilities": {
+                    "c": {"picks": [{"model": "x"}, {"model": "y", "rank": 2}, {"model": "z", "rank": 1}]}
+                },
+            },
+            None,
+            source="env",
+            stale=False,
+            path="p",
+            mtime=0.0,
+        )
+        assert [p["model"] for p in knowledge.pick(b, "c")["picks"]] == ["z", "y", "x"]
+        assert b.as_of == "1970-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _run(args: list[str], capsys) -> tuple[int, dict[str, Any]]:
+    _force_json_renderer()
+    result = CliRunner().invoke(knowledge_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    # With standalone_mode=False click hands back a typer.Exit code as the return value.
+    exit_code = result.return_value if isinstance(result.return_value, int) else result.exit_code
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return exit_code, json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+def _validate(data: dict) -> None:
+    jsonschema.Draft202012Validator(SCHEMA).validate(data)
+
+
+class TestCli:
+    def test_status_with_env_file(self, tmp_path, monkeypatch, capsys):
+        path = _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["status"], capsys)
+        assert rc == 0
+        assert env["ok"] is True
+        assert env["schema"] == "envelope/1"
+        assert env["command"] == "knowledge status"
+        data = env["data"]
+        assert data["loaded"] is True
+        assert data["source"] == "env"
+        assert data["version"] == "0.1.0-fixture"
+        assert data["schema_version"] == 1
+        assert data["env_file"] == str(path)
+        assert data["url"] is None
+        assert data["ttl_seconds"] == knowledge.DEFAULT_TTL_SECONDS
+        assert data["counts"] == {"models": 5, "capabilities": 2, "aliases": 22, "deprecations": 2}
+        _validate(data)
+
+    def test_status_with_nothing(self, capsys):
+        rc, env = _run(["status"], capsys)
+        assert rc == 0
+        assert env["ok"] is True
+        data = env["data"]
+        assert data["loaded"] is False
+        assert data["reason"]
+        assert data["cache_path"].endswith(os.path.join("knowledge", "knowledge.json"))
+        _validate(data)
+
+    def test_status_refresh_forces_fetch(self, monkeypatch, capsys):
+        _seed_cache()
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        _rc, env = _run(["status", "--refresh"], capsys)
+        assert env["data"]["source"] == "fetch"
+        assert calls
+        _validate(env["data"])
+
+    def test_resolve_hit(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["resolve", "Hailuo 03"], capsys)
+        assert rc == 0
+        assert env["command"] == "knowledge resolve"
+        data = env["data"]
+        assert data["query"] == "Hailuo 03"
+        assert data["id"] == "minimax-h3"
+        assert data["model"]["id"] == "minimax-h3"
+        assert data["deprecation"] is None
+        assert data["bundle_version"] == "0.1.0-fixture"
+        assert data["stale"] is False
+        _validate(data)
+
+    def test_resolve_deprecated(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        _rc, env = _run(["resolve", "kling-avatar-2"], capsys)
+        data = env["data"]
+        assert data["deprecation"]["superseded_by"] == "sync-3"
+        _validate(data)
+
+    def test_resolve_miss(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["resolve", "nope-xyz"], capsys)
+        assert rc == 1
+        assert env["ok"] is False
+        assert env["error"]["code"] == "knowledge_unknown_model"
+        assert isinstance(env["error"]["details"]["close_matches"], list)
+        assert env["error"]["details"]["query"] == "nope-xyz"
+
+    def test_resolve_close_matches(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        _rc, env = _run(["resolve", "Hailuo 3"], capsys)
+        assert env["error"]["code"] == "knowledge_unknown_model"
+        assert "hailuo 03" in env["error"]["details"]["close_matches"]
+
+    def test_resolve_without_bundle(self, capsys):
+        rc, env = _run(["resolve", "x"], capsys)
+        assert rc == 1
+        assert env["error"]["code"] == "knowledge_unavailable"
+
+    def test_pick_hit(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["pick", "lipsync"], capsys)
+        assert rc == 0
+        assert env["command"] == "knowledge pick"
+        data = env["data"]
+        assert data["capability"] == "lipsync"
+        ranks = [p["rank"] for p in data["picks"]]
+        assert ranks == sorted(ranks) and len(ranks) == 7
+        assert all("status" in p and "superseded_by" in p for p in data["picks"])
+        by_model = {p["model"]: p for p in data["picks"]}
+        assert by_model["kling"]["status"] == "available"
+        assert by_model["ltx"]["status"] is None
+        assert by_model["ltx"]["template"] == "video_ltx2_3_ia2v"
+        assert by_model["kling"]["template"] is None
+        _validate(data)
+
+    def test_pick_miss(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["pick", "nope"], capsys)
+        assert rc == 1
+        assert env["error"]["code"] == "knowledge_unknown_capability"
+        assert env["error"]["details"]["known"] == ["audio-generation", "lipsync"]
+
+    def test_pick_without_bundle(self, capsys):
+        rc, env = _run(["pick", "lipsync"], capsys)
+        assert rc == 1
+        assert env["error"]["code"] == "knowledge_unavailable"
+
+    def test_pretty_mode_writes_nothing_to_stdout(self, tmp_path, monkeypatch, pretty_no_stdout):
+        _env_bundle(tmp_path, monkeypatch)
+        for args in (["status"], ["resolve", "kling"], ["pick", "lipsync"]):
+            result = CliRunner().invoke(knowledge_cmd.app, args, standalone_mode=False)
+            assert result.exception is None, result.exception
+
+    def test_error_codes_registered(self):
+        from comfy_cli import error_codes
+
+        for code in ("knowledge_unavailable", "knowledge_unknown_model", "knowledge_unknown_capability"):
+            assert error_codes.is_registered(code)
+
+    def test_fixture_manifest_matches_fixture(self):
+        import hashlib
+
+        manifest = json.loads(FIXTURE_MANIFEST.read_text())
+        raw = FIXTURE_KNOWLEDGE.read_bytes()
+        assert manifest["files"]["knowledge.json"]["sha256"] == hashlib.sha256(raw).hexdigest()
+        assert manifest["files"]["knowledge.json"]["bytes"] == len(raw)

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -154,6 +154,15 @@ class TestLoadOrder:
         assert b is not None
         assert b.version == "unknown"
 
+    def test_bundle_with_a_non_finite_constant_is_rejected(self, tmp_path, monkeypatch):
+        p = tmp_path / "k.json"
+        p.write_text('{"models": {"a": {"id": "a", "score": NaN}}}')
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        assert knowledge.load_bundle() is None
+        knowledge._reset_for_testing()
+        p.write_text('{"models": {"a": {"id": "a", "score": 1e400}}}')
+        assert knowledge.load_bundle() is None
+
     def test_env_file_not_a_bundle_returns_none(self, tmp_path, monkeypatch):
         p = tmp_path / "k.json"
         p.write_text(json.dumps({"hello": "world"}))
@@ -675,19 +684,15 @@ class TestCli:
         assert env["error"]["details"]["known"] == ["audio-generation", "lipsync"]
 
     def test_pick_payload_normalizes_rank_and_model(self, tmp_path, monkeypatch, capsys):
-        # Written as text so the bundle can carry 1e400, which json.loads turns into inf.
-        raw = (
-            '{"models": {}, "capabilities": {"c": {"id": "c", "description": ["not", "text"], "as_of": 7, "picks": ['
-            '{"model": "x", "rank": "1"}, {"model": 7, "rank": 2}, {"model": "y", "rank": 1.5}, {"model": "w", "rank": 1e400}'
-            "]}}}"
-        )
+        picks = [{"model": "x", "rank": "1"}, {"model": 7, "rank": 2}, {"model": "y", "rank": 1.5}]
+        cap = {"id": "c", "description": ["not", "text"], "as_of": 7, "picks": picks}
         p = tmp_path / "k.json"
-        p.write_text(raw)
+        p.write_text(json.dumps({"models": {}, "capabilities": {"c": cap}}))
         monkeypatch.setenv(knowledge.ENV_FILE, str(p))
         rc, env = _run(["pick", "c"], capsys)
         assert rc == 0
         got = [(q["model"], q["rank"]) for q in env["data"]["picks"]]
-        assert got == [("y", 1.5), (None, 2), ("x", None), ("w", None)]
+        assert got == [("y", 1.5), (None, 2), ("x", None)]
         assert env["data"]["description"] is None and env["data"]["as_of"] is None
         _validate(env["data"])
 

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -391,12 +391,37 @@ class TestIndex:
         assert knowledge.resolve(bundle, "Kling-Avatar-2")["id"] == "kling-avatar-2"
         assert knowledge.resolve(bundle, "nope-xyz") is None
 
+    def test_resolve_accepts_spelling_variants(self, bundle):
+        for query in ("Hailuo 3", "hailuo3", "HAILUO-03", "Mini Max H3", "sync.3"):
+            assert knowledge.resolve(bundle, query)["id"] == "minimax-h3" if "sync" not in query else True
+        assert knowledge.resolve(bundle, "sync.3")["id"] == "sync-3"
+        assert knowledge.resolve(bundle, "klingg") is None
+
+    def test_normalize(self):
+        assert knowledge._normalize("Hailuo 03") == "hailuo3"
+        assert knowledge._normalize("image to video") == "imagetovideo"
+        assert knowledge._normalize("Flux 1.10") == "flux110"
+        assert knowledge._normalize("v2.0") == "v20"
+
+    def test_normalized_collision_falls_back_to_exact_only(self):
+        data = {
+            "models": {"a": {"id": "a", "aliases": ["Model 01"]}, "b": {"id": "b", "aliases": ["model-1"]}},
+        }
+        b = knowledge._index(data, None, source="env", stale=False, path="p", mtime=0.0)
+        assert "model1" not in b.normalized_aliases
+        assert knowledge.resolve(b, "model 1") is None
+        assert knowledge.resolve(b, "Model 01")["id"] == "a"
+        assert knowledge.resolve(b, "model-1")["id"] == "b"
+        assert knowledge.resolve(b, "A")["id"] == "a"
+
     def test_pick(self, bundle):
         cap = knowledge.pick(bundle, " LIPSYNC ")
         assert cap is not None
         assert [p["rank"] for p in cap["picks"]] == [1, 2, 3, 4, 5, 6, 7]
         assert cap is not bundle.capabilities["lipsync"]
         assert knowledge.pick(bundle, "nope") is None
+        assert knowledge.pick(bundle, "Lip Sync")["id"] == "lipsync"
+        assert knowledge.pick(bundle, "audio generation")["id"] == "audio-generation"
 
     def test_pick_sorts_missing_rank_last(self):
         b = knowledge._index(
@@ -521,11 +546,19 @@ class TestCli:
         assert isinstance(env["error"]["details"]["close_matches"], list)
         assert env["error"]["details"]["query"] == "nope-xyz"
 
+    def test_resolve_spelling_variant_is_a_hit(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["resolve", "Hailuo 3"], capsys)
+        assert rc == 0
+        assert env["data"]["id"] == "minimax-h3"
+        assert env["data"]["query"] == "Hailuo 3"
+        _validate(env["data"])
+
     def test_resolve_close_matches(self, tmp_path, monkeypatch, capsys):
         _env_bundle(tmp_path, monkeypatch)
-        _rc, env = _run(["resolve", "Hailuo 3"], capsys)
+        _rc, env = _run(["resolve", "klingg"], capsys)
         assert env["error"]["code"] == "knowledge_unknown_model"
-        assert "hailuo 03" in env["error"]["details"]["close_matches"]
+        assert "kling" in env["error"]["details"]["close_matches"]
 
     def test_resolve_without_bundle(self, capsys):
         rc, env = _run(["resolve", "x"], capsys)
@@ -548,6 +581,13 @@ class TestCli:
         assert by_model["ltx"]["template"] == "video_ltx2_3_ia2v"
         assert by_model["kling"]["template"] is None
         _validate(data)
+
+    def test_pick_spelling_variant(self, tmp_path, monkeypatch, capsys):
+        _env_bundle(tmp_path, monkeypatch)
+        rc, env = _run(["pick", "Audio Generation"], capsys)
+        assert rc == 0
+        assert env["data"]["capability"] == "audio-generation"
+        _validate(env["data"])
 
     def test_pick_miss(self, tmp_path, monkeypatch, capsys):
         _env_bundle(tmp_path, monkeypatch)


### PR DESCRIPTION
Linear: BE-8558 (parent BE-8296). PR 1 of 3. PR 2 (envelope enrichment, BE-8559) stacks on this branch.

## What

- `comfy_cli/knowledge.py`: loads the comfy-knowledge bundle. Load order is `COMFY_KNOWLEDGE_FILE` > fresh cache > `COMFY_KNOWLEDGE_URL` fetch > stale cache > none. TTL via `COMFY_KNOWLEDGE_TTL` (default 86400). Cache writes reuse the `cql.loader` atomic-write helpers. Credentials are sent only to URLs under the cloud base URL. Manifest sha256 is checked when a manifest is present.
- `comfy knowledge status | resolve <alias-or-id> | pick <capability>` in `comfy_cli/command/knowledge.py`, registered in `cmdline.py`, listed in `discovery.py`. JSON envelope plus pretty form for each.
- `resolve` and `pick` try the exact lowercased alias first, then a normalized form (lowercase, leading zeros stripped from digit runs, non-alphanumerics removed), so `"Hailuo 3"`, `"hailuo-03"` and `"HAILUO 03"` all resolve to `minimax-h3`. No fuzzy auto-match; a typo still misses and returns `close_matches`.
- Three error codes (`knowledge_unavailable`, `knowledge_unknown_model`, `knowledge_unknown_capability`), output schema `comfy_cli/schemas/knowledge.json`, trimmed fixture bundle with manifest, 45 tests. Tests never touch the network.

No new dependencies. No renderer, loader, templates, skills or docs changes.

## Verification

- `pytest` targeted files (test_knowledge, envelope schemas, error registry, discovery, command mentions): 123 passed.
- Full suite: 4813 passed, 62 failed. All 62 reproduce on `origin/main` in a clean worktree (FORCE_COLOR / local `~/.config` leakage in test_logs, test_jobs, test_host_port, test_onboarding); none touch knowledge.
- `ruff check .` and `ruff format --check .` clean on ruff 0.15.15 (the pre-commit pin).
- Manual, with `COMFY_KNOWLEDGE_FILE=../comfy-knowledge/dist/knowledge.json`: `status` loads 41 models / 12 capabilities / 174 aliases; `resolve "Hailuo 3"` -> `minimax-h3`; `pick lipsync` -> 7 ranked picks; `resolve nope` -> `knowledge_unknown_model`, exit 1.

## Notes

- `--refresh` with no URL set reports a fresh cache as `stale-cache`, and an unreadable cache reports the "no cache" reason. Both follow the SPEC's pinned strings; flagged in review as non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUYGReW8iR4Pt4CqZParFg

