### PR TITLE
feat(workflow): add `comfy workflow print --format py`

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -609,6 +609,66 @@ def notes_cmd(
     renderer.emit(payload, command="workflow notes")
 
 
+@app.command(
+    "print", help="Render a workflow as one line of Python-like source per node, with a binding -> node id map."
+)
+@tracking.track_command("workflow")
+def print_cmd(
+    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
+    fmt: Annotated[str, typer.Option("--format", help="Output form. Only `py` today.")] = "py",
+    input_path: Annotated[
+        str | None, typer.Option("--input", help="Offline object_info.json dump for widget names.")
+    ] = None,
+    host: Annotated[str | None, typer.Option("--host")] = None,
+    port: Annotated[int | None, typer.Option("--port")] = None,
+    where: Annotated[str | None, typer.Option("--where", help="Routing for the catalog fetch: local or cloud.")] = None,
+    select: Annotated[
+        str | None, typer.Option("--select", help="Project the payload (see `comfy workflow slots --select`).")
+    ] = None,
+):
+    """Read-only. Reuses the catalog for widget names; refuses (with every reason) anything it cannot print faithfully."""
+    from comfy_cli.workflow_print import PrintUnsupported, render_py
+
+    renderer = get_renderer()
+    if fmt != "py":
+        renderer.error(
+            code="workflow_print_unsupported",
+            message=f"unknown --format {fmt!r}; only `py` is supported",
+            details={"reasons": [f"format {fmt!r}"]},
+        )
+        raise typer.Exit(code=1)
+    p, workflow = _load_workflow_or_fail(renderer, file)
+    graph = _get_graph(input_path, host, port, where=where)
+    try:
+        res = render_py(workflow, graph)
+    except PrintUnsupported as e:
+        renderer.error(
+            code="workflow_print_unsupported",
+            message="workflow contains something `print` cannot render faithfully: " + "; ".join(e.reasons),
+            details={"reasons": e.reasons, "path": str(p)},
+        )
+        raise typer.Exit(code=1) from e
+    payload = {
+        "workflow": str(p),
+        "format": "py",
+        "source": res.source,
+        "bindings": res.bindings,
+        "node_count": res.node_count,
+        "skipped": res.skipped,
+        "warnings": res.warnings,
+    }
+    if renderer.is_pretty():
+        typer.echo(_strip_terminal_controls(res.source), nl=False)
+        for w in res.warnings:
+            typer.echo(f"warning: {_strip_terminal_controls(w)}", err=True)
+    if select:
+        from comfy_cli.selector import emit_selected
+
+        emit_selected(renderer, payload, select, command="workflow print")
+        return
+    renderer.emit(payload, command="workflow print")
+
+
 # ---------------------------------------------------------------------------
 # Saved workflows — list, get, save, delete.
 # ---------------------------------------------------------------------------

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -622,9 +622,13 @@ def print_cmd(
     ] = None,
     host: Annotated[str | None, typer.Option("--host", show_default=False)] = None,
     port: Annotated[int | None, typer.Option("--port", show_default=False)] = None,
-    where: Annotated[str | None, typer.Option("--where", help="Routing for the catalog fetch: local or cloud.")] = None,
+    where: Annotated[
+        str | None,
+        typer.Option("--where", show_default=False, help="Routing for the catalog fetch: local or cloud."),
+    ] = None,
     select: Annotated[
-        str | None, typer.Option("--select", help="Project the payload (see `comfy workflow slots --select`).")
+        str | None,
+        typer.Option("--select", show_default=False, help="Project the payload (see `comfy workflow slots --select`)."),
     ] = None,
 ):
     """Read-only. Reuses the catalog for widget names; refuses (with every reason) anything it cannot print faithfully."""
@@ -639,7 +643,18 @@ def print_cmd(
         )
         raise typer.Exit(code=1)
     p, workflow = _load_workflow_or_fail(renderer, file)
-    graph = _get_graph(input_path, host, port, where=where)
+    # Mirrors slots_cmd: a stale-cache fallback is a fact about the rendered
+    # widget names, so it has to reach the caller. `print`'s `warnings` is a
+    # list of plain strings (slots' is a list of objects), so it is reported
+    # as one, appended to whatever the printer itself warned about.
+    _stale: dict = {}
+    graph = _get_graph(
+        input_path,
+        host,
+        port,
+        on_stale=lambda key, err: _stale.update(source=key, reason=err),
+        where=where,
+    )
     try:
         res = render_py(workflow, graph)
     except PrintUnsupported as e:
@@ -649,6 +664,9 @@ def print_cmd(
             details={"reasons": e.reasons, "path": str(p)},
         )
         raise typer.Exit(code=1) from e
