### PR TITLE
chore(hygiene): remove internal ticket IDs from comments and docstrings

### DIFF
--- a/.github/workflows/public-repo-hygiene.yml
+++ b/.github/workflows/public-repo-hygiene.yml
@@ -27,3 +27,7 @@ jobs:
       # REQUIRED, and must equal the `uses:` SHA above — the reusable asserts
       # they match, which is what pins the checker to the reviewed commit.
       workflows_ref: 4df9bf684ee45d5baf2a49d2068685ce780a8609
+      # `HAILUO-03` is MiniMax's Hailuo 03 model, named in the curated
+      # knowledge bundle and asserted in tests. It is a product name that
+      # happens to match the ticket-ID shape, not an internal reference.
+      ticket_allowlist: HAILUO-03

--- a/comfy_cli/cloud/billing.py
+++ b/comfy_cli/cloud/billing.py
@@ -11,8 +11,8 @@ The rules encoded here are not arbitrary. Two of them are scar tissue:
   to mask a positive component underneath it, reporting "$0.00" to users who
   had credits.
 * The trust guard exists because "$0.00 / Subscribe" was shown to paying
-  customers whose billing rows were mid-migration. When we
-  cannot confirm state, we say so instead of asserting a balance.
+  customers whose billing rows were mid-migration. When we cannot confirm
+  state, we say so instead of asserting a balance.
 """
 
 from __future__ import annotations

--- a/comfy_cli/cloud/billing.py
+++ b/comfy_cli/cloud/billing.py
@@ -11,7 +11,7 @@ The rules encoded here are not arbitrary. Two of them are scar tissue:
   to mask a positive component underneath it, reporting "$0.00" to users who
   had credits.
 * The trust guard exists because "$0.00 / Subscribe" was shown to paying
-  customers whose billing rows were mid-migration (BE-1795 / BE-1798). When we
+  customers whose billing rows were mid-migration. When we
   cannot confirm state, we say so instead of asserting a balance.
 """
 
