### PR TITLE
fix(build): answer every builder failure with an envelope a create can trust (BE-9432)

### DIFF
--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import http.client
 import io
 import json
 import os
 import re
 import subprocess
+import urllib.error
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Annotated
@@ -46,6 +48,7 @@ from comfy_cli._safe_exec import BinaryNotFoundError, resolve_required_binary
 from comfy_cli.command.pack_scan import read_pyproject
 from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH, SUPPORTED_PT_EXTENSIONS
 from comfy_cli.file_utils import atomic_write_text
+from comfy_cli.http import ResponseTooLarge
 from comfy_cli.output import get_renderer
 from comfy_cli.registry.api import sanitize_error_body
 from comfy_cli.workspace_manager import WorkspaceManager
@@ -609,11 +612,21 @@ def _unrenderable(key: str, value) -> str:
     return f"the builder sent `{key}` as {type(value).__name__}, which this CLI cannot render; read it with --json"
 
 
+def _suggestions(entry: dict) -> list | None:
+    """The suggestions an entry carries, or None when it sent a shape this cannot
+    walk. ``"suggestions": 5`` is truthy and not iterable, and the TypeError would
+    cost the reader the whole report after the build row already exists."""
+    ranked = entry.get("suggestions")
+    if not ranked:
+        return []
+    return list(ranked) if isinstance(ranked, list | tuple) else None
+
+
 def _best_suggestion(entry: dict, field: str) -> str:
     """The highest-scored suggestion's ``field``, or "" when none carries one.
     The catalog ranks what it thinks the workflow meant, so the reader gets the
     lead rather than the whole list."""
-    ranked = [s for s in (entry.get("suggestions") or []) if isinstance(s, dict) and s.get(field)]
+    ranked = [s for s in (_suggestions(entry) or []) if isinstance(s, dict) and s.get(field)]
     if not ranked:
         return ""
     best = max(ranked, key=lambda s: s["score"] if isinstance(s.get("score"), int | float) else 0.0)
@@ -624,17 +637,23 @@ def _suggested_pack_lines(entries: list) -> list[str]:
     """`unknownClasses` is the detailed form of `unresolvedClasses`, which already
     prints the names. What it adds is the pack the registry came closest to, so
     that is all this renders, and only for the classes that carry one."""
-    suggested = []
+    suggested, unreadable = [], None
     for entry in entries:
         if not isinstance(entry, dict):
+            continue
+        if _suggestions(entry) is None:
+            unreadable = entry["suggestions"]
             continue
         pack = _best_suggestion(entry, "packId")
         if pack:
             suggested.append(f"{_from_server(entry.get('classType'))} (maybe {pack})")
-    if not suggested:
-        return []
-    meaning = "node classes the registry could not attribute, with the closest pack it named"
-    return [_advisory_line(len(suggested), meaning, suggested)]
+    lines = []
+    if suggested:
+        meaning = "node classes the registry could not attribute, with the closest pack it named"
+        lines.append(_advisory_line(len(suggested), meaning, suggested))
+    if unreadable is not None:
+        lines.append(_unrenderable("suggestions", unreadable))
+    return lines
 
 
 def _model_lines(entries: list) -> list[str]:
