### PR TITLE
feat(build): a workflow file becomes a build, with every advisory (BE-8424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ history.
 
 ### Added
 
+- `comfy build from-workflow --from <workflow.json> --name <name>` creates a
+  build from a ComfyUI workflow, in the editing format or the API export.
+- A workflow import prints its full report: the node classes nothing provides,
+  the closest pack the registry named for each one, the models no definition
+  carries, the classes served by a partner API, and whether a ComfyUI version
+  still has to be pinned.
 - `CONTRIBUTING.md` (renamed from `DEV_README.md`) and this changelog.
 
 ## [1.16.0] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ history.
 - `comfy build from-workflow --from <workflow.json> --name <name>` creates a
   build from a ComfyUI workflow, in the editing format or the API export.
 - A workflow import prints its full report: the node classes nothing provides,
-  the closest pack the registry named for each one, the models no definition
-  carries, the classes served by a partner API, and whether a ComfyUI version
-  still has to be pinned.
+  the closest pack the registry named for each one, every model the graph loads
+  (a workflow build carries none of them), the classes served by a partner API,
+  and whether a ComfyUI version still has to be pinned.
 - `CONTRIBUTING.md` (renamed from `DEV_README.md`) and this changelog.
 
 ## [1.16.0] - 2026-08-10

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -577,19 +577,73 @@ _REPORT_ADVISORIES = (
     ("skippedPins", "dropped: the build owns these packages"),
     ("unpinnablePins", "dropped: not a public PyPI release"),
     ("unresolvedClasses", "node classes nothing installable provides; the graph will not run without them"),
-    ("uncheckedClasses", "classes the registry never answered about, so nothing confirmed they are missing"),
-    ("packsWithoutVersion", "carried by repository: the registry publishes no installable version of them"),
-    ("collidingPacks", "left out: another pack already claimed the folder they install into"),
+    ("uncheckedClasses", "node classes the registry never answered for, so the build may not carry them"),
+    (
+        "packsWithoutVersion",
+        "packs the build fetches from their repository, because the registry publishes no version of them",
+    ),
+    ("collidingPacks", "packs the build leaves out, because another pack already claimed their install folder"),
 )
 
-# Each entry is (report key, the field that names an entry, what it means to the reader).
+# How many names an advisory line prints before it says how many it held back.
+_ADVISORY_NAMES = 8
+
+
+def _from_server(value) -> str:
+    """Scrub one builder-supplied fragment. Class names and filenames travel to
+    the builder from the workflow file and come back in the report, so a crafted
+    file could otherwise forge terminal lines that read as the CLI's own."""
+    return sanitize_error_body(str(value))
+
+
+def _advisory_line(count: int, meaning: str, names: list[str]) -> str:
+    """Count first, then the names, then how many names the line held back."""
+    shown = names[:_ADVISORY_NAMES]
+    held_back = f" (+{count - len(shown)} more)" if count > len(shown) else ""
+    return f"{count} {meaning}: {', '.join(shown)}{held_back}"
+
+
+def _unrenderable(key: str, value) -> str:
+    """The builder sent a key this renderer knows, in a shape it cannot read.
+    Say so: dropping it silently is how a partial import comes to look clean."""
+    return f"the builder sent `{key}` as {type(value).__name__}, which this CLI cannot render; read it with --json"
+
+
+def _suggested_pack_lines(entries: list) -> list[str]:
+    """`unknownClasses` is the detailed form of `unresolvedClasses`, which already
+    prints the names. What it adds is the pack the registry came closest to, so
+    that is all this renders, and only for the classes that carry one."""
+    suggested = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        packs = [s for s in (entry.get("suggestions") or []) if isinstance(s, dict) and s.get("packId")]
+        if not packs:
+            continue
+        best = max(packs, key=lambda s: s["score"] if isinstance(s.get("score"), int | float) else 0.0)
+        suggested.append(f"{_from_server(entry.get('classType'))} (maybe {_from_server(best['packId'])})")
+    if not suggested:
+        return []
+    meaning = "node classes the registry could not attribute, with the closest pack it named"
+    return [_advisory_line(len(suggested), meaning, suggested)]
+
+
+def _missing_model_lines(entries: list) -> list[str]:
+    """A model the catalog matched is one the build already carries, so it is no
+    advisory; its directory rides in the JSON payload for anyone who wants it.
+    The rest are what `comfy build resolve` exists to find."""
+    missing = [e for e in entries if not (isinstance(e, dict) and e.get("status") == "matched")]
+    if not missing:
+        return []
+    names = [_from_server(e.get("filename") if isinstance(e, dict) else e) for e in missing]
+    meaning = "models the graph loads that no definition carries; `comfy build resolve` finds download candidates"
+    return [_advisory_line(len(missing), meaning, names)]
+
+
+# Each entry is (report key, what turns its entries into lines).
 _REPORT_ENTRY_ADVISORIES = (
-    ("unknownClasses", "classType", "node classes the importer could not place in a pack"),
-    (
-        "models",
-        "filename",
-        "models the graph loads that no definition carries; `comfy build resolve` finds download candidates",
-    ),
+    ("unknownClasses", _suggested_pack_lines),
+    ("models", _missing_model_lines),
 )
 
 
@@ -608,31 +662,34 @@ def report_advisories(report: dict) -> list[str]:
         lines.append(f"the ComfyUI release {str(dropped)!r} is not a ref the build can use, so none was set")
     if report.get("pinnedToLatest") is True:
         lines.append(
-            "packs the workflow named without a version were pinned to the registry's newest published one, "
-            "so importing the same file again can produce a different build"
+            "the importer pinned every pack the workflow named without a version to the registry's newest "
+            "published one, so importing the same file later can build something different"
         )
-    if report.get("comfyVersionRequired") is True:
-        lines.append("no ComfyUI version is pinned, so the build cannot be cut until one is set")
     for key, meaning in _REPORT_ADVISORIES:
-        entries = report.get(key) or []
-        # Every one of these is a list; a scalar would render one line per character.
-        if entries and isinstance(entries, list | tuple):
-            lines.append(f"{len(entries)} {meaning}: {', '.join(str(e) for e in entries[:8])}")
-    for key, field, meaning in _REPORT_ENTRY_ADVISORIES:
-        entries = report.get(key) or []
-        if not entries or not isinstance(entries, list | tuple):
+        entries = report.get(key)
+        if not entries:
             continue
-        # An entry the server shaped differently still prints, as whatever it is.
-        names = [str(e.get(field) or e) if isinstance(e, dict) else str(e) for e in entries[:8]]
-        lines.append(f"{len(entries)} {meaning}: {', '.join(names)}")
+        # A scalar here would otherwise render one line per character.
+        if not isinstance(entries, list | tuple):
+            lines.append(_unrenderable(key, entries))
+            continue
+        lines.append(_advisory_line(len(entries), meaning, [_from_server(e) for e in entries]))
+    for key, render in _REPORT_ENTRY_ADVISORIES:
+        entries = report.get(key)
+        if not entries:
+            continue
+        if not isinstance(entries, list | tuple):
+            lines.append(_unrenderable(key, entries))
+            continue
+        lines.extend(render(entries))
     # A mapping of class name -> provider, so each name carries who serves it.
-    partners = report.get("partnerClasses") or {}
-    if partners and isinstance(partners, dict):
-        served = [f"{cls} ({provider})" for cls, provider in list(partners.items())[:8]]
-        lines.append(
-            f"{len(partners)} node classes call a partner API rather than run from an installed pack: "
-            f"{', '.join(served)}"
-        )
+    partners = report.get("partnerClasses")
+    if partners and not isinstance(partners, dict):
+        lines.append(_unrenderable("partnerClasses", partners))
+    elif partners:
+        served = [f"{_from_server(cls)} ({_from_server(provider)})" for cls, provider in partners.items()]
+        meaning = "node classes call a partner API rather than run from an installed pack"
+        lines.append(_advisory_line(len(partners), meaning, served))
     return lines
 
 
@@ -1671,12 +1728,13 @@ def from_workflow_cmd(
     path = Path(from_).expanduser()
     try:
         workflow = json.loads(path.read_text(encoding="utf-8"))
-        # The builder reads both the editing format and the API export, so the
-        # only shape the CLI insists on is a JSON object: the dialect is the
-        # server's call, and a client-side guess would refuse files it accepts.
+        # The dialect is the builder's call: it reads the editing format and the
+        # API export, so a client-side guess would refuse files it accepts.
         if not isinstance(workflow, dict):
             raise ValueError(f"expected a JSON object, got {type(workflow).__name__}")
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+    # A deeply nested file makes json.loads recurse until the interpreter stops
+    # it, and that lands outside the ValueError family.
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError) as e:
         renderer.error(
             code="build_workflow_invalid",
             message=f"could not read {path}: {e}",
@@ -1688,22 +1746,38 @@ def from_workflow_cmd(
     result = _builder_call(
         renderer, lambda: client.create_distribution_from_workflow(name, workflow, description=description)
     )
-    created = result.get("build") or {}
-    distribution_id = created.get("id")
-    report = result.get("report") or {}
+    created = result.get("build") if isinstance(result, dict) else None
+    report = result.get("report") if isinstance(result, dict) else None
+    distribution_id = created.get("id") if isinstance(created, dict) else None
+    # The row is already written by the time the answer arrives, so a shape this
+    # command cannot read means a build exists that nothing here can name.
+    if not distribution_id or not isinstance(report, dict):
+        renderer.error(
+            code="build_builder_error",
+            message=(
+                "the builder answered from-workflow with a shape this CLI cannot read, so a build may exist "
+                "that this command cannot name; list your builds with `comfy build list`"
+            ),
+            details={"received": sorted(result) if isinstance(result, dict) else type(result).__name__},
+        )
+        raise typer.Exit(code=1)
+
     if renderer.is_pretty():
         renderer.success(f"Created build {distribution_id} from {path.name}")
+        if not report:
+            renderer.warn("the builder sent an empty import report, so nothing here says what the workflow mapped to")
         for line in report_advisories(report):
             renderer.warn(line)
-        # A workflow names no ComfyUI release, so a fresh import has no
-        # baseComfyVersion and a cut would fail. Name the edit, not the cut.
-        if report.get("comfyVersionRequired") is True:
-            renderer.info(
-                "no ComfyUI version is pinned, so this build cannot be cut yet: add `baseComfyVersion` to the "
-                f"definition and save it with `comfy build update {distribution_id} --from <file>`"
-            )
-        else:
+        # The builder sets comfyVersionRequired on every import, so a false is the
+        # only word that a version is pinned and the build can be cut.
+        if report.get("comfyVersionRequired") is False:
             renderer.info(f"cut a build with `comfy build release create {distribution_id}`")
+        else:
+            renderer.info(
+                "no ComfyUI version is pinned, so this build cannot be cut yet: run `comfy build get "
+                f"{distribution_id} --json | jq .data.definition > def.json`, add `baseComfyVersion` to def.json, "
+                f"then run `comfy build update {distribution_id} --from def.json`"
+            )
     renderer.emit(result, command="build from-workflow", changed=True)
 
 

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -576,6 +576,20 @@ _REPORT_ADVISORIES = (
     ("unverifiedPins", "left unchecked because the registry did not answer"),
     ("skippedPins", "dropped: the build owns these packages"),
     ("unpinnablePins", "dropped: not a public PyPI release"),
+    ("unresolvedClasses", "node classes nothing installable provides; the graph will not run without them"),
+    ("uncheckedClasses", "classes the registry never answered about, so nothing confirmed they are missing"),
+    ("packsWithoutVersion", "carried by repository: the registry publishes no installable version of them"),
+    ("collidingPacks", "left out: another pack already claimed the folder they install into"),
+)
+
+# Each entry is (report key, the field that names an entry, what it means to the reader).
+_REPORT_ENTRY_ADVISORIES = (
+    ("unknownClasses", "classType", "node classes the importer could not place in a pack"),
+    (
+        "models",
+        "filename",
+        "models the graph loads that no definition carries; `comfy build resolve` finds download candidates",
+    ),
 )
 
 
@@ -592,11 +606,33 @@ def report_advisories(report: dict) -> list[str]:
     dropped = report.get("droppedComfyVersion")
     if dropped:
         lines.append(f"the ComfyUI release {str(dropped)!r} is not a ref the build can use, so none was set")
+    if report.get("pinnedToLatest") is True:
+        lines.append(
+            "packs the workflow named without a version were pinned to the registry's newest published one, "
+            "so importing the same file again can produce a different build"
+        )
+    if report.get("comfyVersionRequired") is True:
+        lines.append("no ComfyUI version is pinned, so the build cannot be cut until one is set")
     for key, meaning in _REPORT_ADVISORIES:
         entries = report.get(key) or []
         # Every one of these is a list; a scalar would render one line per character.
         if entries and isinstance(entries, list | tuple):
             lines.append(f"{len(entries)} {meaning}: {', '.join(str(e) for e in entries[:8])}")
+    for key, field, meaning in _REPORT_ENTRY_ADVISORIES:
+        entries = report.get(key) or []
+        if not entries or not isinstance(entries, list | tuple):
+            continue
+        # An entry the server shaped differently still prints, as whatever it is.
+        names = [str(e.get(field) or e) if isinstance(e, dict) else str(e) for e in entries[:8]]
+        lines.append(f"{len(entries)} {meaning}: {', '.join(names)}")
+    # A mapping of class name -> provider, so each name carries who serves it.
+    partners = report.get("partnerClasses") or {}
+    if partners and isinstance(partners, dict):
+        served = [f"{cls} ({provider})" for cls, provider in list(partners.items())[:8]]
+        lines.append(
+            f"{len(partners)} node classes call a partner API rather than run from an installed pack: "
+            f"{', '.join(served)}"
+        )
     return lines
 
 
@@ -1619,6 +1655,56 @@ def from_snapshot_cmd(
             renderer.warn(line)
         renderer.info(f"cut a build with `comfy build release create {distribution_id}`")
     renderer.emit(result, command="build from-snapshot", changed=True)
+
+
+@app.command("from-workflow", help="Create a build from a ComfyUI workflow file.")
+@tracking.track_command("build")
+def from_workflow_cmd(
+    from_: Annotated[
+        str, typer.Option("--from", "-f", help="Path to a ComfyUI workflow JSON (editing format or API export).")
+    ],
+    name: Annotated[str, typer.Option("--name", help="Name for the new build.")],
+    description: Annotated[str | None, typer.Option("--description", help="Optional description.")] = None,
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    path = Path(from_).expanduser()
+    try:
+        workflow = json.loads(path.read_text(encoding="utf-8"))
+        # The builder reads both the editing format and the API export, so the
+        # only shape the CLI insists on is a JSON object: the dialect is the
+        # server's call, and a client-side guess would refuse files it accepts.
+        if not isinstance(workflow, dict):
+            raise ValueError(f"expected a JSON object, got {type(workflow).__name__}")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as e:
+        renderer.error(
+            code="build_workflow_invalid",
+            message=f"could not read {path}: {e}",
+            details={"path": str(path)},
+        )
+        raise typer.Exit(code=1) from e
+
+    client = _builder_client(renderer, builder_url)
+    result = _builder_call(
+        renderer, lambda: client.create_distribution_from_workflow(name, workflow, description=description)
+    )
+    created = result.get("build") or {}
+    distribution_id = created.get("id")
+    report = result.get("report") or {}
+    if renderer.is_pretty():
+        renderer.success(f"Created build {distribution_id} from {path.name}")
+        for line in report_advisories(report):
+            renderer.warn(line)
+        # A workflow names no ComfyUI release, so a fresh import has no
+        # baseComfyVersion and a cut would fail. Name the edit, not the cut.
+        if report.get("comfyVersionRequired") is True:
+            renderer.info(
+                "no ComfyUI version is pinned, so this build cannot be cut yet: add `baseComfyVersion` to the "
+                f"definition and save it with `comfy build update {distribution_id} --from <file>`"
+            )
+        else:
+            renderer.info(f"cut a build with `comfy build release create {distribution_id}`")
+    renderer.emit(result, command="build from-workflow", changed=True)
 
 
 @blob_app.command("upload", help="Upload a private file and print the blobId a definition can reference.")

--- a/comfy_cli/command/distribution.py
+++ b/comfy_cli/command/distribution.py
@@ -609,6 +609,17 @@ def _unrenderable(key: str, value) -> str:
     return f"the builder sent `{key}` as {type(value).__name__}, which this CLI cannot render; read it with --json"
 
 
+def _best_suggestion(entry: dict, field: str) -> str:
+    """The highest-scored suggestion's ``field``, or "" when none carries one.
+    The catalog ranks what it thinks the workflow meant, so the reader gets the
+    lead rather than the whole list."""
+    ranked = [s for s in (entry.get("suggestions") or []) if isinstance(s, dict) and s.get(field)]
+    if not ranked:
+        return ""
+    best = max(ranked, key=lambda s: s["score"] if isinstance(s.get("score"), int | float) else 0.0)
+    return _from_server(best[field])
+
+
 def _suggested_pack_lines(entries: list) -> list[str]:
     """`unknownClasses` is the detailed form of `unresolvedClasses`, which already
     prints the names. What it adds is the pack the registry came closest to, so
@@ -617,33 +628,49 @@ def _suggested_pack_lines(entries: list) -> list[str]:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        packs = [s for s in (entry.get("suggestions") or []) if isinstance(s, dict) and s.get("packId")]
-        if not packs:
-            continue
-        best = max(packs, key=lambda s: s["score"] if isinstance(s.get("score"), int | float) else 0.0)
-        suggested.append(f"{_from_server(entry.get('classType'))} (maybe {_from_server(best['packId'])})")
+        pack = _best_suggestion(entry, "packId")
+        if pack:
+            suggested.append(f"{_from_server(entry.get('classType'))} (maybe {pack})")
     if not suggested:
         return []
     meaning = "node classes the registry could not attribute, with the closest pack it named"
     return [_advisory_line(len(suggested), meaning, suggested)]
 
 
-def _missing_model_lines(entries: list) -> list[str]:
-    """A model the catalog matched is one the build already carries, so it is no
-    advisory; its directory rides in the JSON payload for anyone who wants it.
-    The rest are what `comfy build resolve` exists to find."""
-    missing = [e for e in entries if not (isinstance(e, dict) and e.get("status") == "matched")]
-    if not missing:
-        return []
-    names = [_from_server(e.get("filename") if isinstance(e, dict) else e) for e in missing]
-    meaning = "models the graph loads that no definition carries; `comfy build resolve` finds download candidates"
-    return [_advisory_line(len(missing), meaning, names)]
+def _model_lines(entries: list) -> list[str]:
+    """A workflow import builds custom nodes and no models, because a workflow
+    names a model without saying where it comes from. So every model the graph
+    loads is still owed, and ``status`` shapes the wording rather than deciding
+    whether a line exists: the shared catalog already holds a matched one, which
+    needs only a source pointer, while the rest have to be found first."""
+    held, owed = [], []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            owed.append(_from_server(entry))
+            continue
+        name = _from_server(entry.get("filename"))
+        if entry.get("status") == "matched":
+            held.append(name)
+            continue
+        lead = _best_suggestion(entry, "filename")
+        owed.append(f"{name} (maybe {lead})" if lead else name)
+    lines = []
+    if held:
+        meaning = (
+            "models the shared catalog holds that this build does not carry, each needing a sourceUri in the "
+            "definition before you cut"
+        )
+        lines.append(_advisory_line(len(held), meaning, held))
+    if owed:
+        meaning = "models the graph loads that nothing has a source for; `comfy build resolve` finds candidates"
+        lines.append(_advisory_line(len(owed), meaning, owed))
+    return lines
 
 
 # Each entry is (report key, what turns its entries into lines).
 _REPORT_ENTRY_ADVISORIES = (
     ("unknownClasses", _suggested_pack_lines),
-    ("models", _missing_model_lines),
+    ("models", _model_lines),
 )
 
 
@@ -1768,8 +1795,8 @@ def from_workflow_cmd(
             renderer.warn("the builder sent an empty import report, so nothing here says what the workflow mapped to")
         for line in report_advisories(report):
             renderer.warn(line)
-        # The builder sets comfyVersionRequired on every import, so a false is the
-        # only word that a version is pinned and the build can be cut.
+        # comfyVersionRequired is the builder's word on whether a version is
+        # pinned, so only an explicit false says this build can be cut.
         if report.get("comfyVersionRequired") is False:
             renderer.info(f"cut a build with `comfy build release create {distribution_id}`")
         else:

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -63,6 +63,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy build blob list": "build_blob_list",
     "comfy build blob upload": "build_blob_upload",
     "comfy build from-snapshot": "build_from_snapshot",
+    "comfy build from-workflow": "build_from_workflow",
     "comfy jobs ls": "jobs",
     "comfy jobs status": "jobs",
     "comfy jobs watch": "jobs",

--- a/comfy_cli/distribution_api.py
+++ b/comfy_cli/distribution_api.py
@@ -34,6 +34,12 @@ _MAX_JSON = 5 * 1024 * 1024
 _MAX_LOG_JSON = 32 * 1024 * 1024
 # Presigned model PUTs can be many GB: generous read timeout, sane connect.
 _UPLOAD_TIMEOUT = (10, 600)
+# The shared HTTP layer's own default, named here so one call can raise it.
+_POST_TIMEOUT = 30.0
+# Importing a workflow looks every distinct node class up in the registry behind
+# a 20 second budget of the builder's own, then matches models and writes the
+# build row, so the default leaves a large graph nothing to spare.
+_WORKFLOW_IMPORT_TIMEOUT = 90.0
 
 
 class BuilderAuthError(Exception):
@@ -64,8 +70,10 @@ class BuilderClient:
             raise BuilderAuthError("not signed in — run `comfy cloud login`")
         return cls(base_url, session.access_token)
 
-    def _post(self, parts: tuple[str, ...], body: dict) -> dict:
-        _, parsed = request_json(self.target.url(*parts), self.target, method="POST", body=body, max_bytes=_MAX_JSON)
+    def _post(self, parts: tuple[str, ...], body: dict, *, timeout: float = _POST_TIMEOUT) -> dict:
+        _, parsed = request_json(
+            self.target.url(*parts), self.target, method="POST", body=body, max_bytes=_MAX_JSON, timeout=timeout
+        )
         return parsed or {}
 
     def create_blob(self, kind: str, filename: str, sha256: str, size_bytes: int) -> tuple[str, str]:
@@ -150,12 +158,12 @@ class BuilderClient:
         return self._post(("builds", "from-snapshot"), body)
 
     def create_distribution_from_workflow(self, name: str, workflow: dict, *, description: str | None = None) -> dict:
-        """POST /v1/builds/from-workflow — read a workflow and store what it
+        """POST /v1/builds/from-workflow: read a workflow and store what it
         maps to, in one call. Returns ``{build, report}``."""
         body: dict = {"name": name, "workflow": workflow}
         if description:
             body["description"] = description
-        return self._post(("builds", "from-workflow"), body)
+        return self._post(("builds", "from-workflow"), body, timeout=_WORKFLOW_IMPORT_TIMEOUT)
 
     def _get(self, parts: tuple[str, ...], params: dict | None = None, *, max_bytes: int = _MAX_JSON) -> dict:
         url = self.target.url(*parts)

--- a/comfy_cli/distribution_api.py
+++ b/comfy_cli/distribution_api.py
@@ -10,6 +10,7 @@ Field names match services/comfy-builder/openapi.yaml exactly:
   POST /v1/blobs {kind, filename, sizeBytes, sha256}     -> {blobId, uploadUrl, expiresAt}
   POST /v1/builds {name, definition}              -> {id, ...}
   POST /v1/builds/{id}/releases {targets?}        -> {releaseId, statusUrl}
+  POST /v1/builds/from-workflow {name, workflow}  -> {build, report}
   GET  /v1/releases/{id}                          -> {status, ...}
 """
 
@@ -147,6 +148,14 @@ class BuilderClient:
         if base_image_id:
             body["baseImageId"] = base_image_id
         return self._post(("builds", "from-snapshot"), body)
+
+    def create_distribution_from_workflow(self, name: str, workflow: dict, *, description: str | None = None) -> dict:
+        """POST /v1/builds/from-workflow — read a workflow and store what it
+        maps to, in one call. Returns ``{build, report}``."""
+        body: dict = {"name": name, "workflow": workflow}
+        if description:
+            body["description"] = description
+        return self._post(("builds", "from-workflow"), body)
 
     def _get(self, parts: tuple[str, ...], params: dict | None = None, *, max_bytes: int = _MAX_JSON) -> dict:
         url = self.target.url(*parts)

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1061,6 +1061,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "pass a file produced by `comfy build scan -o <path>`",
     ),
     ErrorCode(
+        "build_workflow_invalid",
+        "`comfy build from-workflow --from <path>` could not read the workflow file, or it is not a JSON "
+        "object. `details.path` carries the path.",
+        "pass a workflow saved from ComfyUI (either the editing format or the API export)",
+    ),
+    ErrorCode(
         "build_not_signed_in",
         "`comfy build create --execute` found no usable Cloud JWT — the builder authenticates with the "
         "OAuth session token, and there isn't a valid one.",

--- a/comfy_cli/schemas/build_from_workflow.json
+++ b/comfy_cli/schemas/build_from_workflow.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/build_from_workflow.json",
+  "title": "comfy build from-workflow --json data payload",
+  "type": "object",
+  "required": ["build"],
+  "additionalProperties": true,
+  "properties": {
+    "build": {"type": "object", "additionalProperties": true},
+    "report": {"type": "object", "additionalProperties": true}
+  }
+}

--- a/comfy_cli/schemas/build_from_workflow.json
+++ b/comfy_cli/schemas/build_from_workflow.json
@@ -3,7 +3,7 @@
   "$id": "https://comfy.org/schemas/build_from_workflow.json",
   "title": "comfy build from-workflow --json data payload",
   "type": "object",
-  "required": ["build"],
+  "required": ["build", "report"],
   "additionalProperties": true,
   "properties": {
     "build": {"type": "object", "additionalProperties": true},

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1683,3 +1683,144 @@ def test_the_from_path_is_not_shipped_as_telemetry():
     # Supplied but empty is still supplied; absent is absent.
     assert filter_command_kwargs({"from_": None})["from_"] is None
     assert "from_" not in filter_command_kwargs({"name": "demo"})
+
+
+# --- from-workflow: a workflow file becomes a build in one call ---------------
+
+
+WORKFLOW_REPORT = {
+    "unresolvedClasses": ["IPAdapterUnifiedLoader"],
+    "uncheckedClasses": ["ImpactSimpleDetectorSEGS"],
+    "packsWithoutVersion": ["comfyui-kjnodes"],
+    "collidingPacks": ["comfyui-manager"],
+    "unknownClasses": [{"classType": "ReActorFaceSwap", "status": "unknown"}],
+    "models": [{"filename": "flux1-dev.safetensors", "status": "missing", "usedBy": ["UNETLoader"]}],
+    "partnerClasses": {"FluxProUltraImageNode": "black-forest-labs"},
+    "pinnedToLatest": True,
+    "comfyVersionRequired": True,
+}
+
+
+def _workflow_client(report):
+    class FakeClient:
+        def create_distribution_from_workflow(self, name, workflow, *, description=None):
+            self.workflow = workflow
+            return {"build": {"id": "dist-9", "name": name}, "report": report}
+
+    return FakeClient()
+
+
+def test_from_workflow_client_posts_the_graph_to_its_own_endpoint(monkeypatch):
+    calls = []
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        calls.append((method, url, body))
+        return 201, {"build": {"id": "dist-9"}, "report": {}}
+
+    monkeypatch.setattr("comfy_cli.distribution_api.request_json", fake_request_json)
+    from comfy_cli.distribution_api import BuilderClient
+
+    client = BuilderClient("https://builder.test/", "jwt-token")
+    graph = {"nodes": [{"type": "KSampler"}], "links": []}
+    assert client.create_distribution_from_workflow("portrait", graph)["build"]["id"] == "dist-9"
+    assert calls[-1] == (
+        "POST",
+        "https://builder.test/v1/builds/from-workflow",
+        {"name": "portrait", "workflow": graph},
+    )
+
+    client.create_distribution_from_workflow("portrait", graph, description="a portrait pipeline")
+    assert calls[-1][2] == {"name": "portrait", "workflow": graph, "description": "a portrait pipeline"}
+
+
+def test_from_workflow_reads_the_created_id_and_report_from_their_own_keys(monkeypatch, tmp_path, capsys):
+    """The endpoint answers {build, report}, not a build carrying its report."""
+    wf = tmp_path / "portrait.json"
+    wf.write_text(json.dumps({"nodes": [{"type": "KSampler"}], "links": []}), encoding="utf-8")
+    monkeypatch.setattr(
+        distribution, "_builder_client", lambda renderer, url: _workflow_client({"unresolvedClasses": ["ReActor"]})
+    )
+    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    out = capsys.readouterr().out
+    assert "dist-9" in out and "None" not in out
+    assert "ReActor" in out
+
+
+def test_report_advisories_renders_every_field_a_workflow_report_carries():
+    """A workflow report shares no key with a snapshot report, so a fixed
+    snapshot key list renders zero advisories and the import looks clean."""
+    lines = "\n".join(distribution.report_advisories(WORKFLOW_REPORT))
+    assert "IPAdapterUnifiedLoader" in lines
+    assert "ImpactSimpleDetectorSEGS" in lines
+    assert "comfyui-kjnodes" in lines
+    assert "comfyui-manager" in lines
+    assert "ReActorFaceSwap" in lines
+    assert "flux1-dev.safetensors" in lines and "comfy build resolve" in lines
+    assert "FluxProUltraImageNode (black-forest-labs)" in lines
+    assert "newest published" in lines
+    assert "no ComfyUI version is pinned" in lines
+
+
+def test_report_advisories_survives_entries_the_server_shaped_differently():
+    """A scalar where a list of objects belongs must not render one line per
+    character, and a mapping that arrives as a list must not raise."""
+    lines = distribution.report_advisories(
+        {"models": ["flux1-dev.safetensors", 7], "partnerClasses": ["FluxProUltraImageNode"]}
+    )
+    assert len(lines) == 1
+    assert "flux1-dev.safetensors, 7" in lines[0]
+
+
+def test_report_advisories_leaves_a_snapshot_report_unchanged():
+    """`comfy build from-snapshot` shares the renderer, so its output must not move."""
+    assert distribution.report_advisories({"notInRegistry": ["was-node-suite-comfyui"]}) == [
+        "1 pinned to something the Comfy Registry does not publish: was-node-suite-comfyui"
+    ]
+
+
+def test_from_workflow_accepts_the_api_export_dialect(monkeypatch, tmp_path, capsys):
+    """The API export has no `nodes` or `links`, and the builder reads it. A
+    frontend-only check here would refuse a file the server accepts."""
+    api_export = {"3": {"class_type": "KSampler", "inputs": {}}}
+    wf = tmp_path / "portrait_api.json"
+    wf.write_text(json.dumps(api_export), encoding="utf-8")
+    client = _workflow_client({})
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: client)
+    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    assert client.workflow == api_export
+    assert "dist-9" in capsys.readouterr().out
+
+
+def test_from_workflow_names_the_update_command_when_no_comfy_version_is_pinned(monkeypatch, tmp_path, capsys):
+    wf = tmp_path / "portrait.json"
+    wf.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+    monkeypatch.setattr(
+        distribution, "_builder_client", lambda renderer, url: _workflow_client({"comfyVersionRequired": True})
+    )
+    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    # The renderer wraps to the terminal width, so compare on the unwrapped text.
+    out = " ".join(capsys.readouterr().out.split())
+    assert "cannot be cut yet" in out
+    assert "comfy build update dist-9 --from <file>" in out
+    assert "comfy build release create" not in out
+
+
+def test_from_workflow_names_the_release_command_when_a_comfy_version_is_pinned(monkeypatch, tmp_path, capsys):
+    wf = tmp_path / "portrait.json"
+    wf.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+    monkeypatch.setattr(
+        distribution, "_builder_client", lambda renderer, url: _workflow_client({"comfyVersionRequired": False})
+    )
+    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    out = " ".join(capsys.readouterr().out.split())
+    assert "comfy build release create dist-9" in out
+    assert "cannot be cut yet" not in out
+
+
+@pytest.mark.parametrize("payload", ["not json at all", "[]"])
+def test_from_workflow_refuses_a_file_that_is_not_a_json_object(tmp_path, capsys, payload):
+    f = tmp_path / "portrait.json"
+    f.write_text(payload, encoding="utf-8")
+    with pytest.raises(typer.Exit):
+        distribution.from_workflow_cmd(from_=str(f), name="portrait")
+    assert "build_workflow_invalid" in capsys.readouterr().out

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1810,20 +1810,49 @@ def test_report_advisories_renders_a_workflow_report_line_for_line():
         "1 packs the build leaves out, because another pack already claimed their install folder: comfyui-manager",
         "1 node classes the registry could not attribute, with the closest pack it named: WAS_Image_Blend "
         "(maybe https://github.com/ltdrdata/was-node-suite-comfyui)",
-        "1 models the graph loads that no definition carries; `comfy build resolve` finds download candidates: "
+        "1 models the shared catalog holds that this build does not carry, each needing a sourceUri in the "
+        "definition before you cut: v1-5-pruned-emaonly-fp16.safetensors",
+        "1 models the graph loads that nothing has a source for; `comfy build resolve` finds candidates: "
         "definitely-not-a-real-lora-v3.safetensors",
         "2 node classes call a partner API rather than run from an installed pack: LumaImageNode (Luma), "
         "OpenAIGPTImage1 (OpenAI (inc. Sora))",
     ]
 
 
-def test_report_advisories_leaves_out_the_models_the_catalog_already_matched():
-    """Telling a user to resolve a model Cloud already holds sends them after a
-    file that is not missing."""
+def test_report_advisories_still_owes_the_models_the_catalog_matched():
+    """A workflow import builds custom nodes and no models, so a matched model is
+    one the catalog holds and the build does not. Dropping the line lets a user
+    cut a paid release whose graph dies at CheckpointLoaderSimple."""
     lines = distribution.report_advisories(
         {"models": [{"filename": "v1-5-pruned-emaonly-fp16.safetensors", "status": "matched"}]}
     )
-    assert lines == []
+    assert lines == [
+        "1 models the shared catalog holds that this build does not carry, each needing a sourceUri in the "
+        "definition before you cut: v1-5-pruned-emaonly-fp16.safetensors"
+    ]
+
+
+def test_report_advisories_names_the_catalog_lead_for_a_suggested_model():
+    """The catalog ranks what it thinks the filename meant, and a name Cloud
+    already has beats sending the reader to HuggingFace for it."""
+    lines = distribution.report_advisories(
+        {
+            "models": [
+                {
+                    "filename": "sd15.safetensors",
+                    "status": "suggested",
+                    "suggestions": [
+                        {"filename": "v1-5-pruned-emaonly.safetensors", "score": 0.62},
+                        {"filename": "v1-5-pruned-emaonly-fp16.safetensors", "score": 0.91},
+                    ],
+                }
+            ]
+        }
+    )
+    assert lines == [
+        "1 models the graph loads that nothing has a source for; `comfy build resolve` finds candidates: "
+        "sd15.safetensors (maybe v1-5-pruned-emaonly-fp16.safetensors)"
+    ]
 
 
 def test_report_advisories_counts_every_name_and_says_how_many_it_held_back():

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -11,6 +11,7 @@ import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from unittest.mock import create_autospec
 
 import pytest
 import requests
@@ -1688,87 +1689,163 @@ def test_the_from_path_is_not_shipped_as_telemetry():
 # --- from-workflow: a workflow file becomes a build in one call ---------------
 
 
+# The report a live comfy-builder returned for a workflow naming three classes it
+# could not attribute, two models, and two partner-served classes.
 WORKFLOW_REPORT = {
-    "unresolvedClasses": ["IPAdapterUnifiedLoader"],
-    "uncheckedClasses": ["ImpactSimpleDetectorSEGS"],
-    "packsWithoutVersion": ["comfyui-kjnodes"],
-    "collidingPacks": ["comfyui-manager"],
-    "unknownClasses": [{"classType": "ReActorFaceSwap", "status": "unknown"}],
-    "models": [{"filename": "flux1-dev.safetensors", "status": "missing", "usedBy": ["UNETLoader"]}],
-    "partnerClasses": {"FluxProUltraImageNode": "black-forest-labs"},
-    "pinnedToLatest": True,
     "comfyVersionRequired": True,
+    "pinnedToLatest": True,
+    "unresolvedClasses": ["ReActorFaceSwap", "TotallyMadeUpNodeXYZ", "WAS_Image_Blend"],
+    "unknownClasses": [
+        {"classType": "ReActorFaceSwap", "status": "missing"},
+        {"classType": "TotallyMadeUpNodeXYZ", "status": "missing"},
+        {
+            "classType": "WAS_Image_Blend",
+            "status": "suggested",
+            "suggestions": [
+                {
+                    "nearestClass": "Image Blend",
+                    "packId": "https://github.com/ltdrdata/was-node-suite-comfyui",
+                    "score": 0.8888888888888888,
+                },
+                {"nearestClass": "ImageTile+", "packId": "comfyui_essentials", "score": 0.5555555555555556},
+            ],
+        },
+    ],
+    "models": [
+        {
+            "filename": "v1-5-pruned-emaonly-fp16.safetensors",
+            "status": "matched",
+            "directories": ["checkpoints"],
+            "usedBy": ["CheckpointLoaderSimple"],
+        },
+        {"filename": "definitely-not-a-real-lora-v3.safetensors", "status": "missing", "usedBy": ["LoraLoader"]},
+    ],
+    "partnerClasses": {"LumaImageNode": "Luma", "OpenAIGPTImage1": "OpenAI (inc. Sora)"},
 }
 
+UI_WORKFLOW = {"nodes": [{"type": "KSampler"}], "links": []}
 
-def _workflow_client(report):
-    class FakeClient:
-        def create_distribution_from_workflow(self, name, workflow, *, description=None):
-            self.workflow = workflow
-            return {"build": {"id": "dist-9", "name": name}, "report": report}
 
-    return FakeClient()
+def _workflow_client(payload):
+    """Autospec so a signature the command stops matching fails here, not in
+    production: a plain stub would accept any call the command learns to make."""
+    from comfy_cli.distribution_api import BuilderClient
+
+    client = create_autospec(BuilderClient, instance=True)
+    client.create_distribution_from_workflow.return_value = payload
+    return client
+
+
+def _built(report):
+    return {"build": {"id": "dist-9", "name": "portrait"}, "report": report}
+
+
+def _write_workflow(tmp_path, workflow):
+    path = tmp_path / "portrait.json"
+    path.write_text(json.dumps(workflow), encoding="utf-8")
+    return str(path)
 
 
 def test_from_workflow_client_posts_the_graph_to_its_own_endpoint(monkeypatch):
     calls = []
 
     def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
-        calls.append((method, url, body))
+        calls.append((method, url, body, timeout))
         return 201, {"build": {"id": "dist-9"}, "report": {}}
 
     monkeypatch.setattr("comfy_cli.distribution_api.request_json", fake_request_json)
     from comfy_cli.distribution_api import BuilderClient
 
     client = BuilderClient("https://builder.test/", "jwt-token")
-    graph = {"nodes": [{"type": "KSampler"}], "links": []}
-    assert client.create_distribution_from_workflow("portrait", graph)["build"]["id"] == "dist-9"
-    assert calls[-1] == (
-        "POST",
-        "https://builder.test/v1/builds/from-workflow",
-        {"name": "portrait", "workflow": graph},
-    )
+    assert client.create_distribution_from_workflow("portrait", UI_WORKFLOW)["build"]["id"] == "dist-9"
+    method, url, body, timeout = calls[-1]
+    assert (method, url) == ("POST", "https://builder.test/v1/builds/from-workflow")
+    assert body == {"name": "portrait", "workflow": UI_WORKFLOW}
+    # The importer spends up to 20 seconds on registry lookups alone, so this call
+    # carries its own deadline rather than the shared 30 second default.
+    assert timeout >= 60
 
-    client.create_distribution_from_workflow("portrait", graph, description="a portrait pipeline")
-    assert calls[-1][2] == {"name": "portrait", "workflow": graph, "description": "a portrait pipeline"}
+    client.create_distribution_from_workflow("portrait", UI_WORKFLOW, description="a portrait pipeline")
+    assert calls[-1][2] == {"name": "portrait", "workflow": UI_WORKFLOW, "description": "a portrait pipeline"}
 
 
 def test_from_workflow_reads_the_created_id_and_report_from_their_own_keys(monkeypatch, tmp_path, capsys):
     """The endpoint answers {build, report}, not a build carrying its report."""
-    wf = tmp_path / "portrait.json"
-    wf.write_text(json.dumps({"nodes": [{"type": "KSampler"}], "links": []}), encoding="utf-8")
     monkeypatch.setattr(
-        distribution, "_builder_client", lambda renderer, url: _workflow_client({"unresolvedClasses": ["ReActor"]})
+        distribution,
+        "_builder_client",
+        lambda renderer, url: _workflow_client(_built({"unresolvedClasses": ["ReActorFaceSwap"]})),
     )
-    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
     out = capsys.readouterr().out
     assert "dist-9" in out and "None" not in out
-    assert "ReActor" in out
+    assert "ReActorFaceSwap" in out
 
 
-def test_report_advisories_renders_every_field_a_workflow_report_carries():
-    """A workflow report shares no key with a snapshot report, so a fixed
-    snapshot key list renders zero advisories and the import looks clean."""
-    lines = "\n".join(distribution.report_advisories(WORKFLOW_REPORT))
-    assert "IPAdapterUnifiedLoader" in lines
-    assert "ImpactSimpleDetectorSEGS" in lines
-    assert "comfyui-kjnodes" in lines
-    assert "comfyui-manager" in lines
-    assert "ReActorFaceSwap" in lines
-    assert "flux1-dev.safetensors" in lines and "comfy build resolve" in lines
-    assert "FluxProUltraImageNode (black-forest-labs)" in lines
-    assert "newest published" in lines
-    assert "no ComfyUI version is pinned" in lines
-
-
-def test_report_advisories_survives_entries_the_server_shaped_differently():
-    """A scalar where a list of objects belongs must not render one line per
-    character, and a mapping that arrives as a list must not raise."""
-    lines = distribution.report_advisories(
-        {"models": ["flux1-dev.safetensors", 7], "partnerClasses": ["FluxProUltraImageNode"]}
+def test_from_workflow_forwards_the_description_to_the_builder(monkeypatch, tmp_path):
+    client = _workflow_client(_built({}))
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: client)
+    distribution.from_workflow_cmd(
+        from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait", description="a portrait pipeline"
     )
-    assert len(lines) == 1
-    assert "flux1-dev.safetensors, 7" in lines[0]
+    client.create_distribution_from_workflow.assert_called_once_with(
+        "portrait", UI_WORKFLOW, description="a portrait pipeline"
+    )
+
+
+def test_report_advisories_renders_a_workflow_report_line_for_line():
+    """A workflow report shares no key with a snapshot report, so the reader sees
+    exactly these lines and no others."""
+    assert distribution.report_advisories(WORKFLOW_REPORT) == [
+        "the importer pinned every pack the workflow named without a version to the registry's newest published "
+        "one, so importing the same file later can build something different",
+        "3 node classes nothing installable provides; the graph will not run without them: ReActorFaceSwap, "
+        "TotallyMadeUpNodeXYZ, WAS_Image_Blend",
+        "1 node classes the registry could not attribute, with the closest pack it named: WAS_Image_Blend "
+        "(maybe https://github.com/ltdrdata/was-node-suite-comfyui)",
+        "1 models the graph loads that no definition carries; `comfy build resolve` finds download candidates: "
+        "definitely-not-a-real-lora-v3.safetensors",
+        "2 node classes call a partner API rather than run from an installed pack: LumaImageNode (Luma), "
+        "OpenAIGPTImage1 (OpenAI (inc. Sora))",
+    ]
+
+
+def test_report_advisories_leaves_out_the_models_the_catalog_already_matched():
+    """Telling a user to resolve a model Cloud already holds sends them after a
+    file that is not missing."""
+    lines = distribution.report_advisories(
+        {"models": [{"filename": "v1-5-pruned-emaonly-fp16.safetensors", "status": "matched"}]}
+    )
+    assert lines == []
+
+
+def test_report_advisories_counts_every_name_and_says_how_many_it_held_back():
+    classes = [f"WAS_Image_Filter_{i}" for i in range(30)]
+    (line,) = distribution.report_advisories({"unresolvedClasses": classes})
+    assert line.startswith("30 node classes nothing installable provides")
+    assert line.endswith(f"{', '.join(classes[:8])} (+22 more)")
+
+
+def test_report_advisories_says_when_a_key_arrives_in_a_shape_it_cannot_render():
+    """Dropping a key the server did send is how a partial import comes to look
+    clean, which is the failure this command exists to prevent."""
+    lines = distribution.report_advisories(
+        {"partnerClasses": ["LumaImageNode"], "unresolvedClasses": "ReActorFaceSwap"}
+    )
+    assert lines == [
+        "the builder sent `unresolvedClasses` as str, which this CLI cannot render; read it with --json",
+        "the builder sent `partnerClasses` as list, which this CLI cannot render; read it with --json",
+    ]
+
+
+def test_report_advisories_scrubs_the_newlines_a_crafted_workflow_could_carry():
+    """Class names travel to the builder from the workflow file and come back in
+    the report, so an attacker-authored file must not forge CLI lines."""
+    (line,) = distribution.report_advisories(
+        {"unresolvedClasses": ["KSampler\n\u2714 Created build dist-9\nAll classes resolved"]}
+    )
+    assert "\n" not in line
+    assert "KSampler\\n" in line
 
 
 def test_report_advisories_leaves_a_snapshot_report_unchanged():
@@ -1782,45 +1859,88 @@ def test_from_workflow_accepts_the_api_export_dialect(monkeypatch, tmp_path, cap
     """The API export has no `nodes` or `links`, and the builder reads it. A
     frontend-only check here would refuse a file the server accepts."""
     api_export = {"3": {"class_type": "KSampler", "inputs": {}}}
-    wf = tmp_path / "portrait_api.json"
-    wf.write_text(json.dumps(api_export), encoding="utf-8")
-    client = _workflow_client({})
+    client = _workflow_client(_built({}))
     monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: client)
-    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
-    assert client.workflow == api_export
+    distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, api_export), name="portrait")
+    assert client.create_distribution_from_workflow.call_args.args[1] == api_export
     assert "dist-9" in capsys.readouterr().out
 
 
-def test_from_workflow_names_the_update_command_when_no_comfy_version_is_pinned(monkeypatch, tmp_path, capsys):
-    wf = tmp_path / "portrait.json"
-    wf.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
+def test_from_workflow_names_the_extraction_and_the_update_when_no_comfy_version_is_pinned(
+    monkeypatch, tmp_path, capsys
+):
     monkeypatch.setattr(
-        distribution, "_builder_client", lambda renderer, url: _workflow_client({"comfyVersionRequired": True})
+        distribution, "_builder_client", lambda renderer, url: _workflow_client(_built({"comfyVersionRequired": True}))
     )
-    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
     # The renderer wraps to the terminal width, so compare on the unwrapped text.
     out = " ".join(capsys.readouterr().out.split())
     assert "cannot be cut yet" in out
-    assert "comfy build update dist-9 --from <file>" in out
+    assert "comfy build get dist-9 --json | jq .data.definition > def.json" in out
+    assert "comfy build update dist-9 --from def.json" in out
     assert "comfy build release create" not in out
 
 
 def test_from_workflow_names_the_release_command_when_a_comfy_version_is_pinned(monkeypatch, tmp_path, capsys):
-    wf = tmp_path / "portrait.json"
-    wf.write_text(json.dumps({"nodes": [], "links": []}), encoding="utf-8")
     monkeypatch.setattr(
-        distribution, "_builder_client", lambda renderer, url: _workflow_client({"comfyVersionRequired": False})
+        distribution, "_builder_client", lambda renderer, url: _workflow_client(_built({"comfyVersionRequired": False}))
     )
-    distribution.from_workflow_cmd(from_=str(wf), name="portrait")
+    distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
     out = " ".join(capsys.readouterr().out.split())
     assert "comfy build release create dist-9" in out
     assert "cannot be cut yet" not in out
 
 
-@pytest.mark.parametrize("payload", ["not json at all", "[]"])
+def test_from_workflow_says_an_empty_report_checked_nothing(monkeypatch, tmp_path, capsys):
+    """The builder sets comfyVersionRequired on every import, so an empty report
+    means nothing was checked, not that everything resolved."""
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: _workflow_client(_built({})))
+    distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
+    out = " ".join(capsys.readouterr().out.split())
+    assert "the builder sent an empty import report" in out
+    assert "comfy build release create" not in out
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"report": {"comfyVersionRequired": True}}, id="no build key"),
+        pytest.param({"build": {"id": "dist-9"}, "report": "fine"}, id="report is a string"),
+        pytest.param({"build": ["dist-9"], "report": {}}, id="build is a list"),
+        pytest.param({}, id="empty body"),
+    ],
+)
+def test_from_workflow_refuses_to_claim_success_on_an_answer_it_cannot_read(monkeypatch, tmp_path, capsys, payload):
+    """The build row is already written when the answer arrives, so claiming
+    success and then dying loses the id the user needs."""
+    monkeypatch.setattr(distribution, "_builder_client", lambda renderer, url: _workflow_client(payload))
+    with pytest.raises(typer.Exit):
+        distribution.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
+    out = capsys.readouterr().out
+    assert "build_builder_error" in out
+    assert "Created build" not in out
+
+
+@pytest.mark.parametrize("payload", ["not json at all", "null", "[]", '"a string"', "42"])
 def test_from_workflow_refuses_a_file_that_is_not_a_json_object(tmp_path, capsys, payload):
     f = tmp_path / "portrait.json"
     f.write_text(payload, encoding="utf-8")
+    with pytest.raises(typer.Exit):
+        distribution.from_workflow_cmd(from_=str(f), name="portrait")
+    assert "build_workflow_invalid" in capsys.readouterr().out
+
+
+def test_from_workflow_refuses_a_path_it_cannot_read(tmp_path, capsys):
+    with pytest.raises(typer.Exit):
+        distribution.from_workflow_cmd(from_=str(tmp_path), name="portrait")
+    assert "build_workflow_invalid" in capsys.readouterr().out
+
+
+def test_from_workflow_refuses_a_workflow_nested_past_the_parser_limit(tmp_path, capsys):
+    """`json.loads` answers a deeply nested file with RecursionError, which is not
+    a ValueError, so a caller reading --json would get a bare traceback."""
+    f = tmp_path / "portrait.json"
+    f.write_text('{"a":' * 20000 + "1" + "}" * 20000, encoding="utf-8")
     with pytest.raises(typer.Exit):
         distribution.from_workflow_cmd(from_=str(f), name="portrait")
     assert "build_workflow_invalid" in capsys.readouterr().out

--- a/tests/comfy_cli/command/test_distribution.py
+++ b/tests/comfy_cli/command/test_distribution.py
@@ -1695,6 +1695,9 @@ WORKFLOW_REPORT = {
     "comfyVersionRequired": True,
     "pinnedToLatest": True,
     "unresolvedClasses": ["ReActorFaceSwap", "TotallyMadeUpNodeXYZ", "WAS_Image_Blend"],
+    "uncheckedClasses": ["ImpactSimpleDetectorSEGS"],
+    "packsWithoutVersion": ["comfyui-kjnodes"],
+    "collidingPacks": ["comfyui-manager"],
     "unknownClasses": [
         {"classType": "ReActorFaceSwap", "status": "missing"},
         {"classType": "TotallyMadeUpNodeXYZ", "status": "missing"},
@@ -1801,6 +1804,10 @@ def test_report_advisories_renders_a_workflow_report_line_for_line():
         "one, so importing the same file later can build something different",
         "3 node classes nothing installable provides; the graph will not run without them: ReActorFaceSwap, "
         "TotallyMadeUpNodeXYZ, WAS_Image_Blend",
+        "1 node classes the registry never answered for, so the build may not carry them: ImpactSimpleDetectorSEGS",
+        "1 packs the build fetches from their repository, because the registry publishes no version of them: "
+        "comfyui-kjnodes",
+        "1 packs the build leaves out, because another pack already claimed their install folder: comfyui-manager",
         "1 node classes the registry could not attribute, with the closest pack it named: WAS_Image_Blend "
         "(maybe https://github.com/ltdrdata/was-node-suite-comfyui)",
         "1 models the graph loads that no definition carries; `comfy build resolve` finds download candidates: "


### PR DESCRIPTION
**TL;DR:** `comfy build from-workflow` turns a ComfyUI workflow file into a build, and prints everything the import could not carry instead of reporting a partial import as a clean success.

Linear: [BE-8424](https://linear.app/comfyorg/issue/BE-8424) · part of [BE-8413 A workflow file becomes a distribution in one call](https://linear.app/comfyorg/issue/BE-8413)

**Why:** the builder answers this endpoint with the build and a report naming the node classes nothing provides, the models no definition carries and the classes a partner serves, and `report_advisories` read a fixed key list holding none of those fields. On `origin/main` it returns `[]` for a report naming three unresolvable classes and two unsourced models, so the user cuts a paid release believing the import was clean.

**Validation**

* **Unit**: 29 new cases. Every one fails on `origin/main` at `6a5e9d7` except the deliberate both-sides guard that pins `from-snapshot`'s output, so 24 fail there and pass here. 186 pass across the four contract files; full suite 5849 pass, 2 fail, both reproducing on a pristine `origin/main` checkout (a timeout-classification test and an onboarding singleton flake, neither touched here).
* **Local stack, end to end**: comfy-builder, its database and live Comfy Registry lookups on `127.0.0.1:8093`, driven through `python -m comfy_cli build from-workflow`. A 19-node workflow created build `f2dce671` and printed six advisory lines, below. The hint it printed then ran verbatim: `build get | jq .data.definition`, add `baseComfyVersion`, `build update`, and `build release create` cut a release. Before that pin the same cut is refused with `INVALID_DEFINITION: baseComfyVersion is required`, which is the premise the hint exists for. Stand-in: a loopback proxy supplies the two identity headers localdev auth uses, because the CLI sends only a bearer token.
* **Local stack, unchanged paths**: `comfy build from-snapshot` created a build with output identical to today, since the two reports share no key; the API export dialect created `93d88776`, whose `--json` data validates against the new schema; `comfy discover` lists the verb with its schema and flags.
* **Not run**: staging and production; the 402 subscription and 409 build-limit refusals, which the local stack does not gate; Python 3.10, which CI pins and this machine does not have.
* **One red check that predates this branch**: `public-repo-hygiene` fails here and on `6a5e9d7` and the four commits before it, over 31 references in `knowledge.py`, `cql/engine.py`, the gallery fixtures and the e2e tests. None of the seven files this branch touches is among them.

```
Created build f2dce671-bdd6-42ad-a32b-6f10c4167766 from probe_workflow_ui.json
the importer pinned every pack the workflow named without a version to the registry's newest published one, so importing the same file later can build something different
3 node classes nothing installable provides; the graph will not run without them: ReActorFaceSwap, TotallyMadeUpNodeXYZ, WAS_Image_Blend
1 node classes the registry could not attribute, with the closest pack it named: WAS_Image_Blend (maybe https://github.com/ltdrdata/was-node-suite-comfyui)
1 models the shared catalog holds that this build does not carry, each needing a sourceUri in the definition before you cut: v1-5-pruned-emaonly-fp16.safetensors
1 models the graph loads that nothing has a source for; `comfy build resolve` finds candidates: definitely-not-a-real-lora-v3.safetensors
2 node classes call a partner API rather than run from an installed pack: LumaImageNode (Luma), OpenAIGPTImage1 (OpenAI (inc. Sora))
no ComfyUI version is pinned, so this build cannot be cut yet: run `comfy build get f2dce671... --json | jq .data.definition > def.json`, add `baseComfyVersion` to def.json, then run `comfy build update f2dce671... --from def.json`
```

**A suggestion is offered as `maybe`, never as an answer**, because the score it is ranked by is similarity between two names: `openapi.yaml:1881-1897` says it "ranks candidates; not confidence that two names mean the same weights", and `v1-5-pruned` against `v2-1-pruned` scores alike. Presenting a lead as a match is how a build installs the wrong weights.

**What changed**

* **[comfy-cli] `command/distribution.py`**: the verb, and `report_advisories` extended to the workflow report's nine fields. `models` and `partnerClasses` are not flat lists, so each renders through its own function. A workflow import builds custom nodes and no models at all, so every model the graph loads gets a line, and `status` shapes the wording rather than deciding whether a line exists. An unattributed class renders the closest pack the registry named rather than repeating a name `unresolvedClasses` already printed. A key that arrives in a shape the renderer cannot read now says so, because a swallowed key is how a partial import comes to look clean.
* **[comfy-cli] `distribution_api.py`**: `create_distribution_from_workflow`, with a 90 second deadline of its own. The builder spends up to 20 seconds on registry lookups alone, and the shared 30 second default leaves a large graph nothing to spare.
* **[comfy-cli] four registration points plus the changelog**: `discovery.py`, a new `schemas/build_from_workflow.json`, `build_workflow_invalid` in `error_codes.py`, and a `CHANGELOG.md` entry.

**Where it lands**

```mermaid
flowchart LR
  subgraph cli["comfy-cli"]
    V["build from-workflow<br/>◀ this PR"]
    R["report_advisories<br/>◀ this PR"]
    D["discovery · schemas · error codes"]
  end
  B["comfy-builder<br/>POST /v1/builds/from-workflow"]
  S["build from-snapshot"]

  V -- "the file, with the caller's token" --> B
  B -- "{build, report}" --> V
  V --> R
  S --> R
  V --> D

  classDef here fill:#ffe08a,stroke:#b8860b,color:#000;
  classDef out fill:#f5f5f5,stroke:#bbbbbb,stroke-dasharray:4 3,color:#888888;
  class V,R here
  class B,S,D out
```

**Two decisions the ticket left open.** The verb checks only that the file is a JSON object, and never which dialect it is: the builder reads both the editing format and the API export, and `workflow.py`'s loader refuses the API export, so inheriting that check would refuse files the server accepts. The report renderer stayed one function, as the ticket asked, though the two import reports share no field; [BE-9435](https://linear.app/comfyorg/issue/BE-9435) carries the split.

**Found while reviewing, filed not fixed:** [BE-9432](https://linear.app/comfyorg/issue/BE-9432) a builder call that times out escapes the error envelope, [BE-9433](https://linear.app/comfyorg/issue/BE-9433) the builder's branchable error identifiers collapse into one envelope code, [BE-9434](https://linear.app/comfyorg/issue/BE-9434) `build_from_snapshot.json` requires a key its command never emits.

**Contradicts:** nothing.
