### PR TITLE
feat(groom): turn on the review-gated auto-builder

### DIFF
--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -5,9 +5,12 @@ name: Groom
 # GitHub-issue sink) lives in Comfy-Org/github-workflows. This repo carries only
 # the pin and its cadence, exactly like the other shared-workflow callers here.
 #
-# FINDS ONLY. The opt-in auto-builder (`builder: true`, which turns findings into
-# review-gated PRs) is deliberately left OFF. Groom files issues a human triages;
-# it opens no PRs, writes no commits, and never merges.
+# BUILDER MODE IS ON. `builder: true` below turns the top `max_prs` CONFIRMED,
+# non-security findings into REVIEW-GATED PRs; everything else still files as an
+# issue a human triages. Groom therefore writes commits on its own branches and
+# opens PRs, but it NEVER merges — every groom PR goes through this repo's normal
+# review + CI gate like any other. Read the HARD PREREQUISITE block on the
+# `builder:` input below before enabling or re-enabling it.
 #
 # CADENCE lives in the repo Actions variable GROOM_INTERVAL_DAYS, not in this
 # file. Retuning is a variable edit with no workflow change:
@@ -28,13 +31,18 @@ name: Groom
 # reusable declares it required, so an absent key fails the run LOUD at the agent
 # step by design rather than leaving the sweep silently inert.
 #
-# `vars.APP_ID` and `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are optional, but they
-# are ALL-OR-NOTHING and must be set/rotated together. The reusable gates App
-# token minting on `bot_app_id != ''` — the ID alone, NOT the key — so it
-# degrades to github-actions[bot] only when APP_ID is absent. With APP_ID present
+# `vars.APP_ID` and `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` are REQUIRED — not
+# optional — now that `builder: true` is set below, and they remain ALL-OR-NOTHING:
+# set and rotate them together. An absent APP_ID does NOT degrade to
+# github-actions[bot] in builder mode: the reusable's `build_select` job fails its
+# "Validate builder config" step with `exit 1` when `builder` is true and
+# `bot_app_id` is empty, and the `file` job declares `needs: [gate, build_select]`,
+# so that one failure takes the ISSUE sink down with the PR sink and the run emits
+# NOTHING — after the finder and verifier have already billed. With APP_ID present
 # (including inherited from the org) and the private key missing or rotated out,
-# the token step fails in the `file` job, i.e. AFTER the finder and verifier have
-# already billed, discarding that run's findings. If you unset one, unset both.
+# the App-token step fails in that same job, for the same net result. If you unset
+# one, unset both — and turn `builder` off in the same PR (see below: it is not a
+# variable, so there is no faster way to stop the failing runs).
 
 on:
   schedule:
@@ -89,8 +97,10 @@ jobs:
       actions: read
     uses: Comfy-Org/github-workflows/.github/workflows/groom.yml@eaee6df998c39943bc6133ea6fa7cee8d504c41f # main @ eaee6df
     with:
-      # File as cloud-code-bot (App token) rather than github-actions[bot]. Absent
-      # APP_ID degrades to github-actions[bot] instead of failing.
+      # File as cloud-code-bot (App token) rather than github-actions[bot]. This is
+      # REQUIRED under `builder: true` below, not a nicety: an absent APP_ID no
+      # longer degrades to github-actions[bot], it hard-fails `build_select` and
+      # takes the issue sink down with it. See HARD PREREQUISITE (1) below.
       bot_app_id: ${{ vars.APP_ID }}
       # Turn the top `max_prs` CONFIRMED, non-security findings into REVIEW-GATED
       # PRs instead of issues, which is what `vars.GROOM_CONFIG`'s `max_findings: 0`
@@ -99,18 +109,48 @@ jobs:
       # finder + verifier and emits nothing at all.
       #
       # `max_prs` is NOT set here on purpose: `vars.GROOM_CONFIG` already carries
-      # it (currently 2) and the variable outranks this `with:` block, so a value
-      # here would be dead config that reads as authoritative. Retune the variable.
+      # it and the variable outranks this `with:` block, so a value here would be
+      # dead config that reads as authoritative. Retune the variable. Verified
+      # 2026-08-28 to carry `max_prs: 2`; note the fallback if it is ever dropped
+      # from the variable is the reusable's OWN default of 5, not 2, so re-read
+      # the variable rather than assuming this file pins the volume.
       #
