### PR TITLE
feat(build): the CLI says release, with version as a deprecated alias

### DIFF
--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -59,17 +59,36 @@ app = typer.Typer(
     ),
 )
 
-# `comfy build version <verb>` — the resource-verb surface for versions
-# (a version is an immutable build cut of a distribution).
+# `comfy build release <verb>`: the resource-verb surface for releases
+# (a release is an immutable build cut of a distribution; the builder's public
+# API renamed build versions to releases). The module keeps the version_app
+# name so internal references stay put.
 version_app = typer.Typer(
     no_args_is_help=True,
-    help="Inspect and cut build versions.",
+    help="Inspect and cut build releases.",
 )
-app.add_typer(version_app, name="version")
+app.add_typer(version_app, name="release")
+
+
+def _warn_version_deprecated() -> None:
+    """One stderr warning per invocation of the retired `comfy build version`
+    spelling, same wiring as cmdline.py's _add_deprecated_alias. No envelope
+    re-stamp is needed here: the root callback stamps only the top-level group
+    name ("build", identical for both spellings), and every command in this
+    group passes its canonical `build release ...` label to emit explicitly."""
+    renderer = get_renderer()
+    renderer.stderr_console().print(
+        "[yellow]`comfy build version` is deprecated; use `comfy build release` instead.[/yellow]"
+    )
+
+
+# `comfy build version` was the subgroup's name before the builder's public API
+# renamed build versions to releases; kept as a warning alias for old scripts.
+app.add_typer(version_app, name="version", hidden=True, callback=_warn_version_deprecated)
 
 # `comfy build artifact <verb>` / `blob <verb>` — the per-target build
 # outputs and the workspace's private uploaded content.
-artifact_app = typer.Typer(no_args_is_help=True, help="Build artifacts (per-target outputs of a cut version).")
+artifact_app = typer.Typer(no_args_is_help=True, help="Build artifacts (per-target outputs of a cut release).")
 app.add_typer(artifact_app, name="artifact")
 blob_app = typer.Typer(no_args_is_help=True, help="Workspace private blobs (uploaded models / nodes).")
 app.add_typer(blob_app, name="blob")
@@ -742,7 +761,8 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
     ``locate_bytes(upload) -> Path`` finds the local file for a model upload.
     node_zip uploads (hand-dropped local nodes) aren't packaged yet — raises
     NotImplementedError so the caller can surface a clear message. Returns
-    ``{distributionId, versionId, statusUrl, uploaded}``."""
+    ``{distributionId, versionId, releaseId, statusUrl, uploaded}`` (releaseId
+    is the canonical name for the cut; versionId stays because user scripts pin it)."""
     definition = plan["definition"]
     # Preflight the whole upload list before any bytes move: an unsupported local
     # node, or a model whose file can't be found (missing --models-dir), must fail
@@ -768,7 +788,13 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
         # command can surface it (the user can then delete or retry it, not orphan it).
         e.distribution_id = dist_id
         raise
-    return {"distributionId": dist_id, "versionId": version_id, "statusUrl": status_url, "uploaded": uploaded}
+    return {
+        "distributionId": dist_id,
+        "versionId": version_id,
+        "releaseId": version_id,
+        "statusUrl": status_url,
+        "uploaded": uploaded,
+    }
 
 
 def _resolve_models_dir(models_dir: str | None) -> Path | None:
@@ -1225,7 +1251,7 @@ def _create_execute(
     if renderer.is_pretty():
         renderer.success(f"Created build '{name}'")
         renderer.print(f"  build:   {result['distributionId']}")
-        renderer.print(f"  version: {result['versionId']}  (uploaded {result['uploaded']} blob(s))")
+        renderer.print(f"  release: {result['releaseId']}  (uploaded {result['uploaded']} blob(s))")
         renderer.print(f"  status:  {result['statusUrl']}")
     renderer.emit({"name": name, "executed": True, **result}, command="build create", changed=True)
 
@@ -1347,26 +1373,27 @@ def get_cmd(
     renderer.emit(dist, command="build get")
 
 
-@version_app.command("create", help="Cut a new version of a build.")
+@version_app.command("create", help="Cut a new release of a build.")
 @tracking.track_command("build")
 def version_create(
-    distribution_id: Annotated[str, typer.Argument(help="Build id to cut a version of.")],
+    distribution_id: Annotated[str, typer.Argument(help="Build id to cut a release of.")],
     builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
 ):
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    version_id, status_url = _builder_call(renderer, lambda: client.cut_version(distribution_id))
+    release_id, status_url = _builder_call(renderer, lambda: client.cut_version(distribution_id))
     if renderer.is_pretty():
-        renderer.success(f"Cut version {version_id}")
+        renderer.success(f"Cut release {release_id}")
         renderer.print(f"  status: {status_url}")
+    # releaseId is the canonical name; versionId stays because user scripts pin it.
     renderer.emit(
-        {"distributionId": distribution_id, "versionId": version_id, "statusUrl": status_url},
-        command="build version create",
+        {"distributionId": distribution_id, "versionId": release_id, "releaseId": release_id, "statusUrl": status_url},
+        command="build release create",
         changed=True,
     )
 
 
-@version_app.command("list", help="List a build's versions.")
+@version_app.command("list", help="List a build's releases.")
 @tracking.track_command("build")
 def version_list(
     distribution_id: Annotated[str, typer.Argument(help="Build id.")],
@@ -1377,16 +1404,16 @@ def version_list(
     versions = _builder_call(renderer, lambda: client.list_distribution_versions(distribution_id))
     if renderer.is_pretty():
         if not versions:
-            renderer.info("No versions yet.")
+            renderer.info("No releases yet.")
         for v in versions:
             renderer.print(f"  {v.get('id', '?')}  {v.get('status', '')}")
-    renderer.emit({"versions": versions}, command="build version list")
+    renderer.emit({"versions": versions}, command="build release list")
 
 
-@version_app.command("get", help="Show a version's build status.")
+@version_app.command("get", help="Show a release's build status.")
 @tracking.track_command("build")
 def version_get(
-    version_id: Annotated[str, typer.Argument(help="Build version id.")],
+    version_id: Annotated[str, typer.Argument(help="Build release id.")],
     builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
 ):
     renderer = get_renderer()
@@ -1394,13 +1421,13 @@ def version_get(
     version = _builder_call(renderer, lambda: client.get_version(version_id))
     if renderer.is_pretty():
         renderer.console().print_json(json.dumps(version))
-    renderer.emit(version, command="build version get")
+    renderer.emit(version, command="build release get")
 
 
-@version_app.command("logs", help="Read a version's build log for one target.")
+@version_app.command("logs", help="Read a release's build log for one target.")
 @tracking.track_command("build")
 def version_logs(
-    version_id: Annotated[str, typer.Argument(help="Build version id.")],
+    version_id: Annotated[str, typer.Argument(help="Build release id.")],
     os_target: Annotated[
         str | None, typer.Option("--os", help="Target OS to read (linux/windows/mac); builder picks one if omitted.")
     ] = None,
@@ -1410,12 +1437,18 @@ def version_logs(
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
     content = _builder_call(renderer, lambda: client.get_version_logs(version_id, os=os_target, gpu=gpu))
+    # The contract carries both spellings of the id: releaseId is canonical and
+    # versionId stays because user scripts pin it. Mirror whichever the builder
+    # returned into the other so either server generation yields both keys.
+    log_id = content.get("releaseId") or content.get("versionId")
+    if log_id:
+        content = {**content, "versionId": log_id, "releaseId": log_id}
     if renderer.is_pretty():
         log = content.get("log", "")
         renderer.print(log if log else "(no build log captured yet)")
         if content.get("truncated"):
             renderer.warn("log truncated (head and tail kept; middle dropped)")
-    renderer.emit(content, command="build version logs")
+    renderer.emit(content, command="build release logs")
 
 
 @app.command("validate", help="Dry-run resolve a build's definition (nothing is built).")
@@ -1584,7 +1617,7 @@ def from_snapshot_cmd(
         renderer.success(f"Created build {distribution_id} from {path.name}")
         for line in report_advisories(result.get("report") or {}):
             renderer.warn(line)
-        renderer.info(f"cut a build with `comfy build version create {distribution_id}`")
+        renderer.info(f"cut a build with `comfy build release create {distribution_id}`")
     renderer.emit(result, command="build from-snapshot", changed=True)
 
 
@@ -1659,7 +1692,7 @@ def base_images_cmd(builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None)
     renderer.emit({"baseImages": images}, command="build base-images")
 
 
-@app.command("build-targets", help="List the build targets (os/gpu) a version can be cut for.")
+@app.command("build-targets", help="List the build targets (os/gpu) a release can be cut for.")
 @tracking.track_command("build")
 def build_targets_cmd(builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None):
     renderer = get_renderer()
@@ -1682,10 +1715,10 @@ def model_dirs_cmd(builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None):
     renderer.emit({"directories": dirs}, command="build model-dirs")
 
 
-@version_app.command("manifest", help="Show a version's models and runtime policies.")
+@version_app.command("manifest", help="Show a release's models and runtime policies.")
 @tracking.track_command("build")
 def version_manifest(
-    version_id: Annotated[str, typer.Argument(help="Build version id.")],
+    version_id: Annotated[str, typer.Argument(help="Build release id.")],
     builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
 ):
     renderer = get_renderer()
@@ -1693,7 +1726,7 @@ def version_manifest(
     manifest = _builder_call(renderer, lambda: client.get_version_manifest(version_id))
     if renderer.is_pretty():
         renderer.console().print_json(json.dumps(manifest))
-    renderer.emit(manifest, command="build version manifest")
+    renderer.emit(manifest, command="build release manifest")
 
 
 @artifact_app.command("download", help="Get a signed download link for a build artifact.")

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -37,6 +37,16 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy build create": "build_create",
     "comfy build list": "build_list",
     "comfy build get": "build_get",
+    # `comfy build release` is the canonical subgroup; `comfy build version` is
+    # its hidden deprecated alias. Alias envelopes carry the canonical `build
+    # release ...` labels, but both spellings register here so an agent that
+    # looks up the old path still finds the contract (schema files keep their
+    # build_version_* names because user scripts pin them).
+    "comfy build release create": "build_version_create",
+    "comfy build release list": "build_version_list",
+    "comfy build release get": "build_version_get",
+    "comfy build release logs": "build_version_logs",
+    "comfy build release manifest": "build_version_manifest",
     "comfy build version create": "build_version_create",
     "comfy build version list": "build_version_list",
     "comfy build version get": "build_version_get",

--- a/comfy_cli/distribution_api.py
+++ b/comfy_cli/distribution_api.py
@@ -9,8 +9,8 @@ URL and never transit the builder.
 Field names match services/comfy-builder/openapi.yaml exactly:
   POST /v1/blobs {kind, filename, sizeBytes, sha256}     -> {blobId, uploadUrl, expiresAt}
   POST /v1/builds {name, definition}              -> {id, ...}
-  POST /v1/builds/{id}/versions {targets?}        -> {buildVersionId, statusUrl}
-  GET  /v1/build-versions/{id}                    -> {status, ...}
+  POST /v1/builds/{id}/releases {targets?}        -> {releaseId, statusUrl}
+  GET  /v1/releases/{id}                          -> {status, ...}
 """
 
 from __future__ import annotations
@@ -103,17 +103,20 @@ class BuilderClient:
         return self._post(("builds",), body)["id"]
 
     def cut_version(self, distribution_id: str, targets: list[dict] | None = None) -> tuple[str, str]:
-        """Freeze the definition and enqueue a build. Returns (versionId, statusUrl)."""
+        """POST /v1/builds/{id}/releases: freeze the definition and enqueue a
+        build. Returns (releaseId, statusUrl). A server that predates the
+        version-to-release rename still answers with ``buildVersionId``, so
+        that key is the fallback and the CLI works against either generation."""
         body: dict = {}
         if targets:
             body["targets"] = targets
-        r = self._post(("builds", distribution_id, "versions"), body)
-        return r["buildVersionId"], r["statusUrl"]
+        r = self._post(("builds", distribution_id, "releases"), body)
+        return r.get("releaseId") or r["buildVersionId"], r["statusUrl"]
 
     def get_version(self, version_id: str) -> dict:
-        """Poll a version's build status."""
+        """GET /v1/releases/{id}: poll a release's build status."""
         _, parsed = request_json(
-            self.target.url("build-versions", version_id), self.target, method="GET", max_bytes=_MAX_JSON
+            self.target.url("releases", version_id), self.target, method="GET", max_bytes=_MAX_JSON
         )
         return parsed or {}
 
@@ -163,15 +166,18 @@ class BuilderClient:
         return self._get(("builds", distribution_id))
 
     def list_distribution_versions(self, distribution_id: str) -> list[dict]:
-        """GET /v1/builds/{id}/versions -> the distribution's versions."""
-        return self._get(("builds", distribution_id, "versions")).get("versions", [])
+        """GET /v1/builds/{id}/releases -> the distribution's releases. A server
+        that predates the version-to-release rename keys the list ``versions``,
+        so both spellings parse."""
+        body = self._get(("builds", distribution_id, "releases"))
+        return body.get("releases") or body.get("versions") or []
 
     def get_version_logs(self, version_id: str, *, os: str | None = None, gpu: str | None = None) -> dict:
-        """GET /v1/build-versions/{id}/logs -> the build log for one target
+        """GET /v1/releases/{id}/logs -> the build log for one target
         (``os``/``gpu`` select which; the builder picks a target when omitted).
         Returns ``{versionId, os?, gpu?, log, truncated}``. Uses a larger response
         cap than other reads because a build log can be several MiB."""
-        return self._get(("build-versions", version_id, "logs"), {"os": os, "gpu": gpu}, max_bytes=_MAX_LOG_JSON)
+        return self._get(("releases", version_id, "logs"), {"os": os, "gpu": gpu}, max_bytes=_MAX_LOG_JSON)
 
     def delete_distribution(self, distribution_id: str) -> None:
         """DELETE /v1/builds/{id} -> soft-delete. Idempotent (204 even when
@@ -207,9 +213,9 @@ class BuilderClient:
         return parsed or {}
 
     def get_version_manifest(self, version_id: str) -> dict:
-        """GET /v1/build-versions/{id}/manifest -> the version's models and
+        """GET /v1/releases/{id}/manifest -> the release's models and
         runtime policies."""
-        return self._get(("build-versions", version_id, "manifest"))
+        return self._get(("releases", version_id, "manifest"))
 
     def get_artifact_download(self, artifact_id: str) -> dict:
         """GET /v1/build-artifacts/{id}/download -> ``{downloadUrl, expiresAt?}``."""

--- a/comfy_cli/schemas/build_create.json
+++ b/comfy_cli/schemas/build_create.json
@@ -29,11 +29,12 @@
     },
     "distributionId": {"type": "string"},
     "versionId": {"type": "string"},
+    "releaseId": {"type": "string"},
     "statusUrl": {"type": "string"},
     "uploaded": {"type": "integer"}
   },
   "oneOf": [
     {"properties": {"executed": {"const": false}}, "required": ["plan"]},
-    {"properties": {"executed": {"const": true}}, "required": ["distributionId", "versionId", "statusUrl"]}
+    {"properties": {"executed": {"const": true}}, "required": ["distributionId", "versionId", "releaseId", "statusUrl"]}
   ]
 }

--- a/comfy_cli/schemas/build_version_create.json
+++ b/comfy_cli/schemas/build_version_create.json
@@ -1,13 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/build_version_create.json",
-  "title": "comfy build version create --json data payload",
+  "title": "comfy build release create --json data payload",
+  "description": "releaseId is the canonical id of the cut; versionId carries the same value and stays because user scripts pin it.",
   "type": "object",
-  "required": ["distributionId", "versionId", "statusUrl"],
+  "required": ["distributionId", "versionId", "releaseId", "statusUrl"],
   "additionalProperties": true,
   "properties": {
     "distributionId": {"type": "string"},
     "versionId": {"type": "string"},
+    "releaseId": {"type": "string"},
     "statusUrl": {"type": "string"}
   }
 }

--- a/comfy_cli/schemas/build_version_get.json
+++ b/comfy_cli/schemas/build_version_get.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/build_version_get.json",
-  "title": "comfy build version get --json data payload",
-  "description": "A version's build status, as returned by GET /v1/build-versions/{id}.",
+  "title": "comfy build release get --json data payload",
+  "description": "A release's build status, as returned by GET /v1/releases/{id}.",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/comfy_cli/schemas/build_version_list.json
+++ b/comfy_cli/schemas/build_version_list.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/build_version_list.json",
-  "title": "comfy build version list --json data payload",
+  "title": "comfy build release list --json data payload",
   "type": "object",
   "required": ["versions"],
   "additionalProperties": true,

--- a/comfy_cli/schemas/build_version_logs.json
+++ b/comfy_cli/schemas/build_version_logs.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/build_version_logs.json",
-  "title": "comfy build version logs --json data payload",
-  "description": "One build target's captured log, as returned by GET /v1/build-versions/{id}/logs.",
+  "title": "comfy build release logs --json data payload",
+  "description": "One build target's captured log, as returned by GET /v1/releases/{id}/logs. releaseId is the canonical id; versionId carries the same value and stays because user scripts pin it.",
   "type": "object",
-  "required": ["versionId", "log", "truncated"],
+  "required": ["versionId", "releaseId", "log", "truncated"],
   "additionalProperties": true,
   "properties": {
     "versionId": {"type": "string"},
+    "releaseId": {"type": "string"},
     "os": {"type": "string", "enum": ["linux", "windows", "mac"]},
     "gpu": {"type": "string", "enum": ["nvidia", "amd", "cpu", "mps"]},
     "log": {"type": "string"},

--- a/comfy_cli/schemas/build_version_manifest.json
+++ b/comfy_cli/schemas/build_version_manifest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/build_version_manifest.json",
-  "title": "comfy build version manifest --json data payload",
-  "description": "A cut version's models and runtime policies (DistributionManifest).",
+  "title": "comfy build release manifest --json data payload",
+  "description": "A cut release's models and runtime policies (DistributionManifest).",
   "type": "object",
   "additionalProperties": true,
   "properties": {"models": {"type": "array"}}

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -8,6 +8,8 @@ import json
 import os
 import subprocess
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -406,6 +408,7 @@ def test_execute_create_uploads_stitches_and_cuts():
     assert result == {
         "distributionId": "dist-123",
         "versionId": "ver-456",
+        "releaseId": "ver-456",
         "statusUrl": "https://status.example/ver-456",
         "uploaded": 1,
     }
@@ -518,8 +521,8 @@ def test_builder_client_endpoints_and_parsing(monkeypatch):
             return 200, {"blobId": "b1", "uploadUrl": "https://put", "expiresAt": "t"}
         if url.endswith("/v1/builds"):
             return 201, {"id": "d1", "name": "n"}
-        if url.endswith("/versions"):
-            return 202, {"buildVersionId": "v1", "statusUrl": "https://s"}
+        if url.endswith("/releases"):
+            return 202, {"releaseId": "v1", "statusUrl": "https://s"}
         if url.endswith("/v1/models/resolve"):
             return 200, {
                 "results": [{"filename": "a.safetensors", "candidates": [{"sourceUri": "https://u", "sha256": "h"}]}]
@@ -537,6 +540,7 @@ def test_builder_client_endpoints_and_parsing(monkeypatch):
     assert results[0]["candidates"][0]["sourceUri"] == "https://u"
     # URLs carry the /v1 prefix, and the JWT rides on the cloud target
     assert ("POST", "https://builder.test/v1/blobs") in calls
+    assert ("POST", "https://builder.test/v1/builds/d1/releases") in calls
     assert ("POST", "https://builder.test/v1/models/resolve") in calls
     assert c.target.auth_token == "jwt-token" and c.target.is_cloud
 
@@ -550,9 +554,11 @@ def test_builder_client_read_endpoints(monkeypatch):
             return 200, {"builds": [{"id": "d1", "name": "n"}]}
         if url.endswith("/v1/builds/d1"):
             return 200, {"id": "d1", "name": "n", "definition": {"models": []}}
-        if url.endswith("/v1/builds/d1/versions"):
+        if url.endswith("/v1/builds/d1/releases"):
+            # A not-yet-upgraded builder still keys the list `versions`; the
+            # client parses that spelling as well as `releases`.
             return 200, {"versions": [{"id": "v1", "status": "complete"}]}
-        if "/v1/build-versions/v1/logs" in url:
+        if "/v1/releases/v1/logs" in url:
             return 200, {"versionId": "v1", "os": "linux", "gpu": "nvidia", "log": "hello", "truncated": False}
         return 200, {}
 
@@ -632,7 +638,7 @@ def test_builder_client_reference_and_update_endpoints(monkeypatch):
     assert ("GET", "https://builder.test/v1/build-targets", None) in calls
     assert ("GET", "https://builder.test/v1/model-directories", None) in calls
     assert ("GET", "https://builder.test/v1/blobs", None) in calls
-    assert ("GET", "https://builder.test/v1/build-versions/v1/manifest", None) in calls
+    assert ("GET", "https://builder.test/v1/releases/v1/manifest", None) in calls
     assert ("GET", "https://builder.test/v1/build-artifacts/a1/download", None) in calls
 
 
@@ -1510,6 +1516,131 @@ def test_distribution_alias_hidden_from_root_help():
     assert proc.returncode == 0
     assert "build" in proc.stdout
     assert "distribution" not in proc.stdout
+
+
+# --- release subgroup: `comfy build release` is canonical, `comfy build version`
+# --- is its hidden deprecated alias -------------------------------------------
+
+
+class _FakeCutHandler(BaseHTTPRequestHandler):
+    """Answers the cut endpoint the way an upgraded builder does, so the CLI
+    subprocess exercises the real release surface without a network."""
+
+    def do_POST(self):  # noqa: N802 (BaseHTTPRequestHandler's spelling)
+        if self.path == "/v1/builds/dist-1/releases":
+            body = json.dumps({"releaseId": "rel-9", "statusUrl": "https://status.example/rel-9"}).encode()
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def log_message(self, *args):  # keep test output quiet
+        pass
+
+
+def _run_cut(spelling: list[str], tmp_path) -> subprocess.CompletedProcess:
+    server = HTTPServer(("127.0.0.1", 0), _FakeCutHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env = {
+            **os.environ,
+            "NO_COLOR": "1",
+            "COMFY_OUTPUT": "json",
+            "COMFY_BUILDER_TOKEN": "test-jwt",  # skips the OAuth session
+            "COMFY_SECRETS_PATH": str(tmp_path / "secrets.json"),
+            "VIRTUAL_ENV": "",
+            "CONDA_PREFIX": "",
+        }
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "comfy_cli",
+                *spelling,
+                "create",
+                "dist-1",
+                "--builder-url",
+                f"http://127.0.0.1:{server.server_address[1]}",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    finally:
+        server.shutdown()
+
+
+def test_release_create_json_validates_against_extended_schema(tmp_path):
+    """`comfy build release create --json` emits releaseId next to versionId
+    (equal values, statusUrl kept) and the payload satisfies the extended
+    build_version_create.json contract."""
+    jsonschema = pytest.importorskip("jsonschema")
+    proc = _run_cut(["build", "release"], tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    assert "deprecated" not in proc.stderr
+    envelope = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert envelope["command"] == "build release create"
+    data = envelope["data"]
+    assert data["releaseId"] == data["versionId"] == "rel-9"
+    assert data["statusUrl"] == "https://status.example/rel-9"
+    schema_path = Path(distribution.__file__).parents[1] / "schemas" / "build_version_create.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=data, schema=schema)
+
+
+def test_build_version_alias_warns_and_matches_release(tmp_path):
+    """`comfy build version create` still works: one deprecation warning on
+    stderr, and the envelope is identical to the canonical spelling's, canonical
+    `build release create` label included."""
+    canonical = _run_cut(["build", "release"], tmp_path)
+    alias = _run_cut(["build", "version"], tmp_path)
+    assert canonical.returncode == 0 and alias.returncode == 0, alias.stderr
+    assert "`comfy build version` is deprecated; use `comfy build release` instead." in alias.stderr
+    assert alias.stderr.count("is deprecated") == 1
+    assert "deprecated" not in canonical.stderr
+    canonical_env = json.loads(canonical.stdout.strip().splitlines()[-1])
+    alias_env = json.loads(alias.stdout.strip().splitlines()[-1])
+    assert alias_env == canonical_env
+    assert alias_env["command"] == "build release create"
+
+
+def test_build_version_alias_hidden_from_build_help():
+    env = {**os.environ, "NO_COLOR": "1"}
+    proc = subprocess.run(
+        [sys.executable, "-m", "comfy_cli", "build", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0
+    assert "release" in proc.stdout
+    # The alias must not be listed as a subcommand row; "version" may still
+    # appear inside prose, so assert against the command column specifically.
+    listed = {
+        line.strip().split()[1]
+        for line in proc.stdout.splitlines()
+        if line.strip().startswith("│") and len(line.strip().split()) > 1
+    }
+    assert "version" not in listed
+
+
+def test_cut_version_falls_back_to_buildversionid(monkeypatch):
+    """A not-yet-upgraded builder answers the cut with buildVersionId; the
+    client still parses the id so the CLI works against either generation."""
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        assert url == "https://builder.test/v1/builds/d1/releases"
+        return 202, {"buildVersionId": "v1", "statusUrl": "https://s"}
+
+    monkeypatch.setattr("comfy_cli.distribution_api.request_json", fake_request_json)
+    from comfy_cli.distribution_api import BuilderClient
+
+    c = BuilderClient("https://builder.test/", "jwt")
+    assert c.cut_version("d1") == ("v1", "https://s")
 
 
 # --- review follow-ups --------------------------------------------------------


### PR DESCRIPTION
Part of [BE-8948 rename version to release](https://linear.app/comfyorg/issue/BE-8948), sub-issue [BE-8961](https://linear.app/comfyorg/issue/BE-8961). Merge any time; the release carrying it ships after the builder API is live on prod ([Comfy-Org/cloud#7332](https://github.com/Comfy-Org/cloud/pull/7332)).

**Current**: `comfy build release create|list|get|logs|manifest` is the canonical subgroup; `comfy build version` is a hidden deprecated alias over the same commands, warning once per invocation on stderr.

**What changed**: the command group and help text; the API client calls `/v1/builds/{id}/releases` and `/v1/releases/{id}` parsing `releaseId` with a `buildVersionId` fallback (works against either server generation, list key `releases` or `versions` both accepted); the `--json` payloads carry `releaseId` beside `versionId` with equal values, `statusUrl` untouched, schema files keeping their names with extended required lists; the discovery map registers both spellings. The deploy command's request key and the `comfy distribution` alias are untouched.

**Contradicts**: nothing.

<details><summary>Validation</summary>

- `uv run --locked --extra dev pytest -q`: 5702 passed, 39 skipped; the 2 failures (`test_run_json`, `test_onboarding`) reproduce identically on a clean origin/main checkout, so they are pre-existing local-environment issues, not this change.
- Differential: the new release-command tests exit 2 (`release` unknown command) on origin/main and pass here; ruff check and format clean.
- Smoke: `comfy build release --help` and `comfy build version --help` both render; `version` is hidden from `comfy build --help`.
- Not run: a real builder round trip (network mocked; [BE-8962](https://linear.app/comfyorg/issue/BE-8962) owns the staging proof via the deployed API).

</details>