@@ -53,7 +53,7 @@ BALANCE_FIELDS = (
 
 # Shown when we cannot confirm a subscription OR a balance. Never paired with a
 # "$0.00" figure: asserting zero to a customer who is mid-migration is the
-# exact BE-1798 failure this replaces.
+# exact failure this replaces.
 UNCONFIRMED_MESSAGE = (
     "Couldn't confirm an active subscription or balance for this workspace. "
     "If you already subscribe, your account may be mid-migration; contact Comfy support. "

--- a/comfy_cli/cloud/command.py
+++ b/comfy_cli/cloud/command.py
@@ -269,7 +269,7 @@ def whoami_cmd():
 
 
 # ---------------------------------------------------------------------------
-# status (billing / plan / concurrency)
+# status commands - billing, plan, concurrency
 # ---------------------------------------------------------------------------
 
 # Billing payloads are small objects. The cap only exists to bound memory on a

--- a/comfy_cli/comfy_client.py
+++ b/comfy_cli/comfy_client.py
@@ -580,7 +580,7 @@ def extract_output_entries(record: dict) -> list[dict]:
     outputs. This deliberately covers keys beyond the classic
     ``images/gifs/videos/audio/files`` — notably SaveGLB's ``"3d"`` key and
     the cloud worker's singular ``"video"`` key — so 3D/mesh jobs resolve
-    instead of returning ``download_no_outputs`` (BE-4417). The ``"animated"``
+    instead of returning ``download_no_outputs``. The ``"animated"``
     key is skipped explicitly to match core semantics (it emits ``(True,)``
     boolean flags, not file entries).
 

--- a/comfy_cli/command/_cloud_errors.py
+++ b/comfy_cli/command/_cloud_errors.py
@@ -1,4 +1,4 @@
-"""Shared cloud HTTP/URL error → structured-envelope mapping (BE-3266).
+"""Shared cloud HTTP/URL error → structured-envelope mapping.
 
 ``comfy workflow`` and ``comfy jobs`` both talk to Comfy Cloud over ``urllib``
 and must turn transport failures into the same structured error envelopes. This

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -2541,7 +2541,7 @@ def _cloud_status_snapshot(prompt_id: str) -> dict | None:
     # `execution_error` left on a retried-then-succeeded job would otherwise
     # fabricate an `error` row on a green one. `canceled` is spelled out
     # alongside `_ERROR_STATUSES` because the state map above deliberately
-    # leaves cloud's one-l spelling unmapped (BE-6612).
+    # leaves cloud's one-l spelling unmapped.
     failed = state in _ERROR_STATUSES or state == "canceled"
     # The structured record wins over `error_message` when the server sent
     # one: a deployment that fills `error_message` with a short generic string

--- a/comfy_cli/command/launch.py
+++ b/comfy_cli/command/launch.py
@@ -41,7 +41,7 @@ def _hard_exit(code: int) -> None:
     so `comfy_cli.tracking`'s shutdown drain never runs here. That cost nothing
     while Mixpanel sent inline from `track()`: `@track_command` fires the
     `launch` event *before* the command body runs, so it was already delivered.
-    Now that dispatch is queue-and-drain (BE-5868) the event is still queued at
+    Now that dispatch is queue-and-drain the event is still queued at
     this point, and without an explicit drain every `comfy launch` — background
     success included — silently drops its own telemetry.
 

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -87,7 +87,7 @@ def _get_graph(
     # honor it), so callers that do resolve it upstream. Without this, an agent
     # discovering nodes here would read a different server's object_info than the
     # one `comfy run` submits to whenever ComfyUI was launched in the background
-    # on a non-default port (BE-6299).
+    # on a non-default port.
     if input_path is None and mode == "local":
         from comfy_cli.host_port import report_usage_error, resolve_host_port
 

--- a/comfy_cli/command/run/__init__.py
+++ b/comfy_cli/command/run/__init__.py
@@ -106,16 +106,16 @@ def _stdin_is_interactive() -> bool:
     ``pythonw`` contexts ``sys.stdin`` can be ``None``, closed, or backed by a
     revoked file descriptor. Treat every such case as non-interactive so the
     spend gate falls through to the fail-closed machine-mode error instead of
-    raising an uncontrolled exception (BE-4326). Delegates to the shared
+    raising an uncontrolled exception. Delegates to the shared
     fail-safe probe so stdin and stdout are guarded identically.
     """
     return stream_is_tty(getattr(sys, "stdin", None))
 
 
 def _spend_gate(renderer, partner_nodes: list[str], allow_spend: bool, *, details: dict) -> None:
-    """Consent interlock for partner-API (paid) nodes (BE-4326).
+    """Consent interlock for partner-API (paid) nodes.
 
-    Mirrors the ``comfy run-template`` gate (BE-4113): a workflow that embeds
+    Mirrors the ``comfy run-template`` gate: a workflow that embeds
     partner-API nodes (Veo/Kling/BFL/Gemini/…) spends Comfy credits when it
     runs, so require explicit consent before submitting. A no-op when there are
     no partner nodes or ``--allow-spend`` was passed, so partner-free runs are
@@ -341,7 +341,7 @@ def execute(
         return
 
     partner_nodes = _detect_partner_nodes(workflow, object_info)
-    # Spend gate (BE-4326): partner-API nodes spend Comfy credits. Require
+    # Spend gate: partner-API nodes spend Comfy credits. Require
     # explicit consent before resolving a credential or submitting. Fires
     # BEFORE _resolve_partner_credential() below so a refusal never triggers a
     # network OAuth refresh. Detection stays fail-open (object_info == {} → no
@@ -366,7 +366,7 @@ def execute(
         # turned away are still counted: that funnel is exactly what the metric
         # is for, and `credential_present: False` marks them. class_types are
         # node names, not PII — the same data `workflow_unknown_nodes` reports.
-        # It does sit AFTER the BE-4326 spend gate, so a run refused for lack of
+        # It does sit AFTER the spend gate, so a run refused for lack of
         # `--allow-spend` emits no event: the gate deliberately precedes any
         # credential resolution (a refusal must not trigger a network OAuth
         # refresh), and `credential_present` needs that resolution. The
@@ -997,7 +997,7 @@ def execute_cloud(
             # Deliberately `_load_from_target`, not `resilient_load_object_info`:
             # the resilient loader resolves a Target to build its cache key, and
             # the spend gate below must fire before ANY cloud credential is
-            # resolved (BE-4326) — `test_cloud_partner_node_machine_mode_fails_closed`
+            # resolved — `test_cloud_partner_node_machine_mode_fails_closed`
             # pins that. Trade-off: COMFY_OBJECT_INFO_FILE is honored on the
             # UI-conversion path above but not on this API-format fallback.
             from comfy_cli.cql.engine import _load_from_target
@@ -1038,7 +1038,7 @@ def execute_cloud(
     # Pre-submit validation via pure-Python CQL engine.
     _preflight_validate(renderer, parsed_workflow, cloud_object_info, target_label="cloud", where="cloud")
 
-    # Spend gate (BE-4326): the cloud also bills partner-API nodes, so apply the
+    # Spend gate: the cloud also bills partner-API nodes, so apply the
     # same consent interlock as the local path before authenticating/submitting.
     # Fail-open on detection (empty cloud object_info → no gate), and fire before
     # Client() so a refusal never triggers cloud auth.

--- a/comfy_cli/command/run/credentials.py
+++ b/comfy_cli/command/run/credentials.py
@@ -57,7 +57,7 @@ def _resolve_partner_credential() -> tuple[str, str] | None:
     except Exception:  # noqa: BLE001 — best-effort: never abort the run on a refresh hiccup
         # refresh=False reads the store as-is (no network, no lock): an expired
         # session fails its own expiry check and the resolver returns env/stored
-        # key — exactly the pre-BE-3361 behavior on this path.
+        # key — exactly the earlier behavior on this path.
         cred = resolve_cloud_credential(purpose="cloud", refresh=False, allow_clear=False)
     if cred is None:
         return None

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -124,7 +124,7 @@ def _load_gallery(
     its own filtering on top.
 
     A cache older than ``GALLERY_TTL_SECONDS`` is served immediately and
-    revalidated in the background (stale-while-revalidate, BE-3427): a stale
+    revalidated in the background (stale-while-revalidate): a stale
     cache is returned right away and a detached subprocess re-fetches it for
     the *next* invocation, so an offline/firewalled machine never blocks on the
     15s fetch timeout on every call. An explicit ``--refresh`` (or a genuinely
@@ -325,7 +325,7 @@ def _refresh_cwd() -> str | None:
 def _spawn_background_refresh() -> bool:
     """Kick off a detached subprocess that re-fetches the gallery index.
 
-    Serve-stale-while-revalidate (BE-3427): the caller has already returned the
+    Serve-stale-while-revalidate: the caller has already returned the
     stale cache, so this revalidation must never block or delay process exit —
     a firewalled machine would otherwise hang on the 15s fetch timeout on every
     invocation past the TTL. We spawn a fully detached ``comfy templates
@@ -1670,7 +1670,7 @@ def _enforce_spend_gate(
 
     Returns None when the run may proceed (no paid signals, --allow-spend, or
     an interactive yes); raises typer.Exit(1) otherwise. Behavior is the
-    BE-4113 gate moved verbatim out of run_template_cmd.
+    spend gate moved verbatim out of run_template_cmd.
     """
     import sys
 
@@ -1999,7 +1999,7 @@ def run_template_cmd(
             for w in warnings:
                 rprint(f"  [yellow]warning:[/yellow] {w}")
 
-    # -- Spend gate (BE-4113): partner-API nodes spend Comfy credits. Require
+    # -- Spend gate: partner-API nodes spend Comfy credits. Require
     # explicit consent before submitting anything that would burn them.
     _enforce_spend_gate(
         renderer,
@@ -2027,7 +2027,7 @@ def run_template_cmd(
             api_key=api_key,
             # run-template's own spend gate (above) has already consented (or
             # found no paid nodes), so forward consent to avoid a second gate in
-            # execute() (BE-4326). run-template's gate is strictly stronger — it
+            # execute(). run-template's gate is strictly stronger — it
             # also inspects gallery signals — and has already run.
             allow_spend=True,
         )

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -895,7 +895,7 @@ def _http_request(
 def _handle_cloud_http_error(renderer, e, *, operation: str, workflow_id: str | None = None) -> typer.Exit:
     """Map HTTP failures to envelope codes. Returns an Exit to ``raise from``.
 
-    Thin wrapper over the shared cloud-error mapper (BE-3266) that supplies the
+    Thin wrapper over the shared cloud-error mapper that supplies the
     ``workflow``-specific 404 envelope and the oversize/unparseable-response
     checks; everything else is shared with ``jobs``.
     """
@@ -1570,7 +1570,7 @@ def validate_api_workflow(
     # `config.background` step validate would consult whatever answers on the
     # default port while `run` submits to the background server comfy-cli
     # launched on another one, making the verdict meaningless for the server
-    # that will actually execute the workflow (BE-6299). `resolve_target` does
+    # that will actually execute the workflow. `resolve_target` does
     # not consult `config.background` on purpose (other callers, e.g. transfer
     # and system, must not), so — as its docstring says — the callers that do
     # honor it resolve upstream, here.

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -55,7 +55,7 @@ def _emit_edit_error(renderer, e: ValueError, *, hint: str) -> None:
     A :class:`workflow_ops.FatalFindingError` carries the catalog finding, so
     the envelope can name the offending ``value``, ``field``, ``valid_options``
     and ``did_you_mean`` as DETAILS rather than burying them in prose a caller
-    has to regex (BE-7215). Any other ValueError keeps the previous shape.
+    has to regex. Any other ValueError keeps the previous shape.
     """
     if isinstance(e, workflow_ops.FatalFindingError):
         f = e.finding

--- a/comfy_cli/command_mentions.py
+++ b/comfy_cli/command_mentions.py
@@ -166,7 +166,7 @@ def check_mention(
             resolved = f"{resolved} {token}"
             continue
         if subs:
-            # A group with no such subcommand: this is the BE-2996 auth-login
+            # A group with no such subcommand: this is the auth-login
             # bug — the word reads as a subcommand but is really an unparsed
             # positional the group will reject.
             return Violation(mention=mention, resolved=resolved, unknown_token=token)

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -251,7 +251,7 @@ class Port:
     def validate_catalog(self, value: Any) -> list[dict]:
         """Catalog findings for ``value``. Returns a list of finding dicts.
 
-        Every finding carries ``code``, ``severity`` and ``value`` (BE-7215):
+        Every finding carries ``code``, ``severity`` and ``value``:
         ``severity`` so a caller never infers fatality from prose, and ``value``
         so the offending operand is a field rather than something to regex back
         out of ``message``. Fatal codes are :data:`FATAL_FINDING_CODES`.
@@ -408,7 +408,7 @@ _WILDCARD_TYPE_PREFIX = "COMFY_MATCHTYPE"
 _WILDCARD_TYPES = frozenset({"*"})
 
 
-# Finding severity — BE-7215. Every catalog finding carries an explicit
+# Finding severity. Every catalog finding carries an explicit
 # ``severity`` so a consumer never has to infer fatality from prose. The rule the
 # codes below encode: a finding is an ERROR when the value cannot resolve at run
 # time, which is precisely when `Graph.validate_workflow` already refuses it
@@ -882,7 +882,7 @@ class Graph:
     def node(self, name: str) -> Morphism | None:
         # A malformed workflow can supply an unhashable class_type (list/dict);
         # dict.get on an unhashable key raises TypeError, so screen it out here
-        # rather than crash the reachability walk / lookups (BE-3406 hardening).
+        # rather than crash the reachability walk / lookups.
         if not isinstance(name, str):
             return None
         return self._nodes.get(name)
@@ -1465,7 +1465,7 @@ class Graph:
             # Required-presence checks apply only to output-reachable nodes: the
             # server prunes unreachable nodes without validating them, so
             # enforcing required inputs on a disconnected node over-rejects a
-            # prompt the server would run (BE-3406).
+            # prompt the server would run.
             if node_id in reachable:
                 errors.extend(_check_autogrow_required(node_id, autogrow_ports, autogrow_seen, node_data))
                 errors.extend(_check_required_present(node_id, m, node_data))
@@ -1737,7 +1737,7 @@ def _validate_catalog_value(
     errors (the server rejects them); every other catalog finding is a
     namespaced warning.
 
-    ``range_is_error`` gates the below_min/above_max promotion (BE-3406): the
+    ``range_is_error`` gates the below_min/above_max promotion: the
     server only range-checks nodes it actually runs, so on a pruned
     (output-unreachable) node these are demoted back to advisory warnings.
     """

--- a/comfy_cli/output/panels.py
+++ b/comfy_cli/output/panels.py
@@ -288,7 +288,7 @@ def cloud_status_panel(*, payload: Mapping[str, Any], version: str, show_plans: 
     anything, so the human surface and the JSON surface cannot disagree. In
     particular the trust guard is honored upstream: when ``balance_confirmed``
     is false the balance keys are null and this function prints no figure at
-    all, which is the whole point of BE-1798.
+    all, which is the whole point of the guard.
 
     Server-supplied strings (workspace name, plan slugs, the message) go
     through ``Text`` or ``sanitize_markup`` so a crafted name cannot inject

--- a/comfy_cli/target.py
+++ b/comfy_cli/target.py
@@ -108,7 +108,7 @@ def resolve_target(
 
     # Local — resolve host/port by precedence: explicit flag > COMFY_LOCAL_URL
     # env > 127.0.0.1:8188. host/port may be None here; callers that also honor
-    # a persisted background server (run/jobs, and validate/nodes since BE-6306)
+    # a persisted background server (run/jobs, and validate/nodes)
     # resolve that upstream via host_port.resolve_host_port before reaching us.
     from comfy_cli.env_checker import _bracket_host
     from comfy_cli.local_address import resolve_local_host_port

--- a/comfy_cli/tracking.py
+++ b/comfy_cli/tracking.py
@@ -324,16 +324,16 @@ class MixpanelProvider:
 
             # mixpanel-python's default Consumer uses request_timeout=None → an
             # unbounded, synchronous requests.post, so a blackholed telemetry
-            # endpoint (accepts TCP, never responds) hangs whichever thread sends
-            # (BE-3354/BE-3403). Sends now happen on the worker below rather than
+            # endpoint (accepts TCP, never responds) hangs whichever thread sends.
+            # Sends now happen on the worker below rather than
             # the caller's thread, so this bound caps how long ONE send can occupy
             # the queue — and with it, how much of the atexit drain's shared 5s
             # deadline a single in-flight event can consume. retry_limit=1
             # (default is 4 with backoff) keeps a blackholed send to a single ~10s
             # attempt instead of ~40s+ across retries.
             self.client = Mixpanel(token, consumer=MixpanelConsumer(request_timeout=10, retry_limit=1))
-            # Dispatch is queue-and-drain so track() never blocks the caller
-            # (BE-5868): @track_command fires its event *before* running the
+            # Dispatch is queue-and-drain so track() never blocks the caller:
+            # @track_command fires its event *before* running the
             # wrapped command body, and `run` fires execution_start before
             # submitting the workflow, so an inline send put a synchronous HTTP
             # round-trip on the hot path of every consented invocation.
@@ -348,7 +348,7 @@ class MixpanelProvider:
             self._drained = threading.Condition()
             # daemon=True with NO atexit hook of our own, and no shutdown
             # sentinel: `_flush_all_providers` is the single bounded shutdown
-            # drain path (BE-3403), and the worker just dies with the process.
+            # drain path, and the worker just dies with the process.
             # Constructed lazily on the first dispatched event (`_get_providers`
             # is only reached from `_dispatch`), so a run that sends nothing —
             # `comfy --help`, shell completion, no consent — never starts it.
@@ -471,14 +471,14 @@ class PostHogProvider:
         # max_retries/timeout tighten the consumer drain budget from the posthog
         # 7.x defaults (3 × 15s ≈ 50s worst case) to ~21s, so the atexit flush
         # can't linger on a blackholed endpoint after the terminal envelope is
-        # already on stdout (BE-3354/BE-3403).
+        # already on stdout.
         self.client = Posthog(project_api_key=token, host=host, disable_geoip=False, max_retries=1, timeout=10)
         # Posthog's constructor registers its own atexit.register(self.join),
         # which runs self.join() synchronously on the main thread at shutdown —
         # independently of _flush_all_providers and NOT bounded by its daemon
         # deadline. Against a blackholed endpoint that join can still block ~21s
         # after the terminal envelope is on stdout, defeating this change. Drop it
-        # so our bounded flush is the only shutdown drain path (BE-3403).
+        # so our bounded flush is the only shutdown drain path.
         atexit.unregister(self.client.join)
         self.enabled = True
 
@@ -818,7 +818,7 @@ def _flush_all_providers() -> None:
         return
     # Telemetry is best-effort by contract: a blackholed endpoint (accepts TCP,
     # never responds) must never let this atexit hook wedge every consumer of the
-    # CLI's stdout after the terminal envelope is already emitted (BE-3329/BE-3403).
+    # CLI's stdout after the terminal envelope is already emitted.
     # Start every provider's flush in a daemon thread, then join them all against
     # a SINGLE shared deadline so total exit delay stays ~5s regardless of how
     # many providers there are (a per-provider join would make it 5s × N).
@@ -847,7 +847,7 @@ def _flush_all_providers() -> None:
             # to the user's stderr *after* the terminal envelope. That is the one
             # thing this module refuses to do for a telemetry failure. It was
             # unreachable for Mixpanel while flush() was a no-op; it isn't now
-            # that flush() actually drains a queue (BE-5868).
+            # that flush() actually drains a queue.
             logging.debug(f"telemetry flush timed out for {type(provider).__name__}; dropping in-flight events")
 
 
@@ -858,7 +858,7 @@ def flush_for_hard_exit() -> None:
     and failure paths, so `_flush_all_providers` never runs there. That was
     harmless while MixpanelProvider sent inline from `track()` — the `launch`
     event was already delivered before the command body ran. Now that dispatch is
-    queue-and-drain (BE-5868) the event is still sitting in the queue at that
+    queue-and-drain the event is still sitting in the queue at that
     point, so those paths have to drain explicitly or drop it every time.
 
     Bounded by the same `_FLUSH_DEADLINE_SECONDS` budget as the atexit hook, and

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -2048,7 +2048,7 @@ def _max_id(values) -> int:
 
 
 def complete_save_format(workflow: dict) -> dict:
-    """Fill the save-format keys a consumer is entitled to assume (BE-7215).
+    """Fill the save-format keys a consumer is entitled to assume.
 
     We emitted ``{nodes, links, last_node_id}`` and omitted ``version`` and
     ``last_link_id``. The frontend's ``validateComfyWorkflow`` zod schema
@@ -2133,7 +2133,7 @@ def _widget_index(graph, class_type: str, widget: str, widgets_values=None) -> i
 
 
 class FatalFindingError(ValueError):
-    """A catalog finding the server will reject — the edit is refused (BE-7215).
+    """A catalog finding the server will reject — the edit is refused.
 
     Carries the finding verbatim so the command layer can emit ``code``,
     ``value``, ``field`` and ``did_you_mean`` as ENVELOPE FIELDS. Previously

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -467,7 +467,7 @@ op log exists to keep.
   `DEFERRED_OPS` / `BATCHABLE_OPS`, the dispatch tables, and this document in
   one commit — `tests/comfy_cli/test_op_vocabulary_contract.py` fails otherwise.
 
-## 10. Amendment v1.1 — 2026-08-12 (V1-038 / BE-7171)
+## 10. Amendment v1.1 — 2026-08-12 (V1-038)
 
 **`reset_doc` is un-deferred.** `DEFERRED_OPS` is now empty; `apply_op`
 dispatches `reset_doc` and `apply_specs` rejects it as standalone-only with its

--- a/tests/comfy_cli/cloud/test_client.py
+++ b/tests/comfy_cli/cloud/test_client.py
@@ -738,7 +738,7 @@ class TestOutputUrls:
 
     def test_extract_resolves_saveglb_3d_key(self):
         """SaveGLB emits entries under the "3d" key, not the classic media
-        keys — shape-based detection must still resolve them (BE-4417)."""
+        keys — shape-based detection must still resolve them."""
         record = {"outputs": {"10": {"3d": [{"filename": "abc123.glb", "subfolder": "3d", "type": "output"}]}}}
         assert comfy_client.extract_output_entries(record) == [
             {"node_id": "10", "filename": "abc123.glb", "subfolder": "3d", "type": "output"}

--- a/tests/comfy_cli/cloud/test_status_command.py
+++ b/tests/comfy_cli/cloud/test_status_command.py
@@ -10,7 +10,7 @@ The two display rules with history behind them get the most coverage:
 
 * the zero-masking balance chain, where a present-but-zero high-priority field
   must not mask a positive component below it;
-* the trust guard (BE-1795 / BE-1798), where an all-silent backend must produce
+* the trust guard, where an all-silent backend must produce
   neutral copy instead of "$0.00 / Subscribe".
 """
 
@@ -464,7 +464,7 @@ def test_unconfirmed_payload_also_validates(monkeypatch, capsys):
 def test_pretty_mode_renders_without_asserting_a_balance(monkeypatch, capsys):
     """The panel must not print a dollar figure for an unconfirmed workspace.
 
-    This is the BE-1798 regression in its original surface: the JSON payload
+    This is the regression in its original surface: the JSON payload
     withholding the number is only half the fix if the panel prints one anyway.
     """
     _install(

--- a/tests/comfy_cli/command/generate/conftest.py
+++ b/tests/comfy_cli/command/generate/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _auto_confirm_spend():
-    """Pre-authorize the credit-spend gate (BE-4103) for generate tests.
+    """Pre-authorize the credit-spend gate for generate tests.
 
     Most tests in this package exercise behavior *downstream* of the consent
     interlock, and under CliRunner there is no TTY — without this, every

--- a/tests/comfy_cli/command/generate/test_app.py
+++ b/tests/comfy_cli/command/generate/test_app.py
@@ -83,7 +83,7 @@ def test_list_partner_filter(runner):
 
 
 def test_list_json_emits_parseable_models(runner):
-    """--json is an `envelope/1` on stdout, never a Rich table (BE-4933).
+    """--json is an `envelope/1` on stdout, never a Rich table.
     Full envelope/schema coverage lives in test_list_schema_envelope.py."""
     import json
 
@@ -132,7 +132,7 @@ def test_list_query_filter(runner):
 
 
 def test_list_no_matches(runner):
-    # --no-json pins pretty mode: CliRunner has no TTY, and since BE-4933 a
+    # --no-json pins pretty mode: CliRunner has no TTY, and a
     # non-TTY `generate list` resolves to the JSON envelope like every other
     # renderer-backed command.
     r = runner.invoke(cli_app, ["--no-json", "generate", "list", "--partner", "nonexistent"])
@@ -507,7 +507,7 @@ def test_refresh_invalid_body_exits_and_leaves_cache_untouched(runner, monkeypat
 
 
 def test_refresh_fetches_openapi_path(runner, monkeypatch, tmp_path):
-    """Regression (BE-2982): comfy-api serves the spec at `<base_url>/openapi`
+    """Regression: comfy-api serves the spec at `<base_url>/openapi`
     (JSON), not `/openapi.yml` (which 404s). Assert `_refresh()` hits `/openapi`."""
     captured = {}
 
@@ -545,7 +545,7 @@ def test_refresh_fetches_openapi_path(runner, monkeypatch, tmp_path):
 
 
 def test_refresh_rejects_non_spec_body(runner, monkeypatch, tmp_path):
-    """Regression (BE-2982): `/openapi` is followed through redirects and cached
+    """Regression: `/openapi` is followed through redirects and cached
     for 7 days, so a non-spec 200 (HTML interstitial, redirect landing page, JSON
     array/scalar) must be refused rather than poison the cache for a week."""
     cache = tmp_path / "openapi-cache.yml"

--- a/tests/comfy_cli/command/generate/test_app_lifecycle.py
+++ b/tests/comfy_cli/command/generate/test_app_lifecycle.py
@@ -1,4 +1,4 @@
-"""Execution lifecycle + sub-action event tests for ``comfy generate`` (MAR-52)."""
+"""Execution lifecycle + sub-action event tests for ``comfy generate``."""
 
 import httpx
 import pytest

--- a/tests/comfy_cli/command/generate/test_json_errors.py
+++ b/tests/comfy_cli/command/generate/test_json_errors.py
@@ -58,7 +58,7 @@ def _sole_envelope(result) -> dict:
     return env
 
 
-# ─── the BE-4571 case: a flag token where the model alias belongs ────────
+# ─── the flag-token case: a flag token where the model alias belongs ────────
 
 
 def test_json_flag_shaped_target_emits_target_required_envelope(runner):

--- a/tests/comfy_cli/command/generate/test_list_schema_envelope.py
+++ b/tests/comfy_cli/command/generate/test_list_schema_envelope.py
@@ -1,4 +1,4 @@
-"""``comfy generate list`` / ``comfy generate schema`` emit ``envelope/1`` (BE-4933).
+"""``comfy generate list`` / ``comfy generate schema`` emit ``envelope/1``.
 
 These are the two discovery verbs an agent needs before it can run a partner
 model: one enumerates the aliases, the other gives a model's parameters. Both

--- a/tests/comfy_cli/command/generate/test_spec.py
+++ b/tests/comfy_cli/command/generate/test_spec.py
@@ -189,7 +189,7 @@ def test_unknown_model_no_family_still_helpful(monkeypatch):
 
 @pytest.mark.parametrize("text", ["1e+16", "1e-07", "-2e+5"])
 def test_pointless_exponent_parses_as_float(text):
-    """Regression (BE-2982): the spec is now fetched as JSON, and `json.dumps`
+    """Regression: the spec is now fetched as JSON, and `json.dumps`
     emits exponents without a decimal point for very large/small floats. PyYAML's
     YAML 1.1 resolver leaves those as strings, which would leak into flag schemas.
     """

--- a/tests/comfy_cli/command/generate/test_spend_gate.py
+++ b/tests/comfy_cli/command/generate/test_spend_gate.py
@@ -1,4 +1,4 @@
-"""Spend-gate tests for ``comfy generate`` (BE-4103).
+"""Spend-gate tests for ``comfy generate``.
 
 A generation call spends Comfy credits, so the proxy call sits behind a
 consent interlock: interactive TTY runs prompt first, ``--yes`` or the

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -256,7 +256,7 @@ class TestGitOperations:
 
         calls = mock_subprocess.call_args_list
         # git is spawned by its resolved absolute path, never the bare name
-        # Windows' CreateProcess would look up in the CWD first (BE-5358).
+        # Windows' CreateProcess would look up in the CWD first.
         for call in calls:
             argv0 = call[0][0][0]
             assert os.path.isabs(argv0), argv0

--- a/tests/comfy_cli/command/models/test_search.py
+++ b/tests/comfy_cli/command/models/test_search.py
@@ -95,12 +95,12 @@ _CLOUD_FILES_LORAS = [
 ]
 
 
-# A local install as BE-4733 found it: the interesting models (flux, ltx) live
+# A local install as the bug report found it: the interesting models (flux, ltx) live
 # OUTSIDE `checkpoints`, spread across diffusion_models / loras / vae.
 _LOCAL_SEARCH_FOLDERS = ["checkpoints", "diffusion_models", "loras", "vae"]
 
 _LOCAL_FILES_BY_FOLDER: dict[str, list[dict[str, Any]]] = {
-    # BE-5619: real checkpoint filenames — the separators (`_`, `-`, `.`) and the
+    # Real checkpoint filenames — the separators (`_`, `-`, `.`) and the
     # word order are what a whole-string substring match cannot cope with.
     "checkpoints": [
         {"name": "sd_xl_base_1.0.safetensors", "pathIndex": 0},
@@ -545,12 +545,12 @@ class TestSearch:
         _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "flux", "--where", "local"], capsys)
         names = [r["name"] for r in env["data"]["rows"]]
-        # BE-4733: flux lives in diffusion_models, not checkpoints — it must still be found.
+        # Flux lives in diffusion_models, not checkpoints — it must still be found.
         assert names == ["flux1-dev.safetensors"]
         assert env["data"]["rows"][0]["type"] == "diffusion_models"
 
     def test_local_text_matches_across_folders(self, local_target, monkeypatch, capsys):
-        """BE-4733: every on-disk ltx* file is returned, whatever folder it lives in."""
+        """Every on-disk ltx* file is returned, whatever folder it lives in."""
         _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "ltx", "--where", "local"], capsys)
         rows = env["data"]["rows"]
@@ -577,7 +577,7 @@ class TestSearch:
         ],
     )
     def test_local_text_is_token_and_separator_insensitive(self, local_target, monkeypatch, capsys, query):
-        """BE-5619: multi-word queries match `sd_xl_base_1.0.safetensors`.
+        """Multi-word queries match `sd_xl_base_1.0.safetensors`.
 
         None of these exist as a contiguous substring of the filename — the old
         whole-string test returned nothing for every one of them.
@@ -605,7 +605,7 @@ class TestSearch:
         the `x`/`l` seam. Deliberate: the squashed pass is what makes `sdxl` find
         `sd_xl_...`, and the same collapse cannot distinguish a seam from a real
         word boundary. Over-returning on a short token is the acceptable side of
-        this trade — under-returning is the bug BE-4733 reported.
+        this trade — under-returning is the reported bug.
         """
         _patch_urlopen(monkeypatch, _local_routes())
         env = _run(["search", "--text", "xl", "--where", "local"], capsys)

--- a/tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py
+++ b/tests/comfy_cli/command/nodes/test_restore_snapshot_fast_deps.py
@@ -1,4 +1,4 @@
-"""Tests for `comfy node restore-snapshot --fast-deps` (issue #217, BE-4276).
+"""Tests for `comfy node restore-snapshot --fast-deps` (issue #217).
 
 cm_cli's `restore-snapshot` accepts `--uv-compile` but NOT `--no-deps`, so the
 DependencyCompiler-based fast path used by `install`/`reinstall` is unavailable

--- a/tests/comfy_cli/command/test_cloud_errors.py
+++ b/tests/comfy_cli/command/test_cloud_errors.py
@@ -1,4 +1,4 @@
-"""Unit tests for the shared cloud error → envelope mapper (BE-3266)."""
+"""Unit tests for the shared cloud error → envelope mapper."""
 
 from __future__ import annotations
 

--- a/tests/comfy_cli/command/test_launch_stop_envelope.py
+++ b/tests/comfy_cli/command/test_launch_stop_envelope.py
@@ -1,4 +1,4 @@
-"""Envelope emission for the ``launch`` / ``stop`` lifecycle commands (BE-4273).
+"""Envelope emission for the ``launch`` / ``stop`` lifecycle commands.
 
 Unlike other subcommands, ``comfy launch`` / ``comfy stop`` historically emitted
 no ``envelope/1`` on stdout under ``--json``, so programmatic callers (e.g.

--- a/tests/comfy_cli/command/test_model_download_background.py
+++ b/tests/comfy_cli/command/test_model_download_background.py
@@ -765,7 +765,7 @@ class TestSubmitFailsFast:
     def test_unknown_scheme_never_detaches(self, workspace, no_spawn, monkeypatch, capsys):
         """An unrecognized source can't resolve a filename; under skip_prompting
         `ui.prompt_input` returns "" and the empty-filename guard fires — as an
-        `envelope/1` error (BE-4217), not a raw `DownloadException`."""
+        `envelope/1` error, not a raw `DownloadException`."""
         monkeypatch.setattr(models.ui, "prompt_input", lambda *a, **k: k.get("default", ""))
 
         with pytest.raises(typer.Exit) as exc:

--- a/tests/comfy_cli/command/test_nodes_cli.py
+++ b/tests/comfy_cli/command/test_nodes_cli.py
@@ -366,7 +366,7 @@ class TestNodesRefreshPublishedContract:
         assert {f["source"] for f in env["data"]["files"]} == {"bundled"}
 
 
-# local target resolution — config.background parity with `comfy run` (BE-6306)
+# local target resolution — config.background parity with `comfy run`
 # ---------------------------------------------------------------------------
 #
 # `comfy nodes` is the agent's node-discovery surface, so it must read the same
@@ -374,7 +374,7 @@ class TestNodesRefreshPublishedContract:
 # COMFY_LOCAL_URL > 127.0.0.1:8188, skipping the persisted `config.background`
 # step that `run`/`jobs` honor via `host_port.resolve_host_port` — so with
 # ComfyUI launched in the background on a non-default port, discovery listed a
-# different server's nodes than the one the workflow would execute on (BE-6299).
+# different server's nodes than the one the workflow would execute on.
 
 
 BACKGROUND_PORT = 8388

--- a/tests/comfy_cli/command/test_nodes_introspect.py
+++ b/tests/comfy_cli/command/test_nodes_introspect.py
@@ -540,7 +540,7 @@ class TestIsApiNodeRows:
 
 
 class TestPath:
-    """`comfy nodes path` — the envelope an agent plans a graph off (BE-6857)."""
+    """`comfy nodes path` — the envelope an agent plans a graph off."""
 
     @pytest.fixture
     def patched_loader(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/comfy_cli/command/test_nodes_path_emit_ops.py
+++ b/tests/comfy_cli/command/test_nodes_path_emit_ops.py
@@ -1,4 +1,4 @@
-"""Tests for ``comfy nodes path --emit-ops`` (V1-019 / BE-7152).
+"""Tests for ``comfy nodes path --emit-ops`` (V1-019).
 
 ``nodes path`` reports a plan (a routed node sequence); agents then hand-build
 the apply batch from it. ``--emit-ops`` closes that gap: each returned path

--- a/tests/comfy_cli/command/test_nodes_search_expand.py
+++ b/tests/comfy_cli/command/test_nodes_search_expand.py
@@ -1,4 +1,4 @@
-"""Tests for ``comfy nodes search --expand-top N`` (V1-017 / BE-7150).
+"""Tests for ``comfy nodes search --expand-top N`` (V1-017).
 
 The measured agent loop is search → show × N (the show args are ~92% a copy of
 the search hit). ``--expand-top N`` folds the show payload for the top-N hits

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -1,5 +1,5 @@
 """Server-supplied text must not reach the terminal live from *direct*
-``rich.print`` sites (BE-4794).
+``rich.print`` sites.
 
 ``comfy_cli.output.sanitize`` covers everything routed through ``Renderer``,
 but ``Renderer`` is not the only path to the terminal: command modules print
@@ -363,7 +363,7 @@ def test_models_list_folders_table_cells_are_inert(pretty, cloud_catalog):
 
 
 # ---------------------------------------------------------------------------
-# models/models.py — the download-server error text (BE-5023)
+# models/models.py — the download-server error text
 # ---------------------------------------------------------------------------
 #
 # `comfy model download --url <host>` renders whatever the host put in a failed
@@ -500,7 +500,7 @@ def test_download_status_row_error_with_unbalanced_markup_does_not_crash(pretty)
 
 
 # ---------------------------------------------------------------------------
-# jobs.py / system.py / workflow.py — `Table.add_row` cells (BE-6037)
+# jobs.py / system.py / workflow.py — `Table.add_row` cells
 # ---------------------------------------------------------------------------
 #
 # `sanitize.py` names `Table.add_row` as a markup-interpreting sink, and the

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -497,12 +497,12 @@ class TestExecuteErrorHandling:
             mock_exec.connect.assert_called_once()
             mock_exec.queue.assert_called_once()
             mock_exec.watch_execution.assert_called_once()
-            # The run WebSocket must be closed on the success path (BE-3404) —
+            # The run WebSocket must be closed on the success path —
             # the finally-block _safe_close, not left open until teardown.
             mock_exec.ws.close.assert_called_once()
 
     def test_websocket_closed_on_watch_failure(self, workflow_file):
-        # BE-3404: the finally-block close also fires when watch_execution
+        # The finally-block close also fires when watch_execution
         # raises, so a mid-run error doesn't linger the server-side session.
         with (
             patch("comfy_cli.command.run.check_comfy_server_running", return_value=True),
@@ -590,7 +590,7 @@ class TestExecuteErrorHandling:
 
 class TestWaitStateFile:
     """`comfy run --wait` writes the jobs state file at SUBMIT time, not only
-    on success (BE-4750) — so a server that dies mid-run still leaves an
+    on success — so a server that dies mid-run still leaves an
     on-disk record of the prompt that was in flight, and the emitted error
     names it."""
 
@@ -667,7 +667,7 @@ class TestWaitStateFile:
 
     def test_submit_time_record_carries_watcher_identity(self, workflow_file):
         """The foreground --wait process IS the watcher, and the submit-time
-        record says so (BE-6641): pid + create_time stamped exactly like the
+        record says so: pid + create_time stamped exactly like the
         detached watcher's, so a --wait process killed from outside leaves a
         record the stale-watcher reap can finalize instead of a permanent
         phantom `running`."""
@@ -1006,7 +1006,7 @@ class TestWaitStateFile:
 
 class TestCloudWaitWatcherStamp:
     """Cloud `--wait` polls from the foreground with no watcher subprocess, so
-    the submit-time record stamps THIS process as the watcher (BE-6641) — an
+    the submit-time record stamps THIS process as the watcher — an
     external kill then leaves a non-terminal record with a dead pid, which
     `jobs ls`'s stale-watcher reap finalizes as `watcher_crashed`. Every
     in-process exit writes a terminal record the reap ignores."""
@@ -1334,7 +1334,7 @@ class TestResolvePartnerCredential:
 
     def test_refreshes_and_uses_oauth_token(self, monkeypatch: pytest.MonkeyPatch):
         """A signed-in user whose access token lapsed gets a REFRESHED token
-        here — the whole point of BE-3361 — rather than being skipped and
+        here — the whole point of the refresh fix — rather than being skipped and
         hitting ``partner_node_requires_credential``."""
         monkeypatch.delenv("COMFY_CLOUD_API_KEY", raising=False)
         from comfy_cli.auth import store as auth_store
@@ -1379,7 +1379,7 @@ class TestResolvePartnerCredential:
     def test_stale_session_from_transient_failure_falls_through(self, monkeypatch: pytest.MonkeyPatch):
         """A transient refresh failure returns the STALE (expired) session; it
         fails its own expiry check and the resolver falls through — unchanged
-        from the pre-BE-3361 behavior on a network flake."""
+        from the earlier behavior on a network flake."""
         monkeypatch.delenv("COMFY_CLOUD_API_KEY", raising=False)
         from comfy_cli.auth import store as auth_store
         from comfy_cli.cloud import oauth
@@ -1665,7 +1665,7 @@ class TestPartnerNodesDetectedTelemetry:
         assert events[0]["partner_node_count"] == 1
 
     def test_does_not_fire_when_the_spend_gate_refuses(self, tmp_path, monkeypatch):
-        """Documents the one funnel this event does NOT cover: the BE-4326 spend
+        """Documents the one funnel this event does NOT cover: the spend
         gate refuses before any credential resolution (so a refusal never
         triggers a network OAuth refresh), and ``credential_present`` depends on
         that resolution — so a run declined for lack of ``--allow-spend`` emits
@@ -1868,8 +1868,8 @@ class TestPartnerNodesDetectedTelemetry:
 
 
 class TestExecuteSpendGate:
-    """`comfy run` gates partner-API (paid) workflows on `--allow-spend`
-    (BE-4326), mirroring `comfy run-template`'s spend gate. A partner-node
+    """`comfy run` gates partner-API (paid) workflows on `--allow-spend`,
+    mirroring `comfy run-template`'s spend gate. A partner-node
     workflow must not silently spend Comfy credits: machine mode fails closed
     with `spend_consent_required`; a TTY prompts; consent (flag or "yes") lets
     the run proceed to the credential path unchanged. Partner-free workflows
@@ -2027,7 +2027,7 @@ class TestExecuteSpendGate:
 
 
 class TestSpendGateStdinAndMarkup:
-    """Robustness of the interactive spend prompt (BE-4326): a missing/closed
+    """Robustness of the interactive spend prompt: a missing/closed
     stdin must fall through to the fail-closed machine-mode error rather than
     crash, and partner class_type names must not be interpreted as Rich markup."""
 
@@ -2438,8 +2438,8 @@ class TestExecuteCloudAutoConvert:
 
 
 class TestExecuteCloudSpendGate:
-    """The cloud submit also bills partner-API nodes server-side, so BE-4326
-    applies the same consent gate there. Detection is fail-open (empty cloud
+    """The cloud submit also bills partner-API nodes server-side, so the same
+    consent gate applies there. Detection is fail-open (empty cloud
     object_info → no gate), and the gate fires before cloud auth/submit."""
 
     PARTNER_WF = {"1": {"class_type": "Veo3VideoGenerationNode", "inputs": {"prompt": "x"}}}

--- a/tests/comfy_cli/command/test_run_json.py
+++ b/tests/comfy_cli/command/test_run_json.py
@@ -2039,7 +2039,7 @@ class TestMalformedRejectionPayloadStillYieldsAnEnvelope:
 
 
 # --------------------------------------------------------------------------
-# `queued` is emitted only after the job's durable state exists (BE-6072)
+# `queued` is emitted only after the job's durable state exists
 #
 # The event used to precede `jobs_state.write` on every path. That made
 # state-file-backed follow-ups (`jobs ls`, `jobs wait`, compose's item_map)
@@ -2276,7 +2276,7 @@ class TestQueueStashesWarningsWithoutEmitting:
 
 
 class TestErrorEnvelopeCarriesRoutedTarget:
-    """BE-6274: run-path *error* envelopes carry `where` (the routed target),
+    """Run-path *error* envelopes carry `where` (the routed target),
     matching the failure examples in docs/json-output.md.
 
     These go through the real CLI (`comfy run --json --where …`) rather than

--- a/tests/comfy_cli/command/test_run_prompt.py
+++ b/tests/comfy_cli/command/test_run_prompt.py
@@ -1,4 +1,4 @@
-"""Integration/smoke tests for `comfy run --prompt`/`--set` (BE-2535).
+"""Integration/smoke tests for `comfy run --prompt`/`--set`.
 
 The injector is unit-tested offline in
 ``tests/comfy_cli/cql/test_default_workflow.py``. These tests prove the wiring:
@@ -156,7 +156,7 @@ class TestRunCliWiring:
 
 class TestRuntimeCheckpointResolutionLocal:
     """Wiring: `execute` resolves the bundled default's checkpoint against the
-    server's object_info before submit (BE-2994)."""
+    server's object_info before submit."""
 
     def _run_local(self, preloaded, object_info, patch_pprint=False):
         stack = [
@@ -218,7 +218,7 @@ class TestRuntimeCheckpointResolutionLocal:
 class TestCheckpointResolutionEmptyEnumByTarget:
     """`_resolve_default_checkpoint_or_exit` hard-errors on an empty enum only
     for the local target; Comfy Cloud provisions models per-job so it fails
-    open (BE-2994)."""
+    open."""
 
     def test_local_empty_enum_hard_errors(self):
         from comfy_cli.command.run.preflight import _resolve_default_checkpoint_or_exit

--- a/tests/comfy_cli/command/test_run_template.py
+++ b/tests/comfy_cli/command/test_run_template.py
@@ -249,7 +249,7 @@ def test_explicit_port_zero_is_rejected_not_overridden_by_host_port(
     app, gallery_file, template_body, run_spy, monkeypatch
 ):
     """`--port 0` is an out-of-range port, not "no port given" — it must not be
-    silently replaced by the port embedded in `--host h:p` (BE-6486).
+    silently replaced by the port embedded in `--host h:p`.
 
     The check lives in the shared `resolve_host_port`, so the failure is a click
     usage error (exit 2) raised before the server probe.
@@ -350,7 +350,7 @@ def test_allow_spend_unblocks_paid_template(app, gallery_file, template_body, se
 def test_consented_handoff_forwards_allow_spend_so_run_does_not_regate(
     app, gallery_file, template_body, server_up, run_spy
 ):
-    # BE-4326: run-template's spend gate has already consented, so the handoff
+    # Run-template's spend gate has already consented, so the handoff
     # to `comfy run`'s execute() must forward allow_spend=True — otherwise
     # execute()'s own gate would fail closed a second time under --json.
     _force_json_renderer()
@@ -434,7 +434,7 @@ def test_temp_workflow_file_is_cleaned_up(app, gallery_file, template_body, serv
 
 
 # ---------------------------------------------------------------------------
-# Direct unit tests for the extracted spend gate (_enforce_spend_gate, BE-4367)
+# Direct unit tests for the extracted spend gate (_enforce_spend_gate)
 # ---------------------------------------------------------------------------
 
 # A workflow embedding a partner-API node (FluxProNode carries api_node:True in
@@ -459,7 +459,7 @@ def _force_pretty_renderer() -> Renderer:
 class TestEnforceSpendGate:
     """Direct coverage of the consent interlock extracted from run_template_cmd,
     exercising each branch — including the interactive ACCEPT path that had no
-    test anywhere before BE-4367."""
+    test anywhere previously."""
 
     def test_allow_spend_proceeds(self):
         # Paid node present, but --allow-spend consents up front → no gate.
@@ -514,7 +514,7 @@ class TestEnforceSpendGate:
 
     def test_interactive_accept_proceeds(self, monkeypatch):
         # Pretty + tty + a "yes" at the prompt → run proceeds (returns None).
-        # This branch had no coverage anywhere before BE-4367.
+        # This branch had no coverage anywhere previously.
         renderer = _force_pretty_renderer()
         monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
         monkeypatch.setattr("typer.confirm", lambda *a, **k: True)
@@ -608,7 +608,7 @@ class TestEnforceSpendGate:
 
 
 def test_bad_port_terminates_the_stream_with_an_envelope(app, gallery_file, template_body, run_spy, monkeypatch):
-    """A host/port usage error must not leave stdout empty (BE-6660).
+    """A host/port usage error must not leave stdout empty.
 
     `typer.BadParameter` escapes to click, which prints a usage panel on stderr
     and exits 2 — so a JSON/NDJSON consumer used to see the stream just stop,

--- a/tests/comfy_cli/command/test_templates.py
+++ b/tests/comfy_cli/command/test_templates.py
@@ -820,7 +820,7 @@ def test_check_invalid_utf8_workflow_surfaces_invalid_json(gallery_file, tmp_pat
 
 
 # ---------------------------------------------------------------------------
-# Gallery cache TTL (BE-3393): fresh-within-TTL serves the cache, expired
+# Gallery cache TTL: fresh-within-TTL serves the cache, expired
 # re-fetches, and a fetch failure on an expired cache falls back to stale.
 # ---------------------------------------------------------------------------
 
@@ -863,7 +863,7 @@ def test_expired_cache_serves_stale_immediately_and_spawns_background_refresh(
     # Backdate the cache past the TTL so a refresh is due.
     _set_mtime(cache_file, templates_cmd.GALLERY_TTL_SECONDS + 3600)
 
-    # Stale-while-revalidate (BE-3427): the foreground command must NOT block on
+    # Stale-while-revalidate: the foreground command must NOT block on
     # a network fetch when a stale cache is present — it serves the stale copy
     # immediately and revalidates in a detached background process.
     monkeypatch.setattr(templates_cmd, "_fetch_gallery", _fetch_boom)
@@ -1084,7 +1084,7 @@ def test_readonly_cache_dir_still_serves_fetched_data_on_refresh(cache_file, mon
 
 
 # ---------------------------------------------------------------------------
-# Stale-while-revalidate spawn seam (BE-3427): the foreground serves stale and
+# Stale-while-revalidate spawn seam: the foreground serves stale and
 # fires a *detached* background refresher; here we assert the spawn shape.
 # ---------------------------------------------------------------------------
 
@@ -1216,7 +1216,7 @@ def test_explicit_refresh_non_utf8_body_is_fatal_not_uncaught(cache_file, monkey
 
 # ---------------------------------------------------------------------------
 # Exact-name lookups (show/fetch) opt out of stale-while-revalidate so a
-# freshly-added template resolves on the same call (BE-3427 review).
+# freshly-added template resolves on the same call.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/comfy_cli/command/test_templates_fetch_emit_ops.py
+++ b/tests/comfy_cli/command/test_templates_fetch_emit_ops.py
@@ -1,4 +1,4 @@
-"""``comfy templates fetch --emit-ops`` (V1-038 / BE-7171).
+"""``comfy templates fetch --emit-ops`` (V1-038).
 
 ``templates fetch -o workflow.json`` is a BULK WRITER: it replaces the working
 file wholesale. Downstream (the cloud agent's document) that replacement had to

--- a/tests/comfy_cli/command/test_templates_get.py
+++ b/tests/comfy_cli/command/test_templates_get.py
@@ -1,4 +1,4 @@
-"""Tests for ``comfy templates get --where k=v`` (V1-018 / BE-7151).
+"""Tests for ``comfy templates get --where k=v`` (V1-018).
 
 The measured agent loop is ``templates ls`` (to find the name) → ``templates
 fetch`` (copying that name back, 100% verbatim). ``get`` fuses the two: the

--- a/tests/comfy_cli/command/test_transfer_download.py
+++ b/tests/comfy_cli/command/test_transfer_download.py
@@ -285,7 +285,7 @@ GLB_RECORD = {
 
 
 class TestSaveGlb3dDownload:
-    """Regression (BE-4417): a SaveGLB job emits its output under the "3d"
+    """Regression: a SaveGLB job emits its output under the "3d"
     key. Shape-based extraction must resolve it so `comfy download` saves the
     `.glb` instead of erroring `download_no_outputs`."""
 
@@ -964,7 +964,7 @@ class TestSSRFGuardIntact:
 
 class TestDownloadHelperExtraction:
     """Direct, guard-pinning unit tests for the per-URL helpers extracted from
-    ``execute_download`` (BE-3273): ``_download_one_url`` orchestrates naming +
+    ``execute_download``: ``_download_one_url`` orchestrates naming +
     the symlink-dest refusal + branch dispatch; ``_copy_local_one`` and
     ``_stream_http_one`` carry the two download branches. The behavior-preserving
     extraction must keep every guard, envelope code, and exit intact — and the
@@ -1274,11 +1274,11 @@ class TestDefaultOutDir:
 
 class TestDownloadExtensionSanitized:
     """The download extension can be derived from an untrusted `?filename=`
-    query param (a compromised/malicious server). Unlike the `item` token, it
-    was never sanitized, so control/ANSI bytes reached the on-disk name and
-    the echoed path — a terminal-injection vector in human mode. `_sanitize_ext`
-    whitelists it to a safe charset while preserving the no-traversal guarantee
-    (BE-3326)."""
+     query param (a compromised/malicious server). Unlike the `item` token, it
+     was never sanitized, so control/ANSI bytes reached the on-disk name and
+     the echoed path — a terminal-injection vector in human mode. `_sanitize_ext`
+     whitelists it to a safe charset while preserving the no-traversal guarantee
+    ."""
 
     # A real ESC control byte, exactly as a hostile server could return it.
     _ATTACK_NAME = "out.png\x1b[31mHACK"
@@ -1349,7 +1349,7 @@ class TestDownloadExtensionSanitized:
 
     def test_local_source_control_bytes_stripped_from_ext(self, fake_target, tmp_path, capsys):
         # The local-copy branch derives `ext` from the on-disk source name and
-        # must be sanitized too (BE-3326 applies to both branches).
+        # must be sanitized too (the rule applies to both branches).
         src_dir = tmp_path / "output"
         src_dir.mkdir()
         src = src_dir / self._ATTACK_NAME

--- a/tests/comfy_cli/command/test_transfer_download.py
+++ b/tests/comfy_cli/command/test_transfer_download.py
@@ -1274,11 +1274,10 @@ class TestDefaultOutDir:
 
 class TestDownloadExtensionSanitized:
     """The download extension can be derived from an untrusted `?filename=`
-     query param (a compromised/malicious server). Unlike the `item` token, it
-     was never sanitized, so control/ANSI bytes reached the on-disk name and
-     the echoed path — a terminal-injection vector in human mode. `_sanitize_ext`
-     whitelists it to a safe charset while preserving the no-traversal guarantee
-    ."""
+    query param (a compromised/malicious server). Unlike the `item` token, it
+    was never sanitized, so control/ANSI bytes reached the on-disk name and
+    the echoed path — a terminal-injection vector in human mode. `_sanitize_ext`
+    whitelists it to a safe charset while preserving the no-traversal guarantee."""
 
     # A real ESC control byte, exactly as a hostile server could return it.
     _ATTACK_NAME = "out.png\x1b[31mHACK"

--- a/tests/comfy_cli/command/test_transfer_upload.py
+++ b/tests/comfy_cli/command/test_transfer_upload.py
@@ -155,7 +155,7 @@ class TestUploadMachineModeStdoutPurity:
 class TestUploadConnectionError:
     """A connection-level failure (``URLError``/``TimeoutError``) on upload must
     surface as a structured ``upload_failed`` envelope, not an unhandled
-    traceback that breaks ``--json``/NDJSON consumers (BE-2454)."""
+    traceback that breaks ``--json``/NDJSON consumers."""
 
     @pytest.fixture(autouse=True)
     def reset_renderer(self):
@@ -228,7 +228,7 @@ class TestUploadTimeout:
 
     ``--host``/``--port`` can now aim the POST at an arbitrary address, so a
     peer that completes the handshake and then stalls would hang the CLI
-    forever on urllib's no-timeout default (BE-5662).
+    forever on urllib's no-timeout default.
     """
 
     def test_upload_passes_an_explicit_timeout(self, asset, monkeypatch):
@@ -243,8 +243,7 @@ class TestUploadTimeout:
 
 
 class TestUploadHostPortRouting:
-    """``comfy upload --host/--port`` aims a LOCAL upload at a specific ComfyUI
-    (BE-5662).
+    """``comfy upload --host/--port`` aims a LOCAL upload at a specific ComfyUI.
 
     Before this the only lever was the process-wide ``COMFY_LOCAL_URL`` env
     var, so a caller wrapping the CLI (comfy-mcp's ``_with_target``) could not
@@ -491,7 +490,7 @@ class TestExecuteUploadValidatesItsOwnArgs:
     The CLI validates the flags, but comfy-mcp's ``_with_target`` calls
     ``execute_upload`` directly and ``resolve_target`` drops the host verbatim
     into ``http://{host}:{port}`` — so without this the guarantee would belong
-    to the caller, not the function (BE-5662).
+    to the caller, not the function.
     """
 
     @pytest.mark.parametrize("bad", ["attacker.tld/x?", "", "   ", "a%0d%0aX:%201", "127.0.0.1:8188"])

--- a/tests/comfy_cli/command/test_validate_command.py
+++ b/tests/comfy_cli/command/test_validate_command.py
@@ -108,7 +108,7 @@ def test_api_format_unchanged(runner, tmp_path):
     """An API-format file behaves exactly as before: validated directly, no
     `converted_from_ui` key in the payload. The fixture is a complete sd15
     txt2img graph — it carries a SaveImage output node, as any real API-format
-    export does, so it clears the server-parity no-outputs check (BE-3357)."""
+    export does, so it clears the server-parity no-outputs check."""
     api = {
         "4": {
             "class_type": "CheckpointLoaderSimple",
@@ -160,7 +160,7 @@ def test_empty_dict_payload_not_converted_and_rejected(runner, tmp_path):
     """An empty dict is not UI format and is left to the existing validator
     (no conversion, no `converted_from_ui` key) — which now rejects it: the
     server refuses any prompt with zero output nodes, including a node-less
-    one, so validate mirrors that as `prompt_no_outputs` (BE-3357)."""
+    one, so validate mirrors that as `prompt_no_outputs`."""
     wf = _write(tmp_path, "empty.json", {})
 
     result = _validate(runner, wf)
@@ -172,7 +172,7 @@ def test_empty_dict_payload_not_converted_and_rejected(runner, tmp_path):
     assert any(e["code"] == "prompt_no_outputs" for e in data["errors"])
 
 
-# --- partner-node (paid) visibility (BE-4328) -----------------------------------
+# --- partner-node (paid) visibility -----------------------------------
 #
 # `comfy validate` now previews credit spend: it reports `partner_nodes` (the
 # partner-API nodes a workflow uses) and `spends_credits` in its payload, using
@@ -311,14 +311,14 @@ def test_partner_node_name_with_markup_does_not_crash_pretty(runner, tmp_path):
     assert name in result.stdout
 
 
-# --- object_info target resolution (BE-6306) ------------------------------------
+# --- object_info target resolution ------------------------------------
 #
 # `validate` used to resolve its local object_info server as
 # `--host`/`--port` > COMFY_LOCAL_URL > 127.0.0.1:8188, skipping the
 # `config.background` step `comfy run` honors via `host_port.resolve_host_port`.
 # With ComfyUI running as a comfy-cli background server on a non-8188 port, that
 # made validate consult a DIFFERENT server than the one `run` submits to, so its
-# verdict was meaningless (BE-6299: validate passed a workflow `run` rejected for
+# verdict was meaningless (validate passed a workflow `run` rejected for
 # a missing node class). It now resolves through the same chain, and reports the
 # resolved target in the payload as `object_info_source`.
 
@@ -498,7 +498,7 @@ def test_pretty_mode_prints_resolved_source(runner, tmp_path, monkeypatch, captu
     assert f"object_info from http://127.0.0.1:{BACKGROUND_PORT}" in result.stdout
 
 
-# --- review follow-ups on the BE-6306 resolution block ---------------------------
+# --- review follow-ups on the resolution block ---------------------------
 
 
 def test_wildcard_background_host_is_canonicalized(runner, tmp_path, monkeypatch, captured_target):

--- a/tests/comfy_cli/command/test_workflow_delete_nodes.py
+++ b/tests/comfy_cli/command/test_workflow_delete_nodes.py
@@ -1,4 +1,4 @@
-"""Tests for ``comfy workflow delete-nodes <id...>`` (V1-020 / BE-7153).
+"""Tests for ``comfy workflow delete-nodes <id...>`` (V1-020).
 
 The measured agent loop runs ``delete-node`` once per doomed node (×22 runs) —
 N file loads, N writes, N catalog loads. ``delete-nodes`` is the batch verb:

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -623,7 +623,7 @@ class TestAddNode:
 
 
 # ---------------------------------------------------------------------------
-# set-widget (name-addressed)
+# set-widget addressed by name
 # ---------------------------------------------------------------------------
 
 
@@ -1555,7 +1555,7 @@ class TestCapture:
 
 
 # ---------------------------------------------------------------------------
-# capture ↔ apply agreement on UI-only nodes (PR-511 review, Finding 1):
+# capture ↔ apply agreement on UI-only nodes (review finding 1):
 # capture must not emit ops apply refuses — one MarkdownNote in the source
 # used to discard the whole atomic batch (114/306 official templates).
 # ---------------------------------------------------------------------------
@@ -1709,7 +1709,7 @@ class TestCaptureUiOnlyNodes:
 
 
 # ---------------------------------------------------------------------------
-# --stdout envelope contract (PR-511 review, Finding 2): same rules set-slot
+# --stdout envelope contract (review finding 2): same rules set-slot
 # pins — JSON mode puts ONE envelope on stdout with the document riding in
 # data.workflow_json; human mode puts exactly the raw workflow on stdout (the
 # ✓ line used to land inside `> new.json` redirects and corrupt them).
@@ -2246,7 +2246,7 @@ class TestSetWidgetModelNormalization:
         assert not any(w.get("code") == "normalized_value" for w in op.get("warnings", []))
 
     def test_unknown_value_is_refused_not_written(self):
-        """BE-7215: an unknown COMBO value on a non-upload-backed port is FATAL.
+        """An unknown COMBO value on a non-upload-backed port is FATAL.
 
         It used to be applied and reported as a soft warning on an ``ok:true``
         envelope, so the bad value reached the canvas and only failed at run

--- a/tests/comfy_cli/command/test_workflow_saved.py
+++ b/tests/comfy_cli/command/test_workflow_saved.py
@@ -673,7 +673,7 @@ class TestDelete:
 
 
 # ---------------------------------------------------------------------------
-# unparseable 200 body — must surface a loud error, not empty/success (BE-3334)
+# unparseable 200 body — must surface a loud error, not empty/success
 # ---------------------------------------------------------------------------
 
 # A non-empty 200 body the client can't decode as JSON. Four shapes, all malformed:

--- a/tests/comfy_cli/cql/test_default_workflow.py
+++ b/tests/comfy_cli/cql/test_default_workflow.py
@@ -1,7 +1,7 @@
 """Offline unit tests for the bundled default text2img workflow injector.
 
 No server, no object_info, no apply_slots — the injector is a pure direct
-API-format write over the pinned graph (BE-2535).
+API-format write over the pinned graph.
 """
 
 from __future__ import annotations

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -194,7 +194,7 @@ def graph() -> Graph:
 @pytest.fixture
 def graph_sd15() -> Graph:
     """Graph built from the real captured sd15 object_info fixture — the same
-    catalog the BE-3349 repro / BE-3357 acceptance criterion runs against."""
+    catalog the repro and the acceptance criterion run against."""
     import json
     from pathlib import Path
 
@@ -207,7 +207,7 @@ def graph_path() -> Graph:
     """Graph built from the captured path-search object_info fixture: the sd15
     core nodes, the audio nodes (AUDIO is consumed but never reaches IMAGE), a
     second LATENT->IMAGE decoder, and the partner-API image node whose `model`
-    widget is a COMBO of API ids rather than a MODEL input (BE-6857)."""
+    widget is a COMBO of API ids rather than a MODEL input."""
     import json
     from pathlib import Path
 
@@ -679,7 +679,7 @@ class TestTraversal:
 
 
 # ===========================================================================
-# TestPathConstraints — BE-6857
+# TestPathConstraints
 # ===========================================================================
 
 
@@ -1292,8 +1292,8 @@ class TestValidateWorkflow:
 
     def test_below_min_error(self, graph: Graph):
         """A value below the catalog min is a hard error (the server rejects it
-        with value_smaller_than_min) — was a warning before BE-3357. Node "1" is
-        wired to a SaveImage output so it is server-reachable (BE-3406); an
+        with value_smaller_than_min) — was a warning previously. Node "1" is
+        wired to a SaveImage output so it is server-reachable; an
         unreachable node would be pruned and the range demoted to a warning."""
         wf = {
             "1": {
@@ -1379,7 +1379,7 @@ class TestAutogrowInputs:
 
     def test_required_autogrow_with_no_slots_errors(self, graph: Graph):
         # BatchImagesNode "20" is wired to a SaveImage output so it is
-        # server-reachable (BE-3406) — an unreachable node would be pruned.
+        # server-reachable — an unreachable node would be pruned.
         wf = {
             "20": {"class_type": "BatchImagesNode", "inputs": {}},
             "30": {"class_type": "SaveImage", "inputs": {"images": ["20", 0], "filename_prefix": "out"}},
@@ -1412,13 +1412,13 @@ class TestAutogrowInputs:
 
 
 # ===========================================================================
-# TestValidateServerParity — BE-3357: presence, no-outputs, range = errors
+# TestValidateServerParity — presence, no-outputs, range = errors
 # ===========================================================================
 
 
 class TestValidateServerParity:
     """Validate mirrors the three server-side rejections that `validate` used to
-    pass silently (BE-3349 / BE-3357), against the captured sd15 catalog:
+    pass silently, against the captured sd15 catalog:
     required-input presence, the no-outputs check, and range violations."""
 
     def _sd15_full(self) -> dict:
@@ -1481,7 +1481,7 @@ class TestValidateServerParity:
         assert "wire" in err["hint"] and "MODEL" in err["hint"]
 
     def test_be3349_repro_only_links_wired(self, graph_sd15: Graph):
-        """The BE-3349 acceptance case: a KSampler with only its four link inputs
+        """The acceptance case: a KSampler with only its four link inputs
         wired is missing all six widget inputs → six required_input_missing errors."""
         wf = self._sd15_full()
         wf["3"]["inputs"] = {
@@ -1578,7 +1578,7 @@ class TestValidateServerParity:
 
     def test_width_below_min_is_error(self, graph_sd15: Graph):
         """EmptyLatentImage width below the catalog min is a hard error (was a
-        warning before BE-3357)."""
+        warning previously)."""
         wf = self._sd15_full()
         wf["5"]["inputs"]["width"] = 1  # sd15 min is 16
         result = graph_sd15.validate_workflow(wf)
@@ -1595,7 +1595,7 @@ class TestValidateServerParity:
         assert result["valid"] is True, result["errors"]
         assert [e for e in result["errors"] if e.get("node_id") == "_meta"] == []
 
-    # -- Output-reachability pruning (BE-3406): match the server, which only
+    # -- Output-reachability pruning: match the server, which only
     # validates output nodes and their transitive input ancestors. --
 
     def test_disconnected_node_missing_required_is_pruned(self, graph_sd15: Graph):
@@ -1682,7 +1682,7 @@ class TestValidateServerParity:
 
 class TestValidateMalformedInputs:
     """Malformed workflow JSON must yield structured output, never an unhandled
-    traceback (BE-3406 hardening) — the validator's whole contract is to catch
+    traceback — the validator's whole contract is to catch
     bad prompts, so it may not crash on the shapes it's meant to reject."""
 
     def test_non_dict_inputs_does_not_crash(self, graph: Graph):
@@ -1713,7 +1713,7 @@ class TestValidateMalformedInputs:
 class TestValidateEmptyCombo:
     """A COMBO whose option list is declared but EMPTY means the server has zero
     files installed for that field — it rejects every value against it — so it
-    must be reported, not skipped (BE-6585).
+    must be reported, not skipped.
 
     Before this, the membership check was gated on ``self.enum_values`` being
     truthy, so detection got *worse* the emptier the install: ``VAELoader``
@@ -2114,7 +2114,7 @@ class TestValidateUploadBackedCombo:
 
 class TestValidateDynamicCombo:
     """Validate expands a ``COMFY_DYNAMICCOMBO_V3`` selector's chosen option and
-    checks the dotted sub-inputs the server will actually require (BE-3777).
+    checks the dotted sub-inputs the server will actually require.
 
     object_info declares only the selector (``model``); the frontend and
     ``convert_ui_to_api`` lower the selected option's own INPUT_TYPES into
@@ -2531,7 +2531,7 @@ class TestSubgraphIsolation:
                 ]
             },
         }
-        _apply_one_slot(wf, "10/9.text", "VALUE-FOR-10", graph)
+        _apply_one_slot(wf, "10/9.text", "value-for-10", graph)
 
         # Rebuild the definitions index from the (potentially mutated) workflow
         defs = {d["id"]: d for d in wf["definitions"]["subgraphs"]}
@@ -2544,7 +2544,7 @@ class TestSubgraphIsolation:
         # Instance 10 got the new value
         inst10 = next(n for n in wf["nodes"] if n["id"] == 10)
         inst10_def = defs[inst10["type"]]
-        assert inst10_def["nodes"][0]["widgets_values"][0] == "VALUE-FOR-10"
+        assert inst10_def["nodes"][0]["widgets_values"][0] == "value-for-10"
 
     def test_second_write_to_same_instance_no_extra_fork(self, graph: Graph):
         """A second write to the same instance must not create yet another fork."""

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -464,7 +464,7 @@ class TestStatusServerUpNoRecord:
 
     This is what the documented crash recovery ("relaunch, then check")
     produces: a fresh ComfyUI answers the port with an empty history, so the
-    live snapshot comes back None. Before BE-4749 that unconditionally emitted
+    live snapshot comes back None. Previously that unconditionally emitted
     `prompt_not_found` and discarded the `server_died` verdict already sitting
     on disk.
     """
@@ -886,7 +886,7 @@ def test_orphaned_flag_filters_to_watcher_crashed(monkeypatch):
 
 def test_reap_finalizes_nonterminal_record_with_dead_watcher_pid(monkeypatch):
     """A `running` record carrying a dead pid + that pid's REAL create_time —
-    what a `comfy run --wait` killed from outside now leaves behind (BE-6641)
+    what a `comfy run --wait` killed from outside now leaves behind
     — is flipped by the reap to `error`/`watcher_crashed`, surfaces under
     `--orphaned`, and the pid pair is cleared in the rewritten file."""
     import psutil
@@ -1736,7 +1736,7 @@ def test_jobs_cancel_cloud_404_surfaces_prompt_not_found(monkeypatch: pytest.Mon
 @pytest.mark.parametrize("code", [401, 403])
 def test_jobs_cancel_cloud_auth_failure_surfaces_cloud_unauthorized(monkeypatch: pytest.MonkeyPatch, code: int):
     """An expired/insufficient session cancelling a cloud job surfaces the
-    actionable ``cloud_unauthorized`` code (shared envelope handler, BE-3266) —
+    actionable ``cloud_unauthorized`` code (shared envelope handler) —
     not the generic ``cloud_http_error`` it produced before the two call sites
     were unified."""
     import io
@@ -3472,7 +3472,7 @@ def _run_local_watch(monkeypatch, capsys, *, messages, prompt_id="pid-w", argv_e
 
 
 def test_watch_streams_events_and_reports_completed_nodes(monkeypatch, capsys):
-    """The BE-6856 regression, end to end: a multi-node job must produce MORE
+    """The regression, end to end: a multi-node job must produce MORE
     THAN ONE NDJSON line during the watch, and the terminal envelope's
     `completed_nodes` must list the nodes that ran."""
     from comfy_cli import jobs_state

--- a/tests/comfy_cli/output/test_discovery.py
+++ b/tests/comfy_cli/output/test_discovery.py
@@ -81,7 +81,7 @@ def test_discover_annotates_commands_with_schema():
 
 
 def test_discover_lists_run_prompt_and_set_options():
-    # BE-2535: `comfy run --prompt`/`--set` must be visible on the agent
+    # `comfy run --prompt`/`--set` must be visible on the agent
     # surface. The options are auto-introspected into the commands tree.
     envelope = _run_cli(["--json", "discover"])
     run_params = envelope["data"]["commands"]["run"]["params"]

--- a/tests/comfy_cli/output/test_error_envelope_where.py
+++ b/tests/comfy_cli/output/test_error_envelope_where.py
@@ -1,6 +1,6 @@
-"""BE-6275: `where` on the ERROR envelopes of the routed commands.
+"""`where` on the ERROR envelopes of the routed commands.
 
-BE-6274 fixed `Renderer.error()` and the `run` path. This module pins the same
+An earlier change fixed `Renderer.error()` and the `run` path. This module pins the same
 property for every other command that resolves a local/cloud target: once the
 routing decision is made, the failure envelope names the target it routed to
 instead of `where: null`.

--- a/tests/comfy_cli/output/test_renderer.py
+++ b/tests/comfy_cli/output/test_renderer.py
@@ -293,7 +293,7 @@ def test_get_renderer_default_is_pretty():
 
 
 # ---------------------------------------------------------------------------
-# Control-sequence sanitizing at the pretty boundary (BE-4794)
+# Control-sequence sanitizing at the pretty boundary
 # ---------------------------------------------------------------------------
 
 _EVIL = "job \x1b[2Jevil"

--- a/tests/comfy_cli/test_broken_pipe.py
+++ b/tests/comfy_cli/test_broken_pipe.py
@@ -1,4 +1,4 @@
-"""BE-4795: `comfy … | head` must exit 0, not 1.
+"""`comfy … | head` must exit 0, not 1.
 
 A CLI whose stdout consumer closes early is not a failing CLI — the consumer got
 what it asked for. These cover both halves of the entrypoint guard in

--- a/tests/comfy_cli/test_command_mentions.py
+++ b/tests/comfy_cli/test_command_mentions.py
@@ -1,4 +1,4 @@
-"""Guardrail: every ``comfy …`` we print must be a command that exists (BE-2996).
+"""Guardrail: every ``comfy …`` we print must be a command that exists.
 
 The audit found eight help/hint strings pointing users at ``comfy auth login``,
 which has never been a command — the real one is ``comfy cloud login``. Nothing
@@ -170,7 +170,7 @@ def test_valid_mentions_pass(text, tree, globals_):
 @pytest.mark.parametrize(
     ("text", "unknown"),
     [
-        ("comfy auth login", "login"),  # the BE-2996 regression itself
+        ("comfy auth login", "login"),  # the original regression itself
         ("comfy cloud singin", "singin"),
         ("comfy nope", "nope"),
         ("comfy model downlaod --url x", "downlaod"),

--- a/tests/comfy_cli/test_credentials.py
+++ b/tests/comfy_cli/test_credentials.py
@@ -260,7 +260,7 @@ class TestGetSession:
 class TestResolveAllowClear:
     """``resolve_cloud_credential(allow_clear=...)`` plumbs the flag through
     ``get_session`` into ``ensure_fresh_session`` so a best-effort caller (the
-    local partner-node injector, BE-3361) can REFRESH a lapsed session without
+    local partner-node injector) can REFRESH a lapsed session without
     ever CLEARING it on a fatal refresh error.
 
     Exercised against the real secret store (tmp secrets file) so the whole
@@ -316,7 +316,7 @@ class TestResolveAllowClear:
 
     def test_expired_session_is_refreshed(self, persisted, monkeypatch: pytest.MonkeyPatch):
         """Expired session + valid refresh token → a refresh happens and the
-        NEW access token is returned (the BE-3361 fix)."""
+        NEW access token is returned."""
         import time
 
         self._persist_expired()
@@ -362,7 +362,7 @@ class TestResolveAllowClear:
     ):
         """A transient (network) refresh failure returns the stale session,
         which fails its own expiry check → resolver falls through. Same as the
-        pre-BE-3361 behavior on a flake; the session is preserved."""
+        earlier behavior on a flake; the session is preserved."""
         self._persist_expired()
         monkeypatch.setenv("COMFY_CLOUD_API_KEY", "env-key")
 

--- a/tests/comfy_cli/test_cuda_detect.py
+++ b/tests/comfy_cli/test_cuda_detect.py
@@ -159,7 +159,7 @@ class TestDetectViaNvidiaSmiResolvesBinaryPath:
         mock_run.assert_not_called()
 
     def test_rejects_binary_planted_in_cwd(self, tmp_path):
-        """The BE-3434 vector: an ``nvidia-smi`` sitting directly in the CWD is
+        """The attack vector: an ``nvidia-smi`` sitting directly in the CWD is
         never executed."""
         planted = tmp_path / "nvidia-smi"
         planted.write_text("")

--- a/tests/comfy_cli/test_edit_findings_contract.py
+++ b/tests/comfy_cli/test_edit_findings_contract.py
@@ -1,4 +1,4 @@
-"""Freeze the edit-findings contract (BE-7215).
+"""Freeze the edit-findings contract.
 
 Two pins:
 

--- a/tests/comfy_cli/test_host_port.py
+++ b/tests/comfy_cli/test_host_port.py
@@ -217,7 +217,7 @@ def test_run_unsafe_host_exits_before_execute(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# `--port` beats the port embedded in a combined `--host h:p` (BE-6486)
+# `--port` beats the port embedded in a combined `--host h:p`
 # ---------------------------------------------------------------------------
 #
 # The combined-host sites used to merge the two with `if not port and
@@ -275,7 +275,7 @@ def test_jobs_status_out_of_range_port_is_rejected():
 
 
 # ---------------------------------------------------------------------------
-# explicit-flag validation at the shared choke point (BE-6306 review)
+# explicit-flag validation at the shared choke point
 # ---------------------------------------------------------------------------
 #
 # `resolve_local_host_port` resolves each half as `value or env or bg or
@@ -319,7 +319,7 @@ def test_boundary_ports_are_accepted(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# A host/port usage error terminates the JSON/NDJSON stream (BE-6660)
+# A host/port usage error terminates the JSON/NDJSON stream
 # ---------------------------------------------------------------------------
 #
 # `typer.BadParameter` used to escape straight to click, which prints a human

--- a/tests/comfy_cli/test_install.py
+++ b/tests/comfy_cli/test_install.py
@@ -64,7 +64,7 @@ class TestPipInstallManager:
 
 class TestInstallManagerWithFallback:
     """The dedupe'd manager-install-and-degrade helper shared by the pip and
-    fast_deps paths of ``execute`` (BE-4356)."""
+    fast_deps paths of ``execute``."""
 
     @patch("comfy_cli.config_manager.ConfigManager")
     @patch("comfy_cli.command.install.pip_install_manager", return_value=True)

--- a/tests/comfy_cli/test_local_address.py
+++ b/tests/comfy_cli/test_local_address.py
@@ -292,7 +292,7 @@ def test_job_watcher_state_beats_env(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# wildcard bind-address canonicalization (BE-6306 review)
+# wildcard bind-address canonicalization
 # ---------------------------------------------------------------------------
 #
 # `config.background` records the raw `--listen` value `comfy launch` passed to

--- a/tests/comfy_cli/test_reset_doc_op.py
+++ b/tests/comfy_cli/test_reset_doc_op.py
@@ -1,4 +1,4 @@
-"""``reset_doc`` — the guarded, standalone-only document reset (V1-038 / BE-7171).
+"""``reset_doc`` — the guarded, standalone-only document reset (V1-038).
 
 ``reset_doc`` was frozen in ``docs/op-vocabulary-v1.md`` §1.6 but left deferred:
 ``apply_op`` rejected it and ``DEFERRED_OPS`` pinned that rejection. This ticket

--- a/tests/comfy_cli/test_run_execution_lifecycle.py
+++ b/tests/comfy_cli/test_run_execution_lifecycle.py
@@ -1,7 +1,7 @@
-"""Execution lifecycle tests for ``comfy run`` (MAR-52).
+"""Execution lifecycle tests for ``comfy run``.
 
 The CLI's ``run`` command historically emitted a single ``run`` event via the
-``@track_command()`` decorator. Post-MAR-52 it manually emits
+``@track_command()`` decorator. It now manually emits
 ``execution_start`` / ``execution_success`` / ``execution_error`` against the
 canonical PRD §5.1 schema, with ``mixpanel_name="run"`` on the start event to
 preserve Mixpanel-side continuity for the 219K/week legacy stream.

--- a/tests/comfy_cli/test_secret_redaction.py
+++ b/tests/comfy_cli/test_secret_redaction.py
@@ -1,4 +1,4 @@
-"""Regression guard: no command may echo an *unredacted* secret (BE-3363).
+"""Regression guard: no command may echo an *unredacted* secret.
 
 A 2026-07-16 dogfooding transcript reported ``comfy cloud login`` printing an
 API key in plaintext. On current ``main`` that is no longer reproducible —

--- a/tests/comfy_cli/test_subgraph_gallery_templates.py
+++ b/tests/comfy_cli/test_subgraph_gallery_templates.py
@@ -1,6 +1,6 @@
 """Regression sweep over REAL subgraphed gallery templates.
 
-BE-3223 showed subgraph gallery templates must convert fully through
+Subgraph gallery templates must convert fully through
 ``convert_ui_to_api`` and expose their interior slots via
 ``Graph.get_template_schema``, but the existing subgraph tests only use small
 synthetic shapes. These tests pin that behavior against verbatim copies of

--- a/tests/comfy_cli/test_tracking.py
+++ b/tests/comfy_cli/test_tracking.py
@@ -630,7 +630,7 @@ class TestSensitiveNameMatcher:
 
 
 class TestCliParamNameDriftGate:
-    """BE-992 happened because credential flags were added after the redaction
+    """The leak happened because credential flags were added after the redaction
     set was written. Walk the real CLI tree so the next one cannot land
     unredacted."""
 
@@ -671,7 +671,7 @@ class TestCliParamNameDriftGate:
 class TestTrackCommandRealTyperWiring:
     def test_model_download_kwargs_are_filtered_and_redacted(self, tracking_module):
         # `model download` is the command whose `_ctx` + credential kwarg
-        # combination motivated BE-992; invoke it through Typer for real so
+        # combination motivated the redaction fix; invoke it through Typer for real so
         # the Click context actually lands in the tracked kwargs.
         from typer.testing import CliRunner
 

--- a/tests/comfy_cli/test_tracking_lazy_import.py
+++ b/tests/comfy_cli/test_tracking_lazy_import.py
@@ -49,8 +49,8 @@ def test_importing_tracking_does_not_load_telemetry_sdks():
 
 
 def test_importing_the_cli_entrypoint_does_not_load_telemetry_sdks():
-    # cmdline is what `comfy` actually runs, and it is the import chain in the
-    # The original traceback (cmdline -> tracking -> mixpanel -> pydantic).
+    # cmdline is what `comfy` actually runs, and it heads the import chain from
+    # the original traceback: cmdline -> tracking -> mixpanel -> pydantic.
     loaded = _modules_after("import comfy_cli.cmdline")
     assert not loaded & set(_FORBIDDEN), (
         f"comfy_cli.cmdline imported {sorted(loaded & set(_FORBIDDEN))} at module scope; "

--- a/tests/comfy_cli/test_tracking_lazy_import.py
+++ b/tests/comfy_cli/test_tracking_lazy_import.py
@@ -1,4 +1,4 @@
-"""The telemetry SDKs must not be imported just by starting the CLI (BE-3289).
+"""The telemetry SDKs must not be imported just by starting the CLI.
 
 `mixpanel` depends on pydantic, which loads the compiled `pydantic_core`
 extension. A `comfy` process that has that extension loaded holds the .pyd/.so
@@ -50,7 +50,7 @@ def test_importing_tracking_does_not_load_telemetry_sdks():
 
 def test_importing_the_cli_entrypoint_does_not_load_telemetry_sdks():
     # cmdline is what `comfy` actually runs, and it is the import chain in the
-    # BE-3289 traceback (cmdline -> tracking -> mixpanel -> pydantic).
+    # The original traceback (cmdline -> tracking -> mixpanel -> pydantic).
     loaded = _modules_after("import comfy_cli.cmdline")
     assert not loaded & set(_FORBIDDEN), (
         f"comfy_cli.cmdline imported {sorted(loaded & set(_FORBIDDEN))} at module scope; "

--- a/tests/comfy_cli/test_tracking_providers.py
+++ b/tests/comfy_cli/test_tracking_providers.py
@@ -1,4 +1,4 @@
-"""Provider-level tests for the dual-send telemetry refactor (MAR-52).
+"""Provider-level tests for the dual-send telemetry refactor.
 
 These cover the contract each provider has to honor — Mixpanel keeps legacy
 event names via the ``mixpanel_name`` alias kwarg, PostHog stamps every event
@@ -65,7 +65,7 @@ def _mixpanel_track_kwargs(mp_provider):
     """Drain the Mixpanel worker, then return the last ``track(...)`` kwargs.
 
     ``MixpanelProvider`` dispatches through a bounded queue drained by a daemon
-    worker (BE-5868), so the send has not necessarily happened by the time
+    worker, so the send has not necessarily happened by the time
     ``track_event()`` returns. Every assertion on the mocked client goes through
     a ``flush()`` first.
     """
@@ -239,7 +239,7 @@ class TestProviderConstruction:
         assert provider.enabled is False
 
     def test_mixpanel_client_has_bounded_request_timeout(self):
-        """Regression guard for BE-3354/BE-3403: mixpanel-python's default
+        """Regression guard: mixpanel-python's default
         Consumer uses request_timeout=None → an unbounded requests.post that
         hangs the CLI forever on a blackholed endpoint. The provider must build
         its Mixpanel client with an explicit 10s consumer timeout so this can't
@@ -256,7 +256,7 @@ class TestProviderConstruction:
         assert adapter.max_retries.total == 1
 
     def test_posthog_unregisters_its_own_atexit_join(self):
-        """Regression guard for BE-3403: Posthog's constructor registers its own
+        """Regression guard: Posthog's constructor registers its own
         ``atexit.register(self.join)``, which flushes synchronously on the main
         thread at shutdown, unbounded by ``_flush_all_providers``' 5s daemon
         deadline. Against a blackholed endpoint that join can block ~21s after
@@ -298,7 +298,7 @@ def _sent_event_names(provider):
 
 
 class TestMixpanelNonBlockingDispatch:
-    """BE-5868: ``track()`` used to post inline on the calling thread, so every
+    """``track()`` used to post inline on the calling thread, so every
     consented invocation paid a synchronous HTTP round-trip (worst case ~10s
     against a blackholed endpoint) *before* the wrapped command body ran.
     Dispatch is now a bounded queue drained by a daemon worker."""
@@ -390,8 +390,8 @@ class TestMixpanelNonBlockingDispatch:
         """End to end against a blackholed endpoint: ``_flush_all_providers`` runs
         each provider's ``flush()`` in a daemon thread joined against the shared
         5s deadline, so a hung send costs the exit path that much and no more —
-        same treatment as PostHog's internally-unbounded ``client.flush()``
-        (BE-3403). (Mixpanel's ``flush()`` also self-bounds; this covers the
+        same treatment as PostHog's internally-unbounded ``client.flush()``.
+        (Mixpanel's ``flush()`` also self-bounds; this covers the
         caller-side guarantee, which is what holds for every provider.)"""
         import comfy_cli.tracking as tracking_mod
 
@@ -412,7 +412,7 @@ class TestMixpanelNonBlockingDispatch:
             release.set()
 
     def test_worker_is_a_daemon_and_the_provider_registers_no_atexit_hook(self):
-        """Design constraint (BE-3403): ``_flush_all_providers`` is the ONLY
+        """Design constraint: ``_flush_all_providers`` is the ONLY
         shutdown drain path. The worker must die with the process rather than
         join it, and the provider must not add a second, unbounded atexit hook —
         the exact mistake ``PostHogProvider`` has to actively unregister."""
@@ -609,7 +609,7 @@ class TestRedactionThroughFanOut:
         assert "sk-supersecret" not in str(ph_kwargs["properties"])
 
     def test_download_credentials_never_reach_either_provider(self, tracking_with_two_providers):
-        # BE-992 kwarg shape: before the suffix matcher and the underscore
+        # The original kwarg shape: before the suffix matcher and the underscore
         # filter, the un-redacted token still shipped to PostHog because its
         # client coerces the unserializable _ctx instead of raising the way
         # Mixpanel's does.
@@ -700,7 +700,7 @@ class TestLazyProviderConstruction:
             provider = PostHogProvider("phc_test", "https://t.comfy.org")
         assert provider.enabled is True
         kwargs = posthog_cls.call_args.kwargs
-        # main (BE-3403) replaced the branch's `flush_interval=0.2` with a
+        # main replaced the branch's `flush_interval=0.2` with a
         # tighter, more direct bound: cap the consumer's drain budget, and
         # unregister posthog's own atexit join so `_flush_all_providers` is the
         # only shutdown drain and its deadline actually governs.
@@ -754,8 +754,8 @@ class TestAtexitFlush:
         """A provider whose flush() blocks (e.g. a blackholed telemetry endpoint)
         must not wedge the atexit hook past its per-provider deadline. The hook
         runs each flush in a daemon thread and joins with a ~5s timeout, so a
-        60s-hanging provider is abandoned rather than allowed to hang the CLI
-        (BE-3354/BE-3403). Bounds the total at well under the 60s hang."""
+        60s-hanging provider is abandoned rather than allowed to hang the CLI.
+        Bounds the total at well under the 60s hang."""
         import comfy_cli.tracking as tracking_mod
 
         release = threading.Event()
@@ -787,7 +787,7 @@ def _override_warnings(caplog):
 
 
 class TestPostHogTokenResolution:
-    """BE-4931: $POSTHOG_API_KEY is also what posthog-cli calls a *personal*
+    """$POSTHOG_API_KEY is also what posthog-cli calls a *personal*
     (``phx_``) API key, which the ingestion endpoint rejects with a 401. Only a
     ``phc_`` project write key may override the committed default."""
 

--- a/tests/comfy_cli/test_validate_lowers_ui.py
+++ b/tests/comfy_cli/test_validate_lowers_ui.py
@@ -212,7 +212,7 @@ def _subgraph_ui_workflow() -> dict:
     instance (id 57), with none of its link inputs wired — so lowering expands
     it to the composite id ``57:3`` and validation flags its missing inputs.
 
-    An OUTPUT node specifically: BE-3406 prunes output-unreachable nodes before
+    An OUTPUT node specifically: validation prunes output-unreachable nodes before
     the required-input check, so a non-output interior node would produce no
     errors for this test to inspect the ids of."""
     return {
@@ -271,7 +271,7 @@ class TestValidateSubgraphIdTranslation:
     def test_api_format_input_keeps_raw_ids(self, tmp_path):
         # A caller that hands us an already-lowered API doc addresses THAT doc;
         # its ids pass through untouched (no api_node_id annotation).
-        api = {"57:3": {"class_type": "SaveImage", "inputs": {}}}  # output node: reachable (BE-3406)
+        api = {"57:3": {"class_type": "SaveImage", "inputs": {}}}  # output node: reachable
         result = _run_validate(tmp_path, api, _object_info())
         assert result.exit_code == 1
         env = _envelope(result)

--- a/tests/comfy_cli/test_workflow_to_api.py
+++ b/tests/comfy_cli/test_workflow_to_api.py
@@ -1993,7 +1993,7 @@ class TestDynamicComboAfterControlMarker:
         assert inputs["shape.side"] == 10.0
 
     def test_dynamic_combo_sub_seed_strips_implicit_control_marker(self):
-        # BE-3370 review: an INT ``seed``/``noise_seed`` *sub-input* of a
+        # An INT ``seed``/``noise_seed`` *sub-input* of a
         # dynamic combo relies on the frontend's implicit companion, but its
         # dotted name (``model.seed``) never matched the leaf-name check, so the
         # trailing control marker was kept as a real value and shifted every
@@ -2050,7 +2050,7 @@ class TestDynamicComboAfterControlMarker:
     def test_unresolved_selector_warns(self, caplog):
         import logging
 
-        # BE-3370 review: a selector value that matches no option key leaves the
+        # A selector value that matches no option key leaves the
         # option's sub-input slots unconsumed, silently shifting later widgets.
         # We can't recover the alignment, but the mismatch must not be silent.
         object_info = {
@@ -2087,7 +2087,7 @@ class TestDynamicComboAfterControlMarker:
         assert any("matched no option" in rec.message for rec in caplog.records)
 
     def test_deeply_nested_dynamic_combos_do_not_recurse_forever(self, caplog):
-        # BE-3370 review: an unbounded chain of nested COMFY_*COMBO* sub-inputs
+        # An unbounded chain of nested COMFY_*COMBO* sub-inputs
         # must degrade to a warning, not an uncaught RecursionError that aborts
         # the whole conversion. Build a self-referential option chain deeper
         # than _MAX_DYNAMIC_COMBO_DEPTH.


### PR DESCRIPTION
## What

`public-repo-hygiene` was adopted in #758 and has failed on `main` ever since, with 252 findings. Every open PR inherits the red mark, so it says nothing about the PR showing it, and a genuine leak would sit unnoticed among 252 lines.

191 of those findings were internal tracker IDs cited in comments and docstrings. This removes all of them.

The prose around each one stays. What a comment explains about the code earns its place; the tracker number it came from does not, and nobody reading this repo can resolve that number anyway.

Every reference lived in a comment or a docstring, so nothing here changes behaviour. Verified by grepping for the ID shape outside comments before starting: no string literals, no identifiers, no test names.

Two supporting edits:

- A cql engine test wrote the sentinel `VALUE-FOR-10`, which matches the checker's ticket shape. Lowercased to `value-for-10` — it is arbitrary test data either way, written and then asserted back.
- `HAILUO-03` is MiniMax's Hailuo 03 model, named in the curated knowledge bundle and asserted in tests. It is a product name that happens to match the ticket shape, so it goes in the workflow's `ticket_allowlist` input rather than being renamed.

Also carries the two `ERA001` fixes that make `ruff check` pass. #735 enabled the rule with two hits still in the tree, so `main` is red on lint as well. `# status (billing / plan / concurrency)` and `# set-widget (name-addressed)` both parse as call expressions; reworded the way #735 handled `# browse: types / categories`.

## Verification

Ran the real checker locally, loaded from the SHA this repo pins in `.github/workflows/public-repo-hygiene.yml`, so these numbers are the ones CI computes:

| | findings |
| --- | --- |
| before | 252 |
| after | 58 |

The 58 that remain are all `Comfy-Org/<repo>` references. None is a ticket ID. They are triaged and tracked separately, and split three ways: repos that are public and missing from the org-wide allowlist, Hugging Face model paths the checker reads as GitHub repos, and a small number of genuine references to non-public repos.

- Full suite: 5640 passed, 42 failed.
- Those 42 are pre-existing. I ran the same four files on a clean `origin/main` worktree and diffed the failure lists: **identical**, so this change introduces zero failures. They come from `FORCE_COLOR` and `~/.config` leaking into the local environment.
- `ruff check` and `ruff format --diff` clean at the pinned 0.15.15.

## Notes

The remaining `Comfy-Org/<repo>` findings are not fixable from this repo alone. The allowlist is deliberately not a caller input, so the public-repo half needs a change in the shared workflows repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L86eLQSKkxRnc7NchcqSzc