-      # HARD PREREQUISITE — do not merge before it is met. `build_pr` reads
-      # `steps.bot_token.outputs.token` with NO github.token fallback (the issue
-      # sink degrades to github-actions[bot]; the PR sink cannot), and callers
-      # grant only `contents: read`, so there is no other way to push a branch.
-      # This repo has NEITHER `vars.APP_ID` NOR `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`
-      # today, so builder mode would kill every finding at the PR sink AFTER the
-      # agents have billed. Provision the PRIVATE KEY FIRST and the APP_ID SECOND:
-      # the reusable mints whenever bot_app_id is non-empty and hard-fails on an
-      # empty key, so the reverse order breaks the runs that currently work.
+      # `builder` is NOT a `GROOM_CONFIG` knob. The reusable reads it straight off
+      # `inputs.builder` and never layers the variable over it (the variable only
+      # covers the operational knobs listed in its `DEFAULTS` blob), so once this
+      # merges, ONLY ANOTHER PR can turn it back off — there is no variable-level
+      # kill switch. To stop grooming without a PR, disable the workflow.
+      #
+      # HARD PREREQUISITE — do not merge before ALL THREE are met.
+      #
+      # 1. `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` FIRST, then `vars.APP_ID`. This
+      #    repo has NEITHER today, at repo or org level. With `builder: true` and
+      #    an empty `bot_app_id` the reusable's `build_select` job exits 1 in its
+      #    "Validate builder config" step, and because `file` needs
+      #    `build_select`, that kills the ISSUE sink too — the run emits nothing
+      #    at all, AFTER the finder and verifier have billed `ANTHROPIC_API_KEY`.
+      #    (The PR sink is doomed independently: `build_pr` reads
+      #    `steps.bot_token.outputs.token` with no `github.token` fallback and
+      #    callers grant only `contents: read`, so there is no other way to push a
+      #    branch.) Key first, ID second: the reusable mints a token whenever
+      #    `bot_app_id` is non-empty and hard-fails on an empty key, so the
+      #    reverse order breaks the runs that currently work.
+      # 2. Raise `max_findings` above 0 in `vars.GROOM_CONFIG`. The builder builds
+      #    only CONFIRM, non-security findings; DOWNGRADE findings and every
+      #    security / auth-adjacent one are deliberately routed to the `file`
+      #    job's remainder — which `max_findings: 0` then truncates to nothing.
+      #    Leaving it at 0 alongside `builder: true` silently discards exactly the
+      #    class the builder refuses to touch. (Builder BAIL issues ride a
+      #    separate, uncapped path in `build_pr` and are unaffected either way.)
+      # 3. Gate `run-on-gpu.yml` BEFORE provisioning the credentials in (1). It
+      #    triggers on `pull_request` to `main` for `comfy_cli/**` — precisely the
+      #    paths a groom refactor touches — and runs `pip install -e .` plus
+      #    `TEST_E2E=true pytest tests/e2e` on the SELF-HOSTED `gpu-runners`
+      #    group. Groom PRs are same-repo, so that fires with no approval gate,
+      #    executing LLM-authored code on our own hardware before a human reads
+      #    the diff. The reusable's patch-path policy denies workflows, manifests
+      #    and lockfiles but NOT ordinary source, so the gate has to live on our
+      #    side: a maintainer label or a protected environment on that workflow.
       builder: true
       # Keep the assets ref (finder and verifier briefs plus dedup ledger) in
       # lock-step with the `uses:` ref above, so a run always loads the briefs

--- a/.github/workflows/groom.yml
+++ b/.github/workflows/groom.yml
@@ -92,6 +92,26 @@ jobs:
       # File as cloud-code-bot (App token) rather than github-actions[bot]. Absent
       # APP_ID degrades to github-actions[bot] instead of failing.
       bot_app_id: ${{ vars.APP_ID }}
