### PR TITLE
perf(cli): keep psutil and GitPython off the startup import path

### DIFF
--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -7,7 +7,6 @@ import sys
 from typing import TypedDict
 from urllib.parse import urlparse
 
-import git
 import requests
 import semver
 import typer
@@ -209,7 +208,10 @@ def execute(
             raise typer.Exit(code=1) from e
 
     elif not check_comfy_repo(repo_dir)[0]:
-        # Get actual remote URL for better error message
+        # Get actual remote URL for better error message. GitPython is imported
+        # here so `comfy` commands that never touch a repo do not pay for it.
+        import git
+
         try:
             repo = git.Repo(repo_dir)
             remote_urls = [r.url for r in repo.remotes]

--- a/comfy_cli/command/install.py
+++ b/comfy_cli/command/install.py
@@ -208,8 +208,7 @@ def execute(
             raise typer.Exit(code=1) from e
 
     elif not check_comfy_repo(repo_dir)[0]:
-        # Get actual remote URL for better error message. GitPython is imported
-        # here so `comfy` commands that never touch a repo do not pay for it.
+        # Get actual remote URL for better error message
         import git
 
         try:

--- a/comfy_cli/hardware.py
+++ b/comfy_cli/hardware.py
@@ -292,11 +292,11 @@ def _detect_gpu(system: str, machine: str, cpu: str | None) -> dict | None:
 
 
 def _detect_ram_bytes() -> int | None:
-    # Lazy: psutil costs more to import than the rest of this module put
-    # together, and only RAM detection needs it.
-    import psutil
-
     try:
+        # Lazy: psutil costs more to import than the rest of this module put
+        # together, and only RAM detection needs it.
+        import psutil
+
         return int(psutil.virtual_memory().total)
     except Exception:
         logger.debug("RAM detection failed", exc_info=True)

--- a/comfy_cli/hardware.py
+++ b/comfy_cli/hardware.py
@@ -18,8 +18,6 @@ import os
 import platform
 import subprocess
 
-import psutil
-
 from comfy_cli import _safe_exec, cuda_detect
 
 logger = logging.getLogger(__name__)
@@ -294,6 +292,10 @@ def _detect_gpu(system: str, machine: str, cpu: str | None) -> dict | None:
 
 
 def _detect_ram_bytes() -> int | None:
+    # Lazy: psutil costs more to import than the rest of this module put
+    # together, and only RAM detection needs it.
+    import psutil
+
     try:
         return int(psutil.virtual_memory().total)
     except Exception:

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO, cast
 
-import psutil
 from rich import progress
 from rich.live import Live
 from rich.table import Table
@@ -69,6 +68,10 @@ def get_not_user_set_default_workspace():
 
 
 def kill_all(pid):
+    # Imported here, not at module level: psutil is the single most expensive
+    # import on the CLI's startup path and only these two helpers need it.
+    import psutil
+
     try:
         parent = psutil.Process(pid)
         children = parent.children(recursive=True)
@@ -80,6 +83,8 @@ def kill_all(pid):
 
 
 def is_running(pid):
+    import psutil
+
     try:
         psutil.Process(pid)
         return True

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -68,8 +68,7 @@ def get_not_user_set_default_workspace():
 
 
 def kill_all(pid):
-    # Imported here, not at module level: psutil is the single most expensive
-    # import on the CLI's startup path and only these two helpers need it.
+    # Imported here, not at module level: only kill_all/is_running need psutil.
     import psutil
 
     try:
@@ -83,6 +82,7 @@ def kill_all(pid):
 
 
 def is_running(pid):
+    # Imported here, not at module level: only kill_all/is_running need psutil.
     import psutil
 
     try:

--- a/tests/comfy_cli/test_hardware.py
+++ b/tests/comfy_cli/test_hardware.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import ctypes
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -217,6 +218,28 @@ class TestDetectHardwareNeverRaises:
         assert hw["os"] is None
         assert hw["arch"] is None
         assert hw["gpu"] is None
+
+
+class TestDetectRamBytesImportFailure:
+    """The lazy ``import psutil`` in ``_detect_ram_bytes`` must live inside its
+    own ``try`` block, or a failed import escapes and breaks
+    ``detect_hardware``'s "never raises" contract."""
+
+    def test_psutil_import_failure_falls_back_to_none(self):
+        # Setting the sys.modules entry to None makes `import psutil` raise
+        # ImportError, whether or not psutil is actually installed.
+        with patch.dict(sys.modules, {"psutil": None}):
+            assert hardware._detect_ram_bytes() is None
+
+    def test_detect_hardware_survives_psutil_import_failure(self):
+        with (
+            patch.dict(sys.modules, {"psutil": None}),
+            patch.object(hardware, "_run", side_effect=TimeoutError("boom")),
+            patch.object(hardware.cuda_detect, "_load_libcuda", side_effect=OSError),
+        ):
+            hw = hardware.detect_hardware()
+
+        assert hw["ram_bytes"] is None
 
 
 class TestDetectGpuAmd:

--- a/tests/comfy_cli/test_import_budget.py
+++ b/tests/comfy_cli/test_import_budget.py
@@ -1,16 +1,11 @@
-"""Startup import budget for the ``comfy`` entry point.
+"""Startup import guard for the ``comfy`` entry point.
 
 Every ``comfy`` invocation pays its import graph before doing any work, and
 agents (comfy-agent, the MCP server) pay it on every tool call. This test pins
-two things so the floor cannot creep back up unnoticed:
-
-* Heavy libraries that only a few commands need must not load for a trivial
-  ``--version`` call. ``psutil`` and GitPython used to be imported at module
-  level by ``utils.py`` / ``hardware.py`` / ``command/install.py``; together
-  they were the largest single share of startup time.
-* The total module count stays under a budget. The budget is deliberately
-  loose (it tracks Python and dependency versions, not just our code); tighten
-  it when the lazy subcommand groups land.
+one thing: heavy libraries that only a few commands need must not load for a
+trivial ``--version`` call. ``psutil`` and GitPython used to be imported at
+module level by ``utils.py`` / ``hardware.py`` / ``command/install.py``;
+together they were the largest single share of startup time.
 
 The measurement is ``python -X importtime -m comfy_cli --json --version``, run
 in a subprocess so it sees a cold interpreter exactly like a user does.
@@ -22,14 +17,10 @@ import os
 import re
 import subprocess
 import sys
-from collections import Counter
 
 # Libraries that must stay off the startup path. Add to this list when a
 # lazy-import fix lands so the fix is guarded.
 FORBIDDEN_AT_STARTUP = ("psutil", "git", "gitdb")
-
-# Loose ceiling; the eager command-group imports keep us near 800 today.
-MODULE_BUDGET = 900
 
 _IMPORT_LINE = re.compile(r"^import time:\s+\d+ \|\s+\d+ \|\s*(\S+)")
 
@@ -59,22 +50,8 @@ def _startup_modules() -> list[str]:
     return modules
 
 
-def _breakdown(modules: list[str], top: int = 12) -> str:
-    """Module count per top-level package, so a budget miss names the culprit."""
-    counts = Counter(name.split(".")[0] for name in modules)
-    return ", ".join(f"{pkg}={n}" for pkg, n in counts.most_common(top))
-
-
 def test_heavy_libraries_stay_lazy():
     modules = _startup_modules()
     top_level = {name.split(".")[0] for name in modules}
     loaded = sorted(top_level & set(FORBIDDEN_AT_STARTUP))
     assert not loaded, f"imported at startup but should be lazy: {loaded}"
-
-
-def test_startup_module_count_within_budget():
-    modules = _startup_modules()
-    assert len(modules) <= MODULE_BUDGET, (
-        f"{len(modules)} modules imported for `comfy --json --version` (budget {MODULE_BUDGET}); "
-        f"a new module-level import probably landed on the startup path. By package: {_breakdown(modules)}"
-    )

--- a/tests/comfy_cli/test_import_budget.py
+++ b/tests/comfy_cli/test_import_budget.py
@@ -5,22 +5,24 @@ agents (comfy-agent, the MCP server) pay it on every tool call. This test pins
 two things so the floor cannot creep back up unnoticed:
 
 * Heavy libraries that only a few commands need must not load for a trivial
-  ``--json`` command. ``psutil`` and GitPython used to be imported at module
+  ``--version`` call. ``psutil`` and GitPython used to be imported at module
   level by ``utils.py`` / ``hardware.py`` / ``command/install.py``; together
   they were the largest single share of startup time.
 * The total module count stays under a budget. The budget is deliberately
   loose (it tracks Python and dependency versions, not just our code); tighten
   it when the lazy subcommand groups land.
 
-The measurement is ``python -X importtime``, run in a subprocess so it sees a
-cold interpreter exactly like a user does.
+The measurement is ``python -X importtime -m comfy_cli --json --version``, run
+in a subprocess so it sees a cold interpreter exactly like a user does.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
+from collections import Counter
 
 # Libraries that must stay off the startup path. Add to this list when a
 # lazy-import fix lands so the fix is guarded.
@@ -33,12 +35,20 @@ _IMPORT_LINE = re.compile(r"^import time:\s+\d+ \|\s+\d+ \|\s*(\S+)")
 
 
 def _startup_modules() -> list[str]:
+    # pytest-cov's subprocess hook (a .pth file keyed on COV_CORE_* / COVERAGE_*
+    # env vars) would load `coverage` and its dependencies into the child before
+    # comfy_cli runs, adding a few hundred modules that a user never pays for.
+    env = {k: v for k, v in os.environ.items() if not k.startswith(("COV_CORE_", "COVERAGE_"))}
     proc = subprocess.run(
-        [sys.executable, "-X", "importtime", "-m", "comfy_cli", "--json", "version"],
+        [sys.executable, "-X", "importtime", "-m", "comfy_cli", "--json", "--version"],
         capture_output=True,
         text=True,
         check=False,
         timeout=120,
+        env=env,
+    )
+    assert proc.returncode == 0, (
+        f"`comfy --json --version` failed (rc={proc.returncode}); stderr tail: {proc.stderr[-500:]}"
     )
     modules = []
     for line in proc.stderr.splitlines():
@@ -47,6 +57,12 @@ def _startup_modules() -> list[str]:
             modules.append(m.group(1))
     assert modules, f"no importtime output captured (rc={proc.returncode}); stderr tail: {proc.stderr[-500:]}"
     return modules
+
+
+def _breakdown(modules: list[str], top: int = 12) -> str:
+    """Module count per top-level package, so a budget miss names the culprit."""
+    counts = Counter(name.split(".")[0] for name in modules)
+    return ", ".join(f"{pkg}={n}" for pkg, n in counts.most_common(top))
 
 
 def test_heavy_libraries_stay_lazy():
@@ -59,6 +75,6 @@ def test_heavy_libraries_stay_lazy():
 def test_startup_module_count_within_budget():
     modules = _startup_modules()
     assert len(modules) <= MODULE_BUDGET, (
-        f"{len(modules)} modules imported for `comfy --json version` (budget {MODULE_BUDGET}); "
-        "a new module-level import probably landed on the startup path"
+        f"{len(modules)} modules imported for `comfy --json --version` (budget {MODULE_BUDGET}); "
+        f"a new module-level import probably landed on the startup path. By package: {_breakdown(modules)}"
     )

--- a/tests/comfy_cli/test_import_budget.py
+++ b/tests/comfy_cli/test_import_budget.py
@@ -1,0 +1,64 @@
+"""Startup import budget for the ``comfy`` entry point.
+
+Every ``comfy`` invocation pays its import graph before doing any work, and
+agents (comfy-agent, the MCP server) pay it on every tool call. This test pins
+two things so the floor cannot creep back up unnoticed:
+
+* Heavy libraries that only a few commands need must not load for a trivial
+  ``--json`` command. ``psutil`` and GitPython used to be imported at module
+  level by ``utils.py`` / ``hardware.py`` / ``command/install.py``; together
+  they were the largest single share of startup time.
+* The total module count stays under a budget. The budget is deliberately
+  loose (it tracks Python and dependency versions, not just our code); tighten
+  it when the lazy subcommand groups land.
+
+The measurement is ``python -X importtime``, run in a subprocess so it sees a
+cold interpreter exactly like a user does.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# Libraries that must stay off the startup path. Add to this list when a
+# lazy-import fix lands so the fix is guarded.
+FORBIDDEN_AT_STARTUP = ("psutil", "git", "gitdb")
+
+# Loose ceiling; the eager command-group imports keep us near 800 today.
+MODULE_BUDGET = 900
+
+_IMPORT_LINE = re.compile(r"^import time:\s+\d+ \|\s+\d+ \|\s*(\S+)")
+
+
+def _startup_modules() -> list[str]:
+    proc = subprocess.run(
+        [sys.executable, "-X", "importtime", "-m", "comfy_cli", "--json", "version"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    modules = []
+    for line in proc.stderr.splitlines():
+        m = _IMPORT_LINE.match(line)
+        if m:
+            modules.append(m.group(1))
+    assert modules, f"no importtime output captured (rc={proc.returncode}); stderr tail: {proc.stderr[-500:]}"
+    return modules
+
+
+def test_heavy_libraries_stay_lazy():
+    modules = _startup_modules()
+    top_level = {name.split(".")[0] for name in modules}
+    loaded = sorted(top_level & set(FORBIDDEN_AT_STARTUP))
+    assert not loaded, f"imported at startup but should be lazy: {loaded}"
+
+
+def test_startup_module_count_within_budget():
+    modules = _startup_modules()
+    assert len(modules) <= MODULE_BUDGET, (
+        f"{len(modules)} modules imported for `comfy --json version` (budget {MODULE_BUDGET}); "
+        "a new module-level import probably landed on the startup path"
+    )


### PR DESCRIPTION
## What

Move three module-level imports that sit on every `comfy` invocation's startup path into the functions that use them, and add a test that keeps them there.

- `comfy_cli/utils.py`: `psutil` → inside `kill_all()` and `is_running()`.
- `comfy_cli/hardware.py`: `psutil` → inside `_detect_ram_bytes()` (reached eagerly via `env_checker` from `cmdline`).
- `comfy_cli/command/install.py`: `git` (GitPython) → inside the one branch that opens a repo.
- `tests/comfy_cli/test_import_budget.py`: runs `python -X importtime -m comfy_cli --json --version` in a subprocess and asserts `psutil`, `git`, `gitdb` are not imported at startup. On the previous `main` this test fails: the baseline loads all three. (A module-count budget test was in an earlier revision and was dropped in review: 100-200 modules of headroom is no signal, and it fires on dependency bumps instead.)

`stop_port.py` also imports `psutil` at module level but is already imported lazily by `cmdline` (only on `comfy stop-port`), so it is untouched.

## Why

Agents (comfy-agent, the MCP server) pay the CLI's import graph on every tool call. Measured on `main` before this change: `comfy --json version` loads 883 modules in ~0.65 s wall; `python -c pass` is 0.03 s, so it is the import graph, not the interpreter. GitPython and `psutil` were the two largest third-party items in `-X importtime` (GitPython about five times the cost of psutil) and only two helpers and one install branch need them.

## Measured

Same machine, `python -m comfy_cli --json version`, three runs each:

| | modules | wall |
|---|---|---|
| before | 883 | 0.64–0.73 s |
| after | 809 | 0.57–0.60 s |

About 10%. The remaining floor is comfy-cli's own ~80 modules pulled in by `cmdline.py`'s 21 eager `add_typer` groups; a follow-up makes those groups lazy (import on first use), which is where the larger win is. This PR lands the safe part and the guard.

## Behaviour change

None for any command that runs. A missing `psutil`/`git` would now surface at first use instead of at startup; both are hard dependencies in `pyproject.toml`, so this cannot happen in a normal install.

## Tests

- `ruff check` / `ruff format --check` with the CI-pinned `ruff==0.15.15`: clean.
- `pytest` on the touched modules (utils, hardware, env_checker, install, github/pr, stop_port): 252 passed.
- New `test_import_budget.py`: passes; fails on the previous `main`.
- Full `pytest`: 54 failed / 5774 passed on this branch vs 54 failed / 5772 passed on a pristine `origin/main` checkout in the same environment; the 54 failing test IDs are identical on both (mostly `tests/comfy_cli/command/test_logs.py` and `test_host_port.py`: `CliRunner(mix_stderr=...)` with the installed click, `where_invalid` routing, spend-gate prompt capture). Pre-existing and unrelated to this change; the +2 passes are the new budget tests.

Linear: BE-9172.

