### PR TITLE
chore(hygiene): drop org-qualified private repo paths from two docstrings

### DIFF
--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -4,7 +4,7 @@ Parses ComfyUI's ``object_info.json``, builds an indexed compatibility graph,
 and exposes upstream/downstream, path-finding, validation, annotations,
 and widget-order resolution.
 
-Port of ``github.com/Comfy-Org/cql/nodegraph`` (Go).
+Port of the upstream Go ``nodegraph`` package.
 """
 
 from __future__ import annotations

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -1,7 +1,7 @@
 """Find, validate, and index the compiled comfy-knowledge bundle.
 
-The bundle (``knowledge.json`` + optional ``manifest.json``) is produced by
-``Comfy-Org/comfy-knowledge``. It reaches this process by one of three routes,
+The bundle (``knowledge.json`` + optional ``manifest.json``) is produced by the
+comfy-knowledge build pipeline. It reaches this process by one of three routes,
 tried in order: an explicit ``COMFY_KNOWLEDGE_FILE``, the per-user cache, or a
 fetch from ``COMFY_KNOWLEDGE_URL``. A missing or broken bundle is a normal
 state: every entry point here returns ``None`` rather than raising, and nothing


### PR DESCRIPTION
## Summary

Two docstrings carried a provenance note that named a private repo by its full `org/name` path. Neither path was doing any work: the unqualified names they describe already appear elsewhere in the same files, and an unqualified name is not what the hygiene check denies. The fact survives, the path does not.

- `comfy_cli/cql/engine.py`: the port-provenance line now names the Go package without the repo path.
- `comfy_cli/knowledge.py`: the bundle producer is now described by pipeline rather than by repo path.

Comments only, no behaviour change.

## Testing

`ruff format --check` and `ruff check` clean on both files. `tests/comfy_cli/cql/` passes, 337 tests.

## Note on the remaining findings

This clears 2 of the repo's 29 hygiene findings. Of the rest, 19 are public model download URLs that the checker was misreading as GitHub references, fixed upstream in Comfy-Org/github-workflows#217, and 8 are a genuine private-repo reference in `.github/workflows/refresh-cql-catalogs.yml` that needs a design decision rather than a scrub, since the workflow authenticates against that repo and the name is load-bearing. Two markdown link texts in a captured upstream test fixture also remain and are correctly denied.
