### PR TITLE
fix(output): _json_default must return a JSON-native value

### DIFF
--- a/comfy_cli/output/renderer.py
+++ b/comfy_cli/output/renderer.py
@@ -423,18 +423,28 @@ class Renderer:
 
 
 def _json_default(obj: Any) -> Any:
-    # Best-effort JSON coercion for common non-serializable types.
+    """Coerce one unserializable value to a JSON-native one.
+
+    Every return here must be a value ``json`` can already encode. json feeds
+    anything else straight back in, so a hook that returns another opaque
+    object recurses once per hop and one that keeps producing new objects
+    never terminates at all.
+    """
     from pathlib import Path
 
     if isinstance(obj, Path):
         return str(obj)
     if isinstance(obj, Enum):
-        return obj.value
+        value = obj.value
+        return value if value is None or isinstance(value, str | int | float) else str(value)
     if hasattr(obj, "isoformat"):
         try:
-            return obj.isoformat()
+            stamp = obj.isoformat()
         except Exception:  # noqa: BLE001
             pass
+        else:
+            if isinstance(stamp, str):
+                return stamp
     return str(obj)
 
 

--- a/tests/comfy_cli/output/test_renderer.py
+++ b/tests/comfy_cli/output/test_renderer.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 import io
 import json
 import re
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
 
 import pytest
 
 from comfy_cli.caller import Caller
-from comfy_cli.output.renderer import OutputMode, Renderer, get_renderer, reset_renderer_for_testing, set_renderer
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    _json_default,
+    get_renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -563,3 +573,42 @@ class TestWritesTolerateADeadMachineStream:
         r = self._dead_stdout_renderer(monkeypatch, Fussy())
         with pytest.raises(TypeError):
             r.emit({"hello": "world"})
+
+
+class TestJsonDefault:
+    def test_a_non_string_isoformat_does_not_loop(self):
+        class FakeStamp:
+            def isoformat(self):
+                return self  # a Mock or a bad stub does exactly this
+
+        assert json.dumps({"when": FakeStamp()}, default=_json_default)
+
+    def test_a_real_isoformat_is_still_used(self):
+        assert _json_default(datetime(2026, 8, 23, tzinfo=timezone.utc)) == "2026-08-23T00:00:00+00:00"
+
+    def test_an_enum_wrapping_an_opaque_value_is_coerced(self):
+        class Wrapping(Enum):
+            OPAQUE = object()
+
+        assert _json_default(Wrapping.OPAQUE).startswith("<object object")
+
+    def test_the_hook_runs_once_per_value(self):
+        """Single-pass is the whole guarantee: json re-enters the hook for
+        anything it still cannot encode, so one re-entry per value is the same
+        defect as an endless one, caught earlier."""
+
+        class Wrapping(Enum):
+            OPAQUE = object()
+
+        class BadStamp:
+            def isoformat(self):
+                return self
+
+        seen = []
+
+        def counted(obj):
+            seen.append(obj)
+            return _json_default(obj)
+
+        json.dumps({"e": Wrapping.OPAQUE, "s": BadStamp(), "p": Path("/tmp/x")}, default=counted)
+        assert len(seen) == 3


### PR DESCRIPTION
Independent of #756 — this reproduces on `main` with no knowledge code in the tree.

## What

`json.dumps` re-encodes whatever a `default` hook returns and calls the hook again when the result is still not serializable, so a `default` that returns a non-JSON value never terminates. `_json_default` returned `obj.isoformat()` unchecked. Any stub or mock answers `hasattr(obj, "isoformat")` and returns another object of its own kind, so each pass allocated a new object and re-entered.

The rule the hook has to hold is that every return is a value json can already encode. Two branches broke it:

- `isoformat()` was returned unchecked, so a stub that returns a fresh object of its own kind produced a new object per pass and never terminated.
- the `Enum` branch returned `obj.value` unchecked, so an opaque member value came straight back into the hook, and an `Enum` wrapping an `Enum` chained.

Both are now coerced, so the hook runs exactly once per value. There is no recursion depth left to bound, so no `RecursionError` to raise, catch, or swallow. A test asserts the single-pass property directly by counting hook invocations rather than by checking that some depth limit stops it.

## How it showed up

`tests/comfy_cli/command/test_run.py::TestLocalExecuteItemMapAndGroupedOutputs::test_local_wait_envelope_groups_by_node_and_item` never finished on a local checkout. It reaches `_emit_queued`, which puts `execution.validation_warnings` and `execution.workflow_manifest()` into the envelope; that test's mock leaves both as auto-created mocks.

CI never caught it because both test workflows pin Python 3.10, where the C encoder's recursion guard raises `RecursionError` after ~978 nested `default` calls — and `RecursionError` is an `Exception`, so the bare `except Exception: pass` inside `_json_default` swallowed it and the encode limped to a string. Measured: 3.10.20 finishes after 978 calls, 3.11.15 after 979, while 3.12, 3.13 and 3.14 had to be killed by a watchdog. `pyproject.toml` declares `requires-python = ">=3.10"`, so anyone on a newer interpreter hits it.

## Verification

- Before: on clean `main`, that test hangs indefinitely (killed at 40s). A leaked probe process reached 43% of system RAM, so an unattended run can push a machine into swap.
- After: the whole class passes in 0.22s. `tests/comfy_cli/output/test_renderer.py` 56 passed.
- Full suite with **nothing deselected**: 5645 passed, 43 failed in 4m37s. Those 43 are the pre-existing local-env failures (`test_logs`, `test_jobs`, `test_host_port`, `test_onboarding`, `test_pretty_print_sanitize`) that also fail on `main`. Before this change the suite could not complete locally at all.
- New tests fail without the fix and fail fast, so they can never wedge CI: the isoformat case raises `ValueError: Circular reference detected`, and the single-pass counter sees 4 hook calls for 3 values.
- `ruff check .` clean.

## Follow-ups (not in this PR)

- Add a 3.13 or 3.14 leg to the test matrix; `requires-python` claims support past 3.10 and nothing verifies it.
- Consider `pytest-timeout` in the dev extra. It is not installed today, so a hang in CI would burn the whole job timeout instead of failing fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