+      # Turn the top `max_prs` CONFIRMED, non-security findings into REVIEW-GATED
+      # PRs instead of issues, which is what `vars.GROOM_CONFIG`'s `max_findings: 0`
+      # here already assumes: that value PARKS issue filing (a literal `[:0]`
+      # slice, not "unlimited"), so without the builder this repo runs the full
+      # finder + verifier and emits nothing at all.
+      #
+      # `max_prs` is NOT set here on purpose: `vars.GROOM_CONFIG` already carries
+      # it (currently 2) and the variable outranks this `with:` block, so a value
+      # here would be dead config that reads as authoritative. Retune the variable.
+      #
+      # HARD PREREQUISITE — do not merge before it is met. `build_pr` reads
+      # `steps.bot_token.outputs.token` with NO github.token fallback (the issue
+      # sink degrades to github-actions[bot]; the PR sink cannot), and callers
+      # grant only `contents: read`, so there is no other way to push a branch.
+      # This repo has NEITHER `vars.APP_ID` NOR `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`
+      # today, so builder mode would kill every finding at the PR sink AFTER the
+      # agents have billed. Provision the PRIVATE KEY FIRST and the APP_ID SECOND:
+      # the reusable mints whenever bot_app_id is non-empty and hard-fails on an
+      # empty key, so the reverse order breaks the runs that currently work.
+      builder: true
       # Keep the assets ref (finder and verifier briefs plus dedup ledger) in
       # lock-step with the `uses:` ref above, so a run always loads the briefs
       # that match the workflow filing the issues.


### PR DESCRIPTION
## ELI-5

This repo's groom robot was set up to hand its findings over as pull requests, but nobody ever told it it was allowed to write code — so it has been reading the whole repo on a schedule, finding real problems, and throwing them away. This gives it permission. It still can't merge anything; it opens PRs a human reviews.

**Draft on purpose** — one credential has to land in this repo first (below).

## What was broken

`vars.GROOM_CONFIG` here sets `max_findings: 0`. That is a literal slice (`to_file[:0]`), not "unlimited" — it **parks issue filing**, which is correct only when the builder is on and findings arrive as PRs instead. `Comfy-Org/cloud` and `comfy-infra` run that same variable and both set `builder: true` in the caller. This caller never did, so it has had neither sink.

Visible in the record: the variable was set **2026-08-04**, and the last `groom`-labeled issue here is from **2026-07-30**. Every scheduled run since has been green and produced nothing. `max_prs` in the variable was inert the whole time — it only governs the builder path, and `builder` is in the reusable's `_LOCKED_KEYS`, so a variable can never switch it on.

## The fix

`builder: true` in the caller — the reviewed diff the lock is designed to force. Nothing else changes:

- **`max_prs` deliberately not added here.** The variable already carries it (2) and outranks `with:`; a duplicate would be dead config that reads as authoritative.
- **`max_findings: 0` must be raised, not kept** (corrected after review). The original reasoning — "with the builder on it means PRs, not issues" — holds only for the findings the builder will actually build. DOWNGRADE and security/auth-adjacent findings are deliberately excluded from the builder and land in the `file` remainder, where `max_findings: 0` truncates them away. Bail issues really are unaffected (`build_pr` files those on an uncapped path), but the excluded classes are not, so raising the variable is now a merge prerequisite above.
- Findings skipped while the cap was 0 were deferred, not lost; the dedup ledger holds them.

## BLOCKER — merge only after this is done

This repo has **neither `vars.APP_ID` nor `secrets.CLOUD_CODE_BOT_PRIVATE_KEY`** today — confirmed absent at **both repo and org level** via the Actions variables/secrets API.

The damage is **wider than "the PR sink dies"**, corrected after review: with `builder: true` and an empty `bot_app_id`, `build_select` fails its `Validate builder config` step with `exit 1`, and the `file` job declares `needs: [gate, build_select]` — so the **issue sink dies with the PR sink and the run emits nothing at all**, after the finder and verifier have already billed `ANTHROPIC_API_KEY`. (The PR sink is doomed independently: `build_pr` reads `steps.bot_token.outputs.token` with no `github.token` fallback, and callers grant only `contents: read`.) And because `builder` is in the reusable's `_LOCKED_KEYS`, `vars.GROOM_CONFIG` cannot switch it back off — only another PR can.

