### PR TITLE
chore: public-repo hygiene check passes on main

### DIFF
--- a/.github/workflows/public-repo-hygiene.yml
+++ b/.github/workflows/public-repo-hygiene.yml
@@ -30,4 +30,33 @@ jobs:
       # `HAILUO-03` is MiniMax's Hailuo 03 model, named in the curated
       # knowledge bundle and asserted in tests. It is a product name that
       # happens to match the ticket-ID shape, not an internal reference.
-      ticket_allowlist: HAILUO-03
+      # `HALO-03` is a fictional product id used as test fixture data in
+      # tests/comfy_cli/test_knowledge.py and test_knowledge_attach.py — not a
+      # real ticket.
+      ticket_allowlist: HAILUO-03,HALO-03
+      # Each entry below is a genuine false positive that the checker's two
+      # caller-tunable knobs (ticket_allowlist, exclude_paths) cannot clear any
+      # other way — the repo allowlist it also checks against
+      # (PUBLIC_COMFY_ORG_REPOS in Comfy-Org/github-workflows) is org-owned and
+      # deliberately not settable here.
+      exclude_paths: |
+        # refresh-cql-catalogs.yml legitimately reads from the private cloud
+        # monorepo (org-scoped, not github-workflows) — this internal
+        # automation is meant to reach it, so the reference is not a leak,
+        # it's the point of the workflow.
+        .github/workflows/refresh-cql-catalogs.yml
+        # Verbatim gallery/workflow template fixtures checked in for tests;
+        # several embed Comfy-Org/<huggingface-model-repo> strings (e.g.
+        # Qwen-Image_ComfyUI, ACE-Step_ComfyUI_repackaged) that are Hugging
+        # Face model repos, not GitHub repos, so they can never appear in the
+        # checker's GitHub-only repo allowlist. Content must stay byte-for-byte
+        # identical to the real templates, so it can't be reworded either.
+        tests/comfy_cli/fixtures/
+        # Real Hugging Face model download URLs pointing at the org's
+        # stable-diffusion-v1-5-archive space on huggingface.co. Same root
+        # cause as the fixtures above: the checker's org/repo pattern doesn't
+        # distinguish a Hugging Face host from a GitHub one, so a correct,
+        # fully-qualified HF URL still reads as an unlisted GitHub repo
+        # reference.
+        tests/e2e/test_e2e.py
+        comfy_cli/command/run/preflight.py

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -4,7 +4,7 @@ Parses ComfyUI's ``object_info.json``, builds an indexed compatibility graph,
 and exposes upstream/downstream, path-finding, validation, annotations,
 and widget-order resolution.
 
-Port of ``github.com/Comfy-Org/cql/nodegraph`` (Go).
+Port of the Go reference engine's ``nodegraph`` package.
 """
 
 from __future__ import annotations

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -1,7 +1,7 @@
 """Find, validate, and index the compiled comfy-knowledge bundle.
 
 The bundle (``knowledge.json`` + optional ``manifest.json``) is produced by
-``Comfy-Org/comfy-knowledge``. It reaches this process by one of three routes,
+the curated knowledge bundle repo. It reaches this process by one of three routes,
 tried in order: an explicit ``COMFY_KNOWLEDGE_FILE``, the per-user cache, or a
 fetch from ``COMFY_KNOWLEDGE_URL``. A missing or broken bundle is a normal
 state: every entry point here returns ``None`` rather than raising, and nothing


### PR DESCRIPTION
## Summary

The `hygiene / public-repo-hygiene` check (`Comfy-Org/github-workflows` reusable
workflow, pinned at `609f9729…`) has been red on `main`, so every PR shows red.
Findings and disposition:

- **`comfy_cli/cql/engine.py:7`, `comfy_cli/knowledge.py:4`** — source comments
  named two private Comfy-Org GitHub repos (`cql`, `comfy-knowledge`) by
  string. Reworded to describe what they are ("the Go reference engine", "the
  curated knowledge bundle repo") instead of naming them. No behavior change.

- **`.github/workflows/refresh-cql-catalogs.yml`** (8 lines) — this workflow
  genuinely, intentionally clones/reads the private `cloud` repo to fetch
  `no_gpu_nodes.json`. That's the point of the workflow, not a leak, so it's
  now in `exclude_paths` with a comment explaining why.

- **`comfy_cli/command/run/preflight.py:176`, `tests/e2e/test_e2e.py:344`** —
  real `huggingface.co/Comfy-Org/stable-diffusion-v1-5-archive` model download
  URLs. I checked the checker source
  (`check_public_repo_hygiene.py`): it has no Hugging Face allowlist — its
  `Comfy-Org/<name>` pattern matches the literal string regardless of the
  surrounding URL/host, so a fully-qualified HF URL does not clear it (and
  `preflight.py:176` was already a full URL, confirming this). The HF repo
  can't go in the checker's allowlist either — that list is GitHub repos
  only and is org-owned, not settable from this repo. Excluded both files,
  with a comment explaining the HF-vs-GitHub root cause.

- **`tests/comfy_cli/fixtures/**`** (gallery + `sd15_ui_workflow.json`) —
  verbatim gallery/workflow template fixtures; several embed
  `Comfy-Org/<huggingface-model-repo>` strings (Qwen-Image, ACE-Step) for the
  same HF-vs-GitHub reason above. These must stay byte-for-byte identical to
  the real templates, so excluded rather than edited.

- **`HALO-03`** (`test_knowledge_attach.py:146`, `test_knowledge.py:495`) —
  fictional product id used as test fixture data, not a real ticket. Added to
  `ticket_allowlist` alongside the existing `HAILUO-03`.

All changes are in `.github/workflows/public-repo-hygiene.yml` (ticket
allowlist + exclude_paths, each with an explanatory comment) plus the two
docstring rewordings. No fixture files were edited.

## Test plan

- [x] Ran the checker locally exactly as CI invokes it (root `.`, same
      `--exclude`/`--ticket-allow` values now in the workflow):
      `Result: no internal-only references found.` (exit 0; 457 files
      scanned, 4 exclusion entries matched 17 files total, 0 findings)
- [x] `uvx ruff@0.15.15 check .` — all checks passed
- [x] `pytest tests/comfy_cli/test_knowledge.py tests/comfy_cli/test_knowledge_attach.py tests/comfy_cli/cql/test_engine.py tests/comfy_cli/test_run_execution_lifecycle.py` — 355 passed
