### PR TITLE
fix(knowledge): resolve intent phrases to the capability they name (BE-9081)

### DIFF
--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -51,6 +51,14 @@ MAX_VERSION_CHARS = 64
 
 UNAVAILABLE_LOCALLY = "the templates or nodes this row resolves to are absent from this install"
 
+# Grammatical filler dropped before subset matching. Deliberately generic English:
+# naming a capability, model or gallery tag here would be a second copy of the
+# bundle's vocabulary, which then drifts every time comfy-knowledge is recompiled.
+_FILLER = frozenset("a an the of to for from with and or in on my me some this that into make create generate".split())
+# A one-word key must be at least this long to match on its own. Guards against a
+# future alias like "3d" dragging a capability into every query mentioning it.
+MIN_SINGLE_TOKEN_CHARS = 4
+
 REASON_ENV_FILE = "COMFY_KNOWLEDGE_FILE is set but could not be loaded"
 REASON_NO_URL = "no cache and COMFY_KNOWLEDGE_URL is not set"
 REASON_FETCH_FAILED = "fetch failed and no cached bundle exists"
@@ -74,6 +82,9 @@ class Bundle:
     # exact path decides it; a real id always keeps its own key.
     normalized_aliases: dict[str, str] = field(default_factory=dict)
     normalized_capabilities: dict[str, str] = field(default_factory=dict)
+    # (word set, capability id) for every capability id and alias, so an intent
+    # phrase reaches the row its own wording names. See :func:`_resolve_tokens`.
+    capability_tokens: tuple[tuple[frozenset[str], str], ...] = ()
 
 
 # One-element tuple so a memoized ``None`` is distinguishable from "not loaded yet".
@@ -131,6 +142,15 @@ def _normalize(s: str) -> str:
     """Spelling-variant key: "Hailuo 3", "hailuo-03" and "HAILUO 03" all become "hailuo3"."""
     s = re.sub(r"(?<!\d)0+(?=\d)", "", s.lower())
     return re.sub(r"[^a-z0-9]", "", s)
+
+
+def _tokens(s: str) -> frozenset[str]:
+    """Word set for subset matching, with grammatical filler dropped.
+
+    Only generic English is listed here — no capability, model or tag name — so
+    this stays put while the bundle changes underneath it.
+    """
+    return frozenset(t for t in re.split(r"[^a-z0-9]+", s.lower()) if t and t not in _FILLER)
 
 
 def _normalized_map(keys: dict[str, str], *, ids: Collection[str] = ()) -> dict[str, str]:
@@ -465,6 +485,7 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
         model_capabilities=model_capabilities,
         normalized_aliases=_normalized_map(aliases, ids=models),
         normalized_capabilities=_normalized_map(capability_keys, ids=capabilities),
+        capability_tokens=tuple((words, cid) for key, cid in capability_keys.items() if (words := _tokens(key))),
     )
 
 
