### PR TITLE
feat(knowledge): capability reachability — miss nudge and block vocabulary (BE-8810)

### DIFF
--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -603,8 +603,9 @@ def attach(
     and ``nodes`` go through the reverse index. ``catalog_*`` are the ids the
     command actually loaded, used to drop rows and picks that do not resolve
     locally. ``thin`` marks a command whose own result was empty, which is the
-    only case that earns a nudge. Fail-open: any exception leaves ``payload``
-    exactly as it was.
+    only case that earns ``zero_hit``; a query that resolved to nothing earns a
+    nudge on its own. Fail-open: any exception leaves ``payload`` exactly as it
+    was.
     """
     try:
         bundle = load_bundle(cache_only=True)
@@ -612,6 +613,7 @@ def attach(
             return
         query_list = [q.strip()[:MAX_QUERY_CHARS] for q in queries if isinstance(q, str) and q.strip()]
         model_hits, cap_hits = _lookup(bundle, query_list)
+        query_resolved = bool(model_hits or cap_hits)
         seen = {mid for mid, _ in model_hits}
         for ids, index in ((templates, bundle.templates), (nodes, bundle.nodes)):
             for ident in ids:
@@ -655,6 +657,16 @@ def attach(
             block["nudge"] = f"{head}; covered capabilities: {', '.join(sorted(bundle.capabilities))}"
             if _block_bytes(block) > MAX_BLOCK_BYTES:
                 block["nudge"] = head
+        elif query_list and not query_resolved:
+            # A browse that returns rows the reverse index enriched, while the
+            # query itself matched neither a model nor a capability. Not a
+            # zero_hit: that feeds the miss log and means an empty block.
+            head = f"no curated knowledge for {query_list[0]!r}"
+            block["nudge"] = f"{head}; covered capabilities: {', '.join(sorted(bundle.capabilities))}"
+            if _block_bytes(block) > MAX_BLOCK_BYTES:
+                block["nudge"] = head
+            if _block_bytes(block) > MAX_BLOCK_BYTES:
+                del block["nudge"]
         payload["knowledge"] = block
     except Exception:  # noqa: BLE001 — knowledge is additive; the payload ships unchanged on any failure
         return

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -646,6 +646,12 @@ def attach(
             entries.append(_model_entry(bundle, mid, row, matched_on=matched_on, brief=brief))
         entries.sort(key=lambda e: e.get("tier") != "law")
         entries = entries[: MAX_MODELS_BRIEF if brief else MAX_MODELS]
+        if not query_resolved:
+            # A node class or template id passed as both a query and a reverse-index
+            # key lands a row whose matched_on is that exact string. Nudging there
+            # would deny a term the block answers on the same line.
+            asked = set(query_list)
+            query_resolved = any(e["matched_on"] in asked for e in entries)
 
         picks: list[dict] = []
         for cid in cap_hits:

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -568,8 +568,20 @@ def _block_bytes(block: dict) -> int:
     return len(json.dumps(block, ensure_ascii=False).encode())
 
 
+def _nudge_text(block: dict, head: str) -> str:
+    """Point at ``capabilities_available`` rather than repeating the id list."""
+    if "capabilities_available" not in block:
+        return head
+    return f"{head}; see capabilities_available"
+
+
 def _fit(block: dict) -> None:
-    """Drop whole entries (models first, then picks) until the block fits MAX_BLOCK_BYTES."""
+    """Drop whole entries until the block fits MAX_BLOCK_BYTES.
+
+    Models first, then picks, and ``capabilities_available`` last: it is the
+    only thing that tells an agent which search terms reach a ranked table, so
+    it outlives the answers to the current query.
+    """
     while True:
         caps: list[str] = []
         for p in block["picks"]:
@@ -582,6 +594,8 @@ def _fit(block: dict) -> None:
             block["models"].pop()
         elif block["picks"]:
             block["picks"].pop()
+        elif "capabilities_available" in block:
+            del block["capabilities_available"]
         else:
             return
 
@@ -644,6 +658,7 @@ def attach(
             "as_of": bundle.as_of,
             "models": entries,
             "picks": picks,
+            "capabilities_available": sorted(bundle.capabilities),
             "hit_ids": [],
             "zero_hit": False,
         }
@@ -654,15 +669,17 @@ def attach(
                 return
             block["zero_hit"] = True
             head = f"no curated knowledge for {query_list[0]!r}"
-            block["nudge"] = f"{head}; covered capabilities: {', '.join(sorted(bundle.capabilities))}"
+            block["nudge"] = _nudge_text(block, head)
             if _block_bytes(block) > MAX_BLOCK_BYTES:
                 block["nudge"] = head
+            if _block_bytes(block) > MAX_BLOCK_BYTES:
+                block.pop("capabilities_available", None)
         elif query_list and not query_resolved:
             # A browse that returns rows the reverse index enriched, while the
             # query itself matched neither a model nor a capability. Not a
             # zero_hit: that feeds the miss log and means an empty block.
             head = f"no curated knowledge for {query_list[0]!r}"
-            block["nudge"] = f"{head}; covered capabilities: {', '.join(sorted(bundle.capabilities))}"
+            block["nudge"] = _nudge_text(block, head)
             if _block_bytes(block) > MAX_BLOCK_BYTES:
                 block["nudge"] = head
             if _block_bytes(block) > MAX_BLOCK_BYTES:

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -64,6 +64,6 @@
       "description": "Model ids then `cap:<id>` for capabilities, in block order, after capping."
     },
     "zero_hit": { "type": "boolean", "description": "True when nothing curated matched and the command's own result was empty." },
-    "nudge": { "type": "string", "description": "One line present only on a zero-hit thin result: what was asked and which capabilities are covered." }
+    "nudge": { "type": "string", "description": "One line naming what was asked and which capabilities are covered. Present on a zero-hit thin result, and on a non-empty block whose query matched no model or capability directly." }
   }
 }

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -58,12 +58,17 @@
         }
       }
     },
+    "capabilities_available": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Every capability id the bundle covers, sorted. These are the search terms that reach a ranked table. Dropped only when the block would otherwise overrun its byte ceiling."
+    },
     "hit_ids": {
       "type": "array",
       "items": { "type": "string" },
       "description": "Model ids then `cap:<id>` for capabilities, in block order, after capping."
     },
     "zero_hit": { "type": "boolean", "description": "True when nothing curated matched and the command's own result was empty." },
-    "nudge": { "type": "string", "description": "One line naming what was asked and which capabilities are covered. Present on a zero-hit thin result, and on a non-empty block whose query matched no model or capability directly." }
+    "nudge": { "type": "string", "description": "One line naming what was asked, pointing at `capabilities_available` for what is covered. Present on a zero-hit thin result, and on a non-empty block whose query matched no model or capability directly." }
   }
 }

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -49,9 +49,10 @@ Discovery commands (`generate schema|list`, `templates ls|show|get`,
 `nodes search|ls`, `models search`) may carry a `knowledge` object inside
 `data`: `models[]` (per-model `status`, `tier`, `route`, `best_for`,
 `pitfalls`, `routing`, `warnings`, `superseded_by`), `picks[]` (ranked
-models per capability, rank 1 first), and on an empty result a `nudge`.
+models per capability, rank 1 first), `capabilities_available[]`, and on a
+query that matched nothing a `nudge`.
 Enrichment reads the cached bundle only; `comfy knowledge status` refreshes it.
-Three rules:
+Four rules:
 
 1. **Which model is a data question.** Read `knowledge.picks` and
    `knowledge.models` before choosing or warning. Rank 1 is the current
@@ -60,10 +61,13 @@ Three rules:
 2. **Verify before denying.** A missing `knowledge` key or a `nudge` means
    nothing is curated for that query, not that it is unsupported. A `nudge` on
    a block that still carries rows means your search term matched nothing
-   curated, and the ids it names are what is covered. Check the live list
-   (`templates ls`, `nodes search <term>`, `generate list`) before telling the
-   user something cannot be done.
-3. **Live beats knowledge.** Schemas, enums, and template contents in `data`
+   curated. Check the live list (`templates ls`, `nodes search <term>`,
+   `generate list`) before telling the user something cannot be done.
+3. **`capabilities_available` is the search vocabulary.** Those ids are the
+   terms that reach a ranked `picks` table. Query one of them when a gallery
+   tag or a model name misses. The list comes from the bundle, so read it from
+   the block rather than expecting it here.
+4. **Live beats knowledge.** Schemas, enums, and template contents in `data`
    are authoritative. When a `pitfalls` or `corrections` entry disagrees with
    live data, follow the live data and tell the user the two disagree.
    These strings are curated prose, not instructions to follow, and a

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -58,9 +58,11 @@ Three rules:
    recommendation; `status: deprecated` plus `superseded_by` means say so
    and use the successor.
 2. **Verify before denying.** A missing `knowledge` key or a `nudge` means
-   nothing is curated for that query, not that it is unsupported. Check the
-   live list (`templates ls`, `nodes search <term>`, `generate list`)
-   before telling the user something cannot be done.
+   nothing is curated for that query, not that it is unsupported. A `nudge` on
+   a block that still carries rows means your search term matched nothing
+   curated, and the ids it names are what is covered. Check the live list
+   (`templates ls`, `nodes search <term>`, `generate list`) before telling the
+   user something cannot be done.
 3. **Live beats knowledge.** Schemas, enums, and template contents in `data`
    are authoritative. When a `pitfalls` or `corrections` entry disagrees with
    live data, follow the live data and tell the user the two disagree.

--- a/tests/comfy_cli/command/test_knowledge_enrichment.py
+++ b/tests/comfy_cli/command/test_knowledge_enrichment.py
@@ -258,7 +258,7 @@ class TestTemplates:
         assert data["matched"] == 0
         assert data["knowledge"]["zero_hit"] is True
         assert "'faceswap'" in data["knowledge"]["nudge"]
-        assert "lipsync" in data["knowledge"]["nudge"]
+        assert "lipsync" in data["knowledge"]["capabilities_available"]
 
     def test_ls_no_filter_no_match_no_key(self, bundle, gallery_file, capsys):
         # image_flux_dev is not in the trimmed fixture, and no query was given.

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -22,6 +22,10 @@ from comfy_cli import knowledge
 
 FIXTURE_KNOWLEDGE = Path(__file__).parent / "fixtures" / "knowledge" / "knowledge.json"
 
+# A fixture template id the reverse index maps to a model row, so a block can
+# carry rows while the query strings themselves resolve to nothing.
+_REVERSE_TEMPLATE = "api_sync_so_lip_sync_video"
+
 
 def _network_guard(url: str) -> bytes:
     raise AssertionError(f"network touched: {url}")
@@ -279,6 +283,42 @@ class TestNudge:
         k = _attach(queries=["faceswap"], thin=True)["knowledge"]
         assert k["nudge"] == "no curated knowledge for 'faceswap'"
         assert knowledge._block_bytes(k) <= 220
+
+    def test_unresolved_query_on_a_non_empty_block_gets_a_nudge(self):
+        k = _attach(queries=["FLF2V"], templates=[_REVERSE_TEMPLATE])["knowledge"]
+        assert k["models"]
+        assert k["zero_hit"] is False
+        assert "'FLF2V'" in k["nudge"]
+        assert "lipsync" in k["nudge"]
+
+    def test_query_resolving_to_a_model_gets_no_nudge(self):
+        k = _attach(queries=["kling"], templates=[_REVERSE_TEMPLATE])["knowledge"]
+        assert k["models"]
+        assert "nudge" not in k
+
+    def test_query_resolving_to_a_capability_gets_no_nudge(self):
+        k = _attach(queries=["lipsync"])["knowledge"]
+        assert k["picks"]
+        assert "nudge" not in k
+
+    def test_unresolved_query_nudge_degrades_then_disappears(self, monkeypatch):
+        args = {"queries": ["FLF2V"], "templates": [_REVERSE_TEMPLATE]}
+        full = _attach(**args)["knowledge"]
+        head = "no curated knowledge for 'FLF2V'"
+        head_only = dict(full, nudge=head)
+        bare = {key: value for key, value in full.items() if key != "nudge"}
+
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(head_only))
+        k = _attach(**args)["knowledge"]
+        assert k["nudge"] == head
+        assert k["models"]
+        assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
+
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(bare))
+        k = _attach(**args)["knowledge"]
+        assert "nudge" not in k
+        assert k["models"]
+        assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
 
     def test_not_thin_means_no_key(self):
         assert "knowledge" not in _attach(queries=["faceswap"], thin=False)

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -259,14 +259,67 @@ class TestCaps:
         assert len(k["models"]) == 3
 
 
+class TestCapabilitiesAvailable:
+    def test_every_enriched_block_carries_the_vocabulary(self):
+        for kwargs in (
+            {"queries": ["kling"]},
+            {"queries": ["lipsync"]},
+            {"templates": [_REVERSE_TEMPLATE]},
+            {"queries": ["faceswap"], "thin": True},
+        ):
+            k = _attach(**kwargs)["knowledge"]
+            assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+    def test_the_vocabulary_is_the_bundle_capability_keys_sorted(self):
+        bundle = knowledge.load_bundle(cache_only=True)
+        k = _attach(queries=["kling"])["knowledge"]
+        assert k["capabilities_available"] == sorted(bundle.capabilities)
+
+    def test_the_vocabulary_outlives_models_and_picks_under_pressure(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", 600)
+        k = _attach(queries=["kling", "Lip Sync"])["knowledge"]
+        assert k["models"] == [] and 0 < len(k["picks"])
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+    def test_fit_drops_the_vocabulary_only_after_models_and_picks(self, monkeypatch):
+        def block() -> dict:
+            return {
+                "models": [{"id": "kling"}],
+                "picks": [{"capability": "lipsync"}],
+                "capabilities_available": ["audio-generation", "lipsync"],
+                "hit_ids": [],
+            }
+
+        emptied = block()
+        emptied["models"] = []
+        emptied["picks"] = []
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(emptied))
+        k = block()
+        knowledge._fit(k)
+        assert k["models"] == [] and k["picks"] == []
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+        bare = dict(emptied)
+        del bare["capabilities_available"]
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(bare))
+        k = block()
+        knowledge._fit(k)
+        assert "capabilities_available" not in k
+        assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
+
+    def test_no_bundle_still_adds_no_key(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "load_bundle", lambda **_: None)
+        assert "knowledge" not in _attach(queries=["kling"])
+
+
 class TestNudge:
     def test_thin_zero_hit_gets_a_nudge(self):
         k = _attach(queries=["faceswap"], thin=True)["knowledge"]
         assert k["zero_hit"] is True
         assert k["models"] == [] and k["picks"] == [] and k["hit_ids"] == []
         assert "'faceswap'" in k["nudge"]
-        assert "lipsync" in k["nudge"]
-        assert "audio-generation" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
 
     def test_nudge_uses_first_non_blank_query(self):
         k = _attach(queries=["  ", "faceswap", "other"], thin=True)["knowledge"]
@@ -276,12 +329,13 @@ class TestNudge:
         k = _attach(queries=["x-" * 4500], thin=True)["knowledge"]
         assert k["zero_hit"] is True
         assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
-        assert "lipsync" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
 
-    def test_nudge_drops_the_capability_list_rather_than_overrun(self, monkeypatch):
+    def test_zero_hit_nudge_sheds_the_pointer_then_the_vocabulary(self, monkeypatch):
         monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", 220)
         k = _attach(queries=["faceswap"], thin=True)["knowledge"]
         assert k["nudge"] == "no curated knowledge for 'faceswap'"
+        assert "capabilities_available" not in k
         assert knowledge._block_bytes(k) <= 220
 
     def test_unresolved_query_on_a_non_empty_block_gets_a_nudge(self):
@@ -289,7 +343,7 @@ class TestNudge:
         assert k["models"]
         assert k["zero_hit"] is False
         assert "'FLF2V'" in k["nudge"]
-        assert "lipsync" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
 
     def test_query_resolving_to_a_model_gets_no_nudge(self):
         k = _attach(queries=["kling"], templates=[_REVERSE_TEMPLATE])["knowledge"]

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -350,6 +350,13 @@ class TestNudge:
         assert k["models"]
         assert "nudge" not in k
 
+    def test_query_the_reverse_index_resolves_gets_no_nudge(self):
+        # `nodes search <ClassName>` and `templates ls --name-sub <template id>`
+        # pass the same string as a query and as a reverse-index key.
+        k = _attach(queries=[_REVERSE_TEMPLATE], templates=[_REVERSE_TEMPLATE])["knowledge"]
+        assert [e["matched_on"] for e in k["models"]] == [_REVERSE_TEMPLATE]
+        assert "nudge" not in k
+
     def test_query_resolving_to_a_capability_gets_no_nudge(self):
         k = _attach(queries=["lipsync"])["knowledge"]
         assert k["picks"]


### PR DESCRIPTION
Linear: BE-8810 (parent BE-8296). Parts A and C of SPEC-capability-reachability. The comfy-knowledge side is Comfy-Org/comfy-knowledge#4, which is independent of this one.

**Draft, and stacked.** The base is `anne/be-8559-knowledge-enrichment`, the branch behind #756, not `main`.

The spec puts Part A inside #756 and Part C on a new branch off `main` once #756 merges. #756 is still open, and Part C rewrites the nudge that Part A introduces, so Part C cannot sit on `main` today. Both parts are here as separate commits so they can be split:

- `f9c5310` Part A, belongs in #756
- `bb870ca` Part C, belongs in its own PR once #756 lands
- `138d6ca` a review fix on Part A's behavior, belongs with `f9c5310`

## Part A — nudge on a query miss

`attach()` only built a nudge when the block ended up completely empty and the command's own result was empty. A browse that returns rows but misses the capability produced no signal at all.

`templates ls --tag "FLF2V"` matches 28 templates, so `thin` is False. Those 28 ids go through the reverse index and fill `models`. The agent got model rows and no indication that a ranked table for this job exists anywhere. A total miss was loud. A partial miss was silent, and the partial miss is the common one.

`attach()` now captures whether the query strings themselves resolved, before the reverse-index pass appends to `model_hits`, and nudges on a non-empty block whose query resolved to nothing.

`zero_hit` is unchanged. It still means an empty block on a thin result, which is what the query/miss log reads. Overloading it would change the log's meaning retroactively.

The narrowness is deliberate. `generate schema kling` resolves "kling" to a model, so it gets no nudge: the agent asked about a named thing and got it. `--tag FLF2V` resolves to neither a model nor a capability, so it does.

### Review fix on top

The spec's `query_resolved` rule counted only model-alias and capability lookups. A node class or template id passed as both a query and a reverse-index key therefore produced a model row plus a nudge denying that same term:

```
attach(queries=['KlingImage2VideoNode'], nodes=['KlingImage2VideoNode'])
  models: [('kling', matched_on='KlingImage2VideoNode')]
  nudge:  "no curated knowledge for 'KlingImage2VideoNode'; ..."
```

`nodes search <ClassName>` and `templates ls --name-sub <template id>` both take that path. A query now also counts as resolved when a shipped row's `matched_on` is one of the query strings. This is a hole in the spec's rule rather than a drift from it, and it contradicted the spec's own stated intent that a query reaching a named thing gets no nudge.

## Part C — capability vocabulary in the block

The agent was asked to hit a target it had never been shown. The 12 capability ids appeared nowhere it could read before forming a query, and Part A's nudge only helps after a miss, at the cost of a round trip.

Every enriched block now carries `capabilities_available`, read from the bundle. That matters: the set of capability ids is bundle content, which updates without a release, while comfy-cli code does not. Hardcoding the list into `SKILL.md` would put churning data on the slow release path. It is roughly 150 bytes for the current 12 ids, against a `MAX_BLOCK_BYTES` of 8192.

`_fit` counts it and evicts it last, after models and picks are exhausted. It is the only thing telling an agent which search terms reach a ranked table, so it outlives the answers to the current query.

Both nudges now point at it rather than repeating the id list, so the ids live in one place.

One addition beyond the spec: in the `zero_hit` branch, `capabilities_available` is popped if the block still overruns after the nudge degrades to its head. Without it a zero-hit block measured 251 bytes against a 220-byte ceiling once Part C added the key.

## Docs and schemas

`comfy_cli/schemas/knowledge_block.json` declares `capabilities_available`, and the `nudge` description no longer ties it to an empty result.

`comfy_cli/skills/comfy/SKILL.md` gains a rule that `capabilities_available` is the search vocabulary, and rule 2 now covers a nudge on a block that still carries rows. The ids themselves are deliberately not listed in `SKILL.md`.

## Verification

```
uv run --extra dev pytest tests/comfy_cli/test_knowledge_attach.py \
                          tests/comfy_cli/command/test_knowledge_enrichment.py -q
84 passed

uvx ruff@0.15.15 check .           All checks passed!
uvx ruff@0.15.15 format --check .  336 files already formatted
```

End to end against the live gallery, with `COMFY_KNOWLEDGE_FILE` pointed at a bundle built from Comfy-Org/comfy-knowledge#4:

```
FLF2V          hit_ids ['seedance', 'cap:first-last-frame']   picks 3   nudge None
Text to Audio  hit_ids ['cap:audio-generation']               picks 3   nudge None
Image Upscale  hit_ids ['magnific', 'cap:upscale']            picks 3   nudge None
Inpainting     hit_ids ['wan', 'cap:inpaint']                 picks 3   nudge None
Outpainting    hit_ids ['flux-1-fill', 'cap:inpaint']         picks 3   nudge None
Video Upscale  hit_ids ['topaz', 'seedvr2', 'cap:upscale']    picks 3   nudge None

ControlNet     hit_ids ['ltx', 'wan']   picks []   zero_hit False
               nudge "no curated knowledge for 'ControlNet'; see capabilities_available"
```

`capabilities_available` carried all 12 ids on every one of those, hits included.

New tests cover: an unresolved query on a non-empty block, a query resolving to a model, to a capability, and through the reverse index only, the nudge degrading to its head then disappearing under byte pressure, the vocabulary on every enriched block, the vocabulary matching the bundle's capability keys sorted, and `_fit` dropping the vocabulary only after models and picks.

The full comfy-cli suite has pre-existing failures on `main` from local `~/.config` and `FORCE_COLOR` leakage, and one hanging test in `test_run.py`. Both are unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fFbkjpCcwnAFFGfMioG6u
