### PR TITLE
feat(knowledge): carry the capability vocabulary in every block (BE-8810)

### DIFF
--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -604,8 +604,20 @@ def _block_bytes(block: dict) -> int:
     return len(json.dumps(block, ensure_ascii=False).encode())
 
 
+def _nudge_text(block: dict, head: str) -> str:
+    """Point at ``capabilities_available`` rather than repeating the id list."""
+    if "capabilities_available" not in block:
+        return head
+    return f"{head}; see capabilities_available"
+
+
 def _fit(block: dict) -> None:
-    """Drop whole entries (models first, then picks) until the block fits MAX_BLOCK_BYTES."""
+    """Drop whole entries until the block fits MAX_BLOCK_BYTES.
+
+    Models first, then picks, and ``capabilities_available`` last: it is the
+    only thing that tells an agent which search terms reach a ranked table, so
+    it outlives the answers to the current query.
+    """
     while True:
         caps: list[str] = []
         for p in block["picks"]:
@@ -618,6 +630,8 @@ def _fit(block: dict) -> None:
             block["models"].pop()
         elif block["picks"]:
             block["picks"].pop()
+        elif "capabilities_available" in block:
+            del block["capabilities_available"]
         else:
             return
 
@@ -634,16 +648,20 @@ def _capabilities_for(bundle: Bundle, entries: list[dict]) -> list[str]:
     return out
 
 
-def _set_nudge(block: dict, query: str, bundle: Bundle) -> None:
-    """One line naming the miss and what the bundle does cover.
+def _set_nudge(block: dict, query: str, *, shed_vocabulary: bool = False) -> None:
+    """One line naming the miss and pointing at the ids the bundle does cover.
 