@@ -489,9 +510,40 @@ def _lookup(bundle: Bundle, queries: Iterable[str]) -> tuple[list[tuple[str, str
             seen.add(mid)
             models.append((mid, exact))
         cid = exact if exact in bundle.capabilities else bundle.normalized_capabilities.get(_normalize(q))
+        if cid is None:
+            cid = _resolve_tokens(bundle, q)
         if cid is not None and cid not in caps:
             caps.append(cid)
     return models, caps
+
+
+def _resolve_tokens(bundle: Bundle, query: str) -> str | None:
+    """Capability whose id or alias is worded inside ``query``; ``None`` if none is.
+
+    Callers ask in sentences ("image to 3d model mesh") while the bundle is keyed
+    on tags and ids ("Image to Model", "image-to-3d"), and :func:`_normalize`
+    only strips punctuation, so the exact path misses everything phrased. A key
+    matches when all of its words appear in the query, and the longest key wins
+    so a more specific capability is not outvoted by a broader one.
+
+    Ambiguity resolves to nothing rather than to a guess, matching
+    :func:`_normalized_map`: a tie between two capabilities is not an answer.
+    """
+    words = _tokens(query)
+    if not words:
+        return None
+    best: set[str] = set()
+    best_len = 0
+    for key_words, cid in bundle.capability_tokens:
+        if len(key_words) < best_len or not key_words <= words:
+            continue
+        if len(key_words) == 1 and len(next(iter(key_words))) < MIN_SINGLE_TOKEN_CHARS:
+            continue
+        if len(key_words) > best_len:
+            best, best_len = {cid}, len(key_words)
+        else:
+            best.add(cid)
+    return next(iter(best)) if len(best) == 1 else None
 
 
 def _text(value: Any) -> str | None:

--- a/tests/comfy_cli/command/test_knowledge_enrichment.py
+++ b/tests/comfy_cli/command/test_knowledge_enrichment.py
@@ -520,7 +520,10 @@ class TestGenerate:
         available and green, while the bundle keyed no such variant."""
         env = _run_generate(["schema", "kling-lipsync"], tmp_path=tmp_path, with_bundle=True)
         assert env["ok"] is True
-        assert "knowledge" not in env["data"]
+        # The guard is on the model row. 'kling-lipsync' names the lipsync
+        # capability, so its ranked picks are a fair answer; the `kling` family
+        # row is not.
+        assert env["data"]["knowledge"]["models"] == []
 
     def test_list_is_brief_and_byte_identical_without_a_bundle(self, tmp_path):
         enriched = _run_generate(["list", "--query", "kling"], tmp_path=tmp_path, with_bundle=True)

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -85,7 +85,49 @@ class TestLookup:
         bundle = knowledge.load_bundle()
         for q in ("testvid-lipsync", "testvid-avatar", "Testvid Avatar", "flux-kontext-max"):
             assert knowledge.resolve_id(bundle, q) is None, q
-            assert "knowledge" not in _attach(queries=[q]), q
+            # The guard is on the MODEL row. A capability the wording names may
+            # still answer with its ranked picks — 'testvid-lipsync' asking about
+            # lipsync is a question the bundle can answer.
+            assert _attach(queries=[q]).get("knowledge", {}).get("models", []) == [], q
+
+    def test_an_intent_phrase_reaches_the_capability_it_names(self):
+        """Callers ask in sentences; the bundle is keyed on tags and ids. Every
+        word of a key appearing in the query is enough to resolve it."""
+        for q in ("make a talking head video", "lip sync this footage", "audio generation for my clip"):
+            k = _attach(queries=[q])["knowledge"]
+            assert k["picks"], q
+            assert k["hit_ids"] in (["cap:lipsync"], ["cap:audio-generation"]), q
+
+    def test_a_phrase_naming_no_capability_resolves_to_nothing(self):
+        bundle = knowledge.load_bundle()
+        for q in ("how do I load a checkpoint", "a video", "zzzz", "head"):
+            assert knowledge._resolve_tokens(bundle, q) is None, q
+
+    def test_a_tie_between_capabilities_resolves_to_neither(self):
+        """Same rule as the normalized map: two answers are not an answer. The
+        keys differ as strings, so they survive capability_keys' first-wins
+        dedupe and collide only once reduced to word sets."""
+        data = {
+            "models": {},
+            "capabilities": {"alpha": {"aliases": ["video upscale"]}, "beta": {"aliases": ["upscale video"]}},
+        }
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "please upscale this video") is None
+
+    def test_the_longest_key_wins_over_a_broader_one(self):
+        data = {
+            "models": {},
+            "capabilities": {"broad": {"aliases": ["video"]}, "narrow": {"aliases": ["video upscale"]}},
+        }
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "please video upscale this") == "narrow"
+        assert knowledge._resolve_tokens(b, "just a video") == "broad"
+
+    def test_a_short_single_word_key_never_matches_alone(self):
+        """Guards a future alias like '3d' from joining every query that says it."""
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["3d"]}}}
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "a 3d mesh of my cat") is None
 
     def test_lookup_agrees_with_the_resolve_verb(self):
         bundle = knowledge.load_bundle()

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -123,6 +123,18 @@ class TestLookup:
         assert knowledge._resolve_tokens(b, "please video upscale this") == "narrow"
         assert knowledge._resolve_tokens(b, "just a video") == "broad"
 
+    def test_non_english_input_never_resolves_by_accident(self):
+        """The agent answers in the user's language, so it searches in it too.
+        Non-ASCII is dropped by the character class (as :func:`_normalize`
+        already does), leaving whatever ASCII the query carried. That must not
+        add up to a capability on its own."""
+        bundle = knowledge.load_bundle()
+        for q in ("トーキングヘッド動画", "обработка изображения", "vídeo de una persona hablando"):
+            assert knowledge._resolve_tokens(bundle, q) is None, q
+        # A mixed query still resolves on the English term it contains, which is
+        # the common case: capability names are English whatever the user writes.
+        assert knowledge._resolve_tokens(bundle, "この動画に lip sync したい") == "lipsync"
+
     def test_a_short_single_word_key_never_matches_alone(self):
         """Guards a future alias like '3d' from joining every query that says it."""
         data = {"models": {}, "capabilities": {"cap": {"aliases": ["3d"]}}}


### PR DESCRIPTION
Linear: BE-9081 (parent BE-8296). Found while debugging why a cloud agent turn came back with no `knowledge` block.

## The symptom

A staging `find_nodes` turn searched `"image to 3d model mesh"`, got 3 real rows, and carried no knowledge block. The curated answer existed the whole time. Measured inside the shipped runner image (`comfy-agent-cli-runner:v0.233.5`, bundle `afabe836`), all three naming the same capability:

```
nodes search "image to 3d model mesh"   rows=3    no block
nodes search "Image to Model"           rows=20   hit_ids=['tripo-3-1','cap:image-to-3d']  picks=3
nodes search "image-to-3d"              rows=1    hit_ids=['cap:image-to-3d']              picks=3
```

The first form is what an agent actually types. So the curated layer was close to unreachable from a real turn, on capabilities that are fully covered.

## Why

`_normalize` lowercases and strips non-alphanumerics, nothing more. `"image to 3d model mesh"` becomes `imageto3dmodelmesh`, matching neither `imagetomodel` nor `imageto3d`. Resolution was exact-after-normalization, with no token or substring matching. Callers ask in sentences; the bundle is keyed on tags and ids.

BE-8810 added capability `aliases[]`, which fixed exact gallery tags like `Image to Model`. It does not help free text.

## The change

`_lookup` falls back to word-set matching when the exact path misses. A capability id or alias resolves when **all of its words appear in the query**.

- **Longest key wins**, so a specific capability is not outvoted by a broader one.
- **A tie resolves to nothing**, matching the rule `_normalized_map` already applies to ambiguous spellings. Two answers are not an answer.
- **Exact resolution is untouched** and still runs first, so nothing that worked before changes.
- A one-word key must be ≥4 characters to match alone, guarding against a future alias like `3d` joining every query that mentions it.

On the shipped bundle:

```
'image to 3d model mesh'                 -> image-to-3d
'first and last frame video'             -> first-last-frame
'inpaint the background of this photo'   -> inpaint
'upscale my video'                       -> upscale
'text to speech narration'               -> audio-generation
'how do I load a checkpoint'             -> None
'an image'                               -> None
'kling'                                  -> None      (a model; the exact path owns it)
```

The negatives matter as much as the positives. `'an image'` not firing is the safety property.

## On maintaining a vocabulary

The only literal list added is grammatical filler (`the`, `of`, `my`, …). It names no capability, model or gallery tag, so it does not become a second copy of the bundle's vocabulary that drifts every time comfy-knowledge is recompiled. Everything domain-specific still comes from `knowledge.json`.

## Tests

Five new cases cover the phrase path, the negatives, the tie rule, longest-key-wins, and the short-single-word guard.

Two existing tests asserted an unkeyed model variant attaches nothing at all. Their guard is on the **model row**, which still holds and is now asserted directly (`models == []`). `testvid-lipsync` additionally reaches the `lipsync` capability's ranked picks, which is a fair answer to what that string asks.

`ruff check` and `ruff format --check` clean. Knowledge suites: 191 passed. The wider `tests/comfy_cli/` run shows 89 failures that reproduce identically on pristine `origin/main` in the same interpreter (console/output assertions under Python 3.14; the project targets 3.10) — this diff adds none.

## Follow-up

BE-9081 also notes optionally injecting the covered capability ids into the agent's prompt at runtime, read from `knowledge.json` rather than written down. Not needed for this fix, since the model no longer has to speak the index's language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3eNqNSL1Fuzoa8c6iiAyQ