+    warnings = list(res.warnings)
+    if _stale:
+        warnings.append(f"object_info_stale: {_stale['source']}: {_stale['reason']}")
     payload = {
         "workflow": str(p),
         "format": "py",
@@ -656,7 +674,7 @@ def print_cmd(
         "bindings": res.bindings,
         "node_count": res.node_count,
         "skipped": res.skipped,
-        "warnings": res.warnings,
+        "warnings": warnings,
     }
     if select is not None:
         from comfy_cli.selector import emit_selected
@@ -664,7 +682,7 @@ def print_cmd(
         return emit_selected(renderer, payload, select, command="workflow print")
     if renderer.is_pretty():
         typer.echo(_strip_terminal_controls(res.source), nl=False)
-        for w in res.warnings:
+        for w in warnings:
             typer.echo(f"warning: {_strip_terminal_controls(w)}", err=True)
     renderer.emit(payload, command="workflow print")
 

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -679,7 +679,8 @@ def print_cmd(
     if select is not None:
         from comfy_cli.selector import emit_selected
 
-        return emit_selected(renderer, payload, select, command="workflow print")
+        select_payload = _sanitize_selected_strings(payload) if renderer.is_pretty() else payload
+        return emit_selected(renderer, select_payload, select, command="workflow print")
     if renderer.is_pretty():
         typer.echo(_strip_terminal_controls(res.source), nl=False)
         for w in warnings:
@@ -804,6 +805,24 @@ def _strip_terminal_controls(text: str) -> str:
         if (ch in "\t\n" or 0x20 <= ord(ch) < 0x7F)
         or (ord(ch) >= 0xA0 and unicodedata.category(ch) not in _SPOOFING_CATEGORIES)
     )
+
+
+def _sanitize_selected_strings(value: Any) -> Any:
+    """Recursively strip terminal control chars from string leaves of a ``--select`` payload.
+
+    Only needed for pretty mode: ``emit_selected`` there can write a selected
+    bare string (or a JSON-pretty-printed slice) straight to the terminal, so
+    an escape sequence buried in a node title or widget value would reach the
+    terminal unescaped. JSON mode's encoder already escapes control chars, so
+    this is a no-op there and is never called for it.
+    """
+    if isinstance(value, str):
+        return _strip_terminal_controls(value)
+    if isinstance(value, dict):
+        return {k: _sanitize_selected_strings(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_selected_strings(v) for v in value]
+    return value
 
 
 def _reject_unsafe_workflow_key(renderer, key: str) -> str:

--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -617,10 +617,11 @@ def print_cmd(
     file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
     fmt: Annotated[str, typer.Option("--format", help="Output form. Only `py` today.")] = "py",
     input_path: Annotated[
-        str | None, typer.Option("--input", help="Offline object_info.json dump for widget names.")
+        str | None,
+        typer.Option("--input", show_default=False, help="Offline object_info.json dump for widget names."),
     ] = None,
-    host: Annotated[str | None, typer.Option("--host")] = None,
-    port: Annotated[int | None, typer.Option("--port")] = None,
+    host: Annotated[str | None, typer.Option("--host", show_default=False)] = None,
+    port: Annotated[int | None, typer.Option("--port", show_default=False)] = None,
     where: Annotated[str | None, typer.Option("--where", help="Routing for the catalog fetch: local or cloud.")] = None,
     select: Annotated[
         str | None, typer.Option("--select", help="Project the payload (see `comfy workflow slots --select`).")
@@ -657,15 +658,14 @@ def print_cmd(
         "skipped": res.skipped,
         "warnings": res.warnings,
     }
+    if select is not None:
+        from comfy_cli.selector import emit_selected
+
+        return emit_selected(renderer, payload, select, command="workflow print")
     if renderer.is_pretty():
         typer.echo(_strip_terminal_controls(res.source), nl=False)
         for w in res.warnings:
             typer.echo(f"warning: {_strip_terminal_controls(w)}", err=True)
-    if select:
-        from comfy_cli.selector import emit_selected
-
-        emit_selected(renderer, payload, select, command="workflow print")
-        return
     renderer.emit(payload, command="workflow print")
 
 

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -75,7 +75,7 @@ def _split_addr(addr: str, renderer) -> tuple[Any, str]:
         renderer.error(
             code="workflow_edit_invalid",
             message=f"expected `<node_id>.<name>`, got {addr!r}",
-            hint="example: `3.steps` — run `comfy workflow slots <file>` to list node ids",
+            hint="example: `3.steps` — run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read",
         )
         raise typer.Exit(code=1)
     node_str, _, name = addr.partition(".")
@@ -195,7 +195,11 @@ def add_node_cmd(
         )
         raise typer.Exit(code=1) from e
     except ValueError as e:
-        _emit_edit_error(renderer, e, hint="run `comfy workflow slots <file>` to list widget addresses")
+        _emit_edit_error(
+            renderer,
+            e,
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+        )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow add-node")
 
@@ -233,7 +237,11 @@ def set_widget_cmd(
             workflow, graph, node_id, widget, _parse_value(value), actor=actor, base_version=base_version
         )
     except ValueError as e:
-        _emit_edit_error(renderer, e, hint="run `comfy workflow slots <file>` to list widget addresses")
+        _emit_edit_error(
+            renderer,
+            e,
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+        )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow set-widget")
 
@@ -267,7 +275,11 @@ def connect_cmd(
             workflow, graph, from_node, from_slot, to_node, to_slot, actor=actor, base_version=base_version
         )
     except ValueError as e:
-        _emit_edit_error(renderer, e, hint="run `comfy workflow slots <file>` to list widget addresses")
+        _emit_edit_error(
+            renderer,
+            e,
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+        )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow connect")
 
@@ -297,7 +309,11 @@ def delete_cmd(
     try:
         workflow, op = workflow_ops.delete_node(workflow, graph, node_id, actor=actor, base_version=base_version)
     except ValueError as e:
-        _emit_edit_error(renderer, e, hint="run `comfy workflow slots <file>` to list widget addresses")
+        _emit_edit_error(
+            renderer,
+            e,
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+        )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow delete")
 
@@ -345,7 +361,7 @@ def delete_nodes_cmd(
         renderer.error(
             code="workflow_edit_invalid",
             message=f"batch failed: {workflow_ops._rehint_discarded_batch(e, pre_batch_hint)}",
-            hint="run `comfy workflow ls-nodes <file>` for the live node ids; the file was not modified",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read — the ids you used do not match the live graph; the file was not modified",
         )
         raise typer.Exit(code=1) from e
 

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -75,7 +75,8 @@ def _split_addr(addr: str, renderer) -> tuple[Any, str]:
         renderer.error(
             code="workflow_edit_invalid",
             message=f"expected `<node_id>.<name>`, got {addr!r}",
-            hint="example: `3.steps` — run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read",
+            hint="example: `3.steps` — run `comfy workflow print <file>` to see every node, edge and widget "
+            "value with its id in one read",
         )
         raise typer.Exit(code=1)
     node_str, _, name = addr.partition(".")
@@ -198,7 +199,8 @@ def add_node_cmd(
         _emit_edit_error(
             renderer,
             e,
-            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one "
+            "read (`comfy workflow slots <file>` for exact widget addresses)",
         )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow add-node")
@@ -240,7 +242,8 @@ def set_widget_cmd(
         _emit_edit_error(
             renderer,
             e,
-            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one "
+            "read (`comfy workflow slots <file>` for exact widget addresses)",
         )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow set-widget")
@@ -278,7 +281,8 @@ def connect_cmd(
         _emit_edit_error(
             renderer,
             e,
-            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one "
+            "read (`comfy workflow slots <file>` for exact widget addresses)",
         )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow connect")
@@ -312,7 +316,8 @@ def delete_cmd(
         _emit_edit_error(
             renderer,
             e,
-            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact widget addresses)",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one "
+            "read (`comfy workflow slots <file>` for exact widget addresses)",
         )
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow delete")
@@ -361,7 +366,8 @@ def delete_nodes_cmd(
         renderer.error(
             code="workflow_edit_invalid",
             message=f"batch failed: {workflow_ops._rehint_discarded_batch(e, pre_batch_hint)}",
-            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read — the ids you used do not match the live graph; the file was not modified",
+            hint="run `comfy workflow print <file>` to see every node, edge and widget value with its id in one "
+            "read — the ids you used do not match the live graph; the file was not modified",
         )
         raise typer.Exit(code=1) from e
 

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -95,6 +95,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy workflow set-slot": "workflow",
     "comfy workflow vary": "workflow",
     "comfy workflow notes": "workflow",
+    "comfy workflow print": "workflow",
     # structured edit primitives + recipes (CRDT op-based authoring)
     "comfy workflow add-node": "workflow",
     "comfy workflow connect": "workflow",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -547,8 +547,8 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "workflow_print_unsupported",
         "`comfy workflow print` refused: the workflow contains something it cannot render faithfully "
-        "(legacy group node, dangling link, missing subgraph definition, link cycle, unknown --format). "
-        "`details.reasons` lists every reason.",
+        "(legacy group node, duplicate node id, link to a missing node/slot, non-integer link slot, "
+        "link cycle, unknown `--format`). `details.reasons` lists every reason.",
         "fix the listed reasons, or read the graph with `comfy workflow slots` / `comfy workflow ls-nodes`",
     ),
     ErrorCode(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -554,13 +554,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "workflow_slot_invalid",
         "A slot override failed validation (bad shape, unknown address, etc.).",
-        "see `details` — addresses follow `<instance_id>.<input_name>`",
+        "see `details` — addresses follow `<instance_id>.<input_name>`; `comfy workflow print <file>` shows every node with its id and widget names",
     ),
     ErrorCode(
         "workflow_edit_invalid",
         "A structured edit (add-node/connect/set-widget/delete-node) failed: "
         "unknown class_type, missing node, bad slot/widget name, or malformed address.",
-        "run `comfy workflow slots <file>` for widget addresses or `comfy nodes types` for class_types",
+        "run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact `<node_id>.<input>` addresses, `comfy nodes search` for class names)",
     ),
     ErrorCode(
         "workflow_clear_not_batchable",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -545,6 +545,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "in ComfyUI, use the regular save (File > Save Workflow) — the API export is for `comfy run`, not for editing",
     ),
     ErrorCode(
+        "workflow_print_unsupported",
+        "`comfy workflow print` refused: the workflow contains something it cannot render faithfully "
+        "(legacy group node, dangling link, missing subgraph definition, link cycle, unknown --format). "
+        "`details.reasons` lists every reason.",
+        "fix the listed reasons, or read the graph with `comfy workflow slots` / `comfy workflow ls-nodes`",
+    ),
+    ErrorCode(
         "workflow_slot_invalid",
         "A slot override failed validation (bad shape, unknown address, etc.).",
         "see `details` — addresses follow `<instance_id>.<input_name>`",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -554,13 +554,15 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "workflow_slot_invalid",
         "A slot override failed validation (bad shape, unknown address, etc.).",
-        "see `details` — addresses follow `<instance_id>.<input_name>`; `comfy workflow print <file>` shows every node with its id and widget names",
+        "see `details` — addresses follow `<instance_id>.<input_name>`; "
+        "`comfy workflow print <file>` shows every node with its id and widget names",
     ),
     ErrorCode(
         "workflow_edit_invalid",
         "A structured edit (add-node/connect/set-widget/delete-node) failed: "
         "unknown class_type, missing node, bad slot/widget name, or malformed address.",
-        "run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read (`comfy workflow slots <file>` for exact `<node_id>.<input>` addresses, `comfy nodes search` for class names)",
+        "run `comfy workflow print <file>` to see every node, edge and widget value with its id in one read "
+        "(`comfy workflow slots <file>` for exact `<node_id>.<input>` addresses, `comfy nodes search` for class names)",
     ),
     ErrorCode(
         "workflow_clear_not_batchable",

--- a/comfy_cli/help_json.py
+++ b/comfy_cli/help_json.py
@@ -58,6 +58,10 @@ HELP_EXAMPLES: dict[str, list[str]] = {
     ],
     "comfy node": ["comfy node show installed"],
     "comfy manager": ["comfy manager disable-gui"],
+    "comfy workflow print": [
+        "comfy workflow print wf.json --input object_info.json",
+        "comfy --json workflow print wf.json --select bindings",
+    ],
 }
 
 

--- a/comfy_cli/schemas/workflow.json
+++ b/comfy_cli/schemas/workflow.json
@@ -37,7 +37,7 @@
       "additionalProperties": { "type": "string" },
       "description": "print: binding name -> node id. Interior subgraph nodes use qualified keys/ids, e.g. \"10/3/primitive_int\" -> \"10/3/6\"."
     },
-    "node_count": { "type": "integer", "minimum": 0, "description": "print: nodes that got a rendered line (top level + subgraph interiors)." },
+    "node_count": { "type": ["integer", "null"], "minimum": 0, "description": "print: nodes that got a rendered line (top level + subgraph interiors). null for `comfy workflow get` on a non-JSON body." },
     "skipped": {
       "type": "array",
       "description": "print: nodes not rendered as their own line. UI-only splicing nodes (reason \"spliced\", or \"inlined into <id>.<input>\" for a PrimitiveNode); notes, which are rendered as `#`-comments in `source` AND listed here with reason \"note\".",

--- a/comfy_cli/schemas/workflow.json
+++ b/comfy_cli/schemas/workflow.json
@@ -30,6 +30,27 @@
         }
       }
     },
+    "format": { "type": "string", "enum": ["py"], "description": "print: output form. Only `py` today." },
+    "source": { "type": "string", "description": "print: the rendered Python-like source, one line per node." },
+    "bindings": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "print: binding name -> node id. Interior subgraph nodes use qualified keys/ids, e.g. \"10/3/primitive_int\" -> \"10/3/6\"."
+    },
+    "node_count": { "type": "integer", "minimum": 0, "description": "print: nodes that got a rendered line (top level + subgraph interiors)." },
+    "skipped": {
+      "type": "array",
+      "description": "print: nodes not rendered as their own line (UI-only splicing nodes; notes are rendered as comments, not skipped).",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "reason"],
+        "properties": {
+          "id": { "type": "string" },
+          "type": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
     "applied": { "type": "array" },
     "warnings": { "type": "array" },
     "wrote": { "type": ["string", "null"], "description": "file written, or null when nothing was written (set-slot --stdout)" },

--- a/comfy_cli/schemas/workflow.json
+++ b/comfy_cli/schemas/workflow.json
@@ -40,7 +40,7 @@
     "node_count": { "type": "integer", "minimum": 0, "description": "print: nodes that got a rendered line (top level + subgraph interiors)." },
     "skipped": {
       "type": "array",
-      "description": "print: nodes not rendered as their own line (UI-only splicing nodes; notes are rendered as comments, not skipped).",
+      "description": "print: nodes not rendered as their own line. UI-only splicing nodes (reason \"spliced\", or \"inlined into <id>.<input>\" for a PrimitiveNode); notes, which are rendered as `#`-comments in `source` AND listed here with reason \"note\".",
       "items": {
         "type": "object",
         "required": ["id", "type", "reason"],

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -1,0 +1,327 @@
+"""Render a save-format workflow as Python-like source. One direction; nothing parses it back.
+
+Renders the ComfyUI UI-save-format ``workflow`` (``nodes[]`` + ``links[]``) as
+one Python-like statement per node, in topological order, with `#`-comments
+carrying id/title/mode metadata. Purely a read/display aid — the output is not
+meant to be executed or parsed back into a workflow.
+
+``Reroute``/``GetNode``/``SetNode``/``PrimitiveNode`` are treated as skipped
+("ui-only") here; a later task adds resolvers that splice through them instead
+of leaving a dangling ``None`` — the walk below is structured so that only the
+edge-resolution step needs to change for that.
+
+See the design: decisions D1-D13 (Obsidian, "workflow print (design, 2026-08-25)").
+"""
+
+from __future__ import annotations
+
+import json
+import keyword
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from comfy_cli.cql.engine import _expand_widget_entries, _widgets_as_positional
+
+if TYPE_CHECKING:
+    from comfy_cli.cql.engine import Graph
+
+_MODE_LABELS = {2: "mute", 4: "bypass"}
+# Same set as workflow_to_api._UI_ONLY_NODE_TYPES. Notes are handled here (as
+# comments); the rest are skipped with reason "ui-only" until a later task
+# adds splicing resolvers for them.
+_UI_ONLY = frozenset({"Note", "MarkdownNote", "PrimitiveNode", "GetNode", "SetNode", "Reroute"})
+_NOTE_TYPES = frozenset({"Note", "MarkdownNote"})
+_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class PrintResult:
+    source: str  # full text, lines joined with "\n", trailing newline
+    bindings: dict[str, str] = field(default_factory=dict)  # binding name -> node id as string ("3", "10/7")
+    node_count: int = 0  # nodes that got a line (top level + subgraph interiors)
+    skipped: list[dict] = field(default_factory=list)  # {"id": str, "type": str, "reason": str}
+    warnings: list[str] = field(default_factory=list)
+
+
+class PrintUnsupported(Exception):
+    """The workflow can't be printed as-is (structural problem, not a rendering choice)."""
+
+    def __init__(self, reasons: list[str]) -> None:
+        super().__init__("; ".join(reasons))
+        self.reasons = reasons
+
+
+def class_expr(class_type: str) -> str:
+    """The call-target expression for a class type: a bare name when it's a valid,
+    non-keyword Python identifier, else a ``Node[...]`` subscript."""
+    return (
+        class_type
+        if _IDENT.match(class_type) and not keyword.iskeyword(class_type)
+        else f"Node[{json.dumps(class_type)}]"
+    )
+
+
+def binding_name(class_type: str, used: dict[str, int]) -> str:
+    """A snake_case Python identifier for ``class_type``, deduped against ``used``
+    (mutated in place) in call order: repeats get a ``_2``, ``_3``, ... suffix.
+
+    CamelCase -> Camel_Case; an acronym of 2+ capitals splits before a following word
+    (CLIPText -> CLIP_Text, VAEDecode -> VAE_Decode) but a single capital does not (KSampler -> ksampler).
+    """
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z][A-Z])(?=[A-Z][a-z])", "_", class_type)
+    s = re.sub(r"[^A-Za-z0-9]+", "_", s).strip("_").lower()
+    s = re.sub(r"_+", "_", s) or "node"
+    if s[0].isdigit():
+        s = "n" + s
+    if keyword.iskeyword(s):
+        s += "_"
+    used[s] = used.get(s, 0) + 1
+    return s if used[s] == 1 else f"{s}_{used[s]}"
+
+
+def py_literal(value: Any) -> str:
+    """A Python literal rendering of ``value``. Strings via ``json.dumps`` (which
+    is also valid Python string-literal syntax); lists/dicts via ``json.dumps``
+    too — ``True``/``False``/``None`` nested inside those stay JSON-cased
+    (``true``/``false``/``null``); that's acceptable and documented here."""
+    if value is None:
+        return "None"
+    if value is True:
+        return "True"
+    if value is False:
+        return "False"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _sort_key(node_id: str) -> tuple[int, Any]:
+    """Ascending-numeric sort key; non-numeric ids sort after all numeric ones."""
+    try:
+        return (0, int(node_id))
+    except (TypeError, ValueError):
+        return (1, node_id)
+
+
+def _validate(nodes: list[dict], links: list[list]) -> list[str]:
+    """Structural checks that must hold before any ordering/printing work starts.
+    Collects every problem found (rather than stopping at the first) so the
+    caller's ``PrintUnsupported`` can report them all at once."""
+    reasons: list[str] = []
+    for n in nodes:
+        t = n.get("type")
+        extra = n.get("extra")
+        is_legacy_group = (isinstance(t, str) and (t.startswith("workflow>") or t.startswith("workflow/"))) or (
+            isinstance(extra, dict) and extra.get("groupNodes")
+        )
+        if is_legacy_group:
+            reasons.append(f"node {n.get('id')} is a legacy group node ({t})")
+
+    nodes_by_id = {str(n.get("id")): n for n in nodes}
+    for link in links:
+        if not isinstance(link, list) or len(link) < 5:
+            reasons.append(f"link malformed: {link!r}")
+            continue
+        link_id, src_id, src_slot, tgt_id, tgt_slot = link[0], link[1], link[2], link[3], link[4]
+        src_node = nodes_by_id.get(str(src_id))
+        if src_node is None:
+            reasons.append(f"link {link_id} references missing node {src_id}")
+            continue
+        tgt_node = nodes_by_id.get(str(tgt_id))
+        if tgt_node is None:
+            reasons.append(f"link {link_id} references missing node {tgt_id}")
+            continue
+        outputs = src_node.get("outputs")
+        if isinstance(outputs, list) and not (0 <= src_slot < len(outputs)):
+            reasons.append(f"link {link_id} references out-of-range output slot {src_slot} on node {src_id}")
+        inputs = tgt_node.get("inputs")
+        if isinstance(inputs, list) and not (0 <= tgt_slot < len(inputs)):
+            reasons.append(f"link {link_id} references out-of-range input slot {tgt_slot} on node {tgt_id}")
+    return reasons
+
+
+def _toposort(printable: list[dict], link_map: dict[str, tuple]) -> list[dict]:
+    """Kahn's algorithm over ``printable`` nodes, using only links whose source
+    AND target are both printable. Ties break by ascending numeric id."""
+    ids = [str(n.get("id")) for n in printable]
+    printable_ids = set(ids)
+    node_by_id = {str(n.get("id")): n for n in printable}
+
+    deps: dict[str, set[str]] = {i: set() for i in ids}
+    dependents: dict[str, list[str]] = {i: [] for i in ids}
+    for src_id, _src_slot, tgt_id, _tgt_slot in link_map.values():
+        s, t = str(src_id), str(tgt_id)
+        if s in printable_ids and t in printable_ids and s != t:
+            if s not in deps[t]:
+                deps[t].add(s)
+                dependents[s].append(t)
+
+    indegree = {i: len(deps[i]) for i in ids}
+    ready = [i for i in ids if indegree[i] == 0]
+    ready.sort(key=_sort_key)
+    order: list[str] = []
+    while ready:
+        cur = ready.pop(0)
+        order.append(cur)
+        for t in dependents[cur]:
+            indegree[t] -= 1
+            if indegree[t] == 0:
+                ready.append(t)
+        ready.sort(key=_sort_key)
+
+    if len(order) != len(ids):
+        remaining = sorted(set(ids) - set(order), key=_sort_key)
+        raise PrintUnsupported([f"link cycle among nodes {', '.join(remaining)}"])
+    return [node_by_id[i] for i in order]
+
+
+def _edge_ref(binding: str, src_node: dict, src_type: str, slot: int, graph: Graph | None) -> str:
+    """How to reference one output slot of an already-bound source node."""
+    outputs = src_node.get("outputs") or []
+    if len(outputs) == 1:
+        return binding
+    out_name = None
+    if 0 <= slot < len(outputs):
+        out_name = outputs[slot].get("name")
+    if not out_name and graph is not None:
+        m = graph.node(src_type)
+        if m is not None and 0 <= slot < len(m.outputs):
+            out_name = m.outputs[slot].name
+    if out_name and _IDENT.match(out_name) and not keyword.iskeyword(out_name):
+        return f"{binding}.{out_name}"
+    return f"{binding}.out[{slot}]"
+
+
+def _note_comment(node: dict) -> str:
+    widgets = node.get("widgets_values")
+    text = str(widgets[0]) if isinstance(widgets, list) and widgets else ""
+    first_line = text.split("\n")[0] if text else ""
+    non_empty = [ln for ln in text.split("\n") if ln.strip()]
+    extra_lines = max(len(non_empty) - 1, 0)
+    title = node.get("title") or node.get("type")
+    comment = f"# note {node.get('id')} {json.dumps(title, ensure_ascii=False)}: {first_line}"
+    if extra_lines > 0:
+        comment += f" (+{extra_lines} lines)"
+    return comment
+
+
+def _build_args(
+    node: dict,
+    m: Any,
+    graph: Graph | None,
+    bindings: dict[str, str],
+    nodes_by_id: dict[str, dict],
+    printable_ids: set[str],
+    link_map: dict[str, tuple],
+    warnings: list[str],
+) -> tuple[list[str], bool]:
+    """Node call arguments: link inputs (in the node's own input order) first,
+    then widgets. Returns ``(args, unknown)`` where ``unknown`` is True when the
+    class isn't in the catalog (or there is no catalog), which also determines
+    whether widgets print positionally as ``widgets=[...]``."""
+    args: list[str] = []
+    for inp in node.get("inputs") or []:
+        name = inp.get("name")
+        if "widget" in inp:
+            continue  # widget-backed input: printed in the widget pass instead
+        link_id = inp.get("link")
+        if link_id is None:
+            args.append(f"{name}=None")
+            continue
+        link = link_map.get(str(link_id))
+        if link is None:
+            args.append(f"{name}=None")
+            continue
+        src_id, src_slot, _tgt_id, _tgt_slot = link
+        src_node = nodes_by_id.get(str(src_id))
+        if src_node is None or str(src_id) not in printable_ids:
+            # ui-only source (Reroute/GetNode/SetNode/PrimitiveNode) — no
+            # resolver yet, prints as unresolved. See module docstring.
+            args.append(f"{name}=None")
+            continue
+        binding = bindings[str(src_id)]
+        ref = _edge_ref(binding, src_node, src_node.get("type", ""), src_slot, graph)
+        args.append(f"{name}={ref}")
+
+    class_type = node.get("type", "")
+    widgets_values = node.get("widgets_values")
+    unknown = m is None
+    if unknown:
+        positional = widgets_values if isinstance(widgets_values, list) else []
+        if positional:
+            args.append(f"widgets={py_literal(positional)}")
+        warnings.append(f"node {node.get('id')}: class {class_type!r} not in catalog; widgets printed positionally")
+    else:
+        positional = _widgets_as_positional(widgets_values, graph, class_type)
+        entries = _expand_widget_entries(m, positional)
+        for idx, entry in enumerate(entries):
+            value = positional[idx] if idx < len(positional) else None
+            arg_name = "control_after_generate" if entry.port is None else entry.name
+            args.append(f"{arg_name}={py_literal(value)}")
+    return args, unknown
+
+
+def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
+    nodes = workflow.get("nodes") or []
+    links = workflow.get("links") or []
+
+    reasons = _validate(nodes, links)
+    if reasons:
+        raise PrintUnsupported(reasons)
+
+    link_map: dict[str, tuple] = {}
+    for link in links:
+        link_id, src_id, src_slot, tgt_id, tgt_slot = link[0], link[1], link[2], link[3], link[4]
+        link_map[str(link_id)] = (src_id, src_slot, tgt_id, tgt_slot)
+
+    printable = [n for n in nodes if n.get("type") not in _UI_ONLY]
+    notes = [n for n in nodes if n.get("type") in _NOTE_TYPES]
+    ui_only_skipped = [n for n in nodes if n.get("type") in _UI_ONLY and n.get("type") not in _NOTE_TYPES]
+
+    order = _toposort(printable, link_map)
+
+    nodes_by_id = {str(n.get("id")): n for n in nodes}
+    printable_ids = {str(n.get("id")) for n in printable}
+
+    # binding_name is called once per node, in topological order, so the
+    # dedupe suffixes (_2, _3, ...) match print order.
+    used: dict[str, int] = {}
+    bindings: dict[str, str] = {}
+    binding_by_id: dict[str, str] = {}
+    for n in order:
+        nid = str(n.get("id"))
+        name = binding_name(n.get("type", ""), used)
+        bindings[name] = nid
+        binding_by_id[nid] = name
+
+    warnings: list[str] = []
+    lines: list[str] = []
+    for n in order:
+        nid = str(n.get("id"))
+        t = n.get("type", "")
+        m = graph.node(t) if graph is not None else None
+        args, unknown = _build_args(n, m, graph, binding_by_id, nodes_by_id, printable_ids, link_map, warnings)
+        name = binding_by_id[nid]
+        line = f"{name} = {class_expr(t)}({', '.join(args)})  # {n.get('id')}"
+        title = n.get("title")
+        if title and title != t:
+            line += f" {json.dumps(title, ensure_ascii=False)}"
+        mode = n.get("mode")
+        if mode in _MODE_LABELS:
+            line += f" mode={_MODE_LABELS[mode]}"
+        if unknown:
+            line += " class not in catalog"
+        lines.append(line)
+
+    skipped: list[dict] = []
+    for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
+        lines.append(_note_comment(n))
+        skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "note"})
+    for n in ui_only_skipped:
+        skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "ui-only"})
+
+    source = "\n".join(lines) + "\n"
+    return PrintResult(source=source, bindings=bindings, node_count=len(printable), skipped=skipped, warnings=warnings)

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -13,7 +13,9 @@ input), with an inline annotation or warning when that resolution can't find
 a real value. Subgraph instances (a node whose ``type`` is the UUID of an
 entry under ``workflow["definitions"]["subgraphs"]``) get a ``Subgraph[...]``
 call line and their definition is rendered once, after the top-level lines,
-as an indented block addressed as ``<first instance id>/<inner id>``.
+as an indented block addressed as ``<first instance address>/<inner id>`` —
+fully qualified through every nesting level, matching
+``workflow_ops._navigate_subgraph_path``.
 
 See the design: decisions D1-D13 (Obsidian, "workflow print (design, 2026-08-25)").
 """
@@ -163,7 +165,14 @@ def _validate(nodes: list[dict], links: list[list]) -> list[str]:
 
 def _toposort(printable: list[dict], link_map: dict[str, tuple]) -> list[dict]:
     """Kahn's algorithm over ``printable`` nodes, using only links whose source
-    AND target are both printable. Ties break by ascending numeric id."""
+    AND target are both printable. Ties break by ascending numeric id.
+
+    ``link_map`` must already have each link's source resolved past any
+    Reroute/GetNode-SetNode splice (see ``_splice_link_map``) — a raw,
+    unresolved ``A -> Reroute -> B`` link contributes no ordering constraint
+    here (Reroute is never printable), which would silently let ``B`` print
+    before ``A`` whenever ``B``'s id sorts lower.
+    """
     ids = [str(n.get("id")) for n in printable]
     printable_ids = set(ids)
     node_by_id = {str(n.get("id")): n for n in printable}
@@ -232,7 +241,12 @@ def _note_comment(node: dict) -> str:
 
 
 def _collect_reroute_sources(nodes: list[dict], link_map: dict[str, tuple]) -> dict[str, tuple]:
-    """``{reroute_id: (src_id, src_slot)}`` from each Reroute's single input link."""
+    """``{reroute_id: (src_id, src_slot)}`` from each Reroute's single input link.
+
+    Cross-reference: workflow_to_api.py's ``_collect_reroute_sources`` (~line
+    559) does the same collection for API-format conversion — the two must
+    agree on what counts as a Reroute's source.
+    """
     out: dict[str, tuple] = {}
     for n in nodes:
         if n.get("type") != "Reroute":
@@ -253,7 +267,12 @@ def _collect_reroute_sources(nodes: list[dict], link_map: dict[str, tuple]) -> d
 
 def _collect_get_set(nodes: list[dict], link_map: dict[str, tuple]) -> tuple[dict[str, tuple], dict[str, str]]:
     """``set_sources[var] = (src_id, src_slot)`` from each SetNode's first linked
-    input; ``get_vars[get_id] = var`` for each GetNode."""
+    input; ``get_vars[get_id] = var`` for each GetNode.
+
+    Cross-reference: workflow_to_api.py's ``_collect_get_set_mappings`` (~line
+    578) does the same collection for API-format conversion — the two must
+    agree on what a SetNode publishes and what a GetNode reads.
+    """
     set_sources: dict[str, tuple] = {}
     get_vars: dict[str, str] = {}
     for n in nodes:
@@ -300,6 +319,11 @@ def _resolve_source(
     - ``("dead_reroute", reroute_id)`` — a Reroute with no upstream link.
     - ``("missing_set", get_id, var)`` — a GetNode whose variable no SetNode publishes.
     - ``("primitive_no_widget", primitive_id)`` — resolves directly to a PrimitiveNode.
+
+    Cross-reference: workflow_to_api.py's ``_Tracers.trace_reroute`` /
+    ``trace_get_set`` (~line 659) walk the same chains for API-format
+    conversion — the two must agree on how far a chain is followed and where
+    it bottoms out.
     """
     seen: set[str] = set()
     for _ in range(_MAX_SPLICE_HOPS):
@@ -331,11 +355,35 @@ def _resolve_source(
     return ("ok", src_id, src_slot)
 
 
+def _splice_link_map(
+    link_map: dict[str, tuple],
+    nodes_by_id: dict[str, dict],
+    reroute_sources: dict[str, tuple],
+    set_sources: dict[str, tuple],
+    get_vars: dict[str, str],
+    proxy_in_id: str | None,
+) -> dict[str, tuple]:
+    """The dependency graph ``_toposort`` should use: each link's source
+    resolved past any Reroute/GetNode-SetNode splice (and the ``-10`` proxy,
+    which never contributes a dependency). A link whose source doesn't
+    resolve to a real node (dead-end Reroute, unpublished GetNode variable,
+    PrimitiveNode) is dropped — there's no real upstream to order against."""
+    resolved: dict[str, tuple] = {}
+    for lid, (src_id, src_slot, tgt_id, tgt_slot) in link_map.items():
+        outcome = _resolve_source(src_id, src_slot, nodes_by_id, reroute_sources, set_sources, get_vars, proxy_in_id)
+        if outcome[0] != "ok":
+            continue
+        resolved[lid] = (outcome[1], outcome[2], tgt_id, tgt_slot)
+    return resolved
+
+
 @dataclass
 class _RenderCtx:
     """Everything the per-node arg builders need to resolve one edge, for
-    either the top-level workflow (``proxy_in_id`` is ``None``) or one
-    subgraph definition's interior (``proxy_in_id`` is ``"-10"``)."""
+    either the top-level workflow (``proxy_in_id``/``addr_prefix`` are
+    ``None``) or one subgraph definition's interior (``proxy_in_id`` is
+    ``"-10"``, ``addr_prefix`` is this block's own fully-qualified address —
+    e.g. ``"10"`` or ``"10/3"`` for a definition nested inside another)."""
 
     graph: Any
     link_map: dict[str, tuple]
@@ -347,15 +395,30 @@ class _RenderCtx:
     get_vars: dict[str, str]
     proxy_in_id: str | None = None
     proxy_in_names: dict[int, str] = field(default_factory=dict)
+    addr_prefix: str | None = None
 
     def proxy_in_name(self, slot: Any) -> str:
         name = self.proxy_in_names.get(slot)
         return name if name else f"slot{slot}"
 
+    def qualify(self, nid: Any) -> str:
+        """This block's fully-qualified address for a bare local node id —
+        identity at the top level, ``"<addr_prefix>/<nid>"`` inside a
+        definition (chaining through every nesting level, matching
+        ``workflow_ops._navigate_subgraph_path``). Used for bindings, skipped
+        ids, and warning text — NOT for a line's own trailing ``# <id>``
+        comment or its annotations, which stay bare inner ids by design."""
+        nid = str(nid)
+        return f"{self.addr_prefix}/{nid}" if self.addr_prefix else nid
+
 
 def _resolve_edge_text(src_id: Any, src_slot: Any, name: str, tgt_id: str, ctx: _RenderCtx) -> tuple:
     """Resolve one edge to ``(ref_text, annotation, warning)``. ``ref_text`` is
-    ``None`` when the edge can't be resolved to a value (prints as ``None``)."""
+    ``None`` when the edge can't be resolved to a value (prints as ``None``).
+    ``tgt_id`` is the bare id of the node whose input this is; warning text
+    (which ends up in ``PrintResult.warnings``) is qualified via
+    ``ctx.qualify`` — the ``annotation`` (which becomes part of the printed
+    line itself) is not, matching the "bare inner ids in comments" rule."""
     outcome = _resolve_source(
         src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
     )
@@ -379,35 +442,53 @@ def _resolve_edge_text(src_id: Any, src_slot: Any, name: str, tgt_id: str, ctx: 
         return (
             None,
             None,
-            f"node {tgt_id}: input '{name}' reads GetNode {get_id} variable '{var}' that no SetNode publishes",
+            f"node {ctx.qualify(tgt_id)}: input '{name}' reads GetNode {ctx.qualify(get_id)} variable '{var}' "
+            "that no SetNode publishes",
         )
     if kind == "primitive_no_widget":
         return (
             None,
             None,
-            f"node {tgt_id}: input {name!r} fed by PrimitiveNode {outcome[1]} without a widget; printed as None",
+            f"node {ctx.qualify(tgt_id)}: input {name!r} fed by PrimitiveNode {ctx.qualify(outcome[1])} "
+            "without a widget; printed as None",
         )
     return None, None, None
+
+
+def _place_arg(name: str, text: str, args: list[str], extra: dict[str, str]) -> None:
+    """Append ``name=text`` to ``args`` when ``name`` is a valid Python
+    identifier, else collect it into ``extra`` for a trailing ``**{}``."""
+    if _IDENT.match(name) and not keyword.iskeyword(name):
+        args.append(f"{name}={text}")
+    else:
+        extra[name] = text
 
 
 def _build_args(
     node: dict, m: Any, ctx: _RenderCtx, warnings: list[str]
 ) -> tuple[list[str], bool, list[str], list[tuple]]:
-    """Node call arguments: link inputs (in the node's own input order) first,
-    then widgets. Returns ``(args, unknown, annotations, prim_hits)`` where
+    """Node call arguments: link inputs (in the node's own input order,
+    non-identifier names collected into a trailing ``**{}``) first, then
+    widgets. Returns ``(args, unknown, annotations, prim_hits)`` where
     ``unknown`` is True when the class isn't in the catalog (or there is no
-    catalog), ``annotations`` are suffix strings to append to the line comment,
-    and ``prim_hits`` are ``(primitive_id, skipped_reason)`` pairs for
-    PrimitiveNode-into-widget splices found here."""
+    catalog), ``annotations`` are suffix strings to append to the line
+    comment, and ``prim_hits`` are ``(qualified_primitive_id, qualified_skip_reason)``
+    pairs for PrimitiveNode-into-widget splices found here."""
     nid = str(node.get("id"))
     args: list[str] = []
+    extra: dict[str, str] = {}
     annotations: list[str] = []
     prim_hits: list[tuple] = []
 
-    # Pre-pass: widget-backed inputs. A link into one never overrides the
-    # node's own widget value (D9) EXCEPT when it resolves to the subgraph
-    # input proxy (D10) — that value genuinely comes from outside, there is no
-    # static default to fall back to.
+    # Pre-pass: widget-backed inputs. A LIVE link to a real, printable node is
+    # the truth — it's printed as a ref in the link pass below and skipped in
+    # the widget-values pass. A link that resolves to the subgraph input
+    # proxy is similarly a real (if opaque) upstream value. A PrimitiveNode
+    # source is the one case that keeps the node's own static widget value
+    # (that's what ComfyUI itself shows), annotated instead of substituted. A
+    # dead-end (unlinked Reroute, unpublished SetNode variable) falls through
+    # to the static value too — there's nothing better to show.
+    live_link_refs: dict[str, str] = {}
     widget_overrides: dict[str, str] = {}
     for inp in node.get("inputs") or []:
         if "widget" not in inp:
@@ -423,24 +504,33 @@ def _build_args(
         outcome = _resolve_source(
             src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
         )
-        if outcome[0] == "in_proxy":
+        if outcome[0] == "ok":
+            rid_s = str(outcome[1])
+            if rid_s in ctx.printable_ids:
+                src_node = ctx.nodes_by_id.get(rid_s)
+                binding = ctx.binding_by_id.get(rid_s)
+                if src_node is not None and binding is not None:
+                    live_link_refs[name] = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx.graph)
+        elif outcome[0] == "in_proxy":
             widget_overrides[name] = f"IN.{ctx.proxy_in_name(outcome[1])}"
         elif outcome[0] == "primitive_no_widget":
             prim_id = outcome[1]
             annotations.append(f" {name} from primitive {prim_id}")
-            prim_hits.append((prim_id, f"inlined into {nid}.{name}"))
+            prim_hits.append((ctx.qualify(prim_id), f"inlined into {ctx.qualify(nid)}.{name}"))
 
     for inp in node.get("inputs") or []:
         name = inp.get("name")
         if "widget" in inp:
-            continue  # widget-backed input: printed in the widget pass instead
+            if name in live_link_refs:
+                _place_arg(name, live_link_refs[name], args, extra)
+            continue  # otherwise: printed in the widget pass instead
         link_id = inp.get("link")
         if link_id is None:
-            args.append(f"{name}=None")
+            _place_arg(name, "None", args, extra)
             continue
         link = ctx.link_map.get(str(link_id))
         if link is None:
-            args.append(f"{name}=None")
+            _place_arg(name, "None", args, extra)
             continue
         src_id, src_slot, _tgt_id, _tgt_slot = link
         ref, ann, warn = _resolve_edge_text(src_id, src_slot, name, nid, ctx)
@@ -448,7 +538,11 @@ def _build_args(
             warnings.append(warn)
         if ann:
             annotations.append(ann)
-        args.append(f"{name}={ref if ref is not None else 'None'}")
+        _place_arg(name, ref if ref is not None else "None", args, extra)
+
+    if extra:
+        inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
+        args.append(f"**{{{inner}}}")
 
     class_type = node.get("type", "")
     widgets_values = node.get("widgets_values")
@@ -457,13 +551,15 @@ def _build_args(
         positional = widgets_values if isinstance(widgets_values, list) else []
         if positional:
             args.append(f"widgets={py_literal(positional)}")
-        warnings.append(f"node {node.get('id')}: class {class_type!r} not in catalog; widgets printed positionally")
+        warnings.append(f"node {ctx.qualify(nid)}: class {class_type!r} not in catalog; widgets printed positionally")
     else:
         positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
             value = positional[idx] if idx < len(positional) else None
             arg_name = "control_after_generate" if entry.port is None else entry.name
+            if arg_name in live_link_refs:
+                continue  # already printed in the link pass above
             if arg_name in widget_overrides:
                 args.append(f"{arg_name}={widget_overrides[arg_name]}")
             else:
@@ -476,31 +572,41 @@ def _build_args(
 # ---------------------------------------------------------------------------
 
 
+def _subgraph_instance_name(node: dict, sg_def: dict | None, type_uuid: str) -> str:
+    """The identity string for a subgraph instance — used for both its
+    ``Subgraph[...]`` bracket and its binding name: the instance's own title,
+    else the definition's own name, else the definition's uuid."""
+    title = node.get("title") or None
+    if title:
+        return title
+    if sg_def is not None:
+        def_name = sg_def.get("name") or None
+        if def_name:
+            return def_name
+    return type_uuid
+
+
 def _render_subgraph_instance_line(
-    node: dict, type_uuid: str, binding: str, ctx: _RenderCtx, warnings: list[str]
+    node: dict, type_uuid: str, sg_def: dict, binding: str, ctx: _RenderCtx, warnings: list[str]
 ) -> tuple:
     """A subgraph instance's own line: exposed link inputs by name (or, when
     the name isn't a Python identifier, collected into a trailing ``**{}``);
     widget-backed exposed inputs print positionally from ``widgets_values``
     (subgraphs are never in the catalog) unless their link resolves to the
     enclosing definition's own input proxy, in which case that ref is used.
-    Returns ``(line, prim_hits)``."""
+    Any D9 annotation from resolving a link input (e.g. a dead-end Reroute)
+    is appended to the line, same as a regular node. Returns ``(line, prim_hits)``."""
     nid = str(node.get("id"))
-    title = node.get("title") or None
-    bracket = json.dumps(title, ensure_ascii=False) if title else json.dumps(nid)
+    name_str = _subgraph_instance_name(node, sg_def, type_uuid)
+    bracket = json.dumps(name_str, ensure_ascii=False)
     prim_hits: list[tuple] = []
+    annotations: list[str] = []
     args: list[str] = []
     extra: dict[str, str] = {}
 
     inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
     link_inputs = [inp for inp in inputs if "widget" not in inp]
     widget_inputs = [inp for inp in inputs if "widget" in inp]
-
-    def _place(iname: str, text: str) -> None:
-        if _IDENT.match(iname) and not keyword.iskeyword(iname):
-            args.append(f"{iname}={text}")
-        else:
-            extra[iname] = text
 
     for inp in link_inputs:
         iname = inp.get("name") or ""
@@ -510,10 +616,12 @@ def _render_subgraph_instance_line(
             link = ctx.link_map.get(str(link_id))
             if link is not None:
                 src_id, src_slot, _tgt_id, _tgt_slot = link
-                ref, _ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+                ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
                 if warn:
                     warnings.append(warn)
-        _place(iname, ref if ref is not None else "None")
+                if ann:
+                    annotations.append(ann)
+        _place_arg(iname, ref if ref is not None else "None", args, extra)
 
     widgets_values = node.get("widgets_values")
     positional = widgets_values if isinstance(widgets_values, list) else []
@@ -537,35 +645,38 @@ def _render_subgraph_instance_line(
                 if outcome[0] == "in_proxy":
                     override = f"IN.{ctx.proxy_in_name(outcome[1])}"
                 elif outcome[0] == "primitive_no_widget":
-                    prim_hits.append((outcome[1], f"inlined into {nid}.{iname}"))
+                    prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
         if override is not None:
             text = override
         else:
             value = positional[k] if k < len(positional) else None
             text = py_literal(value)
-        _place(iname, text)
+        _place_arg(iname, text, args, extra)
 
     if extra:
         inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
         args.append(f"**{{{inner}}}")
 
     line = f"{binding} = Subgraph[{bracket}]({', '.join(args)})  # {nid} subgraph {type_uuid}"
+    for ann in annotations:
+        line += ann
     return line, prim_hits
 
 
 def _render_missing_subgraph_line(
-    node: dict, type_uuid: str, binding: str, ctx: _RenderCtx, addr: str, warnings: list[str]
+    node: dict, type_uuid: str, binding: str, ctx: _RenderCtx, warnings: list[str]
 ) -> str:
     """D11 (amended): a subgraph instance whose definition is missing is never
     a refusal, at any depth — it's printed opaquely instead. Wired link inputs
     resolve by the instance's own input name (non-identifier names via
     ``**{}``, same as a resolved instance); widget-backed instance inputs
     print positionally as a single ``widgets=[...]`` (there's no definition to
-    name them against). ``addr`` is the node's address for the warning text —
-    the bare id at top level, ``<instance>/<inner>`` inside a definition."""
+    name them against). Any D9 annotation is appended, same as a resolved
+    instance. The warning uses this node's fully-qualified address."""
     nid = str(node.get("id"))
     args: list[str] = []
     extra: dict[str, str] = {}
+    annotations: list[str] = []
 
     inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
     link_inputs = [inp for inp in inputs if "widget" not in inp]
@@ -578,14 +689,12 @@ def _render_missing_subgraph_line(
             link = ctx.link_map.get(str(link_id))
             if link is not None:
                 src_id, src_slot, _tgt_id, _tgt_slot = link
-                ref, _ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+                ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
                 if warn:
                     warnings.append(warn)
-        text = ref if ref is not None else "None"
-        if _IDENT.match(iname) and not keyword.iskeyword(iname):
-            args.append(f"{iname}={text}")
-        else:
-            extra[iname] = text
+                if ann:
+                    annotations.append(ann)
+        _place_arg(iname, ref if ref is not None else "None", args, extra)
 
     if extra:
         inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
@@ -595,11 +704,17 @@ def _render_missing_subgraph_line(
     if isinstance(widgets_values, list) and widgets_values:
         args.append(f"widgets={py_literal(widgets_values)}")
 
-    warnings.append(f"node {addr}: subgraph definition {type_uuid} missing; printed opaquely")
-    return f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})  # {nid} subgraph {type_uuid} definition missing"
+    warnings.append(f"node {ctx.qualify(nid)}: subgraph definition {type_uuid} missing; printed opaquely")
+    line = f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})  # {nid} subgraph {type_uuid} definition missing"
+    for ann in annotations:
+        line += ann
+    return line
 
 
 def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