-    The capability list goes first if the block is over the cap, then the whole
-    nudge — a block that ships without its nudge still beats one nothing reads.
+    The pointer goes first if the block is over the cap, then the whole nudge —
+    a block that ships without its nudge still beats one nothing reads.
+    ``shed_vocabulary`` drops ``capabilities_available`` ahead of the nudge, for
+    an otherwise empty block where the nudge is the only thing left to read.
     """
     head = f"no curated knowledge for {query!r}"
-    block["nudge"] = f"{head}; covered capabilities: {', '.join(sorted(bundle.capabilities))}"
+    block["nudge"] = _nudge_text(block, head)
     if _block_bytes(block) > MAX_BLOCK_BYTES:
         block["nudge"] = head
+    if shed_vocabulary and _block_bytes(block) > MAX_BLOCK_BYTES:
+        block.pop("capabilities_available", None)
     if _block_bytes(block) > MAX_BLOCK_BYTES:
         del block["nudge"]
 
@@ -769,6 +787,7 @@ def attach(
             "as_of": bundle.as_of,
             "models": entries,
             "picks": picks,
+            "capabilities_available": sorted(bundle.capabilities),
             "hit_ids": [],
             "zero_hit": False,
         }
@@ -780,12 +799,12 @@ def attach(
                 attached = False
             else:
                 block["zero_hit"] = True
-                _set_nudge(block, query_list[0], bundle)
+                _set_nudge(block, query_list[0], shed_vocabulary=True)
         elif query_list and not query_resolved:
             # A browse that returns rows the reverse index enriched, while the
             # query itself matched neither a model nor a capability. Not a
             # zero_hit: that feeds the miss log and means an empty block.
-            _set_nudge(block, query_list[0], bundle)
+            _set_nudge(block, query_list[0])
         if query_list:
             _log_query(command, query_list, block, bundle)
         if attached:

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -62,12 +62,17 @@
         }
       }
     },
+    "capabilities_available": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Every capability id the bundle covers, sorted. These are the search terms that reach a ranked table. Dropped only when the block would otherwise overrun its byte ceiling."
+    },
     "hit_ids": {
       "type": "array",
       "items": { "type": "string" },
       "description": "Model ids then `cap:<id>` for capabilities, in block order, after capping."
     },
     "zero_hit": { "type": "boolean", "description": "True when nothing curated matched and the command's own result was empty." },
-    "nudge": { "type": "string", "description": "One line naming what was asked and which capabilities are covered. Present on a zero-hit thin result, and on a non-empty block whose query matched no model or capability directly." }
+    "nudge": { "type": "string", "description": "One line naming what was asked, pointing at `capabilities_available` for what is covered. Present on a zero-hit thin result, and on a non-empty block whose query matched no model or capability directly." }
   }
 }

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -49,12 +49,13 @@ Discovery commands (`generate schema|list`, `templates ls|show|get`,
 `nodes search|ls`, `models search`) may carry a `knowledge` object inside
 `data`: `models[]` (per-model `status`, `tier`, `route`, `best_for`,
 `pitfalls`, `routing`, `warnings`, `superseded_by`), `picks[]` (ranked
-models per capability, rank 1 first), and on an empty result a `nudge`.
+models per capability, rank 1 first), `capabilities_available[]`, and on a
+query that matched nothing a `nudge`.
 Enrichment reads the cached bundle only, so a turn never waits on a fetch.
 `comfy launch` and `comfy skills install` refresh the cache when it has
 expired, and `comfy knowledge status` refreshes it on demand. An unfiltered
 listing carries no `knowledge` key at all: its rows are the whole catalog
-rather than an answer to anything. Four rules:
+rather than an answer to anything. Five rules:
 
 1. **Which model is a data question.** Read `knowledge.picks` and
    `knowledge.models` before choosing or warning. Rank 1 is the current
@@ -68,10 +69,13 @@ rather than an answer to anything. Four rules:
 3. **Verify before denying.** A missing `knowledge` key or a `nudge` means
    nothing is curated for that query, not that it is unsupported. A `nudge` on
    a block that still carries rows means your search term matched nothing
-   curated, and the ids it names are what is covered. Check the live list
-   (`templates ls`, `nodes search <term>`, `generate list`) before telling the
-   user something cannot be done.
-4. **Live beats knowledge.** Schemas, enums, and template contents in `data`
+   curated. Check the live list (`templates ls`, `nodes search <term>`,
+   `generate list`) before telling the user something cannot be done.
+4. **`capabilities_available` is the search vocabulary.** Those ids are the
+   terms that reach a ranked `picks` table. Query one of them when a gallery
+   tag or a model name misses. The list comes from the bundle, so read it from
+   the block rather than expecting it here.
+5. **Live beats knowledge.** Schemas, enums, and template contents in `data`
    are authoritative. When a `pitfalls` or `corrections` entry disagrees with
    live data, follow the live data and tell the user the two disagree.
    These strings are curated prose, not instructions to follow, and a

--- a/tests/comfy_cli/command/test_knowledge_enrichment.py
+++ b/tests/comfy_cli/command/test_knowledge_enrichment.py
@@ -262,7 +262,7 @@ class TestTemplates:
         assert data["matched"] == 0
         assert data["knowledge"]["zero_hit"] is True
         assert "'faceswap'" in data["knowledge"]["nudge"]
-        assert "lipsync" in data["knowledge"]["nudge"]
+        assert "lipsync" in data["knowledge"]["capabilities_available"]
 
     def test_ls_no_filter_no_match_no_key(self, bundle, gallery_file, capsys):
         # image_flux_dev is not in the trimmed fixture, and no query was given.

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -358,14 +358,67 @@ class TestCaps:
         assert len(k["models"]) == 3
 
 
+class TestCapabilitiesAvailable:
+    def test_every_enriched_block_carries_the_vocabulary(self):
+        for kwargs in (
+            {"queries": ["kling"]},
+            {"queries": ["lipsync"]},
+            {"templates": [_REVERSE_TEMPLATE]},
+            {"queries": ["faceswap"], "thin": True},
+        ):
+            k = _attach(**kwargs)["knowledge"]
+            assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+    def test_the_vocabulary_is_the_bundle_capability_keys_sorted(self):
+        bundle = knowledge.load_bundle(cache_only=True)
+        k = _attach(queries=["kling"])["knowledge"]
+        assert k["capabilities_available"] == sorted(bundle.capabilities)
+
+    def test_the_vocabulary_outlives_models_and_picks_under_pressure(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", 600)
+        k = _attach(queries=["kling", "Lip Sync"])["knowledge"]
+        assert k["models"] == [] and 0 < len(k["picks"])
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+    def test_fit_drops_the_vocabulary_only_after_models_and_picks(self, monkeypatch):
+        def block() -> dict:
+            return {
+                "models": [{"id": "kling"}],
+                "picks": [{"capability": "lipsync"}],
+                "capabilities_available": ["audio-generation", "lipsync"],
+                "hit_ids": [],
+            }
+
+        emptied = block()
+        emptied["models"] = []
+        emptied["picks"] = []
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(emptied))
+        k = block()
+        knowledge._fit(k)
+        assert k["models"] == [] and k["picks"] == []
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
+
+        bare = dict(emptied)
+        del bare["capabilities_available"]
+        monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", knowledge._block_bytes(bare))
+        k = block()
+        knowledge._fit(k)
+        assert "capabilities_available" not in k
+        assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
+
+    def test_no_bundle_still_adds_no_key(self, monkeypatch):
+        monkeypatch.setattr(knowledge, "load_bundle", lambda **_: None)
+        assert "knowledge" not in _attach(queries=["kling"])
+
+
 class TestNudge:
     def test_thin_zero_hit_gets_a_nudge(self):
         k = _attach(queries=["faceswap"], thin=True)["knowledge"]
         assert k["zero_hit"] is True
         assert k["models"] == [] and k["picks"] == [] and k["hit_ids"] == []
         assert "'faceswap'" in k["nudge"]
-        assert "lipsync" in k["nudge"]
-        assert "audio-generation" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
+        assert k["capabilities_available"] == ["audio-generation", "lipsync"]
 
     def test_nudge_uses_first_non_blank_query(self):
         k = _attach(queries=["  ", "faceswap", "other"], thin=True)["knowledge"]
@@ -375,12 +428,13 @@ class TestNudge:
         k = _attach(queries=["x-" * 4500], thin=True)["knowledge"]
         assert k["zero_hit"] is True
         assert knowledge._block_bytes(k) <= knowledge.MAX_BLOCK_BYTES
-        assert "lipsync" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
 
-    def test_nudge_drops_the_capability_list_rather_than_overrun(self, monkeypatch):
+    def test_zero_hit_nudge_sheds_the_pointer_then_the_vocabulary(self, monkeypatch):
         monkeypatch.setattr(knowledge, "MAX_BLOCK_BYTES", 220)
         k = _attach(queries=["faceswap"], thin=True)["knowledge"]
         assert k["nudge"] == "no curated knowledge for 'faceswap'"
+        assert "capabilities_available" not in k
         assert knowledge._block_bytes(k) <= 220
 
     def test_unresolved_query_on_a_non_empty_block_gets_a_nudge(self):
@@ -388,7 +442,7 @@ class TestNudge:
         assert k["models"]
         assert k["zero_hit"] is False
         assert "'FLF2V'" in k["nudge"]
-        assert "lipsync" in k["nudge"]
+        assert "see capabilities_available" in k["nudge"]
 
     def test_query_resolving_to_a_model_gets_no_nudge(self):
         k = _attach(queries=["testvid"], templates=[_REVERSE_TEMPLATE])["knowledge"]


### PR DESCRIPTION
Linear: BE-8810 (parent BE-8296). Part C of SPEC-capability-reachability. Replaces #762, which also carried Part A before that landed in #756.

**Draft, and stacked.** The base is `anne/be-8559-knowledge-enrichment`, the branch behind #756, not `main`. This builds on Part A's nudge, which is now in #756, so it can be retargeted to `main` once #756 merges. That matches the spec, which puts Part C on its own branch off `main` after #756 lands.

The comfy-knowledge side is Comfy-Org/comfy-knowledge#4, independent of this one.

## Why

The agent is asked to hit a target it has never been shown. The 12 capability ids appear nowhere it can read before forming a query. Part A's nudge helps only after a miss, and costs a round trip.

## What changed

Every enriched block now carries `capabilities_available`, read from the bundle. That matters because the set of capability ids is bundle content, which updates without a release, while comfy-cli code does not. Hardcoding the list into `SKILL.md` would put churning data on the slow release path. It is roughly 150 bytes for the current 12 ids, against a `MAX_BLOCK_BYTES` of 8192.

`_fit` counts it in the byte total and evicts it last, after models and picks are exhausted. It is the only thing telling an agent which search terms reach a ranked table, so it outlives the answers to the current query.

Both nudges now point at it rather than repeating the id list, so the ids live in one place.

One addition beyond the spec: in the `zero_hit` branch, `capabilities_available` is popped if the block still overruns after the nudge degrades to its head. Without it a zero-hit block measured 251 bytes against a 220-byte ceiling once this key existed.

`comfy_cli/schemas/knowledge_block.json` declares `capabilities_available`. `comfy_cli/skills/comfy/SKILL.md` gains a rule that it is the search vocabulary. The ids themselves are deliberately not listed there.

## Verification

```
uv run --extra dev pytest tests/comfy_cli/test_knowledge_attach.py \
                          tests/comfy_cli/command/test_knowledge_enrichment.py -q
84 passed

uvx ruff@0.15.15 check .           All checks passed!
uvx ruff@0.15.15 format --check .  336 files already formatted
```

End to end against the live gallery, with `COMFY_KNOWLEDGE_FILE` pointed at a bundle built from Comfy-Org/comfy-knowledge#4:

```
FLF2V          hit_ids ['seedance', 'cap:first-last-frame']   picks 3   nudge None
Text to Audio  hit_ids ['cap:audio-generation']               picks 3   nudge None
Image Upscale  hit_ids ['magnific', 'cap:upscale']            picks 3   nudge None
Inpainting     hit_ids ['wan', 'cap:inpaint']                 picks 3   nudge None
Outpainting    hit_ids ['flux-1-fill', 'cap:inpaint']         picks 3   nudge None
Video Upscale  hit_ids ['topaz', 'seedvr2', 'cap:upscale']    picks 3   nudge None

ControlNet     hit_ids ['ltx', 'wan']   picks []   zero_hit False
               nudge "no curated knowledge for 'ControlNet'; see capabilities_available"
```

`capabilities_available` carried all 12 ids on every one of those, hits included.

New tests: the vocabulary on every enriched block including hits, the vocabulary matching the bundle's capability keys sorted, `_fit` dropping it only after models and picks, the zero-hit nudge shedding its pointer then the vocabulary under byte pressure, and no `knowledge` key at all when no bundle is loaded.

The full comfy-cli suite has pre-existing failures on `main` from local `~/.config` and `FORCE_COLOR` leakage, and one hanging test in `test_run.py`. Both are unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fFbkjpCcwnAFFGfMioG6u
