### PR TITLE
feat(cli): add shared require_option / confirm interaction helpers

### DIFF
--- a/comfy_cli/interaction.py
+++ b/comfy_cli/interaction.py
@@ -1,0 +1,338 @@
+"""The three interaction tenets, in one place.
+
+Every ``comfy build`` command follows the same three rules (builder-cli-design
+lines 73-94):
+
+1. Required input missing **in an interactive context** → a good TUI prompt.
+2. Required input missing **in a non-interactive context** → fail with a
+   structured error naming the missing options, and print the command's help.
+3. All required input provided → run to completion with zero interaction, so
+   the command stays scriptable.
+
+``caller.detect_caller()`` already draws the line: ``.agentic is False`` is
+tenet 1, ``.agentic is True`` is tenet 2. Two escape hatches force tenet-3
+behaviour *even on a TTY* — ``-y`` / ``--yes`` accepts every confirmation, and
+the global ``--skip-prompt`` flag suppresses every prompt.
+
+**Output-channel rule.** Tenet 2 has two halves that land on *different*
+streams. The structured error is the machine contract and goes through
+``renderer.error``, which in JSON mode writes exactly one ``envelope/1`` line
+to stdout. The command help is a human adjunct and goes to **stderr, always**;
+otherwise a ``--json`` consumer would find help text glued to its envelope.
+
+That hazard is not theoretical. Under Typer's rich markup mode (this app's
+mode) ``ctx.get_help()`` returns the *empty string* and prints ~1KB of
+formatted help straight to ``sys.stdout`` as a side effect, so the obvious
+``renderer.print(ctx.get_help())`` would print nothing useful *and* corrupt the
+envelope. ``_write_command_help`` captures that side effect and re-emits it on
+stderr. ``tests/comfy_cli/test_interaction.py`` pins both halves.
+
+Nothing here reads the environment: the caller, the skip-prompt flag and the
+click context are all injectable, so tests pass a synthetic ``Caller`` instead
+of mutating ``os.environ``.
+
+The one piece of global state this module *does* read is the installed
+``Renderer``, because a prompt and the envelope share stdout and only the
+renderer knows which of the two owns it — see ``_may_prompt``. It is not
+injectable alongside ``caller`` / ``skip_prompt``, so a test that wants a
+prompt has to give the command a pretty renderer (``--no-json``, or
+``COMFY_OUTPUT=pretty``) rather than only a non-agentic ``Caller``.
+
+Tested in ``tests/comfy_cli/test_interaction.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, NoReturn, TypeVar
+
+import typer
+
+from comfy_cli.caller import Caller, detect_caller
+from comfy_cli.output import get_renderer
+
+if TYPE_CHECKING:
+    import click
+
+__all__ = ["confirm", "require_option"]
+
+T = TypeVar("T")
+
+
+def _skip_prompt_flag() -> bool:
+    """The global ``--skip-prompt``, read live from the house singleton.
+
+    Read at call time, never cached: the root Typer callback installs the flag
+    (``cmdline.setup_workspace_manager``) long after this module is imported,
+    so a value captured at import would always be the pre-parse ``None``. The
+    lazy import mirrors ``ui.py``'s lazy ``questionary`` import — it keeps
+    ``WorkspaceManager``'s ``ConfigManager`` construction off the import path
+    of a module that most commands only touch on an error branch.
+    """
+    from comfy_cli.workspace_manager import WorkspaceManager
+
+    return bool(WorkspaceManager().skip_prompting)
+
+
+def _may_prompt(caller: Caller, skip_prompt: bool) -> bool:
+    """Tenet 1 applies only to a human at a terminal who has not opted out.
+
+    A JSON caller is never prompted, whatever ``detect_caller`` decided. This is
+    the output-channel rule above applied to the *prompt* half: questionary draws
+    on **stdout**, which in JSON mode carries the ``envelope/1`` contract, so a
+    prompt there writes escape sequences into the machine channel and then blocks
+    forever on an answer no ``--json`` consumer is present to give.
+
+    The check is needed because ``detect_caller`` reads only the environment and
+    stdout's tty-ness, never the *requested* output mode, so a human who types
+    ``comfy --json ...`` at a terminal is ``kind="user"``, ``agentic=False``.
+
+    ``is_pretty()`` is the exact predicate rather than an approximation of one.
+    A non-tty stdout already yields ``kind="pipe", agentic=True``
+    (``caller.detect_caller`` branch 4), so reaching this term at all implies
+    stdout *is* a tty; and with a tty, ``Renderer.resolve`` leaves pretty mode
+    only for an explicit ``--json`` / ``--json-stream`` / ``COMFY_OUTPUT``. So
+    "not pretty" here means precisely "this caller asked for machine output",
+    never merely "stdout happens to be redirected".
+    """
+    return not caller.agentic and not skip_prompt and get_renderer().is_pretty()
+
+
+def _write_command_help(ctx: click.Context | None) -> None:
+    """Render *ctx*'s help onto stderr, never stdout.
+
+    The capture-then-re-emit dance is the whole point — as the module docstring
+    records, under Typer's rich markup mode ``get_help()`` prints to
+    ``sys.stdout`` and returns ``""``. ``captured or returned`` covers both
+    that path and plain click's (which returns the text and prints nothing),
+    so this keeps working if the app ever drops rich formatting.
+
+    The help is a human adjunct to the structured error, never a precondition
+    for it, so a context whose help fails to render still gets its envelope —
+    the same best-effort reasoning as ``_cloud_errors._read_error_body``.
+    """
+    if ctx is None:
+        return
+    stream = getattr(sys, "stderr", None)
+    if stream is None:
+        # `print(file=None)` falls back to *stdout*, which would glue help
+        # text onto the JSON envelope — exactly what this function exists to
+        # prevent. Under `pythonw` / a detached parent `sys.stderr` really is
+        # None, so this is a live branch, not a hypothetical. No stderr, no
+        # help; the envelope still goes out.
+        return
+    try:
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            returned = ctx.get_help()
+        text = captured.getvalue() or returned
+        if text.strip():
+            print(text.rstrip("\n"), file=stream, flush=True)
+    except Exception:
+        return
+
+
+def _refuse(
+    *,
+    error_code: str,
+    message: str,
+    hint: str,
+    details: Mapping[str, object],
+    ctx: click.Context | None,
+) -> NoReturn:
+    """Tenet 2, both halves, each on the stream it belongs on.
+
+    The single funnel for every refusal in this module, for the reason
+    ``command/_cloud_errors.py`` exists: two call sites emitting their own
+    error would eventually drift on the stdout-purity invariant, and that
+    invariant is the entire contract here.
+
+    Help first, envelope last — in NDJSON mode the envelope must be the final
+    line, and ``renderer.error`` is what writes it.
+    """
+    _write_command_help(ctx)
+    renderer = get_renderer()
+    renderer.error(code=error_code, message=message, hint=hint, details=details)
+    raise typer.Exit(code=renderer.exit_code or 1)
+
+
+def _option_names(missing: Sequence[str], name: str) -> list[str]:
+    """*missing* in call order, with *name* appended only if it is not there.
+
+    A command that collects its missing options into one list will usually
+    include the option it is currently requiring, and the error must not name
+    it twice; ``dict.fromkeys`` de-duplicates while preserving call order, so
+    the payload reads in the order the command declares its options rather
+    than alphabetically.
+    """
+    return list(dict.fromkeys([*missing, name]))
+
+
+def require_option(
+    name: str,
+    value: T | None,
+    *,
+    prompt_fn: Callable[[], T | None],
+    error_code: str,
+    missing: Sequence[str] = (),
+    caller: Caller | None = None,
+    skip_prompt: bool | None = None,
+    ctx: click.Context | None = None,
+) -> T:
+    """Return *value*, or prompt for it, or refuse — the three tenets in order.
+
+    Args:
+        name: the option this call requires, spelled the way a user types it
+            (``"--name"``), because it lands verbatim in the error payload.
+        value: whatever the command parsed. ``None`` means "not supplied";
+            every other value — including ``""``, ``0`` and ``False`` — counts
+            as given, so a legitimately falsy answer is never re-prompted.
+        prompt_fn: the TUI prompt for tenet 1. Called **at most once**, and
+            only when a prompt is allowed. ``None`` back (questionary's answer
+            when the user aborts with Ctrl-C / EOF) falls through to the
+            tenet-2 refusal rather than asking again.
+        error_code: the registered ``error.code`` for the refusal. An argument
+            rather than a constant so each command registers its own code at
+            its own first call site, per the register-with-first-call-site
+            rule — this module deliberately hardcodes none.
+        missing: every option the command found missing, not just this one, so
+            an agent fixes them all in one retry instead of discovering them
+            one round-trip at a time. *name* is appended if absent.
+        caller: injected for tests; defaults to a live ``detect_caller()``.
+        skip_prompt: injected for tests; ``None`` reads the global
+            ``--skip-prompt`` flag.
+        ctx: the command's click/typer context, whose help accompanies a
+            refusal on stderr. ``None`` skips the help half.
+
+    Returns:
+        The supplied value, or the prompt's answer.
+
+    Raises:
+        typer.Exit: tenet 2 — the value is missing and no prompt is allowed.
+    """
+    if value is not None:
+        return value  # Tenet 3: supplied → run on, zero interaction.
+
+    resolved_caller = caller if caller is not None else detect_caller()
+    skip = skip_prompt if skip_prompt is not None else _skip_prompt_flag()
+
+    if _may_prompt(resolved_caller, skip):
+        answer = prompt_fn()  # Tenet 1. Exactly once — an abort falls through.
+        if answer is not None:
+            return answer
+
+    options = _option_names(missing, name)
+    joined = ", ".join(options)
+    plural = "s" if len(options) > 1 else ""
+    _refuse(  # Tenet 2.
+        error_code=error_code,
+        message=f"Missing required option{plural}: {joined}",
+        hint=f"pass {joined}",
+        details={"missing": options, "caller": resolved_caller.kind},
+        ctx=ctx,
+    )
+
+
+def _ask_confirm(question: str) -> bool | None:
+    """The house prompt: lazy-import ``questionary``, ask, hand back its answer.
+
+    ``questionary`` pulls in ``prompt_toolkit`` (~50ms of import time), so it
+    is imported here rather than at module scope — the same reason every
+    prompting function in ``ui.py`` imports it inline. Returns ``None`` when
+    the user aborts.
+
+    A module-level function rather than an inline import so tests can replace
+    the prompt without a TTY and count how often it was reached.
+    """
+    import questionary
+
+    return questionary.confirm(question).ask()
+
+
+def confirm(
+    question: str,
+    *,
+    yes: bool = False,
+    error_code: str,
+    details: Mapping[str, object] | None = None,
+    caller: Caller | None = None,
+    skip_prompt: bool | None = None,
+    ctx: click.Context | None = None,
+) -> bool:
+    """Ask *question*, or take an escape hatch, or refuse.
+
+    Both escape hatches mean *proceed*, because answering ``False`` would abort
+    the command instead of completing it, which is the opposite of tenet 3:
+    ``--yes`` accepts every confirmation, and the global ``--skip-prompt`` says
+    run to completion without asking.
+
+    ``--skip-prompt`` is honoured **only for a non-agentic caller** — design
+    line 90 scopes it to forcing tenet-3 behaviour *even on a TTY*. It cannot
+    extend to an agent, because the root callback turns it on for every agentic
+    caller automatically (``cmdline.py``, "Agentic callers shouldn't get
+    interactive prompts"). Reading that derived flag as consent would silently
+    accept every destructive confirmation for exactly the callers tenet 2
+    exists to protect, and would make each command's ``*_needs_confirm`` code
+    unreachable. Suppressing a prompt is not answering it; only ``-y`` answers
+    it.
+
+    Note the hatch is keyed on the *caller*, not on ``_may_prompt``: a human who
+    passes ``--json`` is unpromptable yet still non-agentic, so an explicit
+    ``--skip-prompt`` from them means proceed. That is deliberate — they asked
+    for both machine output and no questions — and it is why the check below is
+    ``not resolved_caller.agentic`` rather than a second ``_may_prompt`` call.
+
+    A caller who declines at the prompt gets ``False``, and so does one who
+    aborts it — questionary answers ``None`` on Ctrl-C / EOF, and the safe
+    reading of "no answer" for a confirmation is "not confirmed".
+
+    Args:
+        question: the confirmation text, echoed into the refusal payload so an
+            agent can see what it was being asked to accept.
+        yes: the ``-y`` / ``--yes`` escape hatch.
+        error_code: the registered ``error.code`` for the refusal; see
+            ``require_option``.
+        details: extra payload keys merged into the refusal, for the identifier
+            the command was about to act on. Without it a refusal names only the
+            question, forcing an agent to parse the subject back out of prose.
+        caller: injected for tests; defaults to a live ``detect_caller()``.
+        skip_prompt: injected for tests; ``None`` reads the global
+            ``--skip-prompt`` flag.
+        ctx: the command's click/typer context, whose help accompanies a
+            refusal on stderr.
+
+    Returns:
+        Whether to proceed.
+
+    Raises:
+        typer.Exit: tenet 2 — non-interactive with no ``--yes``.
+    """
+    if yes:
+        return True  # Tenet 3.
+
+    resolved_caller = caller if caller is not None else detect_caller()
+    skip = skip_prompt if skip_prompt is not None else _skip_prompt_flag()
+
+    if _may_prompt(resolved_caller, skip):
+        return _ask_confirm(question) is True  # Tenet 1; `is True` maps an abort to False.
+
+    if skip and not resolved_caller.agentic:
+        return True  # Tenet 3, the other escape hatch: a TTY that opted out of prompts.
+
+    _refuse(  # Tenet 2.
+        error_code=error_code,
+        message=f"Confirmation required, but nothing can answer it: {question}",
+        hint="pass --yes to confirm without prompting",
+        details={
+            # Call-site keys first: the three below are the contract every
+            # consumer reads, so a caller cannot displace them with its payload.
+            **(details or {}),
+            "missing": ["--yes"],
+            "question": question,
+            "caller": resolved_caller.kind,
+        },
+        ctx=ctx,
+    )

--- a/tests/comfy_cli/output/test_error_code_registry.py
+++ b/tests/comfy_cli/output/test_error_code_registry.py
@@ -44,8 +44,17 @@ def _iter_python_files(root: Path):
         yield p
 
 
+#: ``code=`` is ``renderer.error``'s own kwarg. ``error_code=`` is how
+#: ``comfy_cli.interaction``'s ``require_option`` / ``confirm`` take the code:
+#: that helper deliberately hardcodes none, so each command names its own code
+#: at its own call site (the register-with-first-call-site rule). A command
+#: whose only refusal goes through those helpers would otherwise look like it
+#: registered an orphan.
+_CODE_KWARGS = frozenset({"code", "error_code"})
+
+
 def _extract_codes_from_call(call: ast.Call) -> list[str]:
-    """Return any string literal passed as ``code=...`` whose shape matches a code.
+    """Return any string literal passed as a code kwarg whose shape matches a code.
 
     Conservative on what counts as a code (must match the snake_case pattern)
     so we don't accept random ``code=1`` ints (e.g. ``typer.Exit(code=1)``) or
@@ -53,7 +62,7 @@ def _extract_codes_from_call(call: ast.Call) -> list[str]:
     """
     out: list[str] = []
     for kw in call.keywords:
-        if kw.arg != "code":
+        if kw.arg not in _CODE_KWARGS:
             continue
         if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
             value = kw.value.value

--- a/tests/comfy_cli/test_interaction.py
+++ b/tests/comfy_cli/test_interaction.py
@@ -1,0 +1,545 @@
+"""The three interaction tenets (``comfy_cli.interaction``).
+
+1. Missing required input, interactive caller → a TUI prompt.
+2. Missing required input, agentic caller → a structured error naming *every*
+   missing option, plus the command's help — on stderr, never stdout.
+3. Everything supplied → run to completion with zero interaction.
+
+Two invariants get most of the attention here because they are the ones that
+break silently:
+
+- ``prompt_fn`` call *counts*, not just outcomes. A fail-safe helper produces
+  the right answer even when it prompts an agent that cannot answer, so only a
+  count pins "never" and "exactly once".
+- stdout purity under ``--json``. The refusal path writes on two streams, and
+  ``ctx.get_help()`` prints to stdout as a side effect (see
+  ``test_typer_get_help_pollutes_stdout_on_its_own``), so the envelope contract
+  is one bad line away from breaking.
+
+Callers are injected, never derived from ``os.environ``: every
+``detect_caller`` call below passes an explicit ``env`` mapping and ``is_tty``.
+The one exception is deliberate — ``TestRealTerminalDetection`` drives the real
+no-arguments code path in a subprocess attached to a real PTY, because that is
+the only branch a stub cannot honestly stand in for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import click
+import pytest
+import typer
+
+from comfy_cli import interaction
+from comfy_cli.caller import Caller, detect_caller
+from comfy_cli.interaction import confirm, require_option
+from comfy_cli.output import Renderer, set_renderer
+
+CLI_ROOT = Path(__file__).resolve().parents[2]
+
+HUMAN = Caller(kind="user", agentic=False, source_env=None)
+AGENT = Caller(kind="agent", agentic=True, source_env="AI_AGENT")
+
+# (label, env, is_tty, kind, agentic, source_env) — the five branches of
+# `detect_caller`, in the priority order the function evaluates them.
+BRANCHES = (
+    ("explicit_user_agent", {"COMFY_USER_AGENT": "comfy-mcp"}, True, "comfy-mcp", True, "COMFY_USER_AGENT"),
+    ("ai_agent", {"AI_AGENT": "1"}, True, "agent", True, "AI_AGENT"),
+    ("claudecode", {"CLAUDECODE": "1"}, True, "claude-code", True, "CLAUDECODE"),
+    ("non_tty_pipe", {}, False, "pipe", True, None),
+    ("human_at_a_terminal", {}, True, "user", False, None),
+)
+BRANCH_IDS = [row[0] for row in BRANCHES]
+
+
+class Spy:
+    """A prompt that records how often it was reached.
+
+    Outcome assertions cannot distinguish "never prompted" from "prompted and
+    got lucky", so every prompt assertion in this file is a count.
+    """
+
+    def __init__(self, answer: object = None) -> None:
+        self.answer = answer
+        self.calls = 0
+
+    def __call__(self) -> object:
+        self.calls += 1
+        return self.answer
+
+
+def help_context() -> click.Context:
+    """A real Typer command context.
+
+    Deliberately not a stub: Typer's rich markup mode is what makes
+    ``get_help()`` print to stdout instead of returning text, and a stub with
+    a well-behaved ``get_help`` would hide the exact hazard the stdout-purity
+    rule exists to catch.
+    """
+    app = typer.Typer()
+
+    @app.command()
+    def create(
+        name: str = typer.Option(None, "--name"),
+        base_image: str = typer.Option(None, "--base-image"),
+    ) -> None:
+        """Create a build."""
+
+    return click.Context(typer.main.get_command(app), info_name="comfy build create")
+
+
+class TestDetectCallerBranches:
+    """Each of the five branches, by explicit ``env`` + ``is_tty``."""
+
+    @pytest.mark.parametrize(
+        ("env", "is_tty", "kind", "agentic", "source_env"), [r[1:] for r in BRANCHES], ids=BRANCH_IDS
+    )
+    def test_branch_resolves_to_its_caller(self, env, is_tty, kind, agentic, source_env):
+        detected = detect_caller(env=env, is_tty=is_tty)
+        assert (detected.kind, detected.agentic, detected.source_env) == (kind, agentic, source_env)
+
+    @pytest.mark.parametrize(("env", "is_tty", "agentic"), [(r[1], r[2], r[4]) for r in BRANCHES], ids=BRANCH_IDS)
+    def test_branch_routes_to_the_matching_tenet(self, env, is_tty, agentic):
+        """``.agentic`` is the tenet switch, so pin the branch → tenet mapping.
+
+        Detecting the caller correctly is worthless if the helpers then route
+        it to the wrong tenet; this is the assertion ``output/test_caller.py``
+        cannot make because it does not know about ``require_option``.
+        """
+        prompt = Spy(answer="prompted")
+        caller = detect_caller(env=env, is_tty=is_tty)
+
+        if agentic:
+            with pytest.raises(typer.Exit):
+                require_option(
+                    "--name",
+                    None,
+                    prompt_fn=prompt,
+                    error_code="build_missing_option",
+                    caller=caller,
+                    skip_prompt=False,
+                )
+            assert prompt.calls == 0
+        else:
+            answer = require_option(
+                "--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=caller, skip_prompt=False
+            )
+            assert (answer, prompt.calls) == ("prompted", 1)
+
+
+class TestRequireOption:
+    def test_agentic_caller_never_prompts_and_names_every_missing_option(self, capsys):
+        """Tenet 2. Two missing options at once, because "every" is the point:
+        an agent must be able to fix the whole command in one retry rather than
+        discovering the next missing flag on the next round-trip."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build create", version="test"))
+        prompt = Spy(answer="never used")
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name",
+                None,
+                prompt_fn=prompt,
+                error_code="build_missing_option",
+                missing=("--name", "--base-image"),
+                caller=AGENT,
+                skip_prompt=False,
+            )
+
+        assert prompt.calls == 0
+        envelope = json.loads(capsys.readouterr().out.strip())
+        assert envelope["error"]["details"]["missing"] == ["--name", "--base-image"]
+        assert "--base-image" in envelope["error"]["message"]
+
+    def test_the_required_option_is_named_even_when_missing_omits_it(self, capsys):
+        """``missing`` is the command's whole picture and ``name`` is this
+        call's. A refusal that dropped ``--name`` because the caller forgot to
+        list it there would send the agent back with the wrong flags."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build create", version="test"))
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name",
+                None,
+                prompt_fn=Spy(),
+                error_code="build_missing_option",
+                missing=("--base-image",),
+                caller=AGENT,
+                skip_prompt=False,
+            )
+
+        envelope = json.loads(capsys.readouterr().out.strip())
+        assert envelope["error"]["details"]["missing"] == ["--base-image", "--name"]
+
+    def test_interactive_caller_prompts_exactly_once_and_returns_the_answer(self):
+        """Tenet 1."""
+        prompt = Spy(answer="from-the-prompt")
+
+        answer = require_option(
+            "--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN, skip_prompt=False
+        )
+
+        assert answer == "from-the-prompt"
+        assert prompt.calls == 1
+
+    def test_a_json_caller_at_a_terminal_is_refused_rather_than_prompted(self, capsys):
+        """`detect_caller` never reads the requested output mode, so a human who
+        types `comfy --json …` at a terminal is `agentic=False` and would be
+        prompted — drawing a TUI on the envelope channel, then blocking forever
+        on an answer no `--json` consumer is there to give."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=HUMAN, command="build create", version="test"))
+        prompt = Spy(answer="should not be reached")
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN, skip_prompt=False
+            )
+
+        assert prompt.calls == 0
+        assert json.loads(capsys.readouterr().out.strip())["error"]["code"] == "build_missing_option"
+
+    @pytest.mark.parametrize("caller", [HUMAN, AGENT], ids=["human", "agent"])
+    def test_a_supplied_value_is_returned_without_prompting(self, caller):
+        """Tenet 3, for both caller kinds — a supplied value short-circuits
+        before the caller is even consulted."""
+        prompt = Spy(answer="should not be reached")
+
+        answer = require_option(
+            "--name", "given", prompt_fn=prompt, error_code="build_missing_option", caller=caller, skip_prompt=False
+        )
+
+        assert answer == "given"
+        assert prompt.calls == 0
+
+    @pytest.mark.parametrize("value", ["", 0, False, []], ids=["empty_str", "zero", "false", "empty_list"])
+    def test_a_falsy_value_still_counts_as_supplied(self, value):
+        """ "Missing" is ``None``, not falsiness. ``--replicas 0`` and
+        ``--name ""`` are answers; re-prompting for them would ignore the user."""
+        prompt = Spy(answer="wrong")
+
+        answer = require_option(
+            "--name", value, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN, skip_prompt=False
+        )
+
+        assert answer == value
+        assert prompt.calls == 0
+
+    def test_skip_prompt_refuses_instead_of_prompting_a_human(self):
+        """``--skip-prompt`` forces tenet-3 behaviour even on a TTY, and with
+        no value to fall back on that means the tenet-2 refusal."""
+        prompt = Spy(answer="should not be reached")
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN, skip_prompt=True
+            )
+
+        assert prompt.calls == 0
+
+    def test_the_global_skip_prompt_flag_is_honoured_when_not_injected(self, monkeypatch):
+        """With ``skip_prompt=None`` the helper reads the global flag the root
+        callback installs, so ``comfy --skip-prompt build ...`` works without
+        every command threading the flag through by hand."""
+        from comfy_cli.workspace_manager import WorkspaceManager
+
+        monkeypatch.setattr(WorkspaceManager(), "skip_prompting", True)
+        prompt = Spy(answer="should not be reached")
+
+        with pytest.raises(typer.Exit):
+            require_option("--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN)
+
+        assert prompt.calls == 0
+
+    def test_an_aborted_prompt_refuses_instead_of_asking_again(self):
+        """questionary answers ``None`` when the user hits Ctrl-C / EOF. That
+        is still "no value", so it must fall through to the refusal — and must
+        not turn into a re-ask loop."""
+        prompt = Spy(answer=None)
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name", None, prompt_fn=prompt, error_code="build_missing_option", caller=HUMAN, skip_prompt=False
+            )
+
+        assert prompt.calls == 1
+
+
+class TestConfirm:
+    @pytest.fixture(autouse=True)
+    def _forbid_real_prompts(self, monkeypatch):
+        """No test in this class may reach questionary — there is no TTY, so a
+        real prompt would hang the suite rather than fail it."""
+        self.asked: list[str] = []
+
+        def spy(question: str) -> bool | None:
+            self.asked.append(question)
+            return self.answer
+
+        self.answer: bool | None = True
+        monkeypatch.setattr(interaction, "_ask_confirm", spy)
+
+    def test_yes_returns_true_without_prompting(self):
+        assert confirm("Delete it?", yes=True, error_code="build_confirm_required", caller=HUMAN, skip_prompt=False)
+        assert self.asked == []
+
+    def test_skip_prompt_returns_true_without_prompting(self):
+        """The second escape hatch. ``True`` rather than ``False`` because both
+        hatches mean "run to completion" — declining would abort the command,
+        which is the opposite of tenet 3."""
+        assert confirm("Delete it?", error_code="build_confirm_required", caller=HUMAN, skip_prompt=True)
+        assert self.asked == []
+
+    def test_an_interactive_caller_is_asked(self):
+        assert confirm("Delete it?", error_code="build_confirm_required", caller=HUMAN, skip_prompt=False)
+        assert self.asked == ["Delete it?"]
+
+    def test_a_declined_prompt_is_false(self):
+        self.answer = False
+        assert confirm("Delete it?", error_code="build_confirm_required", caller=HUMAN, skip_prompt=False) is False
+
+    def test_an_aborted_prompt_is_false(self):
+        """``None`` is questionary's Ctrl-C / EOF answer. The safe reading of
+        "no answer" for a confirmation is "not confirmed"."""
+        self.answer = None
+        assert confirm("Delete it?", error_code="build_confirm_required", caller=HUMAN, skip_prompt=False) is False
+
+    def test_a_json_caller_at_a_terminal_is_refused_rather_than_prompted(self, capsys):
+        """The confirm half of the same rule: `--json` is a promise that stdout
+        carries one envelope, so a destructive confirmation is refused there
+        instead of opening questionary on that stream."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=HUMAN, command="build delete", version="test"))
+
+        with pytest.raises(typer.Exit):
+            confirm("Delete it?", error_code="build_confirm_required", caller=HUMAN, skip_prompt=False)
+
+        assert self.asked == []
+        assert json.loads(capsys.readouterr().out.strip())["error"]["code"] == "build_confirm_required"
+
+    def test_extra_details_reach_the_refusal_payload(self, capsys):
+        """A refusal has to name the subject it refused to act on; without this
+        an agent would have to parse the id back out of the question text."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build delete", version="test"))
+
+        with pytest.raises(typer.Exit):
+            confirm(
+                "Delete it?",
+                error_code="build_confirm_required",
+                details={"distributionId": "build-1"},
+                caller=AGENT,
+                skip_prompt=False,
+            )
+
+        details = json.loads(capsys.readouterr().out.strip())["error"]["details"]
+        assert details["distributionId"] == "build-1"
+        assert details["missing"] == ["--yes"]
+
+    def test_an_agentic_caller_without_yes_is_refused(self, capsys):
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build delete", version="test"))
+
+        with pytest.raises(typer.Exit):
+            confirm("Delete it?", error_code="build_confirm_required", caller=AGENT, skip_prompt=False)
+
+        assert self.asked == []
+        envelope = json.loads(capsys.readouterr().out.strip())
+        assert envelope["error"]["code"] == "build_confirm_required"
+        assert envelope["error"]["details"]["missing"] == ["--yes"]
+
+    def test_skip_prompt_is_not_consent_for_an_agentic_caller(self, capsys):
+        """The root callback turns ``--skip-prompt`` on for every agentic caller
+        (``cmdline.py``), so honouring it here would auto-accept every
+        destructive confirmation an agent ever reaches and make each command's
+        ``*_needs_confirm`` code unreachable. Suppressing a prompt is not
+        answering it."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build update", version="test"))
+
+        with pytest.raises(typer.Exit):
+            confirm("Rewrite it?", error_code="build_confirm_required", caller=AGENT, skip_prompt=True)
+
+        assert self.asked == []
+        assert json.loads(capsys.readouterr().out.strip())["error"]["code"] == "build_confirm_required"
+
+
+class TestOutputChannels:
+    """Under ``--json``, stdout stays exactly one ``envelope/1`` line — on the
+    refusal path too, which is the one that also has help to print."""
+
+    def test_typer_get_help_pollutes_stdout_on_its_own(self, capsys):
+        """Why ``_write_command_help`` captures rather than printing the return
+        value. Under Typer's rich markup mode ``ctx.get_help()`` returns ``""``
+        and dumps the formatted help straight to ``sys.stdout``, so the obvious
+        ``renderer.print(ctx.get_help())`` would print nothing *and* corrupt
+        the envelope. If this test ever fails, Typer changed and
+        ``_write_command_help`` should be revisited — not deleted."""
+        returned = help_context().get_help()
+
+        captured = capsys.readouterr()
+        assert returned == ""
+        assert "Usage:" in captured.out
+
+    def test_refusal_puts_one_envelope_on_stdout_and_the_help_on_stderr(self, capsys):
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build create", version="test"))
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name",
+                None,
+                prompt_fn=Spy(),
+                error_code="build_missing_option",
+                missing=("--name", "--base-image"),
+                caller=AGENT,
+                skip_prompt=False,
+                ctx=help_context(),
+            )
+
+        captured = capsys.readouterr()
+        lines = [line for line in captured.out.splitlines() if line.strip()]
+        assert len(lines) == 1, f"stdout must be exactly one envelope line, got {lines!r}"
+        envelope = json.loads(lines[0])
+        assert envelope["schema"] == "envelope/1"
+        assert envelope["ok"] is False
+        assert envelope["error"]["code"] == "build_missing_option"
+        assert envelope["error"]["details"]["missing"] == ["--name", "--base-image"]
+        # `comfy build create` pins identity: this command's help, not the root
+        # app's, which is what `cmdline.py`'s `ctx.find_root().get_help()` gives.
+        assert "Usage:" in captured.err
+        assert "comfy build create" in captured.err
+        assert "--base-image" in captured.err
+        assert "Usage:" not in captured.out
+
+    def test_pretty_mode_also_keeps_the_help_off_stdout(self, capsys):
+        """The stderr rule is unconditional, not a JSON-mode special case: a
+        human's ``comfy build create > out.txt`` should not capture help text,
+        and click writes usage-on-error to stderr for the same reason."""
+        set_renderer(Renderer.resolve(no_json_flag=True, caller=HUMAN, command="build create", version="test"))
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name",
+                None,
+                prompt_fn=Spy(),
+                error_code="build_missing_option",
+                caller=HUMAN,
+                skip_prompt=True,
+                ctx=help_context(),
+            )
+
+        captured = capsys.readouterr()
+        assert "Usage:" in captured.err
+        assert "Usage:" not in captured.out
+
+    def test_a_context_whose_help_explodes_still_emits_the_envelope(self, capsys):
+        """The help is an adjunct; the envelope is the contract. A command that
+        cannot render its own help must not cost an agent its structured
+        error."""
+        set_renderer(Renderer.resolve(json_flag=True, caller=AGENT, command="build create", version="test"))
+
+        class Exploding:
+            def get_help(self) -> str:
+                raise RuntimeError("help rendering blew up")
+
+        with pytest.raises(typer.Exit):
+            require_option(
+                "--name",
+                None,
+                prompt_fn=Spy(),
+                error_code="build_missing_option",
+                caller=AGENT,
+                skip_prompt=False,
+                ctx=Exploding(),
+            )
+
+        envelope = json.loads(capsys.readouterr().out.strip())
+        assert envelope["error"]["code"] == "build_missing_option"
+
+
+PTY_PROBE = textwrap.dedent(
+    """
+    import json, os, sys
+    from comfy_cli.caller import detect_caller
+
+    caller = detect_caller()
+    sys.stderr.write(
+        json.dumps(
+            {
+                "kind": caller.kind,
+                "agentic": caller.agentic,
+                "isatty": sys.stdout.isatty(),
+                "markers": {
+                    k: os.environ.get(k)
+                    for k in ("COMFY_USER_AGENT", "AI_AGENT", "CLAUDECODE", "CI")
+                },
+            }
+        )
+        + "\\n"
+    )
+    """
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="pty is POSIX-only")
+class TestRealTerminalDetection:
+    def test_a_real_pty_with_no_agent_markers_is_a_human(self):
+        """The one test that exercises the real TTY probe.
+
+        Everything else here injects a ``Caller``, which proves the routing but
+        not the detection. This attaches a genuine PTY to a child's stdout,
+        scrubs every agent marker from its environment, and calls
+        ``detect_caller()`` with no arguments — the exact call a real
+        invocation makes. The child reports the markers it saw so a ``user``
+        verdict cannot be explained by anything but the terminal.
+
+        The result travels on stderr (a pipe) rather than the PTY so the parent
+        never has to drain a pty master, which would deadlock or raise EIO.
+        """
+        import pty
+
+        master, slave = pty.openpty()
+        env = {k: v for k, v in os.environ.items() if k not in {"COMFY_USER_AGENT", "AI_AGENT", "CLAUDECODE", "CI"}}
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", PTY_PROBE],
+                stdin=subprocess.DEVNULL,
+                stdout=slave,
+                stderr=subprocess.PIPE,
+                env=env,
+                cwd=CLI_ROOT,
+                timeout=120,
+                check=False,
+            )
+        finally:
+            os.close(slave)
+            os.close(master)
+
+        assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+        report = json.loads(proc.stderr.decode("utf-8", "replace").strip().splitlines()[-1])
+        assert report["markers"] == {"COMFY_USER_AGENT": None, "AI_AGENT": None, "CLAUDECODE": None, "CI": None}
+        assert report["isatty"] is True
+        assert report["kind"] == "user"
+        assert report["agentic"] is False
+
+    def test_the_same_probe_without_a_pty_is_a_pipe(self):
+        """The control. Same code, same scrubbed environment, stdout on a pipe
+        instead of a terminal — if this also said ``user``, the test above
+        would be proving nothing."""
+        env = {k: v for k, v in os.environ.items() if k not in {"COMFY_USER_AGENT", "AI_AGENT", "CLAUDECODE", "CI"}}
+        proc = subprocess.run(
+            [sys.executable, "-c", PTY_PROBE],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            env=env,
+            cwd=CLI_ROOT,
+            timeout=120,
+            check=False,
+        )
+
+        assert proc.returncode == 0, proc.stderr.decode("utf-8", "replace")
+        report = json.loads(proc.stderr.decode("utf-8", "replace").strip().splitlines()[-1])
+        assert report["isatty"] is False
+        assert report["kind"] == "pipe"
+        assert report["agentic"] is True


### PR DESCRIPTION
**TL;DR:** Two helpers for the two refusals every command repeats — a required option that was not supplied, and a destructive action that needs consent — both failing closed in machine mode. No caller yet; the build surface adopts them next in the stack.

Stacked on #791. Review that one first; this PR's diff is the 3 files below.

**What changed**

* **comfy_cli/interaction.py** (new): `require_option()` and `confirm()`. Under a TTY they prompt; with no TTY, or for an agentic caller, they skip the prompt and emit the refusal envelope directly, so an agent never blocks on a prompt it cannot see. Both return through the caller's renderer, so the envelope carries the command's own labels.
* **comfy_cli/interaction.py**: the helpers deliberately hardcode **no** error code. Each caller names its own via `error_code=`. That keeps the register-with-first-call-site rule intact — a command's refusal code is registered by the change that introduces the refusal, not by this module, so nothing here pre-registers codes for commands that do not exist yet.
* **tests/comfy_cli/output/test_error_code_registry.py**: the registry scanner learns `error_code=` as a code kwarg beside `renderer.error`'s own `code=`. Without it, a command whose only refusal routes through these helpers would look like it registered an orphan and fail `test_every_registered_code_is_raised`.
* **tests/comfy_cli/test_interaction.py** (new): TTY and non-TTY paths, agentic-caller detection, `--yes` / explicit-option short circuits, and the envelope shape for each refusal.

**Why it lands with no caller:** the alternative is introducing it inside the build-surface change, where 8k lines of command rewrite would bury it. Landing the leaf first keeps this reviewable on its own terms, and the guardrail tests confirm it changes no existing behaviour.

**Validation**

* `uv run --locked --extra dev pytest -q`: 6008 passed, 38 skipped. The one failure (`test_build.py::test_scan_custom_nodes_records_repo_and_ref`) reproduces identically on a clean `origin/main` checkout — pre-existing, not this change.
* `ruff check` / `ruff format --diff` clean at CI's pin (0.15.15).
* The registry guards (`test_every_registered_code_is_raised`, `test_every_raised_code_is_registered`) pass with the scanner change, confirming no code was silently orphaned or pre-registered.

**Contradicts:** nothing.