+    """Called only after every block has been rendered (so nested instances
+    discovered while rendering other blocks are already registered) — lists
+    every fully-qualified instance address, not just the first."""
     name = sg_def.get("name") or def_id
     instances = sorted(state.instances_by_def.get(def_id, []), key=_sort_key)
     first = state.first_instance_by_def.get(def_id, instances[0] if instances else def_id)
@@ -643,19 +758,19 @@ class _State:
         self.first_instance_by_def: dict[str, str] = {}
         self.primitive_reason: dict[str, str] = {}
 
-    def register_instance(self, def_id: str, instance_id: str, depth: int) -> None:
-        self.instances_by_def.setdefault(def_id, []).append(instance_id)
+    def register_instance(self, def_id: str, instance_addr: str, depth: int) -> None:
+        """``instance_addr`` is the fully-qualified address of the instance
+        node (e.g. ``"10"`` at top level, ``"10/3"`` nested one level)."""
+        self.instances_by_def.setdefault(def_id, []).append(instance_addr)
         if def_id not in self.def_seen:
             self.def_seen.add(def_id)
-            self.first_instance_by_def[def_id] = instance_id
+            self.first_instance_by_def[def_id] = instance_addr
             self.def_depth[def_id] = depth
             self.def_order.append(def_id)
 
 
 def _render_node_line(n: dict, name: str, ctx: _RenderCtx, graph: Graph | None, state: _State) -> str:
-    """One printed line for a node that is not itself a (resolvable) subgraph
-    instance: a regular class call, or the ``Node[...]`` fallback for a
-    nested subgraph instance whose definition is missing."""
+    """One printed line for a regular (non-subgraph-instance) node."""
     nid = str(n.get("id"))
     t = n.get("type", "")
     m = graph.node(t) if graph is not None else None
@@ -684,15 +799,14 @@ def _render_nodes(
     binding_by_id: dict[str, str],
     state: _State,
     depth: int,
-    addr_prefix: str | None = None,
 ) -> list[str]:
     """Render one printed line per node in ``order``: a resolved subgraph
     instance gets the ``Subgraph[...]`` format, an instance whose definition
     is missing gets the opaque D11 fallback (never a refusal), everything else
     is a regular class call. Shared between the top-level workflow and a
-    definition's interior (``addr_prefix`` is that definition's first
-    instance id, used to address a missing-definition warning as
-    ``<instance>/<inner>``)."""
+    definition's interior — ``ctx.addr_prefix`` (this block's own
+    fully-qualified address) is what makes a nested instance's address and a
+    nested skip/warning fully qualified through every level."""
     lines: list[str] = []
     for n in order:
         nid = str(n.get("id"))
@@ -700,33 +814,33 @@ def _render_nodes(
         name = binding_by_id[nid]
         if is_subgraph_uuid(t):
             sg_def = defs_by_id.get(t)
+            addr = ctx.qualify(nid)
             if sg_def is not None:
-                line, prim_hits = _render_subgraph_instance_line(n, t, name, ctx, state.warnings)
+                line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state.warnings)
                 for prim_id, reason in prim_hits:
                     state.primitive_reason.setdefault(prim_id, reason)
-                state.register_instance(t, nid, depth)
+                state.register_instance(t, addr, depth)
             else:
-                addr = f"{addr_prefix}/{nid}" if addr_prefix else nid
-                line = _render_missing_subgraph_line(n, t, name, ctx, addr, state.warnings)
+                line = _render_missing_subgraph_line(n, t, name, ctx, state.warnings)
         else:
             line = _render_node_line(n, name, ctx, graph, state)
         lines.append(line)
     return lines
 
 
-def _build_bindings(order: list[dict]) -> dict[str, str]:
+def _build_bindings(order: list[dict], defs_by_id: dict[str, dict]) -> dict[str, str]:
     """Local binding names for one node list, in print order: a subgraph
-    instance (resolved or not — a missing definition doesn't change what it
-    fundamentally is) binds off its own title, falling back to ``"subgraph"``;
-    everything else binds off its class type, as usual."""
+    instance (resolved or not) binds off the same identity string as its
+    bracket — its own title, else its definition's name, else its
+    definition's uuid; everything else binds off its class type, as usual."""
     used: dict[str, int] = {}
     binding_by_id: dict[str, str] = {}
     for n in order:
         nid = str(n.get("id"))
         t = n.get("type", "")
         if is_subgraph_uuid(t):
-            title = n.get("title") or None
-            name = binding_name(title or "subgraph", used)
+            name_str = _subgraph_instance_name(n, defs_by_id.get(t), t)
+            name = binding_name(name_str, used)
         else:
             name = binding_name(t, used)
         binding_by_id[nid] = name
@@ -760,18 +874,20 @@ def _render_definition_block(
     notes = [n for n in interior_nodes if n.get("type") in _NOTE_TYPES]
     ui_only_skipped = [n for n in interior_nodes if n.get("type") in _UI_ONLY and n.get("type") not in _NOTE_TYPES]
 
-    order = _toposort(printable, all_links)
-
     nodes_by_id = {str(n.get("id")): n for n in interior_nodes}
     printable_ids = {str(n.get("id")) for n in printable}
 
+    # Collected BEFORE toposort so a splice contributes a resolved dependency
+    # edge instead of silently dropping the ordering constraint (item 1).
     reroute_sources = _collect_reroute_sources(interior_nodes, all_links)
     set_sources, get_vars = _collect_get_set(interior_nodes, all_links)
+    toposort_links = _splice_link_map(all_links, nodes_by_id, reroute_sources, set_sources, get_vars, _PROXY_IN)
+    order = _toposort(printable, toposort_links)
 
     proxy_in_names = {i: inp.get("name") for i, inp in enumerate(sg_def.get("inputs") or []) if isinstance(inp, dict)}
     proxy_out_names = {i: o.get("name") for i, o in enumerate(sg_def.get("outputs") or []) if isinstance(o, dict)}
 
-    binding_by_id = _build_bindings(order)
+    binding_by_id = _build_bindings(order, state.defs_by_id)
     first_instance = state.first_instance_by_def.get(def_id, def_id)
 
     ctx = _RenderCtx(
@@ -785,20 +901,19 @@ def _render_definition_block(
         get_vars=get_vars,
         proxy_in_id=_PROXY_IN,
         proxy_in_names=proxy_in_names,
+        addr_prefix=first_instance,
     )
 
-    lines = _render_nodes(
-        order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1, addr_prefix=first_instance
-    )
+    lines = _render_nodes(order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1)
 
     for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
         lines.append(_note_comment(n))
-        state.skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "note"})
+        state.skipped.append({"id": ctx.qualify(n.get("id")), "type": n.get("type"), "reason": "note"})
     for n in ui_only_skipped:
         t = n.get("type")
-        nid = str(n.get("id"))
-        reason = state.primitive_reason.get(nid, "spliced") if t == "PrimitiveNode" else "spliced"
-        state.skipped.append({"id": nid, "type": t, "reason": reason})
+        addr = ctx.qualify(n.get("id"))
+        reason = state.primitive_reason.get(addr, "spliced") if t == "PrimitiveNode" else "spliced"
+        state.skipped.append({"id": addr, "type": t, "reason": reason})
 
     out_sources: dict[Any, tuple] = {}
     for oid, oslot, tid, tslot in all_links.values():
@@ -809,7 +924,7 @@ def _render_definition_block(
     for slot in sorted(out_sources, key=_sort_key):
         oid, oslot = out_sources[slot]
         out_name = proxy_out_names.get(slot) or f"out{slot}"
-        ref, _ann, warn = _resolve_edge_text(oid, oslot, out_name, f"{def_id} OUT", ctx)
+        ref, _ann, warn = _resolve_edge_text(oid, oslot, out_name, f"{first_instance} OUT", ctx)
         if warn:
             state.warnings.append(warn)
         lines.append(f"OUT.{out_name} = {ref if ref is not None else 'None'}")
@@ -842,17 +957,18 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     notes = [n for n in nodes if n.get("type") in _NOTE_TYPES]
     ui_only_skipped = [n for n in nodes if n.get("type") in _UI_ONLY and n.get("type") not in _NOTE_TYPES]
 
-    order = _toposort(printable, link_map)
-
     nodes_by_id = {str(n.get("id")): n for n in nodes}
     printable_ids = {str(n.get("id")) for n in printable}
 
+    # Collected BEFORE toposort — see _render_definition_block and item 1.
     reroute_sources = _collect_reroute_sources(nodes, link_map)
     set_sources, get_vars = _collect_get_set(nodes, link_map)
+    toposort_links = _splice_link_map(link_map, nodes_by_id, reroute_sources, set_sources, get_vars, None)
+    order = _toposort(printable, toposort_links)
 
     # binding_name is called once per node, in topological order, so the
     # dedupe suffixes (_2, _3, ...) match print order.
-    binding_by_id = _build_bindings(order)
+    binding_by_id = _build_bindings(order, defs_by_id)
     bindings: dict[str, str] = {name: nid for nid, name in binding_by_id.items()}
 
     ctx = _RenderCtx(
@@ -874,20 +990,27 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
 
     for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
         lines.append(_note_comment(n))
-        skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "note"})
+        skipped.append({"id": ctx.qualify(n.get("id")), "type": n.get("type"), "reason": "note"})
     for n in ui_only_skipped:
         t = n.get("type")
-        nid = str(n.get("id"))
-        reason = state.primitive_reason.get(nid, "spliced") if t == "PrimitiveNode" else "spliced"
-        skipped.append({"id": nid, "type": t, "reason": reason})
+        addr = ctx.qualify(n.get("id"))
+        reason = state.primitive_reason.get(addr, "spliced") if t == "PrimitiveNode" else "spliced"
+        skipped.append({"id": addr, "type": t, "reason": reason})
 
+    # Render every definition block first (this may discover further nested
+    # definitions, appended to state.def_order and picked up by this same
+    # loop) — only THEN emit headers, so each header's instance list is
+    # complete rather than reporting only what was known when it was reached.
     node_count = len(printable)
+    block_lines_by_def: dict[str, list[str]] = {}
     for def_id in state.def_order:
         sg_def = defs_by_id[def_id]
-        lines.append(_definition_header(def_id, sg_def, state))
         block_lines, block_count = _render_definition_block(def_id, sg_def, graph, state, state.def_depth[def_id])
-        lines.extend("    " + bl for bl in block_lines)
+        block_lines_by_def[def_id] = block_lines
         node_count += block_count
+    for def_id in state.def_order:
+        lines.append(_definition_header(def_id, defs_by_id[def_id], state))
+        lines.extend("    " + bl for bl in block_lines_by_def[def_id])
 
     source = "\n".join(lines) + "\n"
     return PrintResult(source=source, bindings=bindings, node_count=node_count, skipped=skipped, warnings=warnings)

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -239,21 +239,33 @@ def _toposort(printable: list[dict], link_map: dict[str, tuple]) -> list[dict]:
     return [node_by_id[i] for i in order]
 
 
-def _edge_ref(binding: str, src_node: dict, src_type: str, slot: int, graph: Graph | None) -> str:
-    """How to reference one output slot of an already-bound source node."""
+def _edge_ref(binding: str, src_node: dict, src_type: str, slot: int, ctx: _RenderCtx) -> tuple[str, str | None]:
+    """How to reference one output slot of an already-bound source node.
+
+    Returns ``(ref, warning)``. ``warning`` is non-None only when litegraph
+    serialized something other than a dict into ``outputs[slot]`` — the ref
+    still falls back to the ``.out[<slot>]`` index form rather than raising.
+    """
     outputs = src_node.get("outputs") or []
     if len(outputs) == 1:
-        return binding
+        return binding, None
     out_name = None
+    warning = None
     if 0 <= slot < len(outputs):
-        out_name = outputs[slot].get("name")
-    if not out_name and graph is not None:
-        m = graph.node(src_type)
+        entry = outputs[slot]
+        if isinstance(entry, dict):
+            out_name = entry.get("name")
+        else:
+            warning = (
+                f"node {ctx.qualify(src_node.get('id'))}: malformed outputs entry at slot {slot}; referenced by index"
+            )
+    if not out_name and ctx.graph is not None:
+        m = ctx.graph.node(src_type)
         if m is not None and 0 <= slot < len(m.outputs):
             out_name = m.outputs[slot].name
     if out_name and _IDENT.match(out_name) and not keyword.iskeyword(out_name):
-        return f"{binding}.{out_name}"
-    return f"{binding}.out[{slot}]"
+        return f"{binding}.{out_name}", warning
+    return f"{binding}.out[{slot}]", warning
 
 
 def _note_comment(node: dict) -> str:
@@ -476,12 +488,12 @@ def _resolve_edge_text(src_id: Any, src_slot: Any, name: str, tgt_id: str, ctx: 
         binding = ctx.binding_by_id.get(rid_s)
         if src_node is None or binding is None:
             return None, None, None
-        ref = _edge_ref(binding, src_node, src_node.get("type", ""), rslot, ctx.graph)
+        ref, edge_warning = _edge_ref(binding, src_node, src_node.get("type", ""), rslot, ctx)
         # R12 (amending D8): the link still prints as wired — the marker only
         # tells the reader the value it carries comes from a bypassed node, so
         # at runtime it is really whatever that node passes through.
         ann = f" {name} via bypassed {rid_s}" if src_node.get("mode") == 4 else None
-        return ref, ann, None
+        return ref, ann, edge_warning
     if kind == "in_proxy":
         return ctx.in_ref(outcome[1]), None, None
     if kind == "dead_reroute":
@@ -575,7 +587,10 @@ def _build_args(
                 src_node = ctx.nodes_by_id.get(rid_s)
                 binding = ctx.binding_by_id.get(rid_s)
                 if src_node is not None and binding is not None:
-                    live_link_refs[name] = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx.graph)
+                    edge_ref, edge_warning = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx)
+                    live_link_refs[name] = edge_ref
+                    if edge_warning:
+                        warnings.append(edge_warning)
                     if src_node.get("mode") == 4:  # R12, same marker as the link pass
                         annotations.append(f" {name} via bypassed {rid_s}")
         elif outcome[0] == "in_proxy":
@@ -783,7 +798,8 @@ def _render_missing_subgraph_line(
         args.append(f"widgets={py_literal(widgets_values)}")
 
     warnings.append(f"node {ctx.qualify(nid)}: subgraph definition {type_uuid} missing; printed opaquely")
-    line = f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})  # {nid} subgraph {type_uuid} definition missing"
+    call = f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})"
+    line = f"{call}  # {nid} subgraph {type_uuid} definition missing"
     for ann in annotations:
         line += ann
     return line

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -77,6 +77,16 @@ def class_expr(class_type: str) -> str:
     )
 
 
+def _member_ref(base: str, name: str) -> str:
+    """``base.name`` when ``name`` is a plain Python identifier, else
+    ``base["name"]`` — so a subgraph proxy input/output whose declared name has
+    a space (or any other non-identifier character) still prints as something
+    that parses."""
+    if _IDENT.match(name) and not keyword.iskeyword(name):
+        return f"{base}.{name}"
+    return f"{base}[{json.dumps(name, ensure_ascii=False)}]"
+
+
 def binding_name(class_type: str, used: dict[str, int]) -> str:
     """A snake_case Python identifier for ``class_type``, deduped against ``used``
     (mutated in place) in call order: repeats get a ``_2``, ``_3``, ... suffix.
@@ -121,6 +131,12 @@ def _sort_key(node_id: str) -> tuple[int, Any]:
         return (1, node_id)
 
 
+def _is_slot_index(value: Any) -> bool:
+    """A link slot must be a real integer index (``bool`` is an int in Python,
+    and is not one)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _validate(nodes: list[dict], links: list[list]) -> list[str]:
     """Structural checks that must hold before any ordering/printing work starts.
     Collects every problem found (rather than stopping at the first) so the
@@ -131,6 +147,8 @@ def _validate(nodes: list[dict], links: list[list]) -> list[str]:
     ``_render_missing_subgraph_line`` and D11 in the task brief (amended).
     """
     reasons: list[str] = []
+    seen_ids: set[str] = set()
+    reported_dupes: set[str] = set()
     for n in nodes:
         t = n.get("type")
         extra = n.get("extra")
@@ -139,6 +157,16 @@ def _validate(nodes: list[dict], links: list[list]) -> list[str]:
         )
         if is_legacy_group:
             reasons.append(f"node {n.get('id')} is a legacy group node ({t})")
+        # Ids key every map here (nodes_by_id, bindings, skipped addresses), so
+        # a repeat silently drops a node and mis-resolves its edges. Report each
+        # duplicated id once, in first-seen order, rather than printing a lie.
+        nid = str(n.get("id"))
+        if nid in seen_ids:
+            if nid not in reported_dupes:
+                reported_dupes.add(nid)
+                reasons.append(f"duplicate node id {nid}")
+        else:
+            seen_ids.add(nid)
 
     nodes_by_id = {str(n.get("id")): n for n in nodes}
     for link in links:
@@ -153,6 +181,12 @@ def _validate(nodes: list[dict], links: list[list]) -> list[str]:
         tgt_node = nodes_by_id.get(str(tgt_id))
         if tgt_node is None:
             reasons.append(f"link {link_id} references missing node {tgt_id}")
+            continue
+        # Slots index into outputs/inputs below and into widgets_values later;
+        # a None or "0" would raise a TypeError deep in the render instead of
+        # being reported here with every other structural problem.
+        if not _is_slot_index(src_slot) or not _is_slot_index(tgt_slot):
+            reasons.append(f"link {link_id} has a non-integer slot")
             continue
         outputs = src_node.get("outputs")
         if isinstance(outputs, list) and not (0 <= src_slot < len(outputs)):
