### PR TITLE
style(tests): restore the blank lines ruff format wants in test_distribution

### DIFF
--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1510,6 +1510,8 @@ def test_distribution_alias_hidden_from_root_help():
     assert proc.returncode == 0
     assert "build" in proc.stdout
     assert "distribution" not in proc.stdout
+
+
 # --- review follow-ups --------------------------------------------------------
 
 


### PR DESCRIPTION
`ruff format --diff` has been failing on `main` since #753, so every open PR inherits a red `ruff_check`.

#753 appended the `# --- review follow-ups ---` section header directly after the last assert of `test_distribution_alias_hidden_from_root_help`, with no blank line between them. `ruff format` wants two blank lines before a top-level definition, and the comment binds to the definition that follows it.

This is the two blank lines, produced by running the pinned formatter. Nothing else changed.

## Verification

```
uvx ruff@0.15.15 format --check .   334 files already formatted
uvx ruff@0.15.15 check .            All checks passed!
pytest tests/comfy_cli/command/test_distribution.py --co   106 tests collected
```

The same ruff version CI pins (`ruff==0.15.15` in `.github/workflows/ruff_check.yml`) reproduces the failure on `main` and is clean with this change.

Note: `Public Repo Hygiene` is also failing on `main` right now. That is a separate problem and this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPPqqQqmnG67EQBccrw6Pi