- [ ] cloud-code-bot (App 2016716) installed on `Comfy-Org/comfy-cli` with contents + pull-requests write
- [ ] **Gate `run-on-gpu.yml` — do this BEFORE the credentials below.** It triggers on `pull_request` to `main` for `comfy_cli/**` and runs `pip install -e .` + `TEST_E2E=true pytest tests/e2e` on the self-hosted `gpu-runners` group. Groom PRs are same-repo, so that fires with no approval gate — LLM-authored code on our hardware before a human reads the diff. The reusable's patch-path policy covers workflows/manifests/lockfiles but not ordinary source, so the gate must live here. Tracked as a follow-up.
- [ ] **Raise `max_findings` above 0 in `vars.GROOM_CONFIG`.** The builder builds only CONFIRM, non-security findings; DOWNGRADE and security/auth-adjacent findings route to the `file` remainder, which `max_findings: 0` slices to nothing — silently discarding exactly the class the builder refuses to touch. (Bail issues are a separate uncapped path and are unaffected.)
- [ ] `secrets.CLOUD_CODE_BOT_PRIVATE_KEY` set — **first**
- [ ] `vars.APP_ID` = `2016716` — **second**
- [ ] `gh workflow run groom.yml --repo Comfy-Org/comfy-cli -f dry_run=true` green, with "Mint bot-identity token" succeeding

**Order matters.** The reusable mints whenever `bot_app_id` is non-empty and hard-fails on an empty key, so setting `APP_ID` before the key breaks the runs that work today. Verify the `op read` returns bytes before piping it into `gh secret set` — a failed read stores an *empty* secret, which passes Actions startup validation and then hard-fails inside the job.

## Security posture

Unchanged, and worth stating since this grants an agent the ability to author code:

- The agent jobs (`audit_find`, `audit_verify`, `build`) run `contents: read` and mint no GitHub token — the process that reads untrusted code never holds write credentials.
- `build_pr` is the only job in the path with a write token. It runs **no agent and no repo code**: it applies the patch artifact on a fresh branch, commits, pushes, opens the PR.
- PRs are review-gated. Groom never merges. Security-adjacent findings are excluded from the builder and stay as issues to investigate.

## Provenance

**Authored by:** agent-work loop

**Verified:** `yaml.safe_load` parses the caller; `ruff check` clean. Every review finding re-verified against the pinned reusable (`eaee6df`) rather than taken on trust: `build_select`'s `exit 1` validation step, `file`'s `needs: [gate, build_select]`, `builder` absent from the `GROOM_CONFIG` `DEFAULTS` overlay, `capped = to_file[:max_findings]` in the `file` job, and `run-on-gpu.yml`'s `pull_request`/`gpu-runners`/`TEST_E2E` steps. Credential and variable state read live from the Actions API (`APP_ID` and `CLOUD_CODE_BOT_PRIVATE_KEY` absent at repo and org; `GROOM_CONFIG` = `max_prs: 2`, `max_findings: 0`).

**Deviations:** The GPU-runner gating finding was deferred to a follow-up rather than fixed here — it changes a different workflow in a way that affects every contributor's PR, so the choice between a protected environment, a maintainer label, or an author-association skip is a maintainer policy call. It is recorded as merge prerequisite #2 above. Raising `max_findings` is a live Actions-variable edit (an operator action, like provisioning the credentials), so it was documented as a prerequisite rather than made unilaterally.

**Background:** Found by sweeping every repo with a groom caller after `Comfy-Org/evals` turned up the same misconfiguration ([evals#487](https://github.com/Comfy-Org/evals/pull/487)): the `max_findings: 0` variable was copied from repos that run `builder: true` to three that don't. Semantics verified against `github-workflows/.github/groom/config.py` (`_LOCKED_KEYS`, and the comment scoping `max_findings` to the `file` job) and `build_pr`'s credential handling at the pinned SHA.

## Testing

- `yaml.safe_load` parses; `jobs.groom.with.builder` resolves to `true`.
- Credential state checked live via the Actions variables/secrets API for this repo (both absent) — hence the draft.
- Not verifiable pre-merge: the builder path only runs from the default branch. The dry run in the checklist above is the gate.