@@ -319,6 +353,8 @@ def _resolve_source(
     - ``("dead_reroute", reroute_id)`` — a Reroute with no upstream link.
     - ``("missing_set", get_id, var)`` — a GetNode whose variable no SetNode publishes.
     - ``("primitive_no_widget", primitive_id)`` — resolves directly to a PrimitiveNode.
+    - ``("splice_cycle", node_id)`` — a Reroute/GetNode chain that loops back on
+      itself, so it never bottoms out at a real value.
 
     Cross-reference: workflow_to_api.py's ``_Tracers.trace_reroute`` /
     ``trace_get_set`` (~line 659) walk the same chains for API-format
@@ -334,7 +370,7 @@ def _resolve_source(
         t = node.get("type") if node else None
         if t == "Reroute":
             if key in seen:
-                return ("ok", src_id, src_slot)
+                return ("splice_cycle", key)
             seen.add(key)
             if key in reroute_sources:
                 src_id, src_slot = reroute_sources[key]
@@ -342,7 +378,7 @@ def _resolve_source(
             return ("dead_reroute", key)
         if t == "GetNode":
             if key in seen:
-                return ("ok", src_id, src_slot)
+                return ("splice_cycle", key)
             seen.add(key)
             var = get_vars.get(key)
             if var in set_sources:
@@ -396,10 +432,18 @@ class _RenderCtx:
     proxy_in_id: str | None = None
     proxy_in_names: dict[int, str] = field(default_factory=dict)
     addr_prefix: str | None = None
+    # The definition whose interior this context renders (``None`` at top
+    # level). A nested subgraph instance registers against it so its own
+    # address can later be expanded through every instance of THIS definition.
+    owner_def: str | None = None
 
     def proxy_in_name(self, slot: Any) -> str:
         name = self.proxy_in_names.get(slot)
         return name if name else f"slot{slot}"
+
+    def in_ref(self, slot: Any) -> str:
+        """``IN.<name>`` / ``IN["<name>"]`` for one input-proxy slot."""
+        return _member_ref("IN", self.proxy_in_name(slot))
 
     def qualify(self, nid: Any) -> str:
         """This block's fully-qualified address for a bare local node id —
@@ -432,11 +476,22 @@ def _resolve_edge_text(src_id: Any, src_slot: Any, name: str, tgt_id: str, ctx: 
         binding = ctx.binding_by_id.get(rid_s)
         if src_node is None or binding is None:
             return None, None, None
-        return _edge_ref(binding, src_node, src_node.get("type", ""), rslot, ctx.graph), None, None
+        ref = _edge_ref(binding, src_node, src_node.get("type", ""), rslot, ctx.graph)
+        # R12 (amending D8): the link still prints as wired — the marker only
+        # tells the reader the value it carries comes from a bypassed node, so
+        # at runtime it is really whatever that node passes through.
+        ann = f" {name} via bypassed {rid_s}" if src_node.get("mode") == 4 else None
+        return ref, ann, None
     if kind == "in_proxy":
-        return f"IN.{ctx.proxy_in_name(outcome[1])}", None, None
+        return ctx.in_ref(outcome[1]), None, None
     if kind == "dead_reroute":
         return None, f" {name} unlinked via reroute {outcome[1]}", None
+    if kind == "splice_cycle":
+        return (
+            None,
+            None,
+            f"node {ctx.qualify(tgt_id)}: input '{name}' unresolved through a reroute/getnode cycle",
+        )
     if kind == "missing_set":
         get_id, var = outcome[1], outcome[2]
         return (
@@ -480,6 +535,16 @@ def _build_args(
     annotations: list[str] = []
     prim_hits: list[tuple] = []
 
+    # Normalised once so both passes below can assume a dict: litegraph has
+    # been seen to serialize junk into ``inputs``, and a bare ``"widget" in inp``
+    # or ``inp.get(...)`` on a str/int would traceback out of the whole render.
+    inputs: list[dict] = []
+    for inp in node.get("inputs") or []:
+        if not isinstance(inp, dict):
+            warnings.append(f"node {ctx.qualify(nid)}: ignoring malformed input entry {inp!r}")
+            continue
+        inputs.append(inp)
+
     # Pre-pass: widget-backed inputs. A LIVE link to a real, printable node is
     # the truth — it's printed as a ref in the link pass below and skipped in
     # the widget-values pass. A link that resolves to the subgraph input
@@ -490,10 +555,10 @@ def _build_args(
     # to the static value too — there's nothing better to show.
     live_link_refs: dict[str, str] = {}
     widget_overrides: dict[str, str] = {}
-    for inp in node.get("inputs") or []:
+    for inp in inputs:
         if "widget" not in inp:
             continue
-        name = inp.get("name")
+        name = inp.get("name") or ""
         link_id = inp.get("link")
         if link_id is None:
             continue
@@ -511,15 +576,17 @@ def _build_args(
                 binding = ctx.binding_by_id.get(rid_s)
                 if src_node is not None and binding is not None:
                     live_link_refs[name] = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx.graph)
+                    if src_node.get("mode") == 4:  # R12, same marker as the link pass
+                        annotations.append(f" {name} via bypassed {rid_s}")
         elif outcome[0] == "in_proxy":
-            widget_overrides[name] = f"IN.{ctx.proxy_in_name(outcome[1])}"
+            widget_overrides[name] = ctx.in_ref(outcome[1])
         elif outcome[0] == "primitive_no_widget":
             prim_id = outcome[1]
             annotations.append(f" {name} from primitive {prim_id}")
             prim_hits.append((ctx.qualify(prim_id), f"inlined into {ctx.qualify(nid)}.{name}"))
 
-    for inp in node.get("inputs") or []:
-        name = inp.get("name")
+    for inp in inputs:
+        name = inp.get("name") or ""
         if "widget" in inp:
             if name in live_link_refs:
                 _place_arg(name, live_link_refs[name], args, extra)
@@ -540,10 +607,6 @@ def _build_args(
             annotations.append(ann)
         _place_arg(name, ref if ref is not None else "None", args, extra)
 
-    if extra:
-        inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
-        args.append(f"**{{{inner}}}")
-
     class_type = node.get("type", "")
     widgets_values = node.get("widgets_values")
     unknown = m is None
@@ -556,14 +619,29 @@ def _build_args(
         positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
-            value = positional[idx] if idx < len(positional) else None
             arg_name = "control_after_generate" if entry.port is None else entry.name
             if arg_name in live_link_refs:
                 continue  # already printed in the link pass above
             if arg_name in widget_overrides:
-                args.append(f"{arg_name}={widget_overrides[arg_name]}")
+                _place_arg(arg_name, widget_overrides[arg_name], args, extra)
+                continue
+            # R11 (amending D4): a dynamic combo's sub-widget the frontend never
+            # serialized a value for prints the catalog's own default, not a
+            # bare None that reads as "explicitly unset".
+            if idx < len(positional):
+                value = positional[idx]
+            elif entry.port is not None and entry.port.options.default is not None:
+                value = entry.port.options.default
             else:
-                args.append(f"{arg_name}={py_literal(value)}")
+                value = None
+            _place_arg(arg_name, py_literal(value), args, extra)
+
+    # Flushed once, AFTER the widget pass: a dynamic combo's sub-widget name is
+    # dotted ("model.size_preset"), which is no more a Python identifier than a
+    # dotted link-input name — both belong in the same trailing **{...}.
+    if extra:
+        inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
+        args.append(f"**{{{inner}}}")
     return args, unknown, annotations, prim_hits
 
 
@@ -643,7 +721,7 @@ def _render_subgraph_instance_line(
                     ctx.proxy_in_id,
                 )
                 if outcome[0] == "in_proxy":
-                    override = f"IN.{ctx.proxy_in_name(outcome[1])}"
+                    override = ctx.in_ref(outcome[1])
                 elif outcome[0] == "primitive_no_widget":
                     prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
         if override is not None:
@@ -714,13 +792,16 @@ def _render_missing_subgraph_line(
 def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
     """Called only after every block has been rendered (so nested instances
     discovered while rendering other blocks are already registered) — lists
-    every fully-qualified instance address, not just the first."""
+    every fully-qualified instance address, not just the first, and spells out
+    the form of BOTH the inner-node addresses and the ``bindings`` keys (they
+    differ: one ends in the inner id, the other in the binding name)."""
     name = sg_def.get("name") or def_id
-    instances = sorted(state.instances_by_def.get(def_id, []), key=_sort_key)
+    instances = sorted(set(state.instance_addresses(def_id)), key=_sort_key)
     first = state.first_instance_by_def.get(def_id, instances[0] if instances else def_id)
     return (
         f"# subgraph {def_id} {json.dumps(name, ensure_ascii=False)} — "
-        f"instances: {', '.join(instances)} (address inner nodes as {first}/<id>)"
+        f"instances: {', '.join(instances)} "
+        f"(address inner nodes as {first}/<id>; bindings keyed {first}/<name>)"
     )
 
 
@@ -754,19 +835,44 @@ class _State:
         self.def_order: list[str] = []
         self.def_seen: set[str] = set()
         self.def_depth: dict[str, int] = {}
-        self.instances_by_def: dict[str, list[str]] = {}
+        # def_id -> [(owning definition id or None at top level, bare local id)].
+        # Stored RELATIVE, not pre-qualified: a definition's interior is rendered
+        # exactly once (under its first instance's address), so an instance
+        # discovered inside a definition that is itself instantiated N times
+        # stands for N real addresses. instance_addresses() expands that.
+        self.instance_sites: dict[str, list[tuple[str | None, str]]] = {}
         self.first_instance_by_def: dict[str, str] = {}
         self.primitive_reason: dict[str, str] = {}
 
-    def register_instance(self, def_id: str, instance_addr: str, depth: int) -> None:
-        """``instance_addr`` is the fully-qualified address of the instance
-        node (e.g. ``"10"`` at top level, ``"10/3"`` nested one level)."""
-        self.instances_by_def.setdefault(def_id, []).append(instance_addr)
+    def register_instance(
+        self, def_id: str, owner_def: str | None, local_id: Any, instance_addr: str, depth: int
+    ) -> None:
+        """``owner_def``/``local_id`` locate the instance relative to whatever
+        block it was found in; ``instance_addr`` is the fully-qualified address
+        that block itself rendered under (``"10"`` at top level, ``"10/3"``
+        nested one level) and is what interior addressing keys off."""
+        self.instance_sites.setdefault(def_id, []).append((owner_def, str(local_id)))
         if def_id not in self.def_seen:
             self.def_seen.add(def_id)
             self.first_instance_by_def[def_id] = instance_addr
             self.def_depth[def_id] = depth
             self.def_order.append(def_id)
+
+    def instance_addresses(self, def_id: str, _seen: frozenset = frozenset()) -> list[str]:
+        """Every fully-qualified address ``def_id`` is instantiated at, expanding
+        each ancestor definition's own instance list — Outer instantiated at 100
+        and 200, each holding Inner at inner id 5, gives ``100/5`` AND ``200/5``.
+        ``_seen`` guards a malformed self-referential definition chain."""
+        if def_id in _seen:
+            return []
+        seen = _seen | {def_id}
+        out: list[str] = []
+        for owner_def, local_id in self.instance_sites.get(def_id, []):
+            if owner_def is None:
+                out.append(local_id)
+                continue
+            out.extend(f"{parent}/{local_id}" for parent in self.instance_addresses(owner_def, seen))
+        return out
 
 
 def _render_node_line(n: dict, name: str, ctx: _RenderCtx, graph: Graph | None, state: _State) -> str:
@@ -819,7 +925,7 @@ def _render_nodes(
                 line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state.warnings)
                 for prim_id, reason in prim_hits:
                     state.primitive_reason.setdefault(prim_id, reason)
-                state.register_instance(t, addr, depth)
+                state.register_instance(t, ctx.owner_def, nid, addr, depth)
             else:
                 line = _render_missing_subgraph_line(n, t, name, ctx, state.warnings)
         else:
@@ -902,6 +1008,7 @@ def _render_definition_block(
         proxy_in_id=_PROXY_IN,
         proxy_in_names=proxy_in_names,
         addr_prefix=first_instance,
+        owner_def=def_id,
     )
 
     lines = _render_nodes(order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1)
@@ -924,10 +1031,13 @@ def _render_definition_block(
     for slot in sorted(out_sources, key=_sort_key):
         oid, oslot = out_sources[slot]
         out_name = proxy_out_names.get(slot) or f"out{slot}"
-        ref, _ann, warn = _resolve_edge_text(oid, oslot, out_name, f"{first_instance} OUT", ctx)
+        # "OUT", not a pre-qualified label: _resolve_edge_text runs the target
+        # through ctx.qualify(), which prefixes this block's own address — so
+        # anything already carrying it comes back doubled ("11/11 OUT").
+        ref, _ann, warn = _resolve_edge_text(oid, oslot, out_name, "OUT", ctx)
         if warn:
             state.warnings.append(warn)
-        lines.append(f"OUT.{out_name} = {ref if ref is not None else 'None'}")
+        lines.append(f"{_member_ref('OUT', out_name)} = {ref if ref is not None else 'None'}")
 
     for nid, name in binding_by_id.items():
         state.bindings[f"{first_instance}/{name}"] = f"{first_instance}/{nid}"

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -119,26 +119,16 @@ def _sort_key(node_id: str) -> tuple[int, Any]:
         return (1, node_id)
 
 
-def _validate(
-    nodes: list[dict],
-    links: list[list],
-    defs_by_id: dict[str, dict] | None = None,
-    *,
-    check_subgraph_refs: bool = True,
-) -> list[str]:
+def _validate(nodes: list[dict], links: list[list]) -> list[str]:
     """Structural checks that must hold before any ordering/printing work starts.
     Collects every problem found (rather than stopping at the first) so the
     caller's ``PrintUnsupported`` can report them all at once.
 
-    ``check_subgraph_refs`` gates the "subgraph instance whose definition is
-    missing" check: on for the workflow's own top-level nodes (an unresolvable
-    top-level instance can't be printed at all), off when validating a
-    definition's interior (an unresolvable *nested* instance just falls
-    through to being rendered like any other not-in-catalog node — see
-    render_py's module docstring and D11 in the task brief).
+    A subgraph instance whose definition is missing is deliberately NOT a
+    refusal here (at any depth): it's printed opaquely instead — see
+    ``_render_missing_subgraph_line`` and D11 in the task brief (amended).
     """
     reasons: list[str] = []
-    defs_by_id = defs_by_id or {}
     for n in nodes:
         t = n.get("type")
         extra = n.get("extra")
@@ -147,8 +137,6 @@ def _validate(
         )
         if is_legacy_group:
             reasons.append(f"node {n.get('id')} is a legacy group node ({t})")
-        if check_subgraph_refs and is_subgraph_uuid(t) and t not in defs_by_id:
-            reasons.append(f"node {n.get('id')} is a subgraph instance whose definition {t} is missing")
 
     nodes_by_id = {str(n.get("id")): n for n in nodes}
     for link in links:
@@ -565,6 +553,52 @@ def _render_subgraph_instance_line(
     return line, prim_hits
 
 
+def _render_missing_subgraph_line(
+    node: dict, type_uuid: str, binding: str, ctx: _RenderCtx, addr: str, warnings: list[str]
+) -> str:
+    """D11 (amended): a subgraph instance whose definition is missing is never
+    a refusal, at any depth — it's printed opaquely instead. Wired link inputs
+    resolve by the instance's own input name (non-identifier names via
+    ``**{}``, same as a resolved instance); widget-backed instance inputs
+    print positionally as a single ``widgets=[...]`` (there's no definition to
+    name them against). ``addr`` is the node's address for the warning text —
+    the bare id at top level, ``<instance>/<inner>`` inside a definition."""
+    nid = str(node.get("id"))
+    args: list[str] = []
+    extra: dict[str, str] = {}
+
+    inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
+    link_inputs = [inp for inp in inputs if "widget" not in inp]
+
+    for inp in link_inputs:
+        iname = inp.get("name") or ""
+        ref = None
+        link_id = inp.get("link")
+        if link_id is not None:
+            link = ctx.link_map.get(str(link_id))
+            if link is not None:
+                src_id, src_slot, _tgt_id, _tgt_slot = link
+                ref, _ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+                if warn:
+                    warnings.append(warn)
+        text = ref if ref is not None else "None"
+        if _IDENT.match(iname) and not keyword.iskeyword(iname):
+            args.append(f"{iname}={text}")
+        else:
+            extra[iname] = text
+
+    if extra:
+        inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
+        args.append(f"**{{{inner}}}")
+
+    widgets_values = node.get("widgets_values")
+    if isinstance(widgets_values, list) and widgets_values:
+        args.append(f"widgets={py_literal(widgets_values)}")
+
+    warnings.append(f"node {addr}: subgraph definition {type_uuid} missing; printed opaquely")
+    return f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})  # {nid} subgraph {type_uuid} definition missing"
+
+
 def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
     name = sg_def.get("name") or def_id
     instances = sorted(state.instances_by_def.get(def_id, []), key=_sort_key)
@@ -650,39 +684,47 @@ def _render_nodes(
     binding_by_id: dict[str, str],
     state: _State,
     depth: int,
+    addr_prefix: str | None = None,
 ) -> list[str]:
-    """Render one printed line per node in ``order``, branching to the
-    subgraph-instance format when the node's type resolves to a present
-    definition. Shared between the top-level workflow and a definition's
-    interior."""
+    """Render one printed line per node in ``order``: a resolved subgraph
+    instance gets the ``Subgraph[...]`` format, an instance whose definition
+    is missing gets the opaque D11 fallback (never a refusal), everything else
+    is a regular class call. Shared between the top-level workflow and a
+    definition's interior (``addr_prefix`` is that definition's first
+    instance id, used to address a missing-definition warning as
+    ``<instance>/<inner>``)."""
     lines: list[str] = []
     for n in order:
         nid = str(n.get("id"))
         t = n.get("type", "")
-        sg_def = defs_by_id.get(t) if is_subgraph_uuid(t) else None
         name = binding_by_id[nid]
-        if sg_def is not None:
-            line, prim_hits = _render_subgraph_instance_line(n, t, name, ctx, state.warnings)
-            for prim_id, reason in prim_hits:
-                state.primitive_reason.setdefault(prim_id, reason)
-            state.register_instance(t, nid, depth)
+        if is_subgraph_uuid(t):
+            sg_def = defs_by_id.get(t)
+            if sg_def is not None:
+                line, prim_hits = _render_subgraph_instance_line(n, t, name, ctx, state.warnings)
+                for prim_id, reason in prim_hits:
+                    state.primitive_reason.setdefault(prim_id, reason)
+                state.register_instance(t, nid, depth)
+            else:
+                addr = f"{addr_prefix}/{nid}" if addr_prefix else nid
+                line = _render_missing_subgraph_line(n, t, name, ctx, addr, state.warnings)
         else:
             line = _render_node_line(n, name, ctx, graph, state)
         lines.append(line)
     return lines
 
 
-def _build_bindings(order: list[dict], defs_by_id: dict[str, dict]) -> dict[str, str]:
+def _build_bindings(order: list[dict]) -> dict[str, str]:
     """Local binding names for one node list, in print order: a subgraph
-    instance binds off its own title (falling back to ``"subgraph"``);
+    instance (resolved or not — a missing definition doesn't change what it
+    fundamentally is) binds off its own title, falling back to ``"subgraph"``;
     everything else binds off its class type, as usual."""
     used: dict[str, int] = {}
     binding_by_id: dict[str, str] = {}
     for n in order:
         nid = str(n.get("id"))
         t = n.get("type", "")
-        sg_def = defs_by_id.get(t) if is_subgraph_uuid(t) else None
-        if sg_def is not None:
+        if is_subgraph_uuid(t):
             title = n.get("title") or None
             name = binding_name(title or "subgraph", used)
         else:
@@ -710,7 +752,7 @@ def _render_definition_block(
             continue
         validate_links.append([lid, oid, oslot, tid, tslot])
 
-    reasons = _validate(interior_nodes, validate_links, state.defs_by_id, check_subgraph_refs=False)
+    reasons = _validate(interior_nodes, validate_links)
     if reasons:
         raise PrintUnsupported(reasons)
 
@@ -729,7 +771,8 @@ def _render_definition_block(
     proxy_in_names = {i: inp.get("name") for i, inp in enumerate(sg_def.get("inputs") or []) if isinstance(inp, dict)}
     proxy_out_names = {i: o.get("name") for i, o in enumerate(sg_def.get("outputs") or []) if isinstance(o, dict)}
 
-    binding_by_id = _build_bindings(order, state.defs_by_id)
+    binding_by_id = _build_bindings(order)
+    first_instance = state.first_instance_by_def.get(def_id, def_id)
 
     ctx = _RenderCtx(
         graph=graph,
@@ -744,7 +787,9 @@ def _render_definition_block(
         proxy_in_names=proxy_in_names,
     )
 
-    lines = _render_nodes(order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1)
+    lines = _render_nodes(
+        order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1, addr_prefix=first_instance
+    )
 
     for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
         lines.append(_note_comment(n))
@@ -761,7 +806,6 @@ def _render_definition_block(
             continue
         if tslot not in out_sources:
             out_sources[tslot] = (oid, oslot)
-    first_instance = state.first_instance_by_def.get(def_id, def_id)
     for slot in sorted(out_sources, key=_sort_key):
         oid, oslot = out_sources[slot]
         out_name = proxy_out_names.get(slot) or f"out{slot}"
@@ -785,7 +829,7 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
         if isinstance(sg, dict) and sg.get("id")
     }
 
-    reasons = _validate(nodes, links, defs_by_id)
+    reasons = _validate(nodes, links)
     if reasons:
         raise PrintUnsupported(reasons)
 
@@ -808,7 +852,7 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
 
     # binding_name is called once per node, in topological order, so the
     # dedupe suffixes (_2, _3, ...) match print order.
-    binding_by_id = _build_bindings(order, defs_by_id)
+    binding_by_id = _build_bindings(order)
     bindings: dict[str, str] = {name: nid for nid, name in binding_by_id.items()}
 
     ctx = _RenderCtx(

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -5,10 +5,15 @@ one Python-like statement per node, in topological order, with `#`-comments
 carrying id/title/mode metadata. Purely a read/display aid — the output is not
 meant to be executed or parsed back into a workflow.
 
-``Reroute``/``GetNode``/``SetNode``/``PrimitiveNode`` are treated as skipped
-("ui-only") here; a later task adds resolvers that splice through them instead
-of leaving a dangling ``None`` — the walk below is structured so that only the
-edge-resolution step needs to change for that.
+``Reroute``/``GetNode``/``SetNode``/``PrimitiveNode`` are UI-only splicing
+nodes: they never get their own line. Instead the edge that would otherwise
+dangle through them is resolved to whatever real value they carry (a Reroute
+chain, a SetNode/GetNode pair, or a PrimitiveNode feeding a widget-backed
+input), with an inline annotation or warning when that resolution can't find
+a real value. Subgraph instances (a node whose ``type`` is the UUID of an
+entry under ``workflow["definitions"]["subgraphs"]``) get a ``Subgraph[...]``
+call line and their definition is rendered once, after the top-level lines,
+as an indented block addressed as ``<first instance id>/<inner id>``.
 
 See the design: decisions D1-D13 (Obsidian, "workflow print (design, 2026-08-25)").
 """
@@ -22,17 +27,25 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from comfy_cli.cql.engine import _expand_widget_entries, _widgets_as_positional
+from comfy_cli.workflow_to_api import is_subgraph_uuid
 
 if TYPE_CHECKING:
     from comfy_cli.cql.engine import Graph
 
 _MODE_LABELS = {2: "mute", 4: "bypass"}
 # Same set as workflow_to_api._UI_ONLY_NODE_TYPES. Notes are handled here (as
-# comments); the rest are skipped with reason "ui-only" until a later task
-# adds splicing resolvers for them.
+# comments); Reroute/GetNode/SetNode/PrimitiveNode are spliced through (see
+# _resolve_source) rather than skipped as dangling.
 _UI_ONLY = frozenset({"Note", "MarkdownNote", "PrimitiveNode", "GetNode", "SetNode", "Reroute"})
 _NOTE_TYPES = frozenset({"Note", "MarkdownNote"})
 _IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Sentinel ids litegraph uses for a subgraph definition's synthetic input/output
+# proxy nodes — matches workflow_to_api._SUBGRAPH_INPUT_NODE_ID / _OUTPUT_NODE_ID.
+_PROXY_IN = "-10"
+_PROXY_OUT = "-20"
+_MAX_SUBGRAPH_DEPTH = 10
+_MAX_SPLICE_HOPS = 100
 
 
 @dataclass(frozen=True)
@@ -106,11 +119,26 @@ def _sort_key(node_id: str) -> tuple[int, Any]:
         return (1, node_id)
 
 
-def _validate(nodes: list[dict], links: list[list]) -> list[str]:
+def _validate(
+    nodes: list[dict],
+    links: list[list],
+    defs_by_id: dict[str, dict] | None = None,
+    *,
+    check_subgraph_refs: bool = True,
+) -> list[str]:
     """Structural checks that must hold before any ordering/printing work starts.
     Collects every problem found (rather than stopping at the first) so the
-    caller's ``PrintUnsupported`` can report them all at once."""
+    caller's ``PrintUnsupported`` can report them all at once.
+
+    ``check_subgraph_refs`` gates the "subgraph instance whose definition is
+    missing" check: on for the workflow's own top-level nodes (an unresolvable
+    top-level instance can't be printed at all), off when validating a
+    definition's interior (an unresolvable *nested* instance just falls
+    through to being rendered like any other not-in-catalog node — see
+    render_py's module docstring and D11 in the task brief).
+    """
     reasons: list[str] = []
+    defs_by_id = defs_by_id or {}
     for n in nodes:
         t = n.get("type")
         extra = n.get("extra")
@@ -119,6 +147,8 @@ def _validate(nodes: list[dict], links: list[list]) -> list[str]:
         )
         if is_legacy_group:
             reasons.append(f"node {n.get('id')} is a legacy group node ({t})")
+        if check_subgraph_refs and is_subgraph_uuid(t) and t not in defs_by_id:
+            reasons.append(f"node {n.get('id')} is a subgraph instance whose definition {t} is missing")
 
     nodes_by_id = {str(n.get("id")): n for n in nodes}
     for link in links:
@@ -208,21 +238,210 @@ def _note_comment(node: dict) -> str:
     return comment
 
 
-def _build_args(
-    node: dict,
-    m: Any,
-    graph: Graph | None,
-    bindings: dict[str, str],
+# ---------------------------------------------------------------------------
+# D9: splicing through Reroute / SetNode+GetNode / PrimitiveNode
+# ---------------------------------------------------------------------------
+
+
+def _collect_reroute_sources(nodes: list[dict], link_map: dict[str, tuple]) -> dict[str, tuple]:
+    """``{reroute_id: (src_id, src_slot)}`` from each Reroute's single input link."""
+    out: dict[str, tuple] = {}
+    for n in nodes:
+        if n.get("type") != "Reroute":
+            continue
+        inputs = n.get("inputs")
+        if not isinstance(inputs, list) or not inputs or not isinstance(inputs[0], dict):
+            continue
+        link_id = inputs[0].get("link")
+        if link_id is None:
+            continue
+        link = link_map.get(str(link_id))
+        if link is None:
+            continue
+        src_id, src_slot, _tgt_id, _tgt_slot = link
+        out[str(n.get("id"))] = (src_id, src_slot)
+    return out
+
+
+def _collect_get_set(nodes: list[dict], link_map: dict[str, tuple]) -> tuple[dict[str, tuple], dict[str, str]]:
+    """``set_sources[var] = (src_id, src_slot)`` from each SetNode's first linked
+    input; ``get_vars[get_id] = var`` for each GetNode."""
+    set_sources: dict[str, tuple] = {}
+    get_vars: dict[str, str] = {}
+    for n in nodes:
+        t = n.get("type")
+        if t not in ("SetNode", "GetNode"):
+            continue
+        widgets = n.get("widgets_values")
+        var = widgets[0] if isinstance(widgets, list) and widgets else None
+        if not isinstance(var, str) or not var:
+            continue
+        if t == "SetNode":
+            for inp in n.get("inputs") or []:
+                if not isinstance(inp, dict):
+                    continue
+                link_id = inp.get("link")
+                if link_id is None:
+                    continue
+                link = link_map.get(str(link_id))
+                if link is None:
+                    continue
+                src_id, src_slot, _tgt_id, _tgt_slot = link
+                set_sources[var] = (src_id, src_slot)
+                break
+        else:
+            get_vars[str(n.get("id"))] = var
+    return set_sources, get_vars
+
+
+def _resolve_source(
+    src_id: Any,
+    src_slot: Any,
     nodes_by_id: dict[str, dict],
-    printable_ids: set[str],
-    link_map: dict[str, tuple],
-    warnings: list[str],
-) -> tuple[list[str], bool]:
+    reroute_sources: dict[str, tuple],
+    set_sources: dict[str, tuple],
+    get_vars: dict[str, str],
+    proxy_in_id: str | None,
+) -> tuple:
+    """Chase an edge's source through Reroute / GetNode+SetNode splices (and,
+    inside a subgraph definition, the ``-10`` input-proxy node) to whatever it
+    ultimately resolves to. Returns one of:
+
+    - ``("ok", id, slot)`` — a real, printable source.
+    - ``("in_proxy", slot)`` — resolves to the definition's own input proxy.
+    - ``("dead_reroute", reroute_id)`` — a Reroute with no upstream link.
+    - ``("missing_set", get_id, var)`` — a GetNode whose variable no SetNode publishes.
+    - ``("primitive_no_widget", primitive_id)`` — resolves directly to a PrimitiveNode.
+    """
+    seen: set[str] = set()
+    for _ in range(_MAX_SPLICE_HOPS):
+        key = str(src_id)
+        if proxy_in_id is not None and key == proxy_in_id:
+            return ("in_proxy", src_slot)
+        node = nodes_by_id.get(key)
+        t = node.get("type") if node else None
+        if t == "Reroute":
+            if key in seen:
+                return ("ok", src_id, src_slot)
+            seen.add(key)
+            if key in reroute_sources:
+                src_id, src_slot = reroute_sources[key]
+                continue
+            return ("dead_reroute", key)
+        if t == "GetNode":
+            if key in seen:
+                return ("ok", src_id, src_slot)
+            seen.add(key)
+            var = get_vars.get(key)
+            if var in set_sources:
+                src_id, src_slot = set_sources[var]
+                continue
+            return ("missing_set", key, var)
+        if t == "PrimitiveNode":
+            return ("primitive_no_widget", key)
+        return ("ok", src_id, src_slot)
+    return ("ok", src_id, src_slot)
+
+
+@dataclass
+class _RenderCtx:
+    """Everything the per-node arg builders need to resolve one edge, for
+    either the top-level workflow (``proxy_in_id`` is ``None``) or one
+    subgraph definition's interior (``proxy_in_id`` is ``"-10"``)."""
+
+    graph: Any
+    link_map: dict[str, tuple]
+    nodes_by_id: dict[str, dict]
+    printable_ids: set[str]
+    binding_by_id: dict[str, str]
+    reroute_sources: dict[str, tuple]
+    set_sources: dict[str, tuple]
+    get_vars: dict[str, str]
+    proxy_in_id: str | None = None
+    proxy_in_names: dict[int, str] = field(default_factory=dict)
+
+    def proxy_in_name(self, slot: Any) -> str:
+        name = self.proxy_in_names.get(slot)
+        return name if name else f"slot{slot}"
+
+
+def _resolve_edge_text(src_id: Any, src_slot: Any, name: str, tgt_id: str, ctx: _RenderCtx) -> tuple:
+    """Resolve one edge to ``(ref_text, annotation, warning)``. ``ref_text`` is
+    ``None`` when the edge can't be resolved to a value (prints as ``None``)."""
+    outcome = _resolve_source(
+        src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
+    )
+    kind = outcome[0]
+    if kind == "ok":
+        _, rid, rslot = outcome
+        rid_s = str(rid)
+        if rid_s not in ctx.printable_ids:
+            return None, None, None
+        src_node = ctx.nodes_by_id.get(rid_s)
+        binding = ctx.binding_by_id.get(rid_s)
+        if src_node is None or binding is None:
+            return None, None, None
+        return _edge_ref(binding, src_node, src_node.get("type", ""), rslot, ctx.graph), None, None
+    if kind == "in_proxy":
+        return f"IN.{ctx.proxy_in_name(outcome[1])}", None, None
+    if kind == "dead_reroute":
+        return None, f" {name} unlinked via reroute {outcome[1]}", None
+    if kind == "missing_set":
+        get_id, var = outcome[1], outcome[2]
+        return (
+            None,
+            None,
+            f"node {tgt_id}: input '{name}' reads GetNode {get_id} variable '{var}' that no SetNode publishes",
+        )
+    if kind == "primitive_no_widget":
+        return (
+            None,
+            None,
+            f"node {tgt_id}: input {name!r} fed by PrimitiveNode {outcome[1]} without a widget; printed as None",
+        )
+    return None, None, None
+
+
+def _build_args(
+    node: dict, m: Any, ctx: _RenderCtx, warnings: list[str]
+) -> tuple[list[str], bool, list[str], list[tuple]]:
     """Node call arguments: link inputs (in the node's own input order) first,
-    then widgets. Returns ``(args, unknown)`` where ``unknown`` is True when the
-    class isn't in the catalog (or there is no catalog), which also determines
-    whether widgets print positionally as ``widgets=[...]``."""
+    then widgets. Returns ``(args, unknown, annotations, prim_hits)`` where
+    ``unknown`` is True when the class isn't in the catalog (or there is no
+    catalog), ``annotations`` are suffix strings to append to the line comment,
+    and ``prim_hits`` are ``(primitive_id, skipped_reason)`` pairs for
+    PrimitiveNode-into-widget splices found here."""
+    nid = str(node.get("id"))
     args: list[str] = []
+    annotations: list[str] = []
+    prim_hits: list[tuple] = []
+
+    # Pre-pass: widget-backed inputs. A link into one never overrides the
+    # node's own widget value (D9) EXCEPT when it resolves to the subgraph
+    # input proxy (D10) — that value genuinely comes from outside, there is no
+    # static default to fall back to.
+    widget_overrides: dict[str, str] = {}
+    for inp in node.get("inputs") or []:
+        if "widget" not in inp:
+            continue
+        name = inp.get("name")
+        link_id = inp.get("link")
+        if link_id is None:
+            continue
+        link = ctx.link_map.get(str(link_id))
+        if link is None:
+            continue
+        src_id, src_slot, _tgt_id, _tgt_slot = link
+        outcome = _resolve_source(
+            src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
+        )
+        if outcome[0] == "in_proxy":
+            widget_overrides[name] = f"IN.{ctx.proxy_in_name(outcome[1])}"
+        elif outcome[0] == "primitive_no_widget":
+            prim_id = outcome[1]
+            annotations.append(f" {name} from primitive {prim_id}")
+            prim_hits.append((prim_id, f"inlined into {nid}.{name}"))
+
     for inp in node.get("inputs") or []:
         name = inp.get("name")
         if "widget" in inp:
@@ -231,20 +450,17 @@ def _build_args(
         if link_id is None:
             args.append(f"{name}=None")
             continue
-        link = link_map.get(str(link_id))
+        link = ctx.link_map.get(str(link_id))
         if link is None:
             args.append(f"{name}=None")
             continue
         src_id, src_slot, _tgt_id, _tgt_slot = link
-        src_node = nodes_by_id.get(str(src_id))
-        if src_node is None or str(src_id) not in printable_ids:
-            # ui-only source (Reroute/GetNode/SetNode/PrimitiveNode) — no
-            # resolver yet, prints as unresolved. See module docstring.
-            args.append(f"{name}=None")
-            continue
-        binding = bindings[str(src_id)]
-        ref = _edge_ref(binding, src_node, src_node.get("type", ""), src_slot, graph)
-        args.append(f"{name}={ref}")
+        ref, ann, warn = _resolve_edge_text(src_id, src_slot, name, nid, ctx)
+        if warn:
+            warnings.append(warn)
+        if ann:
+            annotations.append(ann)
+        args.append(f"{name}={ref if ref is not None else 'None'}")
 
     class_type = node.get("type", "")
     widgets_values = node.get("widgets_values")
@@ -255,20 +471,321 @@ def _build_args(
             args.append(f"widgets={py_literal(positional)}")
         warnings.append(f"node {node.get('id')}: class {class_type!r} not in catalog; widgets printed positionally")
     else:
-        positional = _widgets_as_positional(widgets_values, graph, class_type)
+        positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
             value = positional[idx] if idx < len(positional) else None
             arg_name = "control_after_generate" if entry.port is None else entry.name
-            args.append(f"{arg_name}={py_literal(value)}")
-    return args, unknown
+            if arg_name in widget_overrides:
+                args.append(f"{arg_name}={widget_overrides[arg_name]}")
+            else:
+                args.append(f"{arg_name}={py_literal(value)}")
+    return args, unknown, annotations, prim_hits
+
+
+# ---------------------------------------------------------------------------
+# D10: subgraph instances and definition blocks
+# ---------------------------------------------------------------------------
+
+
+def _render_subgraph_instance_line(
+    node: dict, type_uuid: str, binding: str, ctx: _RenderCtx, warnings: list[str]
+) -> tuple:
+    """A subgraph instance's own line: exposed link inputs by name (or, when
+    the name isn't a Python identifier, collected into a trailing ``**{}``);
+    widget-backed exposed inputs print positionally from ``widgets_values``
+    (subgraphs are never in the catalog) unless their link resolves to the
+    enclosing definition's own input proxy, in which case that ref is used.
+    Returns ``(line, prim_hits)``."""
+    nid = str(node.get("id"))
+    title = node.get("title") or None
+    bracket = json.dumps(title, ensure_ascii=False) if title else json.dumps(nid)
+    prim_hits: list[tuple] = []
+    args: list[str] = []
+    extra: dict[str, str] = {}
+
+    inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
+    link_inputs = [inp for inp in inputs if "widget" not in inp]
+    widget_inputs = [inp for inp in inputs if "widget" in inp]
+
+    def _place(iname: str, text: str) -> None:
+        if _IDENT.match(iname) and not keyword.iskeyword(iname):
+            args.append(f"{iname}={text}")
+        else:
+            extra[iname] = text
+
+    for inp in link_inputs:
+        iname = inp.get("name") or ""
+        ref = None
+        link_id = inp.get("link")
+        if link_id is not None:
+            link = ctx.link_map.get(str(link_id))
+            if link is not None:
+                src_id, src_slot, _tgt_id, _tgt_slot = link
+                ref, _ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+                if warn:
+                    warnings.append(warn)
+        _place(iname, ref if ref is not None else "None")
+
+    widgets_values = node.get("widgets_values")
+    positional = widgets_values if isinstance(widgets_values, list) else []
+    for k, inp in enumerate(widget_inputs):
+        iname = inp.get("name") or ""
+        override = None
+        link_id = inp.get("link")
+        if link_id is not None:
+            link = ctx.link_map.get(str(link_id))
+            if link is not None:
+                src_id, src_slot, _tgt_id, _tgt_slot = link
+                outcome = _resolve_source(
+                    src_id,
+                    src_slot,
+                    ctx.nodes_by_id,
+                    ctx.reroute_sources,
+                    ctx.set_sources,
+                    ctx.get_vars,
+                    ctx.proxy_in_id,
+                )
+                if outcome[0] == "in_proxy":
+                    override = f"IN.{ctx.proxy_in_name(outcome[1])}"
+                elif outcome[0] == "primitive_no_widget":
+                    prim_hits.append((outcome[1], f"inlined into {nid}.{iname}"))
+        if override is not None:
+            text = override
+        else:
+            value = positional[k] if k < len(positional) else None
+            text = py_literal(value)
+        _place(iname, text)
+
+    if extra:
+        inner = ", ".join(f"{json.dumps(k, ensure_ascii=False)}: {v}" for k, v in extra.items())
+        args.append(f"**{{{inner}}}")
+
+    line = f"{binding} = Subgraph[{bracket}]({', '.join(args)})  # {nid} subgraph {type_uuid}"
+    return line, prim_hits
+
+
+def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
+    name = sg_def.get("name") or def_id
+    instances = sorted(state.instances_by_def.get(def_id, []), key=_sort_key)
+    first = state.first_instance_by_def.get(def_id, instances[0] if instances else def_id)
+    return (
+        f"# subgraph {def_id} {json.dumps(name, ensure_ascii=False)} — "
+        f"instances: {', '.join(instances)} (address inner nodes as {first}/<id>)"
+    )
+
+
+def _def_links(sg_def: dict) -> dict[str, tuple]:
+    """Normalise a definition's dict-shaped links into the array-tuple form
+    used everywhere else: ``{str(link_id): (origin_id, origin_slot, target_id, target_slot)}``."""
+    out: dict[str, tuple] = {}
+    for link in sg_def.get("links") or []:
+        if not isinstance(link, dict):
+            continue
+        lid = link.get("id")
+        if lid is None:
+            continue
+        out[str(lid)] = (link.get("origin_id"), link.get("origin_slot"), link.get("target_id"), link.get("target_slot"))
+    return out
+
+
+class _State:
+    """Cross-definition bookkeeping accumulated while rendering: the queue of
+    definitions still to render (in first-use order, growing as nested
+    instances are discovered), and the shared warnings/skipped/bindings lists
+    that end up on the returned ``PrintResult``."""
+
+    def __init__(
+        self, defs_by_id: dict[str, dict], warnings: list[str], skipped: list[dict], bindings: dict[str, str]
+    ) -> None:
+        self.defs_by_id = defs_by_id
+        self.warnings = warnings
+        self.skipped = skipped
+        self.bindings = bindings
+        self.def_order: list[str] = []
+        self.def_seen: set[str] = set()
+        self.def_depth: dict[str, int] = {}
+        self.instances_by_def: dict[str, list[str]] = {}
+        self.first_instance_by_def: dict[str, str] = {}
+        self.primitive_reason: dict[str, str] = {}
+
+    def register_instance(self, def_id: str, instance_id: str, depth: int) -> None:
+        self.instances_by_def.setdefault(def_id, []).append(instance_id)
+        if def_id not in self.def_seen:
+            self.def_seen.add(def_id)
+            self.first_instance_by_def[def_id] = instance_id
+            self.def_depth[def_id] = depth
+            self.def_order.append(def_id)
+
+
+def _render_node_line(n: dict, name: str, ctx: _RenderCtx, graph: Graph | None, state: _State) -> str:
+    """One printed line for a node that is not itself a (resolvable) subgraph
+    instance: a regular class call, or the ``Node[...]`` fallback for a
+    nested subgraph instance whose definition is missing."""
+    nid = str(n.get("id"))
+    t = n.get("type", "")
+    m = graph.node(t) if graph is not None else None
+    args, unknown, annotations, prim_hits = _build_args(n, m, ctx, state.warnings)
+    for prim_id, reason in prim_hits:
+        state.primitive_reason.setdefault(prim_id, reason)
+    line = f"{name} = {class_expr(t)}({', '.join(args)})  # {nid}"
+    title = n.get("title")
+    if title and title != t:
+        line += f" {json.dumps(title, ensure_ascii=False)}"
+    mode = n.get("mode")
+    if mode in _MODE_LABELS:
+        line += f" mode={_MODE_LABELS[mode]}"
+    if unknown:
+        line += " class not in catalog"
+    for ann in annotations:
+        line += ann
+    return line
+
+
+def _render_nodes(
+    order: list[dict],
+    ctx: _RenderCtx,
+    graph: Graph | None,
+    defs_by_id: dict[str, dict],
+    binding_by_id: dict[str, str],
+    state: _State,
+    depth: int,
+) -> list[str]:
+    """Render one printed line per node in ``order``, branching to the
+    subgraph-instance format when the node's type resolves to a present
+    definition. Shared between the top-level workflow and a definition's
+    interior."""
+    lines: list[str] = []
+    for n in order:
+        nid = str(n.get("id"))
+        t = n.get("type", "")
+        sg_def = defs_by_id.get(t) if is_subgraph_uuid(t) else None
+        name = binding_by_id[nid]
+        if sg_def is not None:
+            line, prim_hits = _render_subgraph_instance_line(n, t, name, ctx, state.warnings)
+            for prim_id, reason in prim_hits:
+                state.primitive_reason.setdefault(prim_id, reason)
+            state.register_instance(t, nid, depth)
+        else:
+            line = _render_node_line(n, name, ctx, graph, state)
+        lines.append(line)
+    return lines
+
+
+def _build_bindings(order: list[dict], defs_by_id: dict[str, dict]) -> dict[str, str]:
+    """Local binding names for one node list, in print order: a subgraph
+    instance binds off its own title (falling back to ``"subgraph"``);
+    everything else binds off its class type, as usual."""
+    used: dict[str, int] = {}
+    binding_by_id: dict[str, str] = {}
+    for n in order:
+        nid = str(n.get("id"))
+        t = n.get("type", "")
+        sg_def = defs_by_id.get(t) if is_subgraph_uuid(t) else None
+        if sg_def is not None:
+            title = n.get("title") or None
+            name = binding_name(title or "subgraph", used)
+        else:
+            name = binding_name(t, used)
+        binding_by_id[nid] = name
+    return binding_by_id
+
+
+def _render_definition_block(
+    def_id: str, sg_def: dict, graph: Graph | None, state: _State, depth: int
+) -> tuple[list[str], int]:
+    """Render one subgraph definition's interior: its own nodes (recursing for
+    nested subgraph instances via the same ``_render_nodes``), its notes, its
+    UI-only-splice skips, and ``OUT.<name> = <ref>`` lines for each of its
+    declared outputs. Returns ``(lines, printable_node_count)``."""
+    if depth > _MAX_SUBGRAPH_DEPTH:
+        raise PrintUnsupported(["subgraph nesting deeper than 10"])
+
+    interior_nodes = [n for n in sg_def.get("nodes") or [] if isinstance(n, dict)]
+    all_links = _def_links(sg_def)
+
+    validate_links: list[list] = []
+    for lid, (oid, oslot, tid, tslot) in all_links.items():
+        if str(oid) == _PROXY_IN or str(tid) == _PROXY_OUT:
+            continue
+        validate_links.append([lid, oid, oslot, tid, tslot])
+
+    reasons = _validate(interior_nodes, validate_links, state.defs_by_id, check_subgraph_refs=False)
+    if reasons:
+        raise PrintUnsupported(reasons)
+
+    printable = [n for n in interior_nodes if n.get("type") not in _UI_ONLY]
+    notes = [n for n in interior_nodes if n.get("type") in _NOTE_TYPES]
+    ui_only_skipped = [n for n in interior_nodes if n.get("type") in _UI_ONLY and n.get("type") not in _NOTE_TYPES]
+
+    order = _toposort(printable, all_links)
+
+    nodes_by_id = {str(n.get("id")): n for n in interior_nodes}
+    printable_ids = {str(n.get("id")) for n in printable}
+
+    reroute_sources = _collect_reroute_sources(interior_nodes, all_links)
+    set_sources, get_vars = _collect_get_set(interior_nodes, all_links)
+
+    proxy_in_names = {i: inp.get("name") for i, inp in enumerate(sg_def.get("inputs") or []) if isinstance(inp, dict)}
+    proxy_out_names = {i: o.get("name") for i, o in enumerate(sg_def.get("outputs") or []) if isinstance(o, dict)}
+
+    binding_by_id = _build_bindings(order, state.defs_by_id)
+
+    ctx = _RenderCtx(
+        graph=graph,
+        link_map=all_links,
+        nodes_by_id=nodes_by_id,
+        printable_ids=printable_ids,
+        binding_by_id=binding_by_id,
+        reroute_sources=reroute_sources,
+        set_sources=set_sources,
+        get_vars=get_vars,
+        proxy_in_id=_PROXY_IN,
+        proxy_in_names=proxy_in_names,
+    )
+
+    lines = _render_nodes(order, ctx, graph, state.defs_by_id, binding_by_id, state, depth + 1)
+
+    for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
+        lines.append(_note_comment(n))
+        state.skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "note"})
+    for n in ui_only_skipped:
+        t = n.get("type")
+        nid = str(n.get("id"))
+        reason = state.primitive_reason.get(nid, "spliced") if t == "PrimitiveNode" else "spliced"
+        state.skipped.append({"id": nid, "type": t, "reason": reason})
+
+    out_sources: dict[Any, tuple] = {}
+    for oid, oslot, tid, tslot in all_links.values():
+        if str(tid) != _PROXY_OUT:
+            continue
+        if tslot not in out_sources:
+            out_sources[tslot] = (oid, oslot)
+    first_instance = state.first_instance_by_def.get(def_id, def_id)
+    for slot in sorted(out_sources, key=_sort_key):
+        oid, oslot = out_sources[slot]
+        out_name = proxy_out_names.get(slot) or f"out{slot}"
+        ref, _ann, warn = _resolve_edge_text(oid, oslot, out_name, f"{def_id} OUT", ctx)
+        if warn:
+            state.warnings.append(warn)
+        lines.append(f"OUT.{out_name} = {ref if ref is not None else 'None'}")
+
+    for nid, name in binding_by_id.items():
+        state.bindings[f"{first_instance}/{name}"] = f"{first_instance}/{nid}"
+
+    return lines, len(printable)
 
 
 def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     nodes = workflow.get("nodes") or []
     links = workflow.get("links") or []
+    defs_by_id = {
+        sg.get("id"): sg
+        for sg in (workflow.get("definitions") or {}).get("subgraphs") or []
+        if isinstance(sg, dict) and sg.get("id")
+    }
 
-    reasons = _validate(nodes, links)
+    reasons = _validate(nodes, links, defs_by_id)
     if reasons:
         raise PrintUnsupported(reasons)
 
@@ -286,42 +803,47 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     nodes_by_id = {str(n.get("id")): n for n in nodes}
     printable_ids = {str(n.get("id")) for n in printable}
 
+    reroute_sources = _collect_reroute_sources(nodes, link_map)
+    set_sources, get_vars = _collect_get_set(nodes, link_map)
+
     # binding_name is called once per node, in topological order, so the
     # dedupe suffixes (_2, _3, ...) match print order.
-    used: dict[str, int] = {}
-    bindings: dict[str, str] = {}
-    binding_by_id: dict[str, str] = {}
-    for n in order:
-        nid = str(n.get("id"))
-        name = binding_name(n.get("type", ""), used)
-        bindings[name] = nid
-        binding_by_id[nid] = name
+    binding_by_id = _build_bindings(order, defs_by_id)
+    bindings: dict[str, str] = {name: nid for nid, name in binding_by_id.items()}
+
+    ctx = _RenderCtx(
+        graph=graph,
+        link_map=link_map,
+        nodes_by_id=nodes_by_id,
+        printable_ids=printable_ids,
+        binding_by_id=binding_by_id,
+        reroute_sources=reroute_sources,
+        set_sources=set_sources,
+        get_vars=get_vars,
+    )
 
     warnings: list[str] = []
-    lines: list[str] = []
-    for n in order:
-        nid = str(n.get("id"))
-        t = n.get("type", "")
-        m = graph.node(t) if graph is not None else None
-        args, unknown = _build_args(n, m, graph, binding_by_id, nodes_by_id, printable_ids, link_map, warnings)
-        name = binding_by_id[nid]
-        line = f"{name} = {class_expr(t)}({', '.join(args)})  # {n.get('id')}"
-        title = n.get("title")
-        if title and title != t:
-            line += f" {json.dumps(title, ensure_ascii=False)}"
-        mode = n.get("mode")
-        if mode in _MODE_LABELS:
-            line += f" mode={_MODE_LABELS[mode]}"
-        if unknown:
-            line += " class not in catalog"
-        lines.append(line)
-
     skipped: list[dict] = []
+    state = _State(defs_by_id, warnings, skipped, bindings)
+
+    lines = _render_nodes(order, ctx, graph, defs_by_id, binding_by_id, state, depth=1)
+
     for n in sorted(notes, key=lambda n: _sort_key(str(n.get("id")))):
         lines.append(_note_comment(n))
         skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "note"})
     for n in ui_only_skipped:
-        skipped.append({"id": str(n.get("id")), "type": n.get("type"), "reason": "ui-only"})
+        t = n.get("type")
+        nid = str(n.get("id"))
+        reason = state.primitive_reason.get(nid, "spliced") if t == "PrimitiveNode" else "spliced"
+        skipped.append({"id": nid, "type": t, "reason": reason})
+
+    node_count = len(printable)
+    for def_id in state.def_order:
+        sg_def = defs_by_id[def_id]
+        lines.append(_definition_header(def_id, sg_def, state))
+        block_lines, block_count = _render_definition_block(def_id, sg_def, graph, state, state.def_depth[def_id])
+        lines.extend("    " + bl for bl in block_lines)
+        node_count += block_count
 
     source = "\n".join(lines) + "\n"
-    return PrintResult(source=source, bindings=bindings, node_count=len(printable), skipped=skipped, warnings=warnings)
+    return PrintResult(source=source, bindings=bindings, node_count=node_count, skipped=skipped, warnings=warnings)

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -46,8 +46,6 @@ _IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # proxy nodes — matches workflow_to_api._SUBGRAPH_INPUT_NODE_ID / _OUTPUT_NODE_ID.
 _PROXY_IN = "-10"
 _PROXY_OUT = "-20"
-_MAX_SUBGRAPH_DEPTH = 10
-_MAX_SPLICE_HOPS = 100
 
 
 @dataclass(frozen=True)
@@ -263,7 +261,7 @@ def _edge_ref(binding: str, src_node: dict, src_type: str, slot: int, ctx: _Rend
         m = ctx.graph.node(src_type)
         if m is not None and 0 <= slot < len(m.outputs):
             out_name = m.outputs[slot].name
-    if out_name and _IDENT.match(out_name) and not keyword.iskeyword(out_name):
+    if out_name and isinstance(out_name, str) and _IDENT.match(out_name) and not keyword.iskeyword(out_name):
         return f"{binding}.{out_name}", warning
     return f"{binding}.out[{slot}]", warning
 
@@ -374,7 +372,7 @@ def _resolve_source(
     it bottoms out.
     """
     seen: set[str] = set()
-    for _ in range(_MAX_SPLICE_HOPS):
+    while True:
         key = str(src_id)
         if proxy_in_id is not None and key == proxy_in_id:
             return ("in_proxy", src_slot)
@@ -400,7 +398,6 @@ def _resolve_source(
         if t == "PrimitiveNode":
             return ("primitive_no_widget", key)
         return ("ok", src_id, src_slot)
-    return ("ok", src_id, src_slot)
 
 
 def _splice_link_map(
@@ -687,6 +684,7 @@ def _render_subgraph_instance_line(
     widget-backed exposed inputs print positionally from ``widgets_values``
     (subgraphs are never in the catalog) unless their link resolves to the
     enclosing definition's own input proxy, in which case that ref is used.
+    Gets the same ``mode=bypass``/``mode=mute`` suffix as a regular node.
     Any D9 annotation from resolving a link input (e.g. a dead-end Reroute)
     is appended to the line, same as a regular node. Returns ``(line, prim_hits)``."""
     nid = str(node.get("id"))
@@ -751,6 +749,9 @@ def _render_subgraph_instance_line(
         args.append(f"**{{{inner}}}")
 
     line = f"{binding} = Subgraph[{bracket}]({', '.join(args)})  # {nid} subgraph {type_uuid}"
+    mode = node.get("mode")
+    if mode in _MODE_LABELS:
+        line += f" mode={_MODE_LABELS[mode]}"
     for ann in annotations:
         line += ann
     return line, prim_hits
@@ -764,7 +765,8 @@ def _render_missing_subgraph_line(
     resolve by the instance's own input name (non-identifier names via
     ``**{}``, same as a resolved instance); widget-backed instance inputs
     print positionally as a single ``widgets=[...]`` (there's no definition to
-    name them against). Any D9 annotation is appended, same as a resolved
+    name them against). Gets the same ``mode=bypass``/``mode=mute`` suffix as a
+    resolved instance. Any D9 annotation is appended, same as a resolved
     instance. The warning uses this node's fully-qualified address."""
     nid = str(node.get("id"))
     args: list[str] = []
@@ -800,6 +802,9 @@ def _render_missing_subgraph_line(
     warnings.append(f"node {ctx.qualify(nid)}: subgraph definition {type_uuid} missing; printed opaquely")
     call = f"{binding} = Subgraph[{json.dumps(type_uuid)}]({', '.join(args)})"
     line = f"{call}  # {nid} subgraph {type_uuid} definition missing"
+    mode = node.get("mode")
+    if mode in _MODE_LABELS:
+        line += f" mode={_MODE_LABELS[mode]}"
     for ann in annotations:
         line += ann
     return line
@@ -975,10 +980,14 @@ def _render_definition_block(
     """Render one subgraph definition's interior: its own nodes (recursing for
     nested subgraph instances via the same ``_render_nodes``), its notes, its
     UI-only-splice skips, and ``OUT.<name> = <ref>`` lines for each of its
-    declared outputs. Returns ``(lines, printable_node_count)``."""
-    if depth > _MAX_SUBGRAPH_DEPTH:
-        raise PrintUnsupported(["subgraph nesting deeper than 10"])
+    declared outputs. Returns ``(lines, printable_node_count)``.
 
+    No depth cap: ``state.def_seen`` (see ``_State.register_instance``) already
+    dedupes a definition to its first occurrence in ``state.def_order``, so a
+    self-referential (or mutually-referential) subgraph chain can't grow that
+    queue without bound — depth only grows with genuinely distinct nesting
+    levels, and capping it would misfire on legitimate deep nesting instead of
+    catching anything a cycle could cause."""
     interior_nodes = [n for n in sg_def.get("nodes") or [] if isinstance(n, dict)]
     all_links = _def_links(sg_def)
 
@@ -1062,13 +1071,21 @@ def _render_definition_block(
 
 
 def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
-    nodes = workflow.get("nodes") or []
+    warnings: list[str] = []
+
+    raw_nodes = workflow.get("nodes") or []
+    nodes = [n for n in raw_nodes if isinstance(n, dict)]
+    if len(nodes) != len(raw_nodes):
+        warnings.append(f"workflow: ignoring {len(raw_nodes) - len(nodes)} non-object node entries")
+
     links = workflow.get("links") or []
-    defs_by_id = {
-        sg.get("id"): sg
-        for sg in (workflow.get("definitions") or {}).get("subgraphs") or []
-        if isinstance(sg, dict) and sg.get("id")
-    }
+
+    definitions = workflow.get("definitions")
+    if definitions is not None and not isinstance(definitions, dict):
+        warnings.append("workflow: ignoring non-object definitions block")
+        definitions = None
+    subgraphs = definitions.get("subgraphs") if definitions else None
+    defs_by_id = {sg.get("id"): sg for sg in (subgraphs or []) if isinstance(sg, dict) and sg.get("id")}
 
     reasons = _validate(nodes, links)
     if reasons:
@@ -1108,7 +1125,6 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
         get_vars=get_vars,
     )
 
-    warnings: list[str] = []
     skipped: list[dict] = []
     state = _State(defs_by_id, warnings, skipped, bindings)
 

--- a/tests/comfy_cli/command/test_workflow_print_cmd.py
+++ b/tests/comfy_cli/command/test_workflow_print_cmd.py
@@ -127,6 +127,29 @@ def test_print_select_in_pretty_mode_prints_only_the_selection():
     assert '"ksampler": "3"' in result.output
 
 
+def test_print_select_source_pretty_mode_strips_terminal_controls(tmp_path):
+    # A note's title/text goes straight into `source` as a comment without
+    # passing through `json.dumps` escaping, so an escape sequence in it
+    # would otherwise reach the terminal raw via `--select source` in pretty
+    # mode (the non-select pretty path already strips `res.source` itself;
+    # `--select` bypassed that stripping before this fix).
+    wf = json.loads(SD15.read_text())
+    mutated = False
+    for n in wf["nodes"]:
+        if n.get("type") == "MarkdownNote":
+            n["widgets_values"][0] = "\x1b[31mEVIL\x1b[0m rest of note"
+            mutated = True
+            break
+    assert mutated, "fixture has no MarkdownNote to mutate"
+    p = _write_workflow(tmp_path, wf)
+
+    _force_pretty_renderer()
+    result = CliRunner().invoke(workflow_cmd.app, ["print", str(p), "--input", str(SD15_OI), "--select", "source"])
+    assert result.exit_code == 0, result.output
+    assert "\x1b" not in result.output
+    assert "EVIL" in result.output
+
+
 def test_print_rejects_api_format(tmp_path, capsys):
     p = _write_workflow(tmp_path, {"3": {"class_type": "KSampler", "inputs": {}}})
     env = _run(["print", str(p), "--input", str(SD15_OI)], capsys, expect_ok=False)

--- a/tests/comfy_cli/command/test_workflow_print_cmd.py
+++ b/tests/comfy_cli/command/test_workflow_print_cmd.py
@@ -156,6 +156,12 @@ def test_print_unsupported_lists_reasons(tmp_path, capsys):
     ]
 
 
+def test_print_rejects_unknown_format(capsys):
+    env = _run(["print", str(SD15), "--input", str(SD15_OI), "--format", "json"], capsys, expect_ok=False)
+    assert env["error"]["code"] == "workflow_print_unsupported"
+    assert env["error"]["details"]["reasons"] == ["format 'json'"]
+
+
 def test_print_payload_validates_against_schema(capsys):
     import jsonschema
 

--- a/tests/comfy_cli/command/test_workflow_print_cmd.py
+++ b/tests/comfy_cli/command/test_workflow_print_cmd.py
@@ -1,0 +1,165 @@
+"""Tests for `comfy workflow print` — rendering a workflow as Python-like source.
+
+The pure printer (`comfy_cli.workflow_print`) has its own exhaustive test suite
+in `tests/comfy_cli/test_workflow_print.py`. This file only covers the CLI
+wiring: envelope shape, `--select`, pretty-mode verbatim source, the
+frontend-format guard, and the `workflow_print_unsupported` error path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.output.renderer import (
+    OutputMode,
+    Renderer,
+    reset_renderer_for_testing,
+    set_renderer,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+SD15 = FIXTURES / "sd15_ui_workflow.json"
+SD15_OI = FIXTURES / "sd15_object_info.json"
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _force_pretty_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=True,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=False,
+    )
+    r.mode = OutputMode.PRETTY
+    set_renderer(r)
+    return r
+
+
+def _write_workflow(tmp_path: Path, data: dict, name: str = "test.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return p
+
+
+def _run(args: list[str], capsys, expect_ok: bool = True) -> dict[str, Any]:
+    _force_json_renderer()
+    runner = CliRunner()
+    result = runner.invoke(workflow_cmd.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    lines = [ln for ln in captured.strip().splitlines() if ln.strip()]
+    for line in reversed(lines):
+        try:
+            env = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if expect_ok:
+            assert env.get("ok") is True, env
+        return env
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:500]})")
+
+
+def test_print_json_envelope(capsys):
+    env = _run(["print", str(SD15), "--input", str(SD15_OI)], capsys)
+    assert env["ok"] is True and env["command"] == "workflow print"
+    d = env["data"]
+    assert d["format"] == "py" and d["node_count"] == 7
+    assert (
+        d["source"].splitlines()[0]
+        == 'checkpoint_loader_simple = CheckpointLoaderSimple(ckpt_name="v1-5-pruned-emaonly-fp16.safetensors")  # 4'
+    )
+    assert d["bindings"]["ksampler"] == "3"
+    assert d["workflow"].endswith("sd15_ui_workflow.json")
+
+
+def test_print_select_projects(capsys):
+    env = _run(["print", str(SD15), "--input", str(SD15_OI), "--select", "bindings"], capsys)
+    assert env["data"] == {
+        "checkpoint_loader_simple": "4",
+        "empty_latent_image": "5",
+        "clip_text_encode": "6",
+        "clip_text_encode_2": "7",
+        "ksampler": "3",
+        "vae_decode": "8",
+        "save_image": "9",
+    }
+
+
+def test_print_pretty_prints_source_verbatim(capsys):
+    _force_pretty_renderer()
+    result = CliRunner().invoke(workflow_cmd.app, ["print", str(SD15), "--input", str(SD15_OI)])
+    assert result.exit_code == 0, result.output
+    assert "Node[" not in result.output  # sanity: no rich-markup mangling of brackets
+    assert "ksampler = KSampler(" in result.output and "  # 3" in result.output
+
+
+def test_print_rejects_api_format(tmp_path, capsys):
+    p = _write_workflow(tmp_path, {"3": {"class_type": "KSampler", "inputs": {}}})
+    env = _run(["print", str(p), "--input", str(SD15_OI)], capsys, expect_ok=False)
+    assert env["error"]["code"] == "workflow_not_frontend_format"
+
+
+def test_print_unsupported_lists_reasons(tmp_path, capsys):
+    wf = {
+        "nodes": [
+            {"id": 1, "type": "workflow>Grp", "inputs": [], "outputs": [], "widgets_values": []},
+            {
+                "id": 2,
+                "type": "VAEDecode",
+                "inputs": [{"name": "samples", "type": "LATENT", "link": 7}],
+                "outputs": [],
+                "widgets_values": [],
+            },
+        ],
+        "links": [[7, 99, 0, 2, 0, "LATENT"]],
+        "version": 0.4,
+    }
+    env = _run(["print", str(_write_workflow(tmp_path, wf)), "--input", str(SD15_OI)], capsys, expect_ok=False)
+    assert env["error"]["code"] == "workflow_print_unsupported"
+    assert env["error"]["details"]["reasons"] == [
+        "node 1 is a legacy group node (workflow>Grp)",
+        "link 7 references missing node 99",
+    ]
+
+
+def test_print_payload_validates_against_schema(capsys):
+    import jsonschema
+
+    from comfy_cli.discovery import COMMAND_SCHEMAS
+
+    assert COMMAND_SCHEMAS["comfy workflow print"] == "workflow"
+    schema = json.loads((Path(workflow_cmd.__file__).parent.parent / "schemas" / "workflow.json").read_text())
+    env = _run(["print", str(SD15), "--input", str(SD15_OI)], capsys)
+    jsonschema.Draft202012Validator(schema).validate(env["data"])
+
+
+def test_print_help_mentions_only_real_commands():
+    from comfy_cli.help_json import HELP_EXAMPLES
+
+    assert "comfy workflow print" in HELP_EXAMPLES

--- a/tests/comfy_cli/command/test_workflow_print_cmd.py
+++ b/tests/comfy_cli/command/test_workflow_print_cmd.py
@@ -119,6 +119,14 @@ def test_print_pretty_prints_source_verbatim(capsys):
     assert "ksampler = KSampler(" in result.output and "  # 3" in result.output
 
 
+def test_print_select_in_pretty_mode_prints_only_the_selection():
+    _force_pretty_renderer()
+    result = CliRunner().invoke(workflow_cmd.app, ["print", str(SD15), "--input", str(SD15_OI), "--select", "bindings"])
+    assert result.exit_code == 0, result.output
+    assert "ksampler = KSampler(" not in result.output
+    assert '"ksampler": "3"' in result.output
+
+
 def test_print_rejects_api_format(tmp_path, capsys):
     p = _write_workflow(tmp_path, {"3": {"class_type": "KSampler", "inputs": {}}})
     env = _run(["print", str(p), "--input", str(SD15_OI)], capsys, expect_ok=False)

--- a/tests/comfy_cli/command/test_workflow_saved.py
+++ b/tests/comfy_cli/command/test_workflow_saved.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import io
 import json
 import urllib.error
+from pathlib import Path
 from typing import Any
 
+import jsonschema
 import pytest
 import typer
 from typer.testing import CliRunner
@@ -33,6 +35,11 @@ def reset_singleton():
     reset_renderer_for_testing()
     yield
     reset_renderer_for_testing()
+
+
+_WORKFLOW_SCHEMA = json.loads(
+    (Path(__file__).resolve().parents[3] / "comfy_cli" / "schemas" / "workflow.json").read_text()
+)
 
 
 def _force_json_renderer():
@@ -307,6 +314,10 @@ class TestLocalGet:
         assert env["data"]["node_count"] is None
         assert any(w["code"] == "workflow_content_not_json" for w in env["data"].get("warnings", []))
         assert out.read_bytes() == b"<html>nope</html>"
+        # node_count: null must validate against the shared "workflow" schema
+        # (comfy workflow print resolves to the same schema and can also emit
+        # null) — regression guard for a schema that only allowed "integer".
+        jsonschema.Draft202012Validator(_WORKFLOW_SCHEMA).validate(env["data"])
 
     def test_non_utf8_body_does_not_crash(self, local_target, tmp_path, monkeypatch, capsys):
         # json.loads on non-UTF-8 bytes raises UnicodeDecodeError, not JSONDecodeError.

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -398,7 +398,12 @@ def test_subgraph_instance_and_definition(sd15_graph):
     assert '**{"images.image0":' in inst
     # definition block printed once, names its instances and the address form
     assert "# subgraph d33c1791-dfd2-4102-8540-aa63e4434cd2" in src
+    # item 6: the header states BOTH address forms — inner-node ids and the
+    # (differently shaped) keys the `bindings` map uses.
     assert "instances: 10" in src and "address inner nodes as 10/<id>" in src
+    header = next(ln for ln in src.splitlines() if ln.startswith("# subgraph d33c1791"))
+    assert header.endswith("(address inner nodes as 10/<id>; bindings keyed 10/<name>)")
+    assert any(k.startswith("10/") and res.bindings[k].startswith("10/") for k in res.bindings)
     assert "IN.value" in src and "OUT.IMAGE = " in src
     # inner nodes are addressable
     assert any(v.startswith("10/") or "/" in v for v in res.bindings.values())
@@ -418,8 +423,10 @@ def test_subgraph_instance_and_definition(sd15_graph):
     # da09b826 ("Batch Prompt Iterator") is instantiated only by inner node 3
     # of instance 10 — its header must show the fully qualified address, and
     # inner-node addressing follows the same qualified path.
-    assert '# subgraph da09b826-d678-40e0-a4e4-5f2178043ab6 "Batch Prompt Iterator" — instances: 10/3' in src
-    assert "address inner nodes as 10/3/<id>" in src
+    assert (
+        '# subgraph da09b826-d678-40e0-a4e4-5f2178043ab6 "Batch Prompt Iterator" — instances: 10/3 '
+        "(address inner nodes as 10/3/<id>; bindings keyed 10/3/<name>)" in src
+    )
     assert any(v.startswith("10/3/") for v in res.bindings.values())
     # bracket/binding for that nested instance (no title of its own) fall back
     # to the definition's own name, not the bare inner id.
@@ -609,3 +616,243 @@ def test_definition_lists_every_instance_address(sd15_graph):
     header = next(ln for ln in res.source.splitlines() if ln.startswith(f"# subgraph {inner_uuid}"))
     assert "100/5" in header
     assert "200" in header
+
+
+# ---------------------------------------------------------------------------
+# Final review wave: malformed input, dotted widget names, nested subgraph
+# instance addressing, catalog defaults, bypass markers.
+# ---------------------------------------------------------------------------
+
+SEEDREAM_GOLDEN_LINE = (
+    'byte_dance_seedream_node_v2 = ByteDanceSeedreamNodeV2(prompt="A sci-fi cyberpunk graphic design poster. '
+    "In the center, a striking portrait of a female android with glossy, liquid chrome skin. A vivid swirling "
+    "streak of neon orange, yellow, and pink liquid paint brush stroke horizontally covers her eyes, soft "
+    "smudged color overlay with smooth flowing pigment texture, no cracks or broken facial surfaces. The "
+    "background is a dark, textured charcoal gray. Behind the central figure, large bold white futuristic "
+    'typography reads \\"Seedream 5.0 Pro\\" with a subtle digital glitch and halftone texture. The composition '
+    "is decorated with technical HUD elements, thin white lines, geometric wireframe diagrams, barcodes, and "
+    "small sci-fi text boxes. Semi-transparent glassy spheres with grid textures overlap the foreground, "
+    'creating depth. The overall mood is high-tech, dystopian, and avant-garde.", model="seedream 5.0 pro", '
+    'seed=0, control_after_generate="randomize", watermark=False, thinking=True, '
+    '**{"model.images.image_1": None, "model.size_preset": "(1K) 1024x1024 (1:1)", "model.width": 2048, '
+    '"model.height": 2048})  # 1'
+)
+
+
+def test_seedream_dynamic_combo_golden():
+    # A dynamic combo expands into DOTTED sub-widget names ("model.size_preset")
+    # that are not Python identifiers: they must land in the trailing **{...},
+    # not be pasted in as `model.size_preset=...` (which does not parse).
+    import ast
+
+    wf = json.loads((FIXTURES / "seedream_5_0_pro_t2i_ui.json").read_text())
+    graph = Graph.from_object_info(json.loads((FIXTURES / "object_info_bytedance_seedream_v2.json").read_text()))
+    res = render_py(wf, graph)
+    ast.parse(res.source)  # the whole render is syntactically valid Python
+
+    line = next(ln for ln in res.source.splitlines() if ln.endswith("  # 1"))
+    assert line == SEEDREAM_GOLDEN_LINE
+    kwargs = line.split("**{", 1)[1]
+    for frag in (
+        '"model.size_preset": "(1K) 1024x1024 (1:1)"',
+        '"model.width": 2048',
+        '"model.height": 2048',
+    ):
+        assert frag in kwargs
+    assert "model.size_preset=" not in line and "model.width=" not in line
+    # R11: `thinking` has no serialized widget value; the catalog default prints.
+    assert "thinking=True" in line
+
+
+def test_non_identifier_proxy_names_use_subscripts(sd15_graph):
+    uuid = "22222222-3333-4444-5555-666666666666"
+    sg_def = {
+        "id": uuid,
+        "name": "Odd Names",
+        "inputs": [{"name": "my value", "type": "LATENT"}],
+        "outputs": [{"name": "final image", "type": "IMAGE"}],
+        "nodes": [
+            _node(
+                7,
+                "VAEDecode",
+                inputs=[
+                    {"name": "samples", "type": "LATENT", "link": 1},
+                    {"name": "vae", "type": "VAE", "link": None},
+                ],
+                outputs=[{"name": "IMAGE", "type": "IMAGE"}],
+            )
+        ],
+        "links": [
+            {"id": 1, "origin_id": -10, "origin_slot": 0, "target_id": 7, "target_slot": 0},
+            {"id": 2, "origin_id": 7, "origin_slot": 0, "target_id": -20, "target_slot": 0},
+        ],
+    }
+    wf = {
+        "nodes": [_node(10, uuid, inputs=[{"name": "my value", "type": "LATENT", "link": None}])],
+        "links": [],
+        "definitions": {"subgraphs": [sg_def]},
+        "version": 0.4,
+    }
+    src = render_py(wf, sd15_graph).source
+    assert 'vae_decode = VAEDecode(samples=IN["my value"], vae=None)  # 7' in src
+    assert 'OUT["final image"] = vae_decode' in src
+    assert "IN.my value" not in src and "OUT.final image" not in src
+
+
+@pytest.mark.parametrize("slot", [None, "0"])
+def test_non_integer_link_slot_is_refused_not_raised(sd15_graph, slot):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [7]}], widgets=[1, 1, 1]
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 7}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[7, 1, slot, 2, 0, "LATENT"]],
+    )
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["link 7 has a non-integer slot"]
+
+
+def test_malformed_input_entry_is_skipped_with_warning(sd15_graph):
+    n = _node(2, "VAEDecode", inputs=[{"name": "samples", "type": "LATENT", "link": None}])
+    n["inputs"].extend(["junk", 7])
+    res = render_py(_mini([n], []), sd15_graph)
+    assert "vae_decode = VAEDecode(samples=None)  # 2" in res.source
+    assert "node 2: ignoring malformed input entry 'junk'" in res.warnings
+    assert "node 2: ignoring malformed input entry 7" in res.warnings
+
+
+def test_input_without_name_key_does_not_raise(sd15_graph):
+    wf = _mini([_node(2, "VAEDecode", inputs=[{"type": "LATENT", "link": None}])], [])
+    res = render_py(wf, sd15_graph)
+    assert 'vae_decode = VAEDecode(**{"": None})  # 2' in res.source
+    assert res.warnings == []
+
+
+def test_duplicate_node_id_is_refused(sd15_graph):
+    wf = _mini(
+        [
+            _node(1, "EmptyLatentImage", widgets=[1, 1, 1]),
+            _node(1, "VAEDecode", inputs=[{"name": "samples", "type": "LATENT", "link": None}]),
+        ],
+        [],
+    )
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["duplicate node id 1"]
+
+
+def test_nested_definition_expands_through_every_ancestor_instance(sd15_graph):
+    # Outer is instantiated TWICE (100, 200); its interior — rendered once,
+    # under the first instance — holds Inner at inner id 5. Inner therefore
+    # really exists at 100/5 AND 200/5, and its header must say so.
+    inner_uuid = "33333333-4444-5555-6666-777777777777"
+    outer_uuid = "44444444-5555-6666-7777-888888888888"
+    outer_def = {
+        "id": outer_uuid,
+        "name": "Outer",
+        "nodes": [_node(5, inner_uuid)],
+        "links": [],
+        "inputs": [],
+        "outputs": [],
+    }
+    inner_def = {"id": inner_uuid, "name": "Inner", "nodes": [], "links": [], "inputs": [], "outputs": []}
+    wf = {
+        "nodes": [_node(100, outer_uuid), _node(200, outer_uuid)],
+        "links": [],
+        "definitions": {"subgraphs": [outer_def, inner_def]},
+        "version": 0.4,
+    }
+    res = render_py(wf, sd15_graph)
+    header = next(ln for ln in res.source.splitlines() if ln.strip().startswith(f"# subgraph {inner_uuid}"))
+    assert "instances: 100/5, 200/5" in header
+    # bindings may still key off the first instance only
+    assert "address inner nodes as 100/5/<id>; bindings keyed 100/5/<name>" in header
+
+
+def test_bypassed_source_is_marked_on_the_consumer(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1,
+                "EmptyLatentImage",
+                outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}],
+                widgets=[64, 64, 1],
+                mode=4,
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 1, 0, 2, 0, "LATENT"]],
+    )
+    src = render_py(wf, sd15_graph).source
+    # the link still prints as wired; the marker is the only difference
+    assert "vae_decode = VAEDecode(samples=empty_latent_image, vae=None)  # 2 samples via bypassed 1" in src
+
+
+def test_bypass_marker_does_not_touch_the_sd15_golden(sd15_workflow, sd15_graph):
+    res = render_py(sd15_workflow, sd15_graph)
+    body = "\n".join(ln for ln in res.source.splitlines() if not ln.startswith("# note")) + "\n"
+    assert body == SD15_GOLDEN
+    assert "via bypassed" not in res.source
+
+
+def test_definition_output_warning_is_not_double_qualified(sd15_graph):
+    # A GetNode with no SetNode wired straight to the definition's output: the
+    # warning names the OUT pseudo-target, and must not repeat the instance id.
+    uuid = "55555555-6666-7777-8888-999999999999"
+    sg_def = {
+        "id": uuid,
+        "name": "Dangling Out",
+        "inputs": [],
+        "outputs": [{"name": "IMAGE", "type": "IMAGE"}],
+        "nodes": [_node(9, "GetNode", outputs=[{"name": "IMAGE", "type": "IMAGE"}], widgets=["nope"])],
+        "links": [{"id": 1, "origin_id": 9, "origin_slot": 0, "target_id": -20, "target_slot": 0}],
+    }
+    wf = {
+        "nodes": [_node(11, uuid)],
+        "links": [],
+        "definitions": {"subgraphs": [sg_def]},
+        "version": 0.4,
+    }
+    res = render_py(wf, sd15_graph)
+    assert "OUT.IMAGE = None" in res.source
+    assert "node 11/OUT: input 'IMAGE' reads GetNode 11/9 variable 'nope' that no SetNode publishes" in res.warnings
+    assert not any("11/11" in w for w in res.warnings)
+
+
+def test_reroute_cycle_warns_instead_of_silently_printing_none(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                5,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 1}],
+                outputs=[{"name": "", "type": "LATENT", "links": [3]}],
+            ),
+            _node(
+                6,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 2}],
+                outputs=[{"name": "", "type": "LATENT", "links": [1]}],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 3}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 6, 0, 5, 0, "LATENT"], [2, 5, 0, 6, 0, "LATENT"], [3, 5, 0, 2, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "vae_decode = VAEDecode(samples=None, vae=None)  # 2" in res.source
+    assert "node 2: input 'samples' unresolved through a reroute/getnode cycle" in res.warnings

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -258,3 +258,156 @@ def test_legacy_group_node_is_refused(sd15_graph):
     with pytest.raises(PrintUnsupported) as e:
         render_py(wf, sd15_graph)
     assert e.value.reasons == ["node 1 is a legacy group node (workflow>MyGroup)"]
+
+
+def test_reroute_is_spliced(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[1, 1, 1]
+            ),
+            _node(
+                5,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 1}],
+                outputs=[{"name": "", "type": "LATENT", "links": [2]}],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 2}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 1, 0, 5, 0, "LATENT"], [2, 5, 0, 2, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "vae_decode = VAEDecode(samples=empty_latent_image, vae=None)  # 2" in res.source
+    assert "Reroute" not in res.source
+    assert {"id": "5", "type": "Reroute", "reason": "spliced"} in res.skipped
+
+
+def test_reroute_chain_and_unlinked_reroute(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[1, 1, 1]
+            ),
+            _node(
+                5,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 1}],
+                outputs=[{"name": "", "type": "LATENT", "links": [2]}],
+            ),
+            _node(
+                6,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 2}],
+                outputs=[{"name": "", "type": "LATENT", "links": [3]}],
+            ),
+            _node(
+                7,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": None}],
+                outputs=[{"name": "", "type": "VAE", "links": [4]}],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 3}, {"name": "vae", "type": "VAE", "link": 4}],
+            ),
+        ],
+        [[1, 1, 0, 5, 0, "LATENT"], [2, 5, 0, 6, 0, "LATENT"], [3, 6, 0, 2, 0, "LATENT"], [4, 7, 0, 2, 1, "VAE"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "vae_decode = VAEDecode(samples=empty_latent_image, vae=None)  # 2 vae unlinked via reroute 7" in res.source
+
+
+def test_get_set_is_spliced(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[1, 1, 1]
+            ),
+            _node(5, "SetNode", inputs=[{"name": "LATENT", "type": "*", "link": 1}], widgets=["lat"]),
+            _node(6, "GetNode", outputs=[{"name": "LATENT", "type": "LATENT", "links": [2]}], widgets=["lat"]),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 2}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 1, 0, 5, 0, "LATENT"], [2, 6, 0, 2, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "vae_decode = VAEDecode(samples=empty_latent_image, vae=None)  # 2" in res.source
+    assert {s["type"] for s in res.skipped} == {"SetNode", "GetNode"}
+
+
+def test_get_without_set_warns(sd15_graph):
+    wf = _mini(
+        [
+            _node(6, "GetNode", outputs=[{"name": "LATENT", "type": "LATENT", "links": [2]}], widgets=["nope"]),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 2}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[2, 6, 0, 2, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "samples=None" in res.source
+    assert "node 2: input 'samples' reads GetNode 6 variable 'nope' that no SetNode publishes" in res.warnings
+
+
+def test_primitive_node_is_noted_on_target(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                12,
+                "PrimitiveNode",
+                outputs=[{"name": "STRING", "type": "STRING", "links": [1]}],
+                widgets=["hello", "fixed"],
+            ),
+            _node(1, "EmptyLatentImage", outputs=[], widgets=[1, 1, 1]),
+            _node(
+                6,
+                "CLIPTextEncode",
+                inputs=[
+                    {"name": "clip", "type": "CLIP", "link": None},
+                    {"name": "text", "type": "STRING", "widget": {"name": "text"}, "link": 1},
+                ],
+                widgets=["hello"],
+            ),
+        ],
+        [[1, 12, 0, 6, 1, "STRING"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert 'clip_text_encode = CLIPTextEncode(clip=None, text="hello")  # 6 text from primitive 12' in res.source
+    assert {"id": "12", "type": "PrimitiveNode", "reason": "inlined into 6.text"} in res.skipped
+
+
+def test_subgraph_instance_and_definition(sd15_graph):
+    wf = json.loads((FIXTURES / "subgraph_template_ui.json").read_text())
+    graph = Graph.from_object_info(json.loads((FIXTURES / "subgraph_object_info.json").read_text()))
+    res = render_py(wf, graph)
+    src = res.source
+    # instance line: exposed inputs by name, non-identifier names via **{...}
+    inst = next(ln for ln in src.splitlines() if "# 10 " in ln)
+    assert inst.startswith('generate_image_1 = Subgraph["Generate Image 1"](')
+    assert '**{"images.image0":' in inst
+    # definition block printed once, names its instances and the address form
+    assert "# subgraph d33c1791-dfd2-4102-8540-aa63e4434cd2" in src
+    assert "instances: 10" in src and "address inner nodes as 10/<id>" in src
+    assert "IN.value" in src and "OUT.IMAGE = " in src
+    # inner nodes are addressable
+    assert any(v.startswith("10/") or "/" in v for v in res.bindings.values())
+
+
+def test_missing_subgraph_definition_is_refused(sd15_graph):
+    wf = _mini([_node(10, "d33c1791-dfd2-4102-8540-aa63e4434cd2")], [])
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == [
+        "node 10 is a subgraph instance whose definition d33c1791-dfd2-4102-8540-aa63e4434cd2 is missing"
+    ]

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -402,12 +402,20 @@ def test_subgraph_instance_and_definition(sd15_graph):
     assert "IN.value" in src and "OUT.IMAGE = " in src
     # inner nodes are addressable
     assert any(v.startswith("10/") or "/" in v for v in res.bindings.values())
+    # interior instance 3 of definition f2228dc9 (node 19's subgraph) is itself a
+    # subgraph instance whose own definition is missing from the fixture; it's
+    # printed opaquely with a warning rather than refusing the whole render.
+    assert (
+        "node 19/3: subgraph definition 6d92985e-3e1e-49e2-acea-91c5259d86a8 missing; printed opaquely" in res.warnings
+    )
 
 
-def test_missing_subgraph_definition_is_refused(sd15_graph):
+def test_missing_subgraph_definition_prints_opaquely(sd15_graph):
     wf = _mini([_node(10, "d33c1791-dfd2-4102-8540-aa63e4434cd2")], [])
-    with pytest.raises(PrintUnsupported) as e:
-        render_py(wf, sd15_graph)
-    assert e.value.reasons == [
-        "node 10 is a subgraph instance whose definition d33c1791-dfd2-4102-8540-aa63e4434cd2 is missing"
-    ]
+    res = render_py(wf, sd15_graph)
+    line = next(ln for ln in res.source.splitlines() if "# 10 " in ln)
+    assert line == (
+        'subgraph = Subgraph["d33c1791-dfd2-4102-8540-aa63e4434cd2"]()'
+        "  # 10 subgraph d33c1791-dfd2-4102-8540-aa63e4434cd2 definition missing"
+    )
+    assert "node 10: subgraph definition d33c1791-dfd2-4102-8540-aa63e4434cd2 missing; printed opaquely" in res.warnings

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -408,6 +408,23 @@ def test_subgraph_instance_and_definition(sd15_graph):
     assert (
         "node 19/3: subgraph definition 6d92985e-3e1e-49e2-acea-91c5259d86a8 missing; printed opaquely" in res.warnings
     )
+    # no skipped id is a bare top-level id of a DIFFERENT node: the interior
+    # MarkdownNote (bare inner id "5", inside da09b826 which is itself nested
+    # under instance 10 at inner id 3) must be addressed "10/3/5", not "5" —
+    # top-level node 5 is an unrelated SaveImage.
+    top_level_ids = {str(n["id"]) for n in wf["nodes"]}
+    assert not any(s["id"] in top_level_ids for s in res.skipped)
+    assert {"id": "10/3/5", "type": "MarkdownNote", "reason": "note"} in res.skipped
+    # da09b826 ("Batch Prompt Iterator") is instantiated only by inner node 3
+    # of instance 10 — its header must show the fully qualified address, and
+    # inner-node addressing follows the same qualified path.
+    assert '# subgraph da09b826-d678-40e0-a4e4-5f2178043ab6 "Batch Prompt Iterator" — instances: 10/3' in src
+    assert "address inner nodes as 10/3/<id>" in src
+    assert any(v.startswith("10/3/") for v in res.bindings.values())
+    # bracket/binding for that nested instance (no title of its own) fall back
+    # to the definition's own name, not the bare inner id.
+    assert 'Subgraph["Batch Prompt Iterator"](' in src
+    assert "batch_prompt_iterator = " in src
 
 
 def test_missing_subgraph_definition_prints_opaquely(sd15_graph):
@@ -415,7 +432,180 @@ def test_missing_subgraph_definition_prints_opaquely(sd15_graph):
     res = render_py(wf, sd15_graph)
     line = next(ln for ln in res.source.splitlines() if "# 10 " in ln)
     assert line == (
-        'subgraph = Subgraph["d33c1791-dfd2-4102-8540-aa63e4434cd2"]()'
+        'd33c1791_dfd2_4102_8540_aa63e4434cd2 = Subgraph["d33c1791-dfd2-4102-8540-aa63e4434cd2"]()'
         "  # 10 subgraph d33c1791-dfd2-4102-8540-aa63e4434cd2 definition missing"
     )
     assert "node 10: subgraph definition d33c1791-dfd2-4102-8540-aa63e4434cd2 missing; printed opaquely" in res.warnings
+
+
+def test_reroute_splice_orders_source_before_consumer(sd15_graph):
+    # source 9 -> reroute 5 -> consumer 2. Without resolving the splice before
+    # toposort, the direct link (5 -> 2) drops (Reroute is never printable),
+    # 9 and 2 both have indegree 0, and ties break ascending -> 2 would print
+    # before 9 (use-before-definition).
+    wf = _mini(
+        [
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+            _node(
+                5,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 2}],
+                outputs=[{"name": "", "type": "LATENT", "links": [1]}],
+            ),
+            _node(
+                9, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [2]}], widgets=[1, 1, 1]
+            ),
+        ],
+        [[1, 5, 0, 2, 0, "LATENT"], [2, 9, 0, 5, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    ids_in_order = [ln.rsplit("# ", 1)[1].split()[0] for ln in res.source.splitlines()]
+    assert ids_in_order.index("9") < ids_in_order.index("2")
+
+
+def test_get_set_splice_orders_source_before_consumer(sd15_graph):
+    # source 9 -> SetNode 5 -> GetNode 6 -> consumer 2, same numeric-id trap.
+    wf = _mini(
+        [
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+            _node(6, "GetNode", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=["v"]),
+            _node(5, "SetNode", inputs=[{"name": "LATENT", "type": "*", "link": 2}], widgets=["v"]),
+            _node(
+                9, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [2]}], widgets=[1, 1, 1]
+            ),
+        ],
+        [[1, 6, 0, 2, 0, "LATENT"], [2, 9, 0, 5, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    ids_in_order = [ln.rsplit("# ", 1)[1].split()[0] for ln in res.source.splitlines()]
+    assert ids_in_order.index("9") < ids_in_order.index("2")
+
+
+def test_cycle_through_reroute_is_refused(sd15_graph):
+    # node 1's samples <- node 2 directly; node 2's samples <- node 1 via
+    # reroute 5. Once spliced this is a genuine 2-node cycle, not two
+    # independent, unordered edges.
+    wf = _mini(
+        [
+            _node(
+                1,
+                "VAEDecode",
+                inputs=[
+                    {"name": "samples", "type": "LATENT", "link": 10},
+                    {"name": "vae", "type": "VAE", "link": None},
+                ],
+                outputs=[{"name": "IMAGE", "type": "IMAGE", "links": [20]}],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[
+                    {"name": "samples", "type": "LATENT", "link": 30},
+                    {"name": "vae", "type": "VAE", "link": None},
+                ],
+                outputs=[{"name": "IMAGE", "type": "IMAGE", "links": [40]}],
+            ),
+            _node(
+                5,
+                "Reroute",
+                inputs=[{"name": "", "type": "*", "link": 20}],
+                outputs=[{"name": "", "type": "IMAGE", "links": [30]}],
+            ),
+        ],
+        [[10, 2, 0, 1, 0, "IMAGE"], [20, 1, 0, 5, 0, "IMAGE"], [30, 5, 0, 2, 0, "IMAGE"]],
+    )
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["link cycle among nodes 1, 2"]
+
+
+def test_regular_node_nonidentifier_input_uses_kwargs_dict(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[1, 1, 1]
+            ),
+            _node(
+                8,
+                "BatchImagesNode",
+                inputs=[
+                    {"name": "images.image0", "type": "IMAGE", "link": None},
+                    {"name": "images.image1", "type": "IMAGE", "link": 1},
+                ],
+            ),
+        ],
+        [[1, 1, 0, 8, 1, "IMAGE"]],
+    )
+    res = render_py(wf, sd15_graph)
+    line = next(ln for ln in res.source.splitlines() if "# 8" in ln)
+    assert "images.image0=" not in line
+    assert "images.image1=" not in line
+    assert '**{"images.image0": None, "images.image1": empty_latent_image}' in line
+
+
+def test_widget_backed_input_with_live_link_uses_edge_ref(sd15_graph):
+    wf = _mini(
+        [
+            _node(20, "TextSource", outputs=[{"name": "STRING", "type": "STRING", "links": [1]}]),
+            _node(
+                6,
+                "CLIPTextEncode",
+                inputs=[
+                    {"name": "clip", "type": "CLIP", "link": None},
+                    {"name": "text", "type": "STRING", "widget": {"name": "text"}, "link": 1},
+                ],
+                widgets=["stale"],
+            ),
+        ],
+        [[1, 20, 0, 6, 1, "STRING"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "clip_text_encode = CLIPTextEncode(clip=None, text=text_source)  # 6" in res.source
+    assert "stale" not in res.source
+
+
+def test_sd15_golden_unaffected_by_live_link_widget_fix(sd15_workflow, sd15_graph):
+    # No input in the sd15 fixture has both a "widget" key and a live link
+    # from a real node, so the fix in test_widget_backed_input_with_live_link_uses_edge_ref
+    # must not touch this golden.
+    res = render_py(sd15_workflow, sd15_graph)
+    body = "\n".join(ln for ln in res.source.splitlines() if not ln.startswith("# note")) + "\n"
+    assert body == SD15_GOLDEN
+
+
+def test_definition_lists_every_instance_address(sd15_graph):
+    # INNER is instantiated directly at top level (node 200) AND nested inside
+    # OUTER's own interior (inner node 5 of OUTER's instance, node 100) — its
+    # header must list both, not just whichever was discovered first.
+    inner_uuid = "11111111-2222-3333-4444-555555555555"
+    outer_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    outer_def = {
+        "id": outer_uuid,
+        "name": "Outer",
+        "nodes": [{"id": 5, "type": inner_uuid, "inputs": [], "outputs": [], "widgets_values": []}],
+        "links": [],
+        "inputs": [],
+        "outputs": [],
+    }
+    inner_def = {"id": inner_uuid, "name": "Inner", "nodes": [], "links": [], "inputs": [], "outputs": []}
+    wf = {
+        "nodes": [
+            _node(100, outer_uuid),
+            _node(200, inner_uuid),
+        ],
+        "links": [],
+        "definitions": {"subgraphs": [outer_def, inner_def]},
+        "version": 0.4,
+    }
+    res = render_py(wf, sd15_graph)
+    header = next(ln for ln in res.source.splitlines() if ln.startswith(f"# subgraph {inner_uuid}"))
+    assert "100/5" in header
+    assert "200" in header

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -728,6 +728,23 @@ def test_malformed_input_entry_is_skipped_with_warning(sd15_graph):
     assert "node 2: ignoring malformed input entry 7" in res.warnings
 
 
+def test_malformed_output_entry_falls_back_to_index_ref_with_warning(sd15_graph):
+    # litegraph has been seen to serialize junk into `outputs` too, not just
+    # `inputs` (see test_malformed_input_entry_is_skipped_with_warning above).
+    # A source node not in the catalog keeps the graph-metadata fallback from
+    # masking the bug: `.out[<slot>]` is the only name left to fall back to.
+    src = _node(1, "UnknownSrcNode", widgets=[1, 1, 1])
+    src["outputs"] = ["junk", "junk2"]
+    tgt = _node(
+        2,
+        "VAEDecode",
+        inputs=[{"name": "samples", "type": "LATENT", "link": 7}, {"name": "vae", "type": "VAE", "link": None}],
+    )
+    res = render_py(_mini([src, tgt], [[7, 1, 0, 2, 0, "LATENT"]]), sd15_graph)
+    assert ".out[0]" in res.source
+    assert "node 1: malformed outputs entry at slot 0; referenced by index" in res.warnings
+
+
 def test_input_without_name_key_does_not_raise(sd15_graph):
     wf = _mini([_node(2, "VAEDecode", inputs=[{"type": "LATENT", "link": None}])], [])
     res = render_py(wf, sd15_graph)

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -873,3 +873,74 @@ def test_reroute_cycle_warns_instead_of_silently_printing_none(sd15_graph):
     res = render_py(wf, sd15_graph)
     assert "vae_decode = VAEDecode(samples=None, vae=None)  # 2" in res.source
     assert "node 2: input 'samples' unresolved through a reroute/getnode cycle" in res.warnings
+
+
+def test_non_object_top_level_node_entries_are_ignored_with_warning(sd15_graph):
+    # litegraph has been seen to serialize a bare `null` into `nodes[]`. `_validate`
+    # used to call `.get("type")` on every entry with no isinstance check, so this
+    # raised AttributeError instead of rendering the rest of the workflow.
+    wf = _mini(
+        [None, _node(1, "EmptyLatentImage", widgets=[64, 64, 1]), "junk"],
+        [],
+    )
+    res = render_py(wf, sd15_graph)
+    assert "empty_latent_image = EmptyLatentImage(width=64, height=64, batch_size=1)  # 1" in res.source
+    assert "workflow: ignoring 2 non-object node entries" in res.warnings
+
+
+def test_non_dict_definitions_block_is_ignored_with_warning(sd15_graph):
+    # `(workflow.get("definitions") or {}).get("subgraphs")` assumed `definitions`
+    # was a dict; a non-empty list is truthy so `or {}` never fired, and `.get`
+    # raised AttributeError. A malformed `definitions` block now degrades to "no
+    # definitions" plus a warning, matching `_extract_notes` in command/workflow.py.
+    wf = _mini([_node(1, "EmptyLatentImage", widgets=[64, 64, 1])], [])
+    wf["definitions"] = [1]
+    res = render_py(wf, sd15_graph)
+    assert "empty_latent_image = EmptyLatentImage(width=64, height=64, batch_size=1)  # 1" in res.source
+    assert "workflow: ignoring non-object definitions block" in res.warnings
+
+
+def test_non_string_output_name_falls_back_to_out_index(sd15_graph):
+    # A dict outputs[slot] with a truthy non-string "name" (e.g. an int) used to
+    # reach `_IDENT.match(out_name)` and raise TypeError. It must fall back to the
+    # indexed `.out[<slot>]` form instead, same as a non-identifier string name.
+    wf = _mini(
+        [
+            _node(
+                1,
+                "EmptyLatentImage",
+                outputs=[
+                    {"name": 1, "type": "LATENT", "links": [1]},
+                    {"name": "extra", "type": "X", "links": []},
+                ],
+                widgets=[1, 1, 1],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 1, 0, 2, 0, "LATENT"]],
+    )
+    src = render_py(wf, sd15_graph).source
+    assert "samples=empty_latent_image.out[0]" in src
+
+
+def test_bypass_mode_on_resolved_subgraph_instance(sd15_graph):
+    sub_id = "d33c1791-dfd2-4102-8540-aa63e4434cd2"
+    wf = _mini([_node(10, sub_id, mode=4)], [])
+    wf["definitions"] = {"subgraphs": [{"id": sub_id, "name": "MySub", "nodes": [], "links": []}]}
+    res = render_py(wf, sd15_graph)
+    line = next(ln for ln in res.source.splitlines() if "# 10 " in ln)
+    assert line == f'my_sub = Subgraph["MySub"]()  # 10 subgraph {sub_id} mode=bypass'
+
+
+def test_bypass_mode_on_missing_subgraph_definition(sd15_graph):
+    wf = _mini([_node(10, "d33c1791-dfd2-4102-8540-aa63e4434cd2", mode=4)], [])
+    res = render_py(wf, sd15_graph)
+    line = next(ln for ln in res.source.splitlines() if "# 10 " in ln)
+    assert line == (
+        'd33c1791_dfd2_4102_8540_aa63e4434cd2 = Subgraph["d33c1791-dfd2-4102-8540-aa63e4434cd2"]()'
+        "  # 10 subgraph d33c1791-dfd2-4102-8540-aa63e4434cd2 definition missing mode=bypass"
+    )

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql.engine import Graph
+from comfy_cli.workflow_print import PrintUnsupported, binding_name, class_expr, py_literal, render_py
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(scope="module")
+def sd15_graph() -> Graph:
+    return Graph.from_object_info(json.loads((FIXTURES / "sd15_object_info.json").read_text()))
+
+
+@pytest.fixture
+def sd15_workflow() -> dict:
+    return json.loads((FIXTURES / "sd15_ui_workflow.json").read_text())
+
+
+SD15_GOLDEN = """\
+checkpoint_loader_simple = CheckpointLoaderSimple(ckpt_name="v1-5-pruned-emaonly-fp16.safetensors")  # 4
+empty_latent_image = EmptyLatentImage(width=512, height=512, batch_size=1)  # 5
+clip_text_encode = CLIPTextEncode(clip=checkpoint_loader_simple.CLIP, text="beautiful scenery nature glass bottle landscape, purple galaxy bottle,")  # 6
+clip_text_encode_2 = CLIPTextEncode(clip=checkpoint_loader_simple.CLIP, text="text, watermark")  # 7
+ksampler = KSampler(model=checkpoint_loader_simple.MODEL, positive=clip_text_encode, negative=clip_text_encode_2, latent_image=empty_latent_image, seed=685468484323813, control_after_generate="randomize", steps=20, cfg=8, sampler_name="euler", scheduler="normal", denoise=1)  # 3
+vae_decode = VAEDecode(samples=ksampler, vae=checkpoint_loader_simple.VAE)  # 8
+save_image = SaveImage(images=vae_decode, filename_prefix="SD1.5")  # 9
+"""
+
+
+def test_sd15_golden_source(sd15_workflow, sd15_graph):
+    res = render_py(sd15_workflow, sd15_graph)
+    body = "\n".join(ln for ln in res.source.splitlines() if not ln.startswith("# note")) + "\n"
+    assert body == SD15_GOLDEN
+    assert res.bindings == {
+        "checkpoint_loader_simple": "4",
+        "empty_latent_image": "5",
+        "clip_text_encode": "6",
+        "clip_text_encode_2": "7",
+        "ksampler": "3",
+        "vae_decode": "8",
+        "save_image": "9",
+    }
+    assert res.node_count == 7
+    assert {s["type"] for s in res.skipped} == {"MarkdownNote"}
+    assert len(res.skipped) == 4
+
+
+def test_sd15_notes_print_as_comments(sd15_workflow, sd15_graph):
+    src = render_py(sd15_workflow, sd15_graph).source
+    assert '# note 11 "Note: Model link": [Tutorial](https://docs.comfy.org/tutorials/basic/text-to-image) (+' in src
+    assert '# note 14 "Note: Output": Image will auto-save' in src  # single-line note: no (+N lines)
+    assert "(+0 lines)" not in src
+
+
+@pytest.mark.parametrize(
+    "cls,expected",
+    [
+        ("KSampler", "ksampler"),
+        ("CLIPTextEncode", "clip_text_encode"),
+        ("CheckpointLoaderSimple", "checkpoint_loader_simple"),
+        ("KSampler (Advanced)", "ksampler_advanced"),
+        ("VHS_LoadVideo", "vhs_load_video"),
+        ("class", "class_"),
+        ("123Node", "n123_node"),
+        ("", "node"),
+    ],
+)
+def test_binding_name_shape(cls, expected):
+    assert binding_name(cls, {}) == expected
+
+
+def test_binding_name_dedupes_in_call_order():
+    used = {}
+    assert [binding_name("KSampler", used) for _ in range(3)] == ["ksampler", "ksampler_2", "ksampler_3"]
+
+
+def test_class_expr():
+    assert class_expr("KSampler") == "KSampler"
+    assert class_expr("KSampler (Advanced)") == 'Node["KSampler (Advanced)"]'
+    assert class_expr("VHS_LoadVideo") == "VHS_LoadVideo"
+
+
+def test_py_literal():
+    assert py_literal('a "quoted" str') == '"a \\"quoted\\" str"'
+    assert (
+        py_literal(8.0) == "8.0" and py_literal(8) == "8" and py_literal(True) == "True" and py_literal(None) == "None"
+    )
+    assert py_literal([1, "x"]) == '[1, "x"]' and py_literal({"k": 1}) == '{"k": 1}'
+
+
+def _mini(nodes, links):
+    return {"nodes": nodes, "links": links, "version": 0.4}
+
+
+def _node(id_, type_, inputs=(), outputs=(), widgets=None, **extra):
+    n = {
+        "id": id_,
+        "type": type_,
+        "mode": 0,
+        "inputs": [dict(i) for i in inputs],
+        "outputs": [dict(o) for o in outputs],
+        "widgets_values": list(widgets or []),
+    }
+    n.update(extra)
+    return n
+
+
+def test_mode_annotations_and_title(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1,
+                "EmptyLatentImage",
+                outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}],
+                widgets=[64, 64, 1],
+                mode=4,
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+                mode=2,
+                title="Decode it",
+            ),
+        ],
+        [[1, 1, 0, 2, 0, "LATENT"]],
+    )
+    src = render_py(wf, sd15_graph).source
+    assert "empty_latent_image = EmptyLatentImage(width=64, height=64, batch_size=1)  # 1 mode=bypass" in src
+    assert 'vae_decode = VAEDecode(samples=empty_latent_image, vae=None)  # 2 "Decode it" mode=mute' in src
+
+
+def test_unknown_class_prints_positional_widgets(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[64, 64, 1]
+            ),
+            _node(2, "My Custom Thing", inputs=[{"name": "latent", "type": "LATENT", "link": 1}], widgets=["a", 2]),
+        ],
+        [[1, 1, 0, 2, 0, "LATENT"]],
+    )
+    res = render_py(wf, sd15_graph)
+    assert (
+        'my_custom_thing = Node["My Custom Thing"](latent=empty_latent_image, widgets=["a", 2])  # 2 class not in catalog'
+        in res.source
+    )
+    assert res.warnings == ["node 2: class 'My Custom Thing' not in catalog; widgets printed positionally"]
+
+
+def test_no_catalog_prints_everything_positionally(sd15_workflow):
+    res = render_py(sd15_workflow, None)
+    assert (
+        'ksampler = KSampler(model=checkpoint_loader_simple.MODEL, positive=clip_text_encode, negative=clip_text_encode_2, latent_image=empty_latent_image, widgets=[685468484323813, "randomize", 20, 8, "euler", "normal", 1])  # 3 class not in catalog'
+        in res.source
+    )
+
+
+def test_topological_order_ties_by_id(sd15_graph):
+    # 9 feeds 3; both have no other deps -> 9 must print before 3 even though 3 < 9
+    wf = _mini(
+        [
+            _node(
+                3,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+            _node(
+                9, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": [1]}], widgets=[1, 1, 1]
+            ),
+            _node(
+                5, "EmptyLatentImage", outputs=[{"name": "LATENT", "type": "LATENT", "links": []}], widgets=[2, 2, 1]
+            ),
+        ],
+        [[1, 9, 0, 3, 0, "LATENT"]],
+    )
+    lines = list(render_py(wf, sd15_graph).source.splitlines())
+    assert [ln.rsplit("# ", 1)[1].split()[0] for ln in lines] == ["5", "9", "3"]
+
+
+def test_multi_output_ref_uses_name_single_output_bare(sd15_graph):
+    src = render_py(json.loads((FIXTURES / "sd15_ui_workflow.json").read_text()), sd15_graph).source
+    assert "clip=checkpoint_loader_simple.CLIP" in src and "samples=ksampler," in src
+
+
+def test_non_identifier_output_name_uses_out_index(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1,
+                "EmptyLatentImage",
+                outputs=[
+                    {"name": "LATENT", "type": "LATENT", "links": [1]},
+                    {"name": "weird name", "type": "X", "links": []},
+                ],
+                widgets=[1, 1, 1],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            ),
+        ],
+        [[1, 1, 0, 2, 0, "LATENT"]],
+    )
+    src = render_py(wf, sd15_graph).source
+    assert "samples=empty_latent_image.LATENT" in src  # 2 outputs -> named
+    wf["nodes"][0]["outputs"][0]["name"] = "has space"
+    assert "samples=empty_latent_image.out[0]" in render_py(wf, sd15_graph).source
+
+
+def test_cycle_is_refused(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                1,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 2}, {"name": "vae", "type": "VAE", "link": None}],
+                outputs=[{"name": "IMAGE", "type": "IMAGE", "links": [1]}],
+            ),
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+                outputs=[{"name": "IMAGE", "type": "IMAGE", "links": [2]}],
+            ),
+        ],
+        [[1, 1, 0, 2, 0, "IMAGE"], [2, 2, 0, 1, 0, "IMAGE"]],
+    )
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["link cycle among nodes 1, 2"]
+
+
+def test_dangling_link_is_refused(sd15_graph):
+    wf = _mini(
+        [
+            _node(
+                2,
+                "VAEDecode",
+                inputs=[{"name": "samples", "type": "LATENT", "link": 1}, {"name": "vae", "type": "VAE", "link": None}],
+            )
+        ],
+        [[1, 99, 0, 2, 0, "LATENT"]],
+    )
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["link 1 references missing node 99"]
+
+
+def test_legacy_group_node_is_refused(sd15_graph):
+    wf = _mini([_node(1, "workflow>MyGroup")], [])
+    with pytest.raises(PrintUnsupported) as e:
+        render_py(wf, sd15_graph)
+    assert e.value.reasons == ["node 1 is a legacy group node (workflow>MyGroup)"]