@@ -643,7 +662,7 @@ def _model_lines(entries: list) -> list[str]:
     loads is still owed, and ``status`` shapes the wording rather than deciding
     whether a line exists: the shared catalog already holds a matched one, which
     needs only a source pointer, while the rest have to be found first."""
-    held, owed = [], []
+    held, owed, unreadable = [], [], None
     for entry in entries:
         if not isinstance(entry, dict):
             owed.append(_from_server(entry))
@@ -651,6 +670,10 @@ def _model_lines(entries: list) -> list[str]:
         name = _from_server(entry.get("filename"))
         if entry.get("status") == "matched":
             held.append(name)
+            continue
+        if _suggestions(entry) is None:
+            unreadable = entry["suggestions"]
+            owed.append(name)
             continue
         lead = _best_suggestion(entry, "filename")
         owed.append(f"{name} (maybe {lead})" if lead else name)
@@ -664,6 +687,8 @@ def _model_lines(entries: list) -> list[str]:
     if owed:
         meaning = "models the graph loads that nothing has a source for; `comfy build resolve` finds candidates"
         lines.append(_advisory_line(len(owed), meaning, owed))
+    if unreadable is not None:
+        lines.append(_unrenderable("suggestions", unreadable))
     return lines
 
 
@@ -900,7 +925,14 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
         section, idx = u["slot"]
         definition[section][idx]["blobId"] = blob_id
         uploaded += 1
-    build_id = client.create_build(name, definition)
+    try:
+        build_id = client.create_build(name, definition)
+    except Exception as e:
+        # Every step above this one is blob work that leaves no build behind, so
+        # this frame is the only one that knows a create was actually sent. The
+        # command reads the mark to decide whether a build may exist server-side.
+        e.create_attempted = True
+        raise
     try:
         version_id, status_url = client.cut_version(build_id, targets)
     except Exception as e:
@@ -1183,6 +1215,51 @@ def _load_definition(path: Path, *, require_models: bool = True) -> dict:
 # --builder-url or COMFY_BUILDER_URL (e.g. https://stagingplatformapi.comfy.org/builder).
 DEFAULT_BUILDER_URL = "https://platformapi.comfy.org/builder"
 
+# The builder writes the build row before answering, so a create whose outcome the
+# client never confirmed may still have made a build. Every verb that creates one
+# says so in these words, from here, rather than wording the warning for itself.
+_BUILD_MAY_EXIST_HINT = (
+    "a build may already exist: run `comfy build list` before retrying, because a retry can create a second build"
+)
+
+# What a build id has to look like before this CLI will show one. An id comes back
+# from the builder and is printed, put in an envelope, and interpolated unquoted
+# into command lines the user is told to run: reading it straight out of a response
+# lets a wrong or hostile answer put terminal escapes and shell metacharacters into
+# what the CLI tells a person to type.
+_BUILD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+
+
+# Every way a builder call fails without the caller reading a status line. A
+# refused/DNS/TLS failure at connect raises URLError; a read timeout raises a bare
+# TimeoutError, which is no URLError; a reset or a server hanging up mid-response
+# raises ConnectionError; a truncated body and a mangled status line raise
+# http.client.IncompleteRead and BadStatusLine (both HTTPException); a non-ASCII
+# host reaches http.client's ``host.encode("idna")`` fallback, which raises
+# UnicodeError (a ValueError, so none of the above catch it). requests raises its
+# own family for the presigned uploads, a malformed body reads as KeyError, and an
+# answer past the client cap raises ResponseTooLarge. Each is an envelope, never a
+# traceback: a bare traceback tells a --json caller nothing and, on a create, loses
+# the id of a build that already exists.
+_BUILDER_TRANSPORT_ERRORS = (
+    urllib.error.URLError,
+    TimeoutError,
+    ConnectionError,
+    http.client.HTTPException,
+    UnicodeError,
+    requests.RequestException,
+    KeyError,
+    ResponseTooLarge,
+)
+
+
+def _server_build_id(value) -> str | None:
+    """The build id a response claims, or None when what it sent is not one. A
+    list, a number and a string carrying anything outside the grammar all read as
+    absent: a mangled id in a copy-paste command line is worse than no id, because
+    the user runs the line."""
+    return value if isinstance(value, str) and _BUILD_ID_RE.match(value) else None
+
 
 @app.command(
     "create",
@@ -1280,8 +1357,6 @@ def _create_execute(
 ) -> None:
     """The live --execute path: auth, resolve, upload, create, cut. Maps every
     failure class to a single error envelope + exit(1)."""
-    import urllib.error
-
     client = _builder_client(renderer, builder_url)
 
     # Resolve models to public URLs where a hash-verified match exists. Best
@@ -1291,7 +1366,7 @@ def _create_execute(
         n = resolve_models_via_builder(definition.get("models", []), client)
         if renderer.is_pretty() and n:
             renderer.info(f"Resolved {n} model(s) to public URLs — skipping their upload")
-    except (urllib.error.URLError, requests.RequestException, KeyError) as e:
+    except _BUILDER_TRANSPORT_ERRORS as e:
         renderer.warn(f"model resolution unavailable ({e}); all models will be uploaded")
 
     # The importer is the side of the boundary that knows what the registry
@@ -1299,7 +1374,7 @@ def _create_execute(
     declared = [n.get("name") for n in definition.get("customNodes", [])]
     try:
         imported = client.resolve_snapshot(snapshot_from_definition(definition))
-    except (urllib.error.URLError, requests.RequestException, KeyError, ValueError) as e:
+    except (*_BUILDER_TRANSPORT_ERRORS, ValueError) as e:
         renderer.warn(f"the builder could not read the definition's pins ({e}); they go to the cut unchecked")
     else:
         imported_report = imported.get("report") or {}
@@ -1361,11 +1436,19 @@ def _create_execute(
     except FileNotFoundError as e:
         renderer.error(code="build_upload_unavailable", message=str(e))
         raise typer.Exit(code=1) from e
-    except (urllib.error.URLError, requests.RequestException, KeyError) as e:
+    except _BUILDER_TRANSPORT_ERRORS as e:
         # Same handler as the read verbs: surface the builder's own message (and the
         # limited-beta 403), plus the created build's id when a cut failed
         # after create, so the caller can delete or retry it rather than orphan it.
-        _report_builder_error(renderer, e, build_id=getattr(e, "build_id", None))
+        # Only a create call that was actually sent can have left a build nobody
+        # named: the blob work above it creates nothing, and a failed cut already
+        # carries the build's id, where a retry would duplicate a release instead.
+        _report_builder_error(
+            renderer,
+            e,
+            build_id=getattr(e, "build_id", None),
+            unconfirmed_effect_hint=_BUILD_MAY_EXIST_HINT if getattr(e, "create_attempted", False) else None,
+        )
         raise typer.Exit(code=1) from e
 
     if renderer.is_pretty():
@@ -1397,15 +1480,50 @@ def _builder_client(renderer, builder_url: str | None):
         raise typer.Exit(code=1) from e
 
 
-def _report_builder_error(renderer, e, *, build_id: str | None = None) -> None:
+def _report_builder_error(
+    renderer, e, *, build_id: str | None = None, unconfirmed_effect_hint: str | None = None
+) -> None:
     """Emit one error envelope for a builder failure. Prefers the limited-beta 403,
     then the builder's own error body (e.g. `INVALID_DEFINITION: …` or
     `SUBSCRIPTION_REQUIRED: …`) over urllib's opaque "HTTP Error 400", then the
     generic transport error. Includes a created build's id when supplied,
-    so a cut that fails after create doesn't orphan an unnamed build."""
-    import urllib.error
+    so a cut that fails after create doesn't orphan an unnamed build.
 
-    base = {"distributionId": build_id} if build_id else {}
+    ``unconfirmed_effect_hint`` rides only where the call's effect is unknown. A
+    4xx is the builder refusing before it writes anything, so the effect is known
+    to be none; a 408, a 5xx (the gateway's 504 above all) and a dead connection
+    can each land after the write. A failure that already knows the build's id
+    supersedes it and says to cut that build, whatever the status was."""
+    # 408 sits with the 5xx range here: both say the request may have been
+    # processed, which is the only question the hint answers.
+    answered_a_refusal = isinstance(e, urllib.error.HTTPError) and e.code < 500 and e.code != 408
+    named = _server_build_id(build_id)
+
+    base = {"distributionId": named} if named else {}
+    if unconfirmed_effect_hint and not answered_a_refusal:
+        # The one machine-readable fact in the hint: an agent must not blind-retry.
+        base["effectUnconfirmed"] = True
+
+    # A known build id outranks the rest, whatever the status was: the build exists,
+    # so the next step is to cut that one. The registered hint says "retry", and the
+    # retry a person runs is another create, which builds a second one beside it.
+    if named:
+        hint = f"the build exists as {named}: cut it with `comfy build release create {named}`, not by creating again"
+    elif answered_a_refusal:
+        hint = None
+    else:
+        hint = unconfirmed_effect_hint
+
+    if isinstance(e, ResponseTooLarge):
+        # The builder answered in full and this client refused to read the answer,
+        # so a create that trips the cap has written its row and cannot name it.
+        renderer.error(
+            code="build_builder_error",
+            message=f"builder response exceeded the client size cap ({e})",
+            hint=hint,
+            details=base or None,
+        )
+        return
     if isinstance(e, urllib.error.HTTPError):
         body = ""
         try:
@@ -1423,28 +1541,26 @@ def _report_builder_error(renderer, e, *, build_id: str | None = None) -> None:
         renderer.error(
             code="build_builder_error",
             message=f"builder call failed ({e.code}): {detail}",
+            hint=hint,
             details={**base, "status": e.code, "body": body[:1000]},
         )
         return
-    renderer.error(code="build_builder_error", message=f"builder call failed: {e}", details=base or None)
+    renderer.error(
+        code="build_builder_error",
+        message=f"builder call failed: {e}",
+        hint=hint,
+        details=base or None,
+    )
 
 
-def _builder_call(renderer, fn):
+def _builder_call(renderer, fn, *, unconfirmed_effect_hint: str | None = None):
     """Run a builder API call, mapping every failure class to one error envelope
-    + exit(1) via _report_builder_error."""
-    import urllib.error
-
-    from comfy_cli.http import ResponseTooLarge
-
+    + exit(1) via _report_builder_error. ``unconfirmed_effect_hint`` reaches the
+    envelope only where the call may already have taken effect."""
     try:
         return fn()
-    except ResponseTooLarge as e:
-        # Mostly the build log outgrowing even the raised logs cap; a clear message
-        # beats an unhandled traceback.
-        renderer.error(code="build_builder_error", message=f"builder response exceeded the client size cap ({e})")
-        raise typer.Exit(code=1) from e
-    except (urllib.error.URLError, requests.RequestException, KeyError) as e:
-        _report_builder_error(renderer, e)
+    except _BUILDER_TRANSPORT_ERRORS as e:
+        _report_builder_error(renderer, e, unconfirmed_effect_hint=unconfirmed_effect_hint)
         raise typer.Exit(code=1) from e
 
 
@@ -1656,7 +1772,7 @@ def update_cmd(
         # annotation it leaves is what the default resolver in plan_create reads.
         try:
             resolve_models_via_builder(definition.get("models", []), client)
-        except (requests.RequestException, KeyError, ValueError) as e:
+        except (*_BUILDER_TRANSPORT_ERRORS, ValueError) as e:
             renderer.warn(f"model resolution unavailable ({e})")
         plan = plan_create(definition)
         if plan["uploads"]:
@@ -1730,9 +1846,23 @@ def from_snapshot_cmd(
         lambda: client.create_build_from_snapshot(
             name, as_snapshot_envelope(snapshot), description=description, base_image_id=base_image
         ),
+        unconfirmed_effect_hint=_BUILD_MAY_EXIST_HINT,
     )
-    created = result.get("build") or {}
-    build_id = created.get("id")
+    created = result.get("build") if isinstance(result, dict) else None
+    build_id = _server_build_id(created.get("id") if isinstance(created, dict) else None)
+    # The row is already written by the time the answer arrives, so an id this
+    # command cannot read means a build exists that nothing here can name.
+    if not build_id:
+        renderer.error(
+            code="build_builder_error",
+            message=(
+                "the builder answered from-snapshot with a build id this CLI cannot read, so a build may exist "
+                "that this command cannot name; list your builds with `comfy build list`"
+            ),
+            details={"received": sorted(result) if isinstance(result, dict) else type(result).__name__},
+        )
+        raise typer.Exit(code=1)
+
     if renderer.is_pretty():
         renderer.success(f"Created build {build_id} from {path.name}")
         for line in report_advisories(result.get("report") or {}):
@@ -1770,20 +1900,37 @@ def from_workflow_cmd(
         raise typer.Exit(code=1) from e
 
     client = _builder_client(renderer, builder_url)
-    result = _builder_call(renderer, lambda: client.create_build_from_workflow(name, workflow, description=description))
+    result = _builder_call(
+        renderer,
+        lambda: client.create_build_from_workflow(name, workflow, description=description),
+        unconfirmed_effect_hint=_BUILD_MAY_EXIST_HINT,
+    )
     created = result.get("build") if isinstance(result, dict) else None
     report = result.get("report") if isinstance(result, dict) else None
-    distribution_id = created.get("id") if isinstance(created, dict) else None
-    # The row is already written by the time the answer arrives, so a shape this
+    distribution_id = _server_build_id(created.get("id") if isinstance(created, dict) else None)
+    received = {"received": sorted(result) if isinstance(result, dict) else type(result).__name__}
+    # The row is already written by the time the answer arrives, so an id this
     # command cannot read means a build exists that nothing here can name.
-    if not distribution_id or not isinstance(report, dict):
+    if not distribution_id:
         renderer.error(
             code="build_builder_error",
             message=(
-                "the builder answered from-workflow with a shape this CLI cannot read, so a build may exist "
+                "the builder answered from-workflow with a build id this CLI cannot read, so a build may exist "
                 "that this command cannot name; list your builds with `comfy build list`"
             ),
-            details={"received": sorted(result) if isinstance(result, dict) else type(result).__name__},
+            details=received,
+        )
+        raise typer.Exit(code=1)
+    # The id is good, so the build has a name to give. Sending this reader to
+    # `comfy build list` to find what is already on screen would be the lie.
+    if not isinstance(report, dict):
+        renderer.error(
+            code="build_builder_error",
+            message=(
+                f"the builder created build {distribution_id}, then answered with an import report this CLI "
+                "cannot read, so nothing here says what the workflow mapped to"
+            ),
+            details={**received, "distributionId": distribution_id},
         )
         raise typer.Exit(code=1)
 

--- a/tests/comfy_cli/command/test_build.py
+++ b/tests/comfy_cli/command/test_build.py
@@ -3,12 +3,16 @@ subprocess check of the JSON envelope (same pattern as test_project_command)."""
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
 import json
 import os
+import socket
 import subprocess
 import sys
 import threading
+import urllib.error
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest.mock import create_autospec
@@ -17,8 +21,11 @@ import pytest
 import requests
 import typer
 
+from comfy_cli import error_codes
 from comfy_cli.command import build
+from comfy_cli.http import ResponseTooLarge
 from comfy_cli.output import get_renderer
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
 
 
 @pytest.fixture
@@ -655,13 +662,15 @@ def test_delete_command_needs_confirm_non_interactive():
 
 
 class _RecordingRenderer:
-    """Minimal renderer stand-in that records the error code emitted."""
+    """Minimal renderer stand-in that records the error code and hint emitted."""
 
     def __init__(self):
         self.codes = []
+        self.hints = []
 
-    def error(self, code, message, details=None):
+    def error(self, code, message, *, hint=None, details=None):
         self.codes.append(code)
+        self.hints.append(hint)
 
 
 def test_builder_client_uses_injected_token(monkeypatch):
@@ -749,6 +758,55 @@ def test_builder_call_maps_other_errors_to_builder_error():
     with pytest.raises(typer.Exit):
         _builder_call(r, raise_500)
     assert r.codes == ["build_builder_error"]
+
+
+def test_builder_call_maps_a_stalled_read_to_a_builder_error():
+    import typer
+
+    from comfy_cli.command.build import _builder_call
+
+    def raise_read_timeout():
+        raise TimeoutError("The read operation timed out")
+
+    r = _RecordingRenderer()
+    with pytest.raises(typer.Exit) as exit_:
+        _builder_call(r, raise_read_timeout)
+    assert r.codes == ["build_builder_error"]
+    assert exit_.value.exit_code == 1
+
+
+def _listener_that_hangs_up():
+    """A listener that accepts a connection and closes it without writing a status
+    line, which is how a proxy or a killed worker drops a call the builder already
+    committed. Returns (socket, base_url); the caller closes the socket."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+
+    def serve():
+        with contextlib.suppress(OSError):
+            conn, _ = sock.accept()
+            conn.close()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return sock, f"http://127.0.0.1:{sock.getsockname()[1]}"
+
+
+def test_builder_call_turns_a_dropped_connection_into_an_envelope():
+    """A connection dropped mid-response raises RemoteDisconnected or
+    ConnectionResetError, neither of which is a URLError. Driven against a real
+    socket so the tuple is checked against what Python raises, not what I assumed."""
+    from comfy_cli.builder_api import BuilderClient
+
+    sock, base_url = _listener_that_hangs_up()
+    try:
+        r = _RecordingRenderer()
+        with pytest.raises(typer.Exit) as exit_:
+            build._builder_call(r, BuilderClient(base_url, "jwt").list_builds)
+    finally:
+        sock.close()
+    assert r.codes == ["build_builder_error"]
+    assert exit_.value.exit_code == 1
 
 
 def test_upload_blob_sends_generation_match_header(monkeypatch, tmp_path):
@@ -1231,6 +1289,201 @@ def test_create_execute_still_creates_when_the_builder_cannot_read_pins(monkeypa
     assert builder.created_with["customNodes"][0]["id"] == "pr-was-47064894"
 
 
+def test_create_execute_still_creates_when_reading_the_pins_stalls(monkeypatch):
+    """A stalled importer read raises a bare TimeoutError, which is no URLError.
+    Uncaught it takes the whole create down over a check the cut redoes anyway."""
+    builder = _ImportingBuilder(fail=TimeoutError("The read operation timed out"))
+    _execute(
+        monkeypatch,
+        builder,
+        {
+            "baseComfyVersion": "v0.30.2",
+            "models": [],
+            "customNodes": [{"name": "was", "id": "pr-was-47064894", "registryVersion": "1.0.1"}],
+        },
+    )
+    assert builder.created_with["customNodes"][0]["id"] == "pr-was-47064894"
+
+
+# --- a create says a build may exist only where the create call may have landed ---
+
+
+class _FailingBuilder:
+    """Builder stand-in that fails at exactly one step of the live create."""
+
+    def __init__(self, *, fail_at, error):
+        self.fail_at = fail_at
+        self.error = error
+        self.created_with = None
+
+    def _maybe_fail(self, step):
+        if step == self.fail_at:
+            raise self.error
+
+    def resolve_models(self, filenames):
+        self._maybe_fail("resolve_models")
+        return []
+
+    def resolve_snapshot(self, snapshot):
+        return {"definition": {"customNodes": []}, "report": {}}
+
+    def create_blob(self, kind, filename, sha256, size_bytes):
+        self._maybe_fail("create_blob")
+        return ("blob-1", "https://storage.test/put")
+
+    def upload_blob(self, upload_url, path):
+        self._maybe_fail("upload_blob")
+
+    def create_build(self, name, definition, description=None):
+        self._maybe_fail("create_build")
+        self.created_with = definition
+        return "dist-1"
+
+    def cut_version(self, build_id, targets=None):
+        self._maybe_fail("cut_version")
+        return ("ver-1", "status-url")
+
+
+def _uploading_definition() -> dict:
+    return {
+        "baseComfyVersion": "v0.30.2",
+        "models": [{"type": "unet", "filename": "z.safetensors", "sha256": "abc", "sizeBytes": 4}],
+        "customNodes": [],
+    }
+
+
+def _models_tree_with_the_model(tmp_path) -> Path:
+    root = tmp_path / "models"
+    (root / "unet").mkdir(parents=True)
+    (root / "unet" / "z.safetensors").write_bytes(b"BYTE")
+    return root
+
+
+def _force_json_renderer() -> Renderer:
+    r = Renderer.resolve(is_stdout_tty=False, env={}, json_flag=True)
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _last_envelope(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    assert out, "expected an envelope on stdout"
+    return json.loads(out.splitlines()[-1])
+
+
+_EXPECTED_CREATE_HINT = (
+    "a build may already exist: run `comfy build list` before retrying, because a retry can create a second build"
+)
+# What renderer.error substitutes whenever a call site passes no hint.
+_REGISTERED_BUILDER_HINT = error_codes.get("build_builder_error").hint
+# A failure that already knows the build's id says what to do with that build.
+_EXPECTED_CUT_HINT = (
+    "the build exists as dist-1: cut it with `comfy build release create dist-1`, not by creating again"
+)
+
+
+@pytest.mark.parametrize(
+    ("fail_at", "error", "expected_hint", "expected_unconfirmed", "expected_dist_id"),
+    [
+        pytest.param(
+            "create_build",
+            TimeoutError("The read operation timed out"),
+            _EXPECTED_CREATE_HINT,
+            True,
+            None,
+            id="stalled_create_may_have_written_the_row",
+        ),
+        pytest.param(
+            "create_build",
+            urllib.error.HTTPError("https://x", 504, "Gateway Timeout", None, io.BytesIO(b"gateway timeout")),
+            _EXPECTED_CREATE_HINT,
+            True,
+            None,
+            id="gateway_504_may_have_written_the_row",
+        ),
+        pytest.param(
+            "create_build",
+            urllib.error.HTTPError(
+                "https://x", 400, "Bad Request", None, io.BytesIO(b'{"error":"INVALID_DEFINITION"}')
+            ),
+            _REGISTERED_BUILDER_HINT,
+            None,
+            None,
+            id="refused_definition_wrote_no_row",
+        ),
+        pytest.param(
+            "upload_blob",
+            requests.HTTPError("403 Forbidden from storage"),
+            _REGISTERED_BUILDER_HINT,
+            None,
+            None,
+            id="blob_upload_fails_before_any_create",
+        ),
+        pytest.param(
+            "create_build",
+            urllib.error.HTTPError("https://x", 408, "Request Timeout", None, io.BytesIO(b"request timeout")),
+            _EXPECTED_CREATE_HINT,
+            True,
+            None,
+            id="request_timeout_408_may_have_written_the_row",
+        ),
+        pytest.param(
+            "create_build",
+            ResponseTooLarge("response exceeds the 8 MiB cap"),
+            _EXPECTED_CREATE_HINT,
+            True,
+            None,
+            id="an_answer_past_the_cap_was_still_an_answer",
+        ),
+        pytest.param(
+            "cut_version",
+            TimeoutError("The read operation timed out"),
+            _EXPECTED_CUT_HINT,
+            None,
+            "dist-1",
+            id="cut_fails_after_the_build_exists_and_is_named",
+        ),
+    ],
+)
+def test_create_says_a_build_may_exist_only_where_the_create_call_may_have_landed(
+    monkeypatch, tmp_path, capsys, fail_at, error, expected_hint, expected_unconfirmed, expected_dist_id
+):
+    monkeypatch.setattr(build, "_builder_client", lambda renderer, url: _FailingBuilder(fail_at=fail_at, error=error))
+    renderer = _force_json_renderer()
+
+    with pytest.raises(typer.Exit):
+        build._create_execute(
+            renderer,
+            _uploading_definition(),
+            name="demo",
+            builder_url=None,
+            models_dir=str(_models_tree_with_the_model(tmp_path)),
+        )
+
+    err = _last_envelope(capsys)["error"]
+    details = err["details"] or {}
+    assert err["code"] == "build_builder_error"
+    assert err["hint"] == expected_hint
+    assert details.get("effectUnconfirmed") is expected_unconfirmed
+    assert details.get("distributionId") == expected_dist_id
+
+
+def test_create_execute_still_creates_when_model_resolution_stalls(monkeypatch, tmp_path):
+    """Resolution only saves an upload. A stall in it must cost the upload, not the
+    create, so the model uploads and the build is still made."""
+    builder = _FailingBuilder(fail_at="resolve_models", error=TimeoutError("The read operation timed out"))
+    monkeypatch.setattr(build, "_builder_client", lambda renderer, url: builder)
+    build._create_execute(
+        get_renderer(),
+        _uploading_definition(),
+        name="demo",
+        builder_url=None,
+        models_dir=str(_models_tree_with_the_model(tmp_path)),
+    )
+    assert builder.created_with["models"][0]["blobId"] == "blob-1"
+
+
 # --- the freeze describes the target env, and carries no credential -----------
 
 
@@ -1365,6 +1618,23 @@ def test_report_advisories_reads_the_refused_release_as_one_value():
     assert "'v9.9.9'" in line and "6 " not in line
 
 
+def test_report_advisories_says_when_a_suggestion_list_cannot_be_walked():
+    """`"suggestions": 5` is truthy and not iterable: the comprehension raised
+    TypeError mid-render, losing the whole report after the row already existed."""
+    lines = build.report_advisories({"unknownClasses": [{"classType": "ReActorFaceSwap", "suggestions": 5}]})
+    assert lines == ["the builder sent `suggestions` as int, which this CLI cannot render; read it with --json"]
+
+
+def test_report_advisories_still_owes_the_model_whose_suggestions_it_cannot_walk():
+    """The unreadable part is the lead, not the entry: the model is still owed, and
+    saying so beats dropping the line that says the graph needs it."""
+    lines = build.report_advisories(
+        {"models": [{"filename": "lora-v3.safetensors", "status": "missing", "suggestions": 5}]}
+    )
+    assert "lora-v3.safetensors" in lines[0]
+    assert lines[1] == "the builder sent `suggestions` as int, which this CLI cannot render; read it with --json"
+
+
 def test_report_advisories_names_a_folder_collision():
     (line,) = build.report_advisories({"collidingNodes": ["ComfyUI-Easy-Use"]})
     assert "already claimed the folder" in line and "ComfyUI-Easy-Use" in line
@@ -1427,6 +1697,52 @@ def test_from_snapshot_schema_matches_what_the_builder_serves():
     schema = json.loads(schema_path.read_text())
     payload = {"build": {"id": "dist-7", "name": "demo"}, "report": {}}
     jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_from_snapshot_says_a_build_may_exist_when_its_create_call_stalls(monkeypatch, tmp_path, capsys):
+    """Drives the real verb down to the transport: from-snapshot creates a build in
+    one call, so a stall there is the case the hint exists for."""
+    monkeypatch.setenv("COMFY_BUILDER_TOKEN", "jwt")
+
+    def stall(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", stall)
+    _force_json_renderer()
+    snap = tmp_path / "export.json"
+    snap.write_text(json.dumps({"type": "comfyui-desktop-2-snapshot", "snapshots": [{}]}), encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        build.from_snapshot_cmd(from_=str(snap), name="demo")
+
+    err = _last_envelope(capsys)["error"]
+    assert err["code"] == "build_builder_error"
+    assert err["hint"] == _EXPECTED_CREATE_HINT
+    assert err["details"]["effectUnconfirmed"] is True
+
+
+def test_from_snapshot_refuses_a_build_id_it_cannot_vouch_for(monkeypatch, tmp_path, capsys):
+    """from-snapshot prints the id into a `comfy build release create <id>` line,
+    so an id outside the grammar is refused rather than pasted into that line."""
+
+    class FakeClient:
+        def create_build_from_snapshot(self, name, snapshot, *, description=None, base_image_id=None):
+            return {"build": {"id": "dist-7; rm -rf ~"}, "report": {}}
+
+    monkeypatch.setattr(build, "_builder_client", lambda renderer, url: FakeClient())
+    _force_json_renderer()
+    snap = tmp_path / "export.json"
+    snap.write_text(json.dumps({"type": "comfyui-desktop-2-snapshot", "snapshots": [{}]}), encoding="utf-8")
+
+    with pytest.raises(typer.Exit):
+        build.from_snapshot_cmd(from_=str(snap), name="demo")
+
+    captured = capsys.readouterr()
+    err = json.loads(captured.out.strip().splitlines()[-1])["error"]
+    assert err["code"] == "build_builder_error"
+    assert "comfy build list" in err["message"]
+    assert "rm -rf" not in captured.out
+    assert "rm -rf" not in captured.err
 
 
 def test_from_snapshot_refuses_a_file_that_is_not_json(tmp_path, capsys):
@@ -1976,6 +2292,81 @@ def test_from_workflow_refuses_to_claim_success_on_an_answer_it_cannot_read(monk
     out = capsys.readouterr().out
     assert "build_builder_error" in out
     assert "Created build" not in out
+
+
+# A build id is printed and interpolated unquoted into command lines the user is
+# told to run, so the grammar is the only thing standing between a bad answer and
+# a line someone pastes into a shell.
+_FORGED_LINE_ID = "dist-9\n\x1b[2KCreated build dist-0"
+
+
+@pytest.mark.parametrize(
+    ("build_id", "forbidden"),
+    [
+        pytest.param(["dist-9"], "dist-9", id="a_list_is_not_an_id"),
+        pytest.param(4815162342, "4815162342", id="a_number_is_not_an_id"),
+        pytest.param("dist-9; rm -rf ~", "rm -rf", id="shell_metacharacters_are_not_an_id"),
+        pytest.param(_FORGED_LINE_ID, "Created build dist-0", id="a_newline_forging_a_line_is_not_an_id"),
+    ],
+)
+def test_from_workflow_refuses_a_build_id_it_cannot_vouch_for(monkeypatch, tmp_path, capsys, build_id, forbidden):
+    """Printing a mangled id is worse than printing none, because the id lands in
+    `comfy build get <id>` and `comfy build update <id>` lines a user runs."""
+    monkeypatch.setattr(
+        build,
+        "_builder_client",
+        lambda renderer, url: _workflow_client({"build": {"id": build_id}, "report": {}}),
+    )
+    _force_json_renderer()
+
+    with pytest.raises(typer.Exit):
+        build.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
+
+    captured = capsys.readouterr()
+    err = json.loads(captured.out.strip().splitlines()[-1])["error"]
+    assert err["code"] == "build_builder_error"
+    assert "comfy build list" in err["message"]
+    assert forbidden not in captured.out
+    assert forbidden not in captured.err
+
+
+def test_from_workflow_names_the_build_when_only_the_report_is_unreadable(monkeypatch, tmp_path, capsys):
+    """The id parsed, so the build has a name to give. Sending this reader to
+    `comfy build list` to find what is already on screen would be the lie."""
+    monkeypatch.setattr(
+        build,
+        "_builder_client",
+        lambda renderer, url: _workflow_client({"build": {"id": "dist-9"}, "report": "fine"}),
+    )
+    _force_json_renderer()
+
+    with pytest.raises(typer.Exit):
+        build.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
+
+    err = _last_envelope(capsys)["error"]
+    assert err["details"]["distributionId"] == "dist-9"
+    assert "dist-9" in err["message"]
+    assert "comfy build list" not in err["message"]
+    assert "effectUnconfirmed" not in err["details"]
+
+
+def test_from_workflow_says_a_build_may_exist_when_its_create_call_stalls(monkeypatch, tmp_path, capsys):
+    """from-workflow creates a build in one call, so a stall there is exactly the
+    case the hint exists for."""
+    monkeypatch.setenv("COMFY_BUILDER_TOKEN", "jwt")
+
+    def stall(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        raise TimeoutError("The read operation timed out")
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", stall)
+    _force_json_renderer()
+
+    with pytest.raises(typer.Exit):
+        build.from_workflow_cmd(from_=_write_workflow(tmp_path, UI_WORKFLOW), name="portrait")
+
+    err = _last_envelope(capsys)["error"]
+    assert err["hint"] == _EXPECTED_CREATE_HINT
+    assert err["details"]["effectUnconfirmed"] is True
 
 
 @pytest.mark.parametrize("payload", ["not json at all", "null", "[]", '"a string"', "42"])


### PR DESCRIPTION
**TL;DR:** Every way a builder call can fail now produces an envelope, and a create that may already have written a build says so instead of inviting the retry that duplicates it.

Linear: [BE-9432](https://linear.app/comfyorg/issue/BE-9432/comfy-cli-a-builder-call-that-times-out-escapes-the-error-envelope-and)

**Why:** urllib wraps only the request phase in `URLError`, so a stalled read, a reset, a server hanging up mid-response and a truncated body all escaped as tracebacks: a human saw a stack, a `--json` caller saw nothing at all. The builder writes the build row before it answers, so on a create that silence costs the id of a build that already exists, and the retry it invites makes a second one.

**Validation**
* **Unit**: 156 pass in `test_distribution.py`. Nineteen of the new cases fail on `origin/main` (`e4f661f`) with this branch's test file copied in. `ruff@0.15.15 check` and `format --diff` both clean. Two whole-suite failures and the hygiene check are red here and equally red on a clean `origin/main` checkout, in files this change never opens.
* **Local stack, end to end**: the real CLI at a socket that accepts and stalls, both `from-snapshot` and `from-workflow`. On `origin/main` stdout is empty and stderr ends `TimeoutError: timed out`; here stdout carries one `build_builder_error` envelope with the `comfy build list` hint and `details.effectUnconfirmed`. Exit 1 on both.
* **Local stack, a build id the builder made up**: a response whose id is `dist-9\n\x1b[2KCreated build dist-0` prints a forged `Created build dist-0` line on the base. Here `from-workflow` refuses the id and says a build exists it cannot name. A list, a number and `dist-9; rm -rf ~` take the same path.
* **Local stack, the cases that must not change**: a blob PUT answering 412 before any create, and a create refused with 400, both keep the registered hint and no `effectUnconfirmed`. A cut answering 500 after the create now names the build and says to cut that one rather than retry. A builder answering 201 gives a byte-identical success envelope on both branches.
* **Not run**: the real builder behind `platformapi.comfy.org`, which needs a Cloud JWT and would spend a build slot. Every run above used a local HTTP double, so none of them proves the builder's own behaviour.

**What changed**
* **[comfy-cli] distribution.py, one `_BUILDER_TRANSPORT_ERRORS` tuple at five handlers**: every read-phase failure becomes an envelope, `update_cmd`'s resolve included, and an oversize answer goes through the same reporter instead of its own bare `renderer.error`.
* **[comfy-cli] the three create verbs**: carry a hint and `details.effectUnconfirmed`, released only where the create may really have landed. `execute_create` marks the create attempt, a status under 500 other than 408 is a refusal that wrote nothing, and a failure that already knows the id supersedes both and says to cut that build.
* **[comfy-cli] a build id from a response**: gets the grammar this file already gives a registry id, and is refused rather than printed. Seen and left: `create --execute`'s success path still prints its id unguarded ([BE-9472](https://linear.app/comfyorg/issue/BE-9472)), and a presigned upload URL still reaches the error message ([BE-9469](https://linear.app/comfyorg/issue/BE-9469)).

**Contradicts:** nothing. `details.effectUnconfirmed` is an additive optional field, which the envelope's own bump rule exempts (`comfy_cli/output/renderer.py:28-31`).
