### PR TITLE
test: stabilize config isolation and unit-test memory use

### DIFF
--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -8,7 +8,7 @@ import shutil
 import tarfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import BinaryIO, cast
+from typing import Any, BinaryIO, cast
 
 from rich import progress
 from rich.live import Live
@@ -16,6 +16,11 @@ from rich.table import Table
 
 from comfy_cli.constants import DEFAULT_COMFY_WORKSPACE, OS, PROC
 from comfy_cli.typing import PathLike
+
+#: Instance cache per ``@singleton`` class, keyed by the wrapper the decorator
+#: returns. Kept here rather than on that wrapper because several tests reach
+#: the decorated class through ``Wrapper.__closure__[0]``.
+_SINGLETON_CACHES: dict[Any, dict[type, Any]] = {}
 
 
 def singleton(cls):
@@ -35,7 +40,21 @@ def singleton(cls):
             instances[cls] = cls(*args, **kwargs)
         return instances[cls]
 
+    _SINGLETON_CACHES[get_instance] = instances
     return get_instance
+
+
+def reset_singleton_for_testing(factory: Any) -> None:
+    """Drop the instance cached behind a ``@singleton``-decorated class.
+
+    The instance captures process-wide state when it is constructed
+    (``ConfigManager`` reads the config dir exactly once). Tests repoint that
+    state per test, so without this the FIRST test's instance silently serves
+    every later one.
+    """
+    cache = _SINGLETON_CACHES.get(factory)
+    if cache is not None:
+        cache.clear()
 
 
 def get_os():

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,3 +1,5 @@
 {
-    "pythonPlatform": "All", 
+    "pythonPlatform": "All",
+    "venvPath": ".",
+    "venv": ".venv"
 }

--- a/tests/comfy_cli/command/github/test_pr.py
+++ b/tests/comfy_cli/command/github/test_pr.py
@@ -27,6 +27,18 @@ from comfy_cli.command.install import (
 from comfy_cli.git_utils import checkout_pr, git_checkout_tag
 
 
+def _env_without_github_token() -> dict[str, str]:
+    """Everything cleared except ``$PATH``, for the no-ambient-credential tests.
+
+    They only need ``GITHUB_TOKEN`` gone (``install._github_get`` reads it).
+    Clearing ``$PATH`` too makes ``shutil.which("git")`` fall back to
+    ``os.defpath`` (``/bin:/usr/bin``), which happens to hold git on FHS
+    distros but not on NixOS and friends — there every real git call in these
+    tests dies with "'git' was not found on PATH".
+    """
+    return {"PATH": os.environ.get("PATH", "")}
+
+
 @pytest.fixture(scope="function")
 def runner():
     g_exclusivity.reset_for_testing()
@@ -605,7 +617,7 @@ class TestGetLatestRelease:
         }
         mock_get.return_value = mock_response
 
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", _env_without_github_token(), clear=True):
             get_latest_release("comfyanonymous", "ComfyUI")
 
         headers = mock_get.call_args.kwargs.get("headers", {})
@@ -988,7 +1000,7 @@ class TestCheckoutStableComfyUI:
         rate_limited.headers = {"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1777415867"}
         mock_get.return_value = rate_limited
 
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", _env_without_github_token(), clear=True):
             with pytest.raises(GitHubRateLimitError, match="1777415867"):
                 checkout_stable_comfyui("latest", str(tmp_path))
 
@@ -1001,7 +1013,7 @@ class TestCheckoutStableComfyUI:
         GitHub API call should be made even when the network is hostile."""
         TestResolveLatestTagFromLocal._make_repo(tmp_path, ["v0.19.5", "v0.20.0", "v0.20.1"])
 
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", _env_without_github_token(), clear=True):
             checkout_stable_comfyui("latest", str(tmp_path))
 
         # Resolved locally; never touched the API
@@ -1055,7 +1067,7 @@ class TestInstallExecuteWithLatest:
             )
 
         with (
-            patch.dict("os.environ", {}, clear=True),
+            patch.dict("os.environ", _env_without_github_token(), clear=True),
             patch("requests.get", side_effect=crash_on_api),
             patch("comfy_cli.command.install.clone_comfyui") as mock_clone,
             patch("comfy_cli.command.install.ensure_workspace_python", return_value=sys.executable),
@@ -1098,7 +1110,7 @@ class TestInstallExecuteWithLatest:
         self._make_comfy_repo(repo_dir)
 
         with (
-            patch.dict("os.environ", {}, clear=True),
+            patch.dict("os.environ", _env_without_github_token(), clear=True),
             patch(
                 "requests.get",
                 side_effect=AssertionError("API must not be called for specific versions"),

--- a/tests/comfy_cli/command/test_run.py
+++ b/tests/comfy_cli/command/test_run.py
@@ -2887,6 +2887,11 @@ class TestLocalExecuteItemMapAndGroupedOutputs:
         mock_exec.output_entries = []
         mock_exec.cached_node_ids = []
         mock_exec.executed_node_ids = []
+        # `_emit_queued` hands these to `json.dumps` in NDJSON mode. Unstubbed
+        # MagicMocks make its `default` hook recurse forever on `isoformat`,
+        # retaining every child mock — ~28GB, and the OOM killed the suite.
+        mock_exec.validation_warnings = []
+        mock_exec.workflow_manifest.return_value = []
         return mock_exec
 
     def _run(self, workflow_file, mock_exec, *, wait, extra_patches=()):

--- a/tests/comfy_cli/conftest.py
+++ b/tests/comfy_cli/conftest.py
@@ -47,6 +47,8 @@ def _isolate_config_path(tmp_path, monkeypatch):
     mid-session because tests were clobbering them.
     """
     from comfy_cli import constants