### PR DESCRIPTION
Part 1 of BE-9191 (the agent-side `print_workflow` tool is a follow-up in the cloud repo after the pin bump).

## What

`comfy workflow print --format py`: render a save-format (UI) workflow as one Python-like line per node, with a binding-name → node-id map. Read-only; nothing parses the text back.

```
$ comfy workflow print wf.json --input object_info.json
checkpoint_loader_simple = CheckpointLoaderSimple(ckpt_name="v1-5-pruned-emaonly-fp16.safetensors")  # 4
empty_latent_image = EmptyLatentImage(width=512, height=512, batch_size=1)  # 5
clip_text_encode = CLIPTextEncode(clip=checkpoint_loader_simple.CLIP, text="beautiful scenery nature glass bottle landscape, purple galaxy bottle,")  # 6
clip_text_encode_2 = CLIPTextEncode(clip=checkpoint_loader_simple.CLIP, text="text, watermark")  # 7
ksampler = KSampler(model=checkpoint_loader_simple.MODEL, positive=clip_text_encode, negative=clip_text_encode_2, latent_image=empty_latent_image, seed=685468484323813, control_after_generate="randomize", steps=20, cfg=8, sampler_name="euler", scheduler="normal", denoise=1)  # 3
vae_decode = VAEDecode(samples=ksampler, vae=checkpoint_loader_simple.VAE)  # 8
save_image = SaveImage(images=vae_decode, filename_prefix="SD1.5")  # 9
# note 11 "Note: Model link": [Tutorial](https://docs.comfy.org/tutorials/basic/text-to-image) (+12 lines)
```

`--json` carries the same text as `source` plus `bindings` (`{"ksampler": "3", ...}`), `node_count`, `skipped` (notes and spliced UI-only nodes) and `warnings`; `--select` works like `slots`.

## Why

The agent cannot read a workflow today: it reasons about the graph through `ls-nodes` (rows, no edges) and N × `slots` calls, and edits against a topology it has not seen. One read that shows nodes, edges and every widget value in ~7 lines is the cheapest fix for that. Humans get a diffable artifact for free. Design: Obsidian `Comfy-Agent — workflow print (design, 2026-08-25)`.

## Rules (the ones that matter)

- One bound line per node, topological order, id inline. Class names that are not identifiers print as `Node["KSampler (Advanced)"]`; no mangling table.
- Widget names come from the catalog (`_expand_widget_entries`, so dynamic combos and `control_after_generate` behave as `slots` does); a slot absent from `widgets_values` prints the catalog default (the effective value), non-identifier names (`model.size_preset`) go in a trailing `**{...}`. A class the catalog does not know prints `widgets=[...]` positionally with a `# class not in catalog` note instead of refusing (the agent's catalog lags custom nodes).
- Edges: `binding` for single-output sources, `binding.NAME` otherwise, `binding.out[i]` when the output name is not an identifier. A widget-backed input with a live link prints the link, not the stale static value.
- Bypass/mute print as `mode=` annotations; links print as wired (printing preserves, compiling lowers), and a consumer of a bypassed node gets ` <input> via bypassed <id>` on its own line.
- `Reroute` and `GetNode`/`SetNode` are spliced through; `PrimitiveNode` is inlined with `# text from primitive 12`; notes print as one-line comments (full text is `workflow notes`).
- Subgraphs: the instance prints as `Subgraph["<title>"](...)`, each definition once as an indented block with `IN.<slot>` / `OUT.<slot> = ...` and fully qualified interior addresses (`10/3/<id>`, the form `slots` uses; the header also states the binding-key form). A missing definition prints opaquely with a warning (a real gallery template in the fixtures has one).
- Refuse and report, listing every reason (`workflow_print_unsupported`): legacy group nodes, duplicate node ids, links to missing nodes/slots or with non-integer slots, link cycles. Other malformed input degrades to a warning; nothing escapes as a traceback.

## Errors as navigation

The hints on `workflow_edit_invalid` / `workflow_slot_invalid` and the six edit-verb failure sites now lead with `comfy workflow print <file>` (they pointed at `workflow slots` / `ls-nodes`, which list rows without edges; the failure that dominates in prod is an edit against a node id that is not in the live graph). `slots` stays the pointer for exact `<node_id>.<input>` addresses; the misleading `nodes types` (connection types, not class names) is gone from the registry default. MCP inherits this; the agent's own steering is BE-9538.

## Files

- `comfy_cli/workflow_print.py` — the printer, pure (workflow dict + optional `Graph` → `PrintResult` or `PrintUnsupported`).
- `comfy_cli/command/workflow.py` — `print_cmd`, same shape as `notes`/`slots`; imports the printer lazily.
- Registrations: `discovery.py`, `schemas/workflow.json`, `error_codes.py`, `help_json.py`.
- Tests: `tests/comfy_cli/test_workflow_print.py` (printer: golden over the sd15 fixture, splicing, subgraph fixture, refusals), `tests/comfy_cli/command/test_workflow_print_cmd.py` (envelope, `--select`, pretty mode, schema validation, refusal envelope).

## Tests

- `ruff check` / `ruff format --check` with the CI-pinned `ruff==0.15.15`: clean.
- New tests: 57 (48 printer, incl. goldens over the sd15 and seedream V3 dynamic-combo fixtures, + 9 CLI). Contract suites (`test_discovery`, `test_error_code_registry`, `test_command_mentions`, `test_help_json`, `test_workflow_notes`, `test_workflow_slots`) plus the new files: 202 passed.
- Full `pytest`: 54 failed / 5862 passed; the 54 failing test IDs are identical to a pristine `origin/main` run in the same environment (env-only: `CliRunner(mix_stderr=...)` with the installed click, `where_invalid` routing, spend-gate prompt capture). All pass in CI on `main`.

Linear: BE-9191.