+    from comfy_cli.config_manager import ConfigManager
+    from comfy_cli.utils import reset_singleton_for_testing
 
     fake_root = tmp_path / "comfy-cli-config"
     fake_root.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -54,7 +56,14 @@ def _isolate_config_path(tmp_path, monkeypatch):
     # whichever ``get_os()`` resolves to lands in our tmp dir.
     for k in list(constants.DEFAULT_CONFIG.keys()):
         monkeypatch.setitem(constants.DEFAULT_CONFIG, k, str(fake_root))
+    # ConfigManager is a @singleton that reads the config dir once, at
+    # construction — so repointing the dir alone leaves the FIRST test's
+    # in-memory config serving every later one. Any test that runs the CLI
+    # entrypoint writes `setup_nudged` into it, which then breaks the
+    # onboarding tests' "fresh config" premise hundreds of tests later.
+    reset_singleton_for_testing(ConfigManager)
     yield fake_root
+    reset_singleton_for_testing(ConfigManager)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/comfy_cli/test_global_python_install.py
+++ b/tests/comfy_cli/test_global_python_install.py
@@ -84,6 +84,10 @@ class TestGlobalPythonInstallExecute:
             patch("comfy_cli.command.install.ensure_workspace_python", return_value=python) as mock_ensure,
             patch("comfy_cli.command.install.clone_comfyui"),
             patch("comfy_cli.command.install.check_comfy_repo", return_value=(True, None)),
+            # The non-fast-deps path bootstraps pip into `python` for real; left
+            # live it shells out to `uv pip install --python <python>`, which
+            # fails wherever that stand-in path isn't a real interpreter.
+            patch("comfy_cli.command.install.ensure_pip"),
             patch("comfy_cli.command.install.pip_install_comfyui_dependencies") as mock_pip,
             patch("comfy_cli.command.install.DependencyCompiler") as MockCompiler,
             patch("comfy_cli.command.install.WorkspaceManager"),


### PR DESCRIPTION
**TL;DR:** Four test-harness fixes, no command behaviour changes: a `@singleton` that leaked config across tests, an OOM that killed the suite, a live pip bootstrap in a mocked install path, and an unrestored environment.

First of a stack that lands the `comfy-build.yaml` spec surface. It is independent of that work and mergeable on its own.

**What changed**

* **comfy_cli/utils.py**: `singleton` now records each decorated class's instance cache, and `reset_singleton_for_testing()` clears it. `ConfigManager` reads the config dir exactly once, at construction, so repointing the dir per test left the FIRST test's instance serving every later one. Any test that ran the CLI entrypoint then wrote `setup_nudged` into that shared instance, breaking the onboarding tests' "fresh config" premise hundreds of tests later. The cache lives beside the decorator rather than on the wrapper because several tests reach the decorated class through `Wrapper.__closure__[0]`.
* **tests/comfy_cli/conftest.py**: `_isolate_config_path` resets the `ConfigManager` singleton around each test, so the tmp-dir repoint actually takes effect.
* **tests/comfy_cli/command/test_run.py**: stub `validation_warnings` and `workflow_manifest` on the executor mock. `_emit_queued` hands those to `json.dumps` in NDJSON mode, and unstubbed `MagicMock`s made its `default` hook recurse on `isoformat`, retaining every child mock — ~28GB, and the OOM killer took the suite.
* **tests/comfy_cli/test_global_python_install.py**: patch `ensure_pip`. The non-fast-deps path bootstraps pip into the target interpreter for real, which fails wherever the stand-in path is not a real interpreter.
* **tests/comfy_cli/command/github/test_pr.py**: restore the ambient environment the test mutates.
* **pyrightconfig.json**: point the checker at `.venv` so it resolves installed packages.

**Validation**

* `uv run --locked --extra dev pytest -q`: 5970 passed, 38 skipped. The one failure (`test_build.py::test_scan_custom_nodes_records_repo_and_ref`) reproduces identically on a clean `origin/main` checkout in this environment — pre-existing, not this change.
* `ruff check` / `ruff format --diff` clean at CI's pin (0.15.15).
* The OOM fix is the one claim the suite cannot show by passing: before it, a full run was killed by the OOM reaper on this machine; after, it completes in ~6 minutes.

**Contradicts:** nothing.