### PR TITLE
feat(build): add the comfy-build.yaml spec, path, target and diff primitives

### DIFF
--- a/comfy_cli/command/build_diff.py
+++ b/comfy_cli/command/build_diff.py
@@ -1,0 +1,321 @@
+"""Reconciling a fresh local scan against a build spec's stored ``definition``.
+
+``comfy build update`` rescans the installation and has to answer two questions
+from one pass over the same data: *what will change* — the diff it renders and
+confirms — and *what the new document is* — the ``definition`` it writes.
+
+**The rescan is merged, not substituted.** Everything the scanners produce comes
+from the scan; everything else is carried over from the stored entry. That
+distinction is load-bearing, not a nicety:
+
+- ``push`` caches ``blobId`` on an uploaded entry and may persist a resolver's
+  ``sourceUri``; ``pull`` merges server state and unknown keys back in
+  (plan decisions D-I). Substituting the definition wholesale would delete all
+  of it, so ``pull`` → ``update`` would churn the spec every single time.
+- Conversely the merge starts from the *scanned* entry, so a fact the scan no
+  longer reports — a pack that stopped being a git checkout, say — genuinely
+  disappears rather than lingering as stale metadata.
+
+**A content change invalidates the cache it backs.** ``blobId`` names bytes the
+builder already holds; once a model's ``sha256`` or a node's ``localDigest``
+moves, that blob is the wrong bytes and a persisted ``sourceUri`` is the wrong
+URL. Both are dropped here so the next ``push`` re-uploads instead of silently
+shipping what the user replaced (plan decisions D-I, "derived-field rules").
+
+Diff and merge live together because they share one notion of entry identity
+and because ``update`` diffs the merge *result* against the stored document —
+which is what makes "empty diff" mean exactly "the file will not change".
+
+Pure: no Typer, no filesystem, no renderer beyond the one rendering helper.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias
+
+from comfy_cli.command.build_spec import JsonObject, JsonValue
+
+Change: TypeAlias = Literal["added", "removed", "changed"]
+Status: TypeAlias = Literal["changed", "unchanged"]
+
+__all__ = [
+    "CategoryDiff",
+    "DefinitionDiff",
+    "EntryDiff",
+    "diff_definitions",
+    "merge_definition",
+    "render_definition_diff",
+    "summarize_definition_diff",
+]
+
+#: The row markers the build design fixes for the pretty table (lines 466-471).
+_MARKS: Final[Mapping[Change, str]] = {"added": "+", "removed": "-", "changed": "~"}
+
+#: Every change a collection entry can undergo, in the order both the counts
+#: object and the summary line report them.
+_CHANGES: Final[tuple[Change, ...]] = ("added", "removed", "changed")
+
+#: The two ``definition`` collections and the fields identifying one entry in
+#: each. Identity is what a person means by "the same model" / "the same pack":
+#: a model is its placement target, a node is its folder. Deliberately NARROWER
+#: than the canonical sort key in ``build_spec`` (which also carries ``sha256``
+#: / ``id`` / ``repository``) — a model whose bytes moved must read as one
+#: CHANGED row, not as an addition beside a removal.
+_IDENTITY: Final[Mapping[str, tuple[str, ...]]] = {
+    "models": ("type", "filename"),
+    "customNodes": ("name",),
+}
+
+#: Every key the scanners own, per collection (``build.scan_models`` and
+#: ``build.scan_custom_nodes``). A key outside these sets was written by
+#: something other than a scan — ``push``, ``pull``, or a hand edit — and the
+#: merge carries it over untouched.
+_SCANNED_KEYS: Final[Mapping[str, frozenset[str]]] = {
+    "models": frozenset({"type", "filename", "localPath", "sha256", "sizeBytes", "source"}),
+    "customNodes": frozenset(
+        {
+            "name",
+            "localPath",
+            "source",
+            "repository",
+            "gitRef",
+            "id",
+            "registryVersion",
+            "localDigest",
+            "localSizeBytes",
+        }
+    ),
+}
+
+#: The field whose value IS an entry's content identity. A model has no
+#: ``localDigest``; its ``sha256`` plays that role.
+_CONTENT_IDENTITY: Final[Mapping[str, str]] = {"models": "sha256", "customNodes": "localDigest"}
+
+#: Cached references a content change makes wrong. Only a model can carry a
+#: resolver-derived ``sourceUri``; a node has no public resolution path.
+_INVALIDATED_BY_CONTENT: Final[Mapping[str, tuple[str, ...]]] = {
+    "models": ("blobId", "sourceUri"),
+    "customNodes": ("blobId",),
+}
+
+#: Definition-level keys the scan owns. Everything else at that level — an
+#: unknown key a newer builder introduced, say — survives the rescan.
+_SCANNED_DEFINITION_KEYS: Final[frozenset[str]] = frozenset(
+    {"schema", "models", "customNodes", "baseComfyVersion", "pipDependencies", "environment"}
+)
+
+#: Distinguishes "absent" from a stored ``null`` when comparing scalars.
+_ABSENT: Final = object()
+
+
+@dataclass(frozen=True, slots=True)
+class EntryDiff:
+    """One affected ``models[]`` / ``customNodes[]`` entry."""
+
+    change: Change
+    name: str
+    fields: tuple[str, ...] = ()
+
+    def as_json(self) -> dict[str, object]:
+        return {"change": self.change, "name": self.name, "fields": list(self.fields)}
+
+
+@dataclass(frozen=True, slots=True)
+class CategoryDiff:
+    """Every affected entry in one collection, in identity order."""
+
+    entries: tuple[EntryDiff, ...]
+
+    def count(self, change: Change) -> int:
+        return sum(1 for entry in self.entries if entry.change == change)
+
+    def counts(self) -> dict[str, int]:
+        return {change: self.count(change) for change in _CHANGES}
+
+    def as_json(self) -> dict[str, object]:
+        return {**self.counts(), "entries": [entry.as_json() for entry in self.entries]}
+
+
+@dataclass(frozen=True, slots=True)
+class DefinitionDiff:
+    """Per-category counts plus the affected entries — the design's shape."""
+
+    collections: Mapping[str, CategoryDiff]
+    scalars: Mapping[str, Status]
+
+    @property
+    def is_empty(self) -> bool:
+        return not any(category.entries for category in self.collections.values()) and all(
+            status == "unchanged" for status in self.scalars.values()
+        )
+
+    def as_json(self) -> dict[str, object]:
+        """The table's information, structurally — an agent parses no table.
+
+        Collections carry counts plus entries; single-valued categories carry
+        the bare ``"changed"``/``"unchanged"`` the design uses for them
+        (builder-cli-design lines 451-458).
+        """
+        payload: dict[str, object] = {name: diff.as_json() for name, diff in self.collections.items()}
+        payload.update(self.scalars)
+        return payload
+
+    def as_drift(self) -> dict[str, object]:
+        """The same comparison as ``as_json``, reported as the design's drift.
+
+        ``status`` answers *whether* the installation has moved and by how much,
+        so it carries the per-category counts alone (builder-cli-design lines
+        451-458). The affected entries stay with ``update``'s diff, which is
+        about to act on them; a report nobody acts on does not need the list.
+        """
+        payload: dict[str, object] = {name: diff.counts() for name, diff in self.collections.items()}
+        payload.update(self.scalars)
+        return payload
+
+
+def _entries(definition: Mapping[str, JsonValue], collection: str) -> list[JsonObject]:
+    """The collection's entries.
+
+    ``read_build_spec`` has already proven every entry is a mapping and the
+    collection a list (``build_spec._sorted_entries`` refuses anything else),
+    so the only shape this has to cope with is the key being absent.
+    """
+    value = definition.get(collection)
+    return [entry for entry in value if isinstance(entry, dict)] if isinstance(value, list) else []
+
+
+def _identity(entry: JsonObject, collection: str) -> tuple[str, ...]:
+    return tuple(str(entry.get(field) or "") for field in _IDENTITY[collection])
+
+
+def _index(entries: Sequence[JsonObject], collection: str) -> dict[tuple[str, ...], list[JsonObject]]:
+    """Group entries by identity.
+
+    A group rather than a single entry because a hand-edited spec can hold two
+    models sharing ``(type, filename)``; pairing them positionally keeps such a
+    file diffable instead of turning it into a crash or an arbitrary winner.
+    """
+    grouped: dict[tuple[str, ...], list[JsonObject]] = {}
+    for entry in entries:
+        grouped.setdefault(_identity(entry, collection), []).append(entry)
+    return grouped
+
+
+def _merge_entry(stored: JsonObject, scanned: JsonObject, collection: str) -> JsonObject:
+    """The scanned entry, plus every key the scanner does not own."""
+    carried = {key: value for key, value in stored.items() if key not in _SCANNED_KEYS[collection]}
+    identity_field = _CONTENT_IDENTITY[collection]
+    if stored.get(identity_field) != scanned.get(identity_field):
+        for field in _INVALIDATED_BY_CONTENT[collection]:
+            carried.pop(field, None)
+    return {**scanned, **carried}
+
+
+def _merge_collection(
+    stored: Sequence[JsonObject],
+    scanned: Sequence[JsonObject],
+    collection: str,
+) -> list[JsonObject]:
+    previous = _index(stored, collection)
+    taken: dict[tuple[str, ...], int] = {}
+    merged: list[JsonObject] = []
+    for entry in scanned:
+        identity = _identity(entry, collection)
+        group = previous.get(identity, [])
+        position = taken.get(identity, 0)
+        taken[identity] = position + 1
+        merged.append(_merge_entry(group[position], entry, collection) if position < len(group) else entry)
+    return merged
+
+
+def merge_definition(stored: Mapping[str, JsonValue], scanned: Mapping[str, JsonValue]) -> JsonObject:
+    """Return the ``definition`` a rescan produces against ``stored``.
+
+    The scan wins on every fact it reports; the stored document keeps the
+    derived and unknown keys it alone knows about. An entry present only in the
+    scan is added verbatim; an entry the scan no longer sees is dropped, since
+    the whole command means "recompute the spec from the local installation".
+    """
+    carried = {key: value for key, value in stored.items() if key not in _SCANNED_DEFINITION_KEYS}
+    merged: JsonObject = {**scanned, **carried}
+    for collection in _IDENTITY:
+        merged[collection] = list(
+            _merge_collection(_entries(stored, collection), _entries(scanned, collection), collection)
+        )
+    return merged
+
+
+def _changed_fields(stored: JsonObject, updated: JsonObject) -> tuple[str, ...]:
+    keys = stored.keys() | updated.keys()
+    return tuple(sorted(key for key in keys if stored.get(key) != updated.get(key)))
+
+
+def _diff_collection(stored: Sequence[JsonObject], updated: Sequence[JsonObject], collection: str) -> CategoryDiff:
+    previous = _index(stored, collection)
+    current = _index(updated, collection)
+    entries: list[EntryDiff] = []
+    for identity in sorted(previous.keys() | current.keys()):
+        before = previous.get(identity, [])
+        after = current.get(identity, [])
+        name = "/".join(part for part in identity if part) or "?"
+        entries.extend(
+            EntryDiff("changed", name, fields)
+            for fields in (_changed_fields(old, new) for old, new in zip(before, after))
+            if fields
+        )
+        entries.extend(EntryDiff("added", name) for _ in after[len(before) :])
+        entries.extend(EntryDiff("removed", name) for _ in before[len(after) :])
+    return CategoryDiff(entries=tuple(entries))
+
+
+def _diff_scalars(stored: Mapping[str, JsonValue], updated: Mapping[str, JsonValue]) -> dict[str, Status]:
+    """Every non-collection category, so an unknown key is reported too."""
+    keys = (stored.keys() | updated.keys()) - set(_IDENTITY)
+    return {
+        key: ("unchanged" if stored.get(key, _ABSENT) == updated.get(key, _ABSENT) else "changed")
+        for key in sorted(keys)
+    }
+
+
+def diff_definitions(stored: Mapping[str, JsonValue], updated: Mapping[str, JsonValue]) -> DefinitionDiff:
+    """Compare the document about to be written against the one on disk."""
+    return DefinitionDiff(
+        collections={
+            collection: _diff_collection(_entries(stored, collection), _entries(updated, collection), collection)
+            for collection in _IDENTITY
+        },
+        scalars=_diff_scalars(stored, updated),
+    )
+
+
+def summarize_definition_diff(diff: DefinitionDiff) -> str:
+    """The one-line summary printed under the table and echoed in the prompt."""
+    if diff.is_empty:
+        return "no changes"
+    parts = [
+        f"{name} +{category.count('added')} -{category.count('removed')} ~{category.count('changed')}"
+        for name, category in diff.collections.items()
+    ]
+    parts.extend(name for name, status in diff.scalars.items() if status == "changed")
+    return ", ".join(parts)
+
+
+def render_definition_diff(renderer, diff: DefinitionDiff) -> None:
+    """The pretty view: a Rich table grouped by category, then the summary."""
+    from rich.table import Table
+
+    table = Table(title="Pending spec changes")
+    table.add_column("", style="bold", no_wrap=True)
+    table.add_column("category", style="cyan", no_wrap=True)
+    table.add_column("entry", style="white")
+    table.add_column("fields", style="dim")
+    for name, category in diff.collections.items():
+        for entry in category.entries:
+            table.add_row(_MARKS[entry.change], name, entry.name, ", ".join(entry.fields))
+    for name, status in diff.scalars.items():
+        if status == "changed":
+            table.add_row(_MARKS["changed"], name, "", "")
+    renderer.console().print(table)
+    renderer.print(summarize_definition_diff(diff))

--- a/comfy_cli/command/build_paths.py
+++ b/comfy_cli/command/build_paths.py
@@ -1,0 +1,194 @@
+"""PATH resolution for the `comfy build` command tree, and later for deploy.
+
+Every build command takes one optional positional `PATH` that answers two
+questions at once — *where is the spec* and *where is the install* — because a
+ComfyUI install and its spec normally live in the same folder (build design
+lines 291-312):
+
+===================== ========================== ==================
+You pass              Spec resolves to           Install root
+===================== ========================== ==================
+nothing               ``./comfy-build.yaml``     ``.``
+a directory           ``<dir>/comfy-build.yaml`` ``<dir>``
+a ``.yaml``/``.json`` that file                  the file's parent
+===================== ========================== ==================
+
+``--models-dir``, ``--custom-nodes-dir`` and ``--python`` override the INSTALL
+half only — never the spec half. That is what makes split and Desktop layouts,
+where the code and the data directory sit apart, expressible with a single
+positional.
+
+`ls` and the `refs` command groups are workspace-level and involve no spec, so
+they ignore PATH entirely: they simply never call this module.
+
+Deploy reuses the spec half verbatim and raises the *same*
+``build_spec_not_found`` code rather than a second one (deploy design lines
+251-271).
+
+This module is pure — no Typer, no renderer, no filesystem writes. A missing
+spec surfaces as :class:`BuildSpecNotFoundError`, which the command layer
+renders through ``renderer.error(code=e.code, message=str(e), details=e.details)``
+the way ``workflow_ops``' typed errors are rendered.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from comfy_cli.command.build_spec import BuildSpecInvalidError
+from comfy_cli.constants import DEFAULT_COMFY_MODEL_PATH
+
+#: The canonical spec filename a directory PATH expands to.
+SPEC_FILENAME = "comfy-build.yaml"
+
+#: Suffixes that mark PATH as a spec FILE rather than a directory. Fixed by the
+#: build design's resolution table. Classification is by suffix ALONE, never by
+#: what is on disk, so one argument means one thing whether or not the file
+#: exists yet — `init` resolves a spec it is about to create.
+SPEC_SUFFIXES: frozenset[str] = frozenset({".yaml", ".json"})
+
+#: ``custom_nodes/`` has no shared constant; ``command/build.py:80`` keeps its
+#: own copy. Duplicated rather than imported so this module stays free of the
+#: heavy command module it will be imported *by*.
+CUSTOM_NODES_DIRNAME = "custom_nodes"
+
+
+class BuildSpecNotFoundError(ValueError):
+    """No spec at the path PATH resolved to.
+
+    Every build command except `init` fails with this (build design lines
+    307-309); `init` is the one command that resolves with
+    ``require_spec=False``, because creating the spec is its whole job.
+
+    Subclasses ``ValueError`` — matching the house typed errors in
+    ``workflow_ops`` — deliberately rather than ``FileNotFoundError``, so a
+    broad ``except OSError`` around neighbouring file IO cannot swallow it.
+    """
+
+    code = "build_spec_not_found"
+    hint = "create a comfy-build.yaml at that path, or pass the PATH that holds the spec"
+
+    def __init__(self, spec_file: Path) -> None:
+        self.spec_file = spec_file
+        # `details.path` is the EXACT absolute path probed, so an agent can
+        # retry against it without re-deriving the resolution rules.
+        self.details: dict[str, str] = {"path": str(spec_file)}
+        super().__init__(f"no build spec at {spec_file}")
+
+
+@dataclass(frozen=True, slots=True)
+class InstallOverrides:
+    """The three flags that redirect the install half of PATH.
+
+    ``None`` means "not overridden — derive it from the install root".
+    """
+
+    models_dir: Path | None = None
+    custom_nodes_dir: Path | None = None
+    python: Path | None = None
+
+    @classmethod
+    def from_options(
+        cls,
+        models_dir: str | None = None,
+        custom_nodes_dir: str | None = None,
+        python: str | None = None,
+    ) -> InstallOverrides:
+        """Parse the raw Typer option strings once, at the boundary."""
+        return cls(
+            models_dir=Path(models_dir) if models_dir else None,
+            custom_nodes_dir=Path(custom_nodes_dir) if custom_nodes_dir else None,
+            python=Path(python) if python else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BuildPaths:
+    """Both halves of a resolved PATH. Every path is absolute.
+
+    ``python`` is the only optional member: there is no filesystem-free default
+    for the interpreter, so ``None`` means "not overridden — detect it from
+    ``install_root``".
+    """
+
+    spec_file: Path
+    install_root: Path
+    models_dir: Path
+    custom_nodes_dir: Path
+    python: Path | None
+
+
+def resolve_local_path(scan_root: Path, local_path: str, *, entry: str) -> Path:
+    """Resolve one spec localPath lexically against its own scan root."""
+    root = scan_root.resolve()
+    path = PurePosixPath(local_path)
+    drive_qualified = re.match(r"^[A-Za-z]:", local_path) is not None
+    if "\\" in local_path or drive_qualified or path.is_absolute() or ".." in path.parts:
+        raise BuildSpecInvalidError(f"{entry}: invalid localPath {local_path!r}")
+    return root.joinpath(*path.parts)
+
+
+def _absolute(path: Path) -> Path:
+    """Anchor ``path`` at the cwd without resolving symlinks or collapsing ``..``.
+
+    ``Path.resolve()`` would rewrite a symlinked PATH into wherever it points,
+    so a spec the caller named as ``link/comfy-build.yaml`` would be probed —
+    and reported in ``build_spec_not_found`` — under a directory they never
+    typed. Anchoring stays lexical so the resolved paths are the caller's own.
+    """
+    expanded = path.expanduser()
+    return expanded if expanded.is_absolute() else Path.cwd() / expanded
+
+
+def resolve_build_paths(
+    path: str | Path | None = None,
+    *,
+    overrides: InstallOverrides | None = None,
+    require_spec: bool = True,
+) -> BuildPaths:
+    """Map the positional ``PATH`` to its spec file and its install root.
+
+    Args:
+        path: the positional ``PATH``. ``None`` (or empty) is the cwd.
+        overrides: ``--models-dir``/``--custom-nodes-dir``/``--python``. These
+            touch the install half only; ``spec_file`` is unaffected by them.
+        require_spec: raise when the resolved spec is absent. `init` — the only
+            command allowed to proceed without one — passes ``False``.
+
+    Raises:
+        BuildSpecNotFoundError: ``require_spec`` and no spec at the resolved
+            path. Its ``details["path"]`` is the exact absolute path probed.
+    """
+    given = Path(path) if path else None
+    # Classify the path the CALLER gave, not the cwd it may stand in for: a bare
+    # `comfy build` run inside a directory literally named `foo.yaml` is still
+    # row one, not the spec-file row.
+    is_spec_file = given is not None and given.suffix in SPEC_SUFFIXES
+    anchored = _absolute(given) if given is not None else Path.cwd()
+
+    spec_file = anchored if is_spec_file else anchored / SPEC_FILENAME
+    install_root = anchored.parent if is_spec_file else anchored
+
+    if require_spec and not spec_file.is_file():
+        raise BuildSpecNotFoundError(spec_file)
+
+    opts = overrides or InstallOverrides()
+    models_dir = _absolute(opts.models_dir) if opts.models_dir else install_root / DEFAULT_COMFY_MODEL_PATH
+    if opts.custom_nodes_dir:
+        custom_nodes_dir = _absolute(opts.custom_nodes_dir)
+    elif opts.models_dir:
+        # Split layout: `--models-dir` names the data root, and `custom_nodes/`
+        # is its sibling — the rule `scan` already uses (build.py:783-784).
+        custom_nodes_dir = models_dir.parent / CUSTOM_NODES_DIRNAME
+    else:
+        custom_nodes_dir = install_root / CUSTOM_NODES_DIRNAME
+
+    return BuildPaths(
+        spec_file=spec_file,
+        install_root=install_root,
+        models_dir=models_dir,
+        custom_nodes_dir=custom_nodes_dir,
+        python=_absolute(opts.python) if opts.python else None,
+    )

--- a/comfy_cli/command/build_spec.py
+++ b/comfy_cli/command/build_spec.py
@@ -1,0 +1,269 @@
+"""Canonical reader and writer for the ``comfy-build/1`` file format."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Final, Literal, TypeAlias, assert_never
+
+import yaml
+
+from comfy_cli.file_utils import atomic_write_text
+
+SPEC_SCHEMA: Final = "comfy-build/1"
+_TOP_LEVEL_KEYS: Final = ("schema", "id", "name", "description", "syncedRevision", "definition")
+_DEFINITION_KEYS: Final = (
+    "schema",
+    "baseComfyVersion",
+    "models",
+    "customNodes",
+    "pipDependencies",
+    "environment",
+)
+_SORT_KEYS: Final = {
+    "models": ("type", "filename", "sha256"),
+    "customNodes": ("name", "id", "repository"),
+}
+
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+BuildSpec: TypeAlias = JsonObject
+SpecFormat: TypeAlias = Literal["yaml", "json"]
+
+
+class BuildSpecError(Exception):
+    message: str
+    path: Path | None
+
+    def __init__(self, message: str, *, path: Path | None = None) -> None:
+        self.message = message
+        self.path = path
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        return f"{self.path}: {self.message}" if self.path is not None else self.message
+
+
+class BuildSpecInvalidError(BuildSpecError):
+    code = "build_spec_invalid"
+
+
+class BuildSpecWriteError(BuildSpecError):
+    code = "build_spec_write_error"
+
+
+class _LiteralString(str):
+    pass
+
+
+class _CanonicalDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data) -> bool:
+        return True
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, indentless=False)
+
+    def determine_block_hints(self, text: str) -> str:
+        hints = super().determine_block_hints(text)
+        if text.endswith("\n") and "+" not in hints:
+            return f"{hints}+"
+        return hints
+
+
+def _represent_literal(dumper: _CanonicalDumper, value: _LiteralString):
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style="|")
+
+
+_CanonicalDumper.add_representer(_LiteralString, _represent_literal)
+
+
+def _invalid(message: str, path: Path | None) -> BuildSpecInvalidError:
+    return BuildSpecInvalidError(message, path=path)
+
+
+def _parse_json_value(value, *, location: str, path: Path | None) -> JsonValue:
+    match value:
+        case None | str() | bool() | int():
+            return value
+        case float() if math.isfinite(value):
+            return value
+        case float():
+            raise _invalid(f"{location} contains a non-finite number", path)
+        case list():
+            return [
+                _parse_json_value(item, location=f"{location}[{index}]", path=path) for index, item in enumerate(value)
+            ]
+        case dict():
+            parsed: JsonObject = {}
+            for key, item in value.items():
+                match key:
+                    case str():
+                        parsed[key] = _parse_json_value(item, location=f"{location}.{key}", path=path)
+                    case _:
+                        raise _invalid(f"{location} contains a non-string mapping key", path)
+            return parsed
+        case _:
+            raise _invalid(f"{location} contains a value that is not JSON-compatible", path)
+
+
+def _parse_json_object(value, *, location: str, path: Path | None) -> JsonObject:
+    parsed = _parse_json_value(value, location=location, path=path)
+    match parsed:
+        case dict() as mapping:
+            return mapping
+        case _:
+            raise _invalid(f"{location} must be a mapping", path)
+
+
+def _normalized_sort_key(entry: JsonObject, keys: tuple[str, ...], *, location: str) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for key in keys:
+        match entry.get(key):
+            case None:
+                normalized.append("")
+            case str() as value:
+                normalized.append(value)
+            case value:
+                raise BuildSpecInvalidError(f"{location}.{key} must be a string or null, got {type(value).__name__}")
+    return tuple(normalized)
+
+
+def _sorted_entries(value: JsonValue, collection: str) -> list[JsonValue]:
+    match value:
+        case list() as entries:
+            keyed: list[tuple[tuple[str, ...], JsonObject]] = []
+            for index, entry in enumerate(entries):
+                match entry:
+                    case dict():
+                        key = _normalized_sort_key(
+                            entry, _SORT_KEYS[collection], location=f"definition.{collection}[{index}]"
+                        )
+                        keyed.append((key, entry))
+                    case _:
+                        raise BuildSpecInvalidError(f"definition.{collection}[{index}] must be a mapping")
+            keyed.sort(key=lambda item: item[0])
+            for previous, current in zip(keyed, keyed[1:]):
+                if previous[0] == current[0]:
+                    raise BuildSpecInvalidError(
+                        f"definition.{collection} contains duplicate sort identity {current[0]!r}"
+                    )
+            return [entry for _, entry in keyed]
+        case _:
+            raise BuildSpecInvalidError(f"definition.{collection} must be a list")
+
+
+def _canonicalize_value(value: JsonValue, path: tuple[str, ...]) -> JsonValue:
+    match value:
+        case dict() as mapping:
+            return _canonicalize_mapping(mapping, path)
+        case list() as items:
+            return [_canonicalize_value(item, (*path, str(index))) for index, item in enumerate(items)]
+        case str() if path == ("definition", "pipDependencies"):
+            return _LiteralString(value.replace("\r\n", "\n").replace("\r", "\n"))
+        case _:
+            return value
+
+
+def _canonicalize_mapping(mapping: Mapping[str, JsonValue], path: tuple[str, ...]) -> JsonObject:
+    if path == ():
+        known_keys = _TOP_LEVEL_KEYS
+    elif path == ("definition",):
+        known_keys = _DEFINITION_KEYS
+    else:
+        known_keys = ()
+
+    ordered: JsonObject = {}
+    for key in (*known_keys, *sorted(set(mapping) - set(known_keys))):
+        if key not in mapping:
+            continue
+        value = mapping[key]
+        if path == ("definition",) and key in _SORT_KEYS:
+            value = _sorted_entries(value, key)
+        ordered[key] = _canonicalize_value(value, (*path, key))
+    return ordered
+
+
+def canonicalize_build_spec(spec: Mapping[str, JsonValue], *, source: Path | None = None) -> BuildSpec:
+    """Return a recursively ordered copy after enforcing the ``comfy-build/1`` boundary."""
+    document = _parse_json_object(dict(spec), location="$", path=source)
+
+    match document.get("schema"):
+        case "comfy-build/1":
+            pass
+        case unsupported:
+            raise _invalid(f"unsupported build spec schema {unsupported!r}; expected {SPEC_SCHEMA!r}", source)
+    for key in ("name", "description"):
+        if not isinstance(document.get(key), str):
+            raise _invalid(f"{key} must be a string", source)
+    for key in ("id", "syncedRevision"):
+        if key not in document:
+            document[key] = None
+        else:
+            match document[key]:
+                case None | str():
+                    pass
+                case _:
+                    raise _invalid(f"{key} must be a string or null", source)
+    if not isinstance(document.get("definition"), dict):
+        raise _invalid("definition must be a mapping", source)
+    return _canonicalize_mapping(document, ())
+
+
+def serialize_build_spec(spec: Mapping[str, JsonValue], *, format: SpecFormat) -> str:
+    """Serialize a spec to canonical YAML or JSON with exactly one final LF."""
+    canonical = canonicalize_build_spec(spec)
+    match format:
+        case "json":
+            return json.dumps(canonical, ensure_ascii=False, allow_nan=False, indent=2) + "\n"
+        case "yaml":
+            output = yaml.dump(
+                canonical,
+                Dumper=_CanonicalDumper,
+                allow_unicode=True,
+                default_flow_style=False,
+                explicit_end=False,
+                explicit_start=False,
+                line_break="\n",
+                sort_keys=False,
+                width=4096,
+            )
+            if output.endswith("...\n"):
+                output = output[:-4]
+            output = output.replace('  pipDependencies: ""\n', "  pipDependencies: |-\n", 1)
+            return output.rstrip("\n") + "\n"
+        case unreachable:
+            assert_never(unreachable)
+
+
+def read_build_spec(path: Path) -> BuildSpec:
+    """Read YAML or JSON from ``path`` and return its canonical in-memory shape."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise _invalid(f"could not read build spec: {error}", path) from error
+
+    try:
+        if path.suffix.lower() == ".json":
+            raw = json.loads(text)
+        else:
+            for event in yaml.parse(text, Loader=yaml.SafeLoader):
+                if isinstance(event, yaml.events.AliasEvent) or getattr(event, "anchor", None) is not None:
+                    raise _invalid("YAML anchors and aliases are not supported", path)
+            raw = yaml.safe_load(text)
+    except (json.JSONDecodeError, yaml.YAMLError) as error:
+        raise _invalid(f"could not parse build spec: {error}", path) from error
+
+    document = _parse_json_object(raw, location="$", path=path)
+    return canonicalize_build_spec(document, source=path)
+
+
+def write_build_spec(path: Path, spec: Mapping[str, JsonValue]) -> None:
+    """Atomically write ``spec`` using the format selected by ``path`` suffix."""
+    format: SpecFormat = "json" if path.suffix.lower() == ".json" else "yaml"
+    content = serialize_build_spec(spec, format=format)
+    try:
+        atomic_write_text(path, content, fsync=True)
+    except OSError as error:
+        raise BuildSpecWriteError(f"could not write build spec: {error}", path=path) from error

--- a/comfy_cli/command/build_targets.py
+++ b/comfy_cli/command/build_targets.py
@@ -1,0 +1,118 @@
+"""The ``<os>/<gpu>`` build-target vocabulary shared by every release-cutting command.
+
+A target belongs to a *release*, never to a push (build design lines 253-279):
+an implicit target spends build minutes the caller never asked for, so nothing
+here ever substitutes a default. ``--target os/gpu`` is the single spelling, and
+a value that is not exactly two non-empty segments is refused rather than
+guessed at.
+
+The *vocabulary* is deliberately not enumerated here. ``GET /v1/build-targets``
+is the builder's own allow-list — the same one it validates a cut against — and
+its OpenAPI note is explicit that the wire enums are wider than the buildable
+list, so a client that hardcoded either would offer targets the builder rejects
+at cut time. This module therefore owns the *shape* and lets the builder own the
+values; ``catalog_choices`` turns that endpoint's response into picker choices.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "TARGET_FORM",
+    "BuildTarget",
+    "BuildTargetInvalidError",
+    "catalog_choices",
+    "parse_build_targets",
+]
+
+#: How the option is spelled in help text, hints and errors, in one place.
+TARGET_FORM: Final = "<os>/<gpu>"
+
+#: A concrete pair, so an error never leaves the reader guessing at the shape.
+TARGET_EXAMPLE: Final = "linux/nvidia"
+
+
+class BuildTargetInvalidError(ValueError):
+    """One or more ``--target`` values that are not exactly ``<os>/<gpu>``.
+
+    Carries every rejected value rather than only the first, so a caller fixes
+    them all in one retry — the same reasoning as ``require_option``'s
+    ``missing`` list.
+    """
+
+    def __init__(self, values: Sequence[str]) -> None:
+        self.values: Final = tuple(values)
+        subject = "value" if len(self.values) == 1 else "values"
+        joined = ", ".join(repr(value) for value in self.values)
+        super().__init__(f"--target {subject} {joined} must be of the form {TARGET_FORM}, for example {TARGET_EXAMPLE}")
+
+
+@dataclass(frozen=True, slots=True)
+class BuildTarget:
+    """One parsed target pair."""
+
+    os: str
+    gpu: str
+
+    def as_wire(self) -> dict[str, str]:
+        """The builder's ``Target`` shape (``accelVariant`` is server-derived)."""
+        return {"os": self.os, "gpu": self.gpu}
+
+    def spelling(self) -> str:
+        """The value a caller would type back into ``--target``."""
+        return f"{self.os}/{self.gpu}"
+
+
+def _parse_one(value: str) -> BuildTarget | None:
+    segments = [segment.strip() for segment in value.split("/")]
+    if len(segments) != 2 or not all(segments):
+        return None
+    os_name, gpu = segments
+    return BuildTarget(os_name, gpu)
+
+
+def parse_build_targets(values: Sequence[str]) -> list[BuildTarget]:
+    """Parse every ``--target`` value, in call order.
+
+    Raises:
+        BuildTargetInvalidError: naming *every* value that is not exactly two
+            non-empty ``/``-separated segments.
+    """
+    targets: list[BuildTarget] = []
+    invalid: list[str] = []
+    for value in values:
+        parsed = _parse_one(value)
+        if parsed is None:
+            invalid.append(value)
+        else:
+            targets.append(parsed)
+    if invalid:
+        raise BuildTargetInvalidError(invalid)
+    return targets
+
+
+def catalog_choices(options: Sequence[Mapping[str, object]]) -> list[str]:
+    """``<os>/<gpu>`` spellings from a ``GET /v1/build-targets`` response, in menu order.
+
+    Each option is a ``BuildTargetOption`` — ``{target: {os, gpu}, label, ...}``
+    — and only the pair is a choice; the rest is display metadata the builder
+    ignores on a request. Anything not shaped like a pair is skipped rather than
+    raised on: the picker is an aid, and a catalog the CLI cannot read fully
+    should still offer what it can.
+    """
+    choices: list[str] = []
+    for option in options:
+        target = option.get("target")
+        if not isinstance(target, Mapping):
+            continue
+        os_name = target.get("os")
+        gpu = target.get("gpu")
+        if not isinstance(os_name, str) or not isinstance(gpu, str) or not os_name or not gpu:
+            continue
+        spelling = f"{os_name}/{gpu}"
+        if spelling not in choices:
+            choices.append(spelling)
+    return choices

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1052,6 +1052,25 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     # --- build (the serverless builder) --------------------------------------
     ErrorCode(
+        "build_spec_invalid",
+        "A build spec or legacy scan definition could not be read, has an unsupported schema, or is invalid. "
+        "`details.path` carries the path when one is available.",
+        "fix the named field, or regenerate the file",
+    ),
+    ErrorCode(
+        "build_spec_write_error",
+        "`comfy build` could not write the build spec or legacy scan definition. `details` carries the "
+        "path and the underlying OS error.",
+        "check the directory exists and is writable",
+    ),
+    ErrorCode(
+        "build_spec_not_found",
+        "A `comfy build` command found no spec at the path `PATH` resolved to — `<dir>/comfy-build.yaml` for "
+        "a directory, or the file itself for a `.yaml`/`.json` `PATH`. `details.path` carries the exact "
+        "absolute path probed.",
+        "create a comfy-build.yaml at that path, or pass the PATH that holds the spec",
+    ),
+    ErrorCode(
         "build_models_dir_missing",
         "`comfy build scan` could not find a models/ directory to scan. `details.path` carries the "
         "resolved path. Either no workspace is selected or the given `--models-dir` doesn't exist.",

--- a/tests/comfy_cli/command/test_build_diff.py
+++ b/tests/comfy_cli/command/test_build_diff.py
@@ -1,0 +1,178 @@
+"""The rescan merge and diff that `comfy build update` is built on."""
+
+from __future__ import annotations
+
+from comfy_cli.command.build_diff import diff_definitions, merge_definition, summarize_definition_diff
+
+
+def _definition(*, models=(), nodes=(), **extra) -> dict:
+    return {
+        "schema": "distribution-definition/0",
+        "models": list(models),
+        "customNodes": list(nodes),
+        "pipDependencies": "example==1.0.0\n",
+        "environment": {"os": "Linux", "arch": "x86_64", "pythonVersion": "3.12.0", "torch": None},
+        **extra,
+    }
+
+
+def _model(filename: str = "ae.safetensors", *, sha256: str = "d0", **extra) -> dict:
+    return {
+        "type": "vae",
+        "filename": filename,
+        "localPath": f"vae/{filename}",
+        "sha256": sha256,
+        "sizeBytes": 4,
+        "source": "local",
+        **extra,
+    }
+
+
+def _node(name: str = "pack", *, digest: str = "n0", **extra) -> dict:
+    return {
+        "name": name,
+        "localPath": name,
+        "repository": None,
+        "gitRef": None,
+        "source": "local",
+        "localDigest": digest,
+        "localSizeBytes": 9,
+        **extra,
+    }
+
+
+def test_an_unchanged_rescan_merges_back_to_the_stored_document() -> None:
+    # Given
+    stored = _definition(models=[_model()], nodes=[_node()])
+
+    # When
+    merged = merge_definition(stored, _definition(models=[_model()], nodes=[_node()]))
+
+    # Then
+    assert merged == stored
+    assert diff_definitions(stored, merged).is_empty
+
+
+def test_derived_and_unknown_keys_survive_a_rescan_that_left_the_bytes_alone() -> None:
+    # Given: what `push` and `pull` leave behind on an entry the scan still sees.
+    stored = _definition(
+        models=[_model(blobId="blob-1", sourceUri="https://hf.co/x", futureKey="keep")],
+        nodes=[_node(blobId="blob-2", futureKey="keep")],
+    )
+
+    # When
+    merged = merge_definition(stored, _definition(models=[_model()], nodes=[_node()]))
+
+    # Then
+    assert merged["models"][0] == stored["models"][0]
+    assert merged["customNodes"][0] == stored["customNodes"][0]
+    assert diff_definitions(stored, merged).is_empty
+
+
+def test_a_moved_model_digest_invalidates_the_blob_and_source_uri_it_backed() -> None:
+    # Given
+    stored = _definition(models=[_model(sha256="old", blobId="blob-1", sourceUri="https://hf.co/x", futureKey="keep")])
+
+    # When
+    merged = merge_definition(stored, _definition(models=[_model(sha256="new")]))
+
+    # Then
+    entry = merged["models"][0]
+    assert entry["sha256"] == "new"
+    assert "blobId" not in entry
+    assert "sourceUri" not in entry
+    assert entry["futureKey"] == "keep"
+
+
+def test_a_moved_node_digest_invalidates_the_blob_it_backed() -> None:
+    # Given
+    stored = _definition(nodes=[_node(digest="old", blobId="blob-2", futureKey="keep")])
+
+    # When
+    merged = merge_definition(stored, _definition(nodes=[_node(digest="new")]))
+
+    # Then
+    entry = merged["customNodes"][0]
+    assert entry["localDigest"] == "new"
+    assert "blobId" not in entry
+    assert entry["futureKey"] == "keep"
+
+
+def test_a_source_the_scan_no_longer_reports_disappears() -> None:
+    # Given: a pack that used to be a git checkout and is now bare bytes.
+    stored = _definition(nodes=[{"name": "pack", "localPath": "pack", "repository": "https://g/x", "source": "git"}])
+
+    # When
+    merged = merge_definition(stored, _definition(nodes=[_node()]))
+
+    # Then
+    assert merged["customNodes"][0]["repository"] is None
+    assert merged["customNodes"][0]["source"] == "local"
+
+
+def test_an_unknown_definition_key_survives_the_rescan() -> None:
+    # Given
+    stored = _definition(models=[_model()], futureBlock={"kept": True})
+
+    # When
+    merged = merge_definition(stored, _definition(models=[_model()]))
+
+    # Then
+    assert merged["futureBlock"] == {"kept": True}
+    assert diff_definitions(stored, merged).is_empty
+
+
+def test_counts_and_entries_name_every_affected_row() -> None:
+    # Given
+    stored = _definition(models=[_model("gone.safetensors"), _model("kept.safetensors", sha256="old")])
+    scanned = _definition(models=[_model("kept.safetensors", sha256="new"), _model("fresh.safetensors")])
+
+    # When
+    diff = diff_definitions(stored, merge_definition(stored, scanned))
+
+    # Then
+    models = diff.as_json()["models"]
+    assert (models["added"], models["removed"], models["changed"]) == (1, 1, 1)
+    assert {(e["change"], e["name"]) for e in models["entries"]} == {
+        ("added", "vae/fresh.safetensors"),
+        ("removed", "vae/gone.safetensors"),
+        ("changed", "vae/kept.safetensors"),
+    }
+    changed = next(e for e in models["entries"] if e["change"] == "changed")
+    assert changed["fields"] == ["sha256"]
+
+
+def test_a_single_valued_category_reports_a_bare_status() -> None:
+    # Given
+    stored = _definition(baseComfyVersion="v0.3.0")
+
+    # When
+    diff = diff_definitions(stored, merge_definition(stored, _definition(baseComfyVersion="v0.4.0")))
+
+    # Then
+    payload = diff.as_json()
+    assert payload["baseComfyVersion"] == "changed"
+    assert payload["pipDependencies"] == "unchanged"
+    assert not diff.is_empty
+
+
+def test_two_entries_sharing_an_identity_pair_positionally() -> None:
+    # Given: only a hand-edited spec gets here, and it must stay diffable.
+    stored = _definition(models=[_model(sha256="a"), _model(sha256="b")])
+
+    # When
+    diff = diff_definitions(stored, merge_definition(stored, _definition(models=[_model(sha256="a")])))
+
+    # Then
+    models = diff.as_json()["models"]
+    assert (models["added"], models["removed"], models["changed"]) == (0, 1, 0)
+
+
+def test_the_summary_says_so_when_nothing_moved() -> None:
+    # Given
+    stored = _definition(models=[_model()])
+
+    # When / Then
+    assert summarize_definition_diff(diff_definitions(stored, stored)) == "no changes"
+    drifted = diff_definitions(stored, _definition())
+    assert summarize_definition_diff(drifted) == "models +0 -1 ~0, customNodes +0 -0 ~0"

--- a/tests/comfy_cli/command/test_build_paths.py
+++ b/tests/comfy_cli/command/test_build_paths.py
@@ -1,0 +1,233 @@
+"""Pin the `comfy build` PATH resolution table (build design lines 291-312).
+
+One optional positional answers two questions — where the spec is and where the
+install is — so the three rows of that table, and the rule that
+``--models-dir``/``--custom-nodes-dir``/``--python`` move only the install half,
+are the whole contract. Every test runs from a temp cwd so nothing leaks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from comfy_cli import error_codes
+from comfy_cli.command.build_paths import (
+    SPEC_FILENAME,
+    BuildSpecNotFoundError,
+    InstallOverrides,
+    resolve_build_paths,
+)
+
+#: The install-half members. A row names the ones it expects to MOVE; every
+#: other member must still equal the no-override baseline — that is what makes
+#: "overrides the install half only" an assertion rather than a comment.
+INSTALL_MEMBERS = ("models_dir", "custom_nodes_dir", "python")
+
+
+@pytest.fixture
+def cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An empty temp cwd. Yields ``Path.cwd()`` — not ``tmp_path`` — because the
+    OS resolves symlinks in the working directory and the two can differ."""
+    monkeypatch.chdir(tmp_path)
+    return Path.cwd()
+
+
+def _write_spec(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("schema: comfy-build/1\n", encoding="utf-8")
+    return path
+
+
+# (positional PATH, spec relative to cwd, install root relative to cwd)
+RESOLUTION_ROWS = [
+    pytest.param(None, SPEC_FILENAME, ".", id="nothing"),
+    pytest.param("", SPEC_FILENAME, ".", id="empty-string"),
+    pytest.param(".", SPEC_FILENAME, ".", id="dot"),
+    pytest.param("install", f"install/{SPEC_FILENAME}", "install", id="directory"),
+    pytest.param("nested/install", f"nested/install/{SPEC_FILENAME}", "nested/install", id="nested-directory"),
+    pytest.param(Path("install"), f"install/{SPEC_FILENAME}", "install", id="directory-as-Path"),
+    pytest.param("spec.yaml", "spec.yaml", ".", id="yaml-file"),
+    pytest.param("cfg/spec.yaml", "cfg/spec.yaml", "cfg", id="yaml-file-nested"),
+    pytest.param("spec.json", "spec.json", ".", id="json-file"),
+    pytest.param("cfg/spec.json", "cfg/spec.json", "cfg", id="json-file-nested"),
+]
+
+
+@pytest.mark.parametrize(("given", "rel_spec", "rel_root"), RESOLUTION_ROWS)
+def test_path_resolves_to_a_spec_file_and_an_install_root(cwd: Path, given, rel_spec: str, rel_root: str):
+    """Given a PATH from the design's table, When resolved, Then both halves match the row."""
+    _write_spec(cwd / rel_spec)
+
+    paths = resolve_build_paths(given)
+
+    assert paths.spec_file == cwd / rel_spec
+    assert paths.install_root == cwd / rel_root
+    assert paths.spec_file.is_absolute()
+    assert paths.install_root.is_absolute()
+    # The spec always sits directly in the install root — true of all three rows.
+    assert paths.spec_file.parent == paths.install_root
+
+
+@pytest.mark.parametrize(("given", "rel_spec", "rel_root"), RESOLUTION_ROWS)
+def test_the_install_half_defaults_to_the_install_root(cwd: Path, given, rel_spec: str, rel_root: str):
+    """Given no override flags, When resolved, Then models/custom_nodes hang off the root."""
+    _write_spec(cwd / rel_spec)
+
+    paths = resolve_build_paths(given)
+
+    assert paths.models_dir == paths.install_root / "models"
+    assert paths.custom_nodes_dir == paths.install_root / "custom_nodes"
+    # No filesystem-free default exists for the interpreter.
+    assert paths.python is None
+
+
+def test_an_absolute_path_is_used_verbatim(cwd: Path, tmp_path: Path):
+    """Given an absolute PATH, When resolved, Then the cwd is not consulted."""
+    elsewhere = tmp_path.parent / "absolute-install"
+    _write_spec(elsewhere / SPEC_FILENAME)
+
+    paths = resolve_build_paths(str(elsewhere))
+
+    assert paths.install_root == elsewhere
+    assert paths.spec_file == elsewhere / SPEC_FILENAME
+
+
+# (overrides, the install members it may move → their paths relative to cwd)
+OVERRIDE_ROWS = [
+    pytest.param(
+        InstallOverrides.from_options(models_dir="elsewhere/models"),
+        # A split layout moves custom_nodes/ with it: the sibling rule `scan`
+        # already uses (build.py:783-784).
+        {"models_dir": "elsewhere/models", "custom_nodes_dir": "elsewhere/custom_nodes"},
+        id="models-dir",
+    ),
+    pytest.param(
+        InstallOverrides.from_options(custom_nodes_dir="elsewhere/nodes"),
+        {"custom_nodes_dir": "elsewhere/nodes"},
+        id="custom-nodes-dir",
+    ),
+    pytest.param(
+        InstallOverrides.from_options(python="venv/bin/python"),
+        {"python": "venv/bin/python"},
+        id="python",
+    ),
+    pytest.param(
+        InstallOverrides.from_options(
+            models_dir="d/models",
+            custom_nodes_dir="n/nodes",
+            python="p/bin/python",
+        ),
+        {"models_dir": "d/models", "custom_nodes_dir": "n/nodes", "python": "p/bin/python"},
+        id="all-three",
+    ),
+]
+
+
+@pytest.mark.parametrize(("overrides", "moved"), OVERRIDE_ROWS)
+def test_overrides_move_the_install_half_only(cwd: Path, overrides: InstallOverrides, moved: dict[str, str]):
+    """Given install-half overrides, When resolved, Then the spec half is untouched."""
+    _write_spec(cwd / "install" / SPEC_FILENAME)
+    baseline = resolve_build_paths("install")
+
+    paths = resolve_build_paths("install", overrides=overrides)
+
+    assert paths.spec_file == baseline.spec_file
+    assert paths.install_root == baseline.install_root
+    for member in INSTALL_MEMBERS:
+        expected = cwd / moved[member] if member in moved else getattr(baseline, member)
+        assert getattr(paths, member) == expected, member
+
+
+MISSING_SPEC_ROWS = [
+    pytest.param(None, SPEC_FILENAME, id="nothing"),
+    pytest.param("install", f"install/{SPEC_FILENAME}", id="directory"),
+    pytest.param("cfg/spec.yaml", "cfg/spec.yaml", id="yaml-file"),
+    pytest.param("cfg/spec.json", "cfg/spec.json", id="json-file"),
+]
+
+
+@pytest.mark.parametrize(("given", "probed"), MISSING_SPEC_ROWS)
+def test_a_missing_spec_names_the_exact_absolute_path_probed(cwd: Path, given, probed: str):
+    """Given an empty cwd, When a non-`init` command resolves, Then it fails naming the probe."""
+    with pytest.raises(BuildSpecNotFoundError) as excinfo:
+        resolve_build_paths(given)
+
+    error = excinfo.value
+    expected = cwd / probed
+    assert error.code == "build_spec_not_found"
+    assert error.spec_file == expected
+    assert error.details == {"path": str(expected)}
+    assert Path(error.details["path"]).is_absolute()
+    assert str(expected) in str(error)
+
+
+def test_a_directory_that_does_not_exist_still_reports_the_spec_it_would_hold(cwd: Path):
+    """Given a PATH that is not on disk at all, When resolved, Then the probe is still the spec path."""
+    with pytest.raises(BuildSpecNotFoundError) as excinfo:
+        resolve_build_paths("no/such/dir")
+
+    assert excinfo.value.details == {"path": str(cwd / "no" / "such" / "dir" / SPEC_FILENAME)}
+
+
+def test_init_may_resolve_a_spec_that_does_not_exist_yet(cwd: Path):
+    """Given `require_spec=False`, When the spec is absent, Then resolution succeeds."""
+    paths = resolve_build_paths("install", require_spec=False)
+
+    assert paths.spec_file == cwd / "install" / SPEC_FILENAME
+    assert paths.install_root == cwd / "install"
+    assert not paths.spec_file.exists()
+
+
+def test_a_directory_named_like_a_spec_file_does_not_hijack_a_bare_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Given a cwd literally named `*.yaml`, When PATH is omitted, Then it is still row one."""
+    workdir = tmp_path / "project.yaml"
+    _write_spec(workdir / SPEC_FILENAME)
+    monkeypatch.chdir(workdir)
+    here = Path.cwd()
+
+    for given in (None, "."):
+        paths = resolve_build_paths(given)
+        assert paths.install_root == here
+        assert paths.spec_file == here / SPEC_FILENAME
+
+
+def test_resolution_does_not_follow_a_symlink_out_of_the_named_root(cwd: Path):
+    """Given a symlinked PATH, When resolved, Then the paths stay under the name the caller typed."""
+    real = cwd / "real"
+    _write_spec(real / SPEC_FILENAME)
+    (cwd / "link").symlink_to(real, target_is_directory=True)
+
+    paths = resolve_build_paths("link")
+
+    assert paths.install_root == cwd / "link"
+    assert paths.spec_file == cwd / "link" / SPEC_FILENAME
+    assert paths.spec_file.parent == paths.install_root
+    # Not an accident: following the link WOULD have landed on a path the
+    # caller never named, which is exactly what the error payload must not say.
+    assert paths.spec_file != real / SPEC_FILENAME
+    assert paths.spec_file.resolve() == (real / SPEC_FILENAME).resolve()
+
+
+def test_a_parent_traversal_is_left_for_the_os_to_walk(cwd: Path):
+    """Given a PATH containing `..`, When resolved, Then it is not collapsed lexically.
+
+    Collapsing `link/../x` to `x` would silently retarget the path whenever
+    `link` is a symlink, so the component survives into the resolved paths.
+    """
+    _write_spec(cwd / "other" / SPEC_FILENAME)
+
+    paths = resolve_build_paths("real/../other", require_spec=False)
+
+    assert paths.install_root == cwd / "real" / ".." / "other"
+    assert ".." in paths.spec_file.parts
+
+
+def test_the_error_code_is_registered():
+    """The registry is the agent-facing contract; the raised code must be in it."""
+    registered = error_codes.get(BuildSpecNotFoundError.code)
+    assert registered is not None
+    assert registered.hint

--- a/tests/comfy_cli/command/test_build_spec.py
+++ b/tests/comfy_cli/command/test_build_spec.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from comfy_cli.command import build_spec
+from comfy_cli.command.build_spec import (
+    BuildSpecInvalidError,
+    BuildSpecWriteError,
+    canonicalize_build_spec,
+    read_build_spec,
+    serialize_build_spec,
+    write_build_spec,
+)
+
+
+def _spec() -> dict:
+    return {
+        "schema": "comfy-build/1",
+        "id": "bld_123",
+        "name": "Studio build",
+        "description": "Reference pipeline",
+        "syncedRevision": "revision-7",
+        "definition": {
+            "schema": "distribution-definition/0",
+            "baseComfyVersion": "v0.3.40",
+            "models": [
+                {"type": "loras", "filename": "z.safetensors", "sha256": "bbb", "sizeBytes": 2},
+                {"type": "checkpoints", "filename": "a.safetensors", "sha256": "aaa", "sizeBytes": 1},
+            ],
+            "customNodes": [
+                {"name": "Zeta", "id": "zeta", "repository": "https://example.com/zeta"},
+                {"name": "Alpha", "id": "alpha", "repository": "https://example.com/alpha"},
+            ],
+            "pipDependencies": "torch==2.4.0\ntorchvision==0.19.0",
+            "environment": {"python": "3.12", "platform": "linux-x86_64"},
+        },
+    }
+
+
+def _write_yaml(path: Path, value: dict) -> None:
+    path.write_text(yaml.safe_dump(value, allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+
+def test_round_trip_reproduces_canonical_yaml_bytes(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    canonical = serialize_build_spec(_spec(), format="yaml")
+    path.write_text(canonical, encoding="utf-8")
+
+    # When
+    write_build_spec(path, read_build_spec(path))
+
+    # Then
+    assert path.read_bytes() == canonical.encode()
+
+
+def test_permutations_at_nested_mapping_and_entry_depths_are_byte_identical() -> None:
+    # Given
+    first = _spec()
+    first["definition"]["future"] = {"zeta": 2, "alpha": {"right": 2, "left": 1}}
+    first["definition"]["models"][0]["future"] = [{"z": 2, "a": 1}]
+    second = {
+        "definition": {
+            "future": {"alpha": {"left": 1, "right": 2}, "zeta": 2},
+            "environment": {"platform": "linux-x86_64", "python": "3.12"},
+            "pipDependencies": "torch==2.4.0\ntorchvision==0.19.0",
+            "customNodes": [
+                {"repository": "https://example.com/alpha", "id": "alpha", "name": "Alpha"},
+                {"repository": "https://example.com/zeta", "id": "zeta", "name": "Zeta"},
+            ],
+            "models": [
+                {"sizeBytes": 1, "sha256": "aaa", "filename": "a.safetensors", "type": "checkpoints"},
+                {
+                    "future": [{"a": 1, "z": 2}],
+                    "sizeBytes": 2,
+                    "sha256": "bbb",
+                    "filename": "z.safetensors",
+                    "type": "loras",
+                },
+            ],
+            "baseComfyVersion": "v0.3.40",
+            "schema": "distribution-definition/0",
+        },
+        "syncedRevision": "revision-7",
+        "description": "Reference pipeline",
+        "name": "Studio build",
+        "id": "bld_123",
+        "schema": "comfy-build/1",
+    }
+
+    # When
+    first_bytes = serialize_build_spec(first, format="yaml")
+    second_bytes = serialize_build_spec(second, format="yaml")
+
+    # Then
+    assert first_bytes == second_bytes
+
+
+def test_pip_dependency_line_permutation_produces_different_output() -> None:
+    # Given
+    first = _spec()
+    second = deepcopy(first)
+    second["definition"]["pipDependencies"] = "torchvision==0.19.0\ntorch==2.4.0"
+
+    # When
+    first_bytes = serialize_build_spec(first, format="yaml")
+    second_bytes = serialize_build_spec(second, format="yaml")
+
+    # Then
+    assert first_bytes != second_bytes
+    assert "torch==2.4.0\n    torchvision==0.19.0" in first_bytes
+
+
+def test_unknown_nested_mapping_survives_and_is_recursively_ordered(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    spec = _spec()
+    spec["definition"]["futureBuilderField"] = {"z": {"two": 2, "one": 1}, "a": 0}
+    _write_yaml(path, spec)
+
+    # When
+    loaded = read_build_spec(path)
+    write_build_spec(path, loaded)
+
+    # Then
+    output = path.read_text(encoding="utf-8")
+    assert read_build_spec(path)["definition"]["futureBuilderField"] == {
+        "a": 0,
+        "z": {"one": 1, "two": 2},
+    }
+    assert output.index("  a: 0") < output.index("  z:")
+    assert output.index("    one: 1") < output.index("    two: 2")
+
+
+def test_metadata_is_preserved_when_only_definition_changes(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    write_build_spec(path, _spec())
+    loaded = read_build_spec(path)
+    metadata = {key: loaded[key] for key in ("id", "name", "description", "syncedRevision")}
+
+    # When
+    loaded["definition"] = {"schema": "distribution-definition/0", "models": [], "customNodes": []}
+    write_build_spec(path, loaded)
+
+    # Then
+    rewritten = read_build_spec(path)
+    assert {key: rewritten[key] for key in metadata} == metadata
+
+
+@pytest.mark.parametrize(
+    ("collection", "entries"),
+    [
+        ("models", [{"type": None, "filename": "same"}, {"filename": "same", "type": None}]),
+        ("customNodes", [{"name": "same", "id": None}, {"id": None, "name": "same"}]),
+    ],
+)
+def test_duplicate_full_sort_tuple_is_rejected(collection: str, entries: list[dict]) -> None:
+    # Given
+    spec = _spec()
+    spec["definition"][collection] = entries
+
+    # When / Then
+    with pytest.raises(BuildSpecInvalidError, match=collection) as raised:
+        canonicalize_build_spec(spec)
+    assert raised.value.code == "build_spec_invalid"
+
+
+def test_missing_and_null_sort_components_share_empty_string_ordering() -> None:
+    # Given
+    spec = _spec()
+    spec["definition"]["models"] = [
+        {"type": None, "filename": "z"},
+        {"filename": "a", "sha256": None},
+        {"type": "checkpoints", "filename": "m"},
+    ]
+
+    # When
+    canonical = canonicalize_build_spec(spec)
+
+    # Then
+    assert [entry["filename"] for entry in canonical["definition"]["models"]] == ["a", "z", "m"]
+
+
+def test_unsupported_schema_is_rejected_with_build_spec_invalid(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    path.write_text("schema: comfy-build/2\ndefinition: {}\n", encoding="utf-8")
+
+    # When / Then
+    with pytest.raises(BuildSpecInvalidError, match="comfy-build/2") as raised:
+        read_build_spec(path)
+    assert raised.value.code == "build_spec_invalid"
+
+
+def test_yaml_anchor_or_alias_is_rejected_on_read(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    path.write_text(
+        "schema: comfy-build/1\nid: null\nname: anchored\ndescription: test\nsyncedRevision: null\n"
+        "definition:\n  schema: distribution-definition/0\n  environment: &env {python: '3.12'}\n  copied: *env\n",
+        encoding="utf-8",
+    )
+
+    # When / Then
+    with pytest.raises(BuildSpecInvalidError, match="anchor|alias"):
+        read_build_spec(path)
+
+
+def test_writer_emits_no_aliases_for_shared_python_values() -> None:
+    # Given
+    spec = _spec()
+    shared = {"python": "3.12"}
+    spec["definition"]["one"] = shared
+    spec["definition"]["two"] = shared
+
+    # When
+    output = serialize_build_spec(spec, format="yaml")
+
+    # Then
+    assert "&id" not in output
+    assert "*id" not in output
+
+
+def test_empty_collections_are_not_elided_to_null() -> None:
+    # Given
+    spec = _spec()
+    spec["definition"]["models"] = []
+    spec["definition"]["environment"] = {}
+    spec["definition"]["pipDependencies"] = ""
+
+    # When
+    output = serialize_build_spec(spec, format="yaml")
+
+    # Then
+    assert "models: []" in output
+    assert "environment: {}" in output
+    assert "pipDependencies: |-" in output
+
+
+def test_unicode_is_emitted_as_utf8_without_ascii_escaping() -> None:
+    # Given
+    spec = _spec()
+    spec["name"] = "构建 café"
+    spec["description"] = "モデル"
+
+    # When
+    output = serialize_build_spec(spec, format="yaml")
+
+    # Then
+    assert "构建 café" in output
+    assert "モデル" in output
+    assert "\\u" not in output
+
+
+def test_lf_single_trailing_newline_and_literal_chomping_are_stable(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    spec = _spec()
+    spec["definition"]["pipDependencies"] = "first==1\r\nsecond==2"
+
+    # When
+    first = serialize_build_spec(spec, format="yaml")
+    path.write_text(first, encoding="utf-8")
+    second = serialize_build_spec(read_build_spec(path), format="yaml")
+
+    # Then
+    assert "\r" not in first
+    assert first.endswith("\n") and not first.endswith("\n\n")
+    assert not first.startswith("---")
+    assert "pipDependencies: |-" in first
+    assert second == first
+
+
+def test_absent_id_and_synced_revision_are_written_as_null() -> None:
+    # Given
+    spec = _spec()
+    del spec["id"]
+    del spec["syncedRevision"]
+
+    # When
+    output = serialize_build_spec(spec, format="yaml")
+
+    # Then
+    parsed = yaml.safe_load(output)
+    assert parsed["id"] is None
+    assert parsed["syncedRevision"] is None
+
+
+def test_json_path_uses_same_known_key_order_and_canonical_newline(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.json"
+
+    # When
+    write_build_spec(path, _spec())
+    output = path.read_text(encoding="utf-8")
+    parsed = json.loads(output)
+
+    # Then
+    assert list(parsed)[:6] == ["schema", "id", "name", "description", "syncedRevision", "definition"]
+    assert list(parsed["definition"])[:6] == [
+        "schema",
+        "baseComfyVersion",
+        "models",
+        "customNodes",
+        "pipDependencies",
+        "environment",
+    ]
+    assert output.endswith("\n") and not output.endswith("\n\n")
+
+
+def test_failed_write_raises_build_spec_write_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+
+    def fail_write(_path: Path, _content: str, *, fsync: bool) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(build_spec, "atomic_write_text", fail_write)
+
+    # When / Then
+    with pytest.raises(BuildSpecWriteError, match="disk full") as raised:
+        write_build_spec(path, _spec())
+    assert raised.value.code == "build_spec_write_error"

--- a/tests/comfy_cli/command/test_build_spec_determinism.py
+++ b/tests/comfy_cli/command/test_build_spec_determinism.py
@@ -1,0 +1,278 @@
+"""Cross-machine no-churn proof for the ``comfy-build/1`` serializer (plan decision D-C).
+
+Todo 6's ``test_build_spec.py`` pins the reader/writer's *behaviour*. This file pins the
+one property that makes ``comfy build update`` trustworthy in a shared repository: two
+developers with different absolute install roots, usernames and hostnames must produce
+byte-identical spec files for the same logical install, so ``git diff`` only ever shows
+real content changes.
+"""
+
+from __future__ import annotations
+
+import getpass
+import re
+import socket
+from itertools import permutations
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.command.build_spec import (
+    SpecFormat,
+    canonicalize_build_spec,
+    read_build_spec,
+    serialize_build_spec,
+    write_build_spec,
+)
+
+# A real-world-shaped requirements body: a PEP-508 pin, a multi-line ``--hash=`` block whose
+# continuations are indented, an editable VCS install, and a trailing plain pin. Reordering or
+# reflowing any of these lines corrupts the value, so the serializer must treat it as opaque.
+_PIP_DEPENDENCIES = (
+    "torch==2.4.0\n"
+    "some-pkg==1.0.0 \\\n"
+    "    --hash=sha256:3b8f1c2d4e5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e \\\n"
+    "    --hash=sha256:9e0f1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7\n"
+    "-e git+https://github.com/comfy-org/example-node.git@v1.2.3#egg=example-node\n"
+    "aiohttp==3.10.5\n"
+)
+
+# ``syncedRevision`` is a server-issued opaque token that happens to be timestamp-shaped
+# (build design lines 180-198). Keeping it timestamp-shaped is deliberate: it is what makes
+# the "no timestamps anywhere else" assertion non-vacuous.
+_SYNCED_REVISION = "2026-08-23T12:34:56.789012Z"
+
+_ISO8601 = re.compile(r"\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)?")
+_ABSOLUTE_PATH = re.compile(r"(?:^|[\s\"'(\[=])(?:[A-Za-z]:)?[\\/][A-Za-z0-9_.\-]+[\\/]")
+
+_SENTINEL_USER = "sentinel-user-9d2f"
+_SENTINEL_HOST = "sentinel-host-4c7b"
+_SENTINEL_HOME = "/sentinel-home-1a3e"
+
+
+def _model_sort_key(entry: dict) -> tuple[str, str, str]:
+    return (entry.get("type") or "", entry.get("filename") or "", entry.get("sha256") or "")
+
+
+def _node_sort_key(entry: dict) -> tuple[str, str, str]:
+    return (entry.get("name") or "", entry.get("id") or "", entry.get("repository") or "")
+
+
+def _model(models_root: Path, kind: str, filename: str, sha256: str) -> dict:
+    absolute = models_root / kind / filename
+    return {
+        "type": kind,
+        "filename": filename,
+        "sha256": sha256,
+        "sizeBytes": 4096,
+        "source": "local",
+        "localPath": absolute.relative_to(models_root).as_posix(),
+    }
+
+
+def _node(nodes_root: Path, name: str, node_id: str | None, repository: str, dirname: str) -> dict:
+    absolute = nodes_root / dirname
+    return {
+        "name": name,
+        "id": node_id,
+        "repository": repository,
+        "source": "local",
+        "localPath": absolute.relative_to(nodes_root).as_posix(),
+    }
+
+
+def _nodes(nodes_root: Path) -> list[dict]:
+    # "Essentials" appears twice with distinct ids - a legitimate shape per decision D-I that
+    # the serializer must order deterministically rather than reject.
+    return [
+        _node(nodes_root, "Essentials", "acme-essentials", "https://github.com/acme/essentials", "acme-essentials"),
+        _node(nodes_root, "Zeta", None, "https://github.com/acme/zeta", "zeta"),
+        _node(
+            nodes_root, "Essentials", "cubiq-essentials", "https://github.com/cubiq/essentials", "ComfyUI_essentials"
+        ),
+        _node(nodes_root, "Alpha", "alpha", "https://github.com/acme/alpha", "alpha"),
+    ]
+
+
+def _spec_for_root(root: Path) -> dict:
+    """Build the one logical install as an author working under the absolute ``root`` would."""
+    models_root = root / "models"
+    nodes_root = root / "custom_nodes"
+    return {
+        "schema": "comfy-build/1",
+        "id": "bld_determinism",
+        "name": "Determinism fixture",
+        "description": "One logical install, two absolute roots",
+        "syncedRevision": _SYNCED_REVISION,
+        "definition": {
+            "schema": "distribution-definition/0",
+            "baseComfyVersion": "v0.3.40",
+            "models": [
+                _model(models_root, "loras", "z.safetensors", "b" * 64),
+                _model(models_root, "checkpoints", "a.safetensors", "a" * 64),
+                _model(models_root, "checkpoints", "b.safetensors", "c" * 64),
+            ],
+            "customNodes": _nodes(nodes_root),
+            "pipDependencies": _PIP_DEPENDENCIES,
+            "environment": {"python": "3.12", "platform": "linux-x86_64"},
+        },
+    }
+
+
+def _pip_block(output: str) -> str:
+    body = output.split("  pipDependencies: |", 1)[1]
+    return body.split("\n  environment:", 1)[0]
+
+
+@pytest.fixture
+def two_roots(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Two genuinely different absolute install roots, differing in name and in depth."""
+    first = tmp_path_factory.mktemp("alpha")
+    second = tmp_path_factory.mktemp("beta-deeper") / "nested" / "install"
+    second.mkdir(parents=True)
+    return first, second
+
+
+@pytest.fixture
+def masked_machine_identity(monkeypatch: pytest.MonkeyPatch) -> tuple[str, ...]:
+    """Force every machine-identity lookup to a sentinel so a leak is visible on any host."""
+    monkeypatch.setattr(getpass, "getuser", lambda: _SENTINEL_USER)
+    monkeypatch.setattr(socket, "gethostname", lambda: _SENTINEL_HOST)
+    monkeypatch.setattr(socket, "getfqdn", lambda *_args: _SENTINEL_HOST)
+    for name in ("USER", "USERNAME", "LOGNAME"):
+        monkeypatch.setenv(name, _SENTINEL_USER)
+    monkeypatch.setenv("HOSTNAME", _SENTINEL_HOST)
+    monkeypatch.setenv("HOME", _SENTINEL_HOME)
+    return (_SENTINEL_USER, _SENTINEL_HOST, _SENTINEL_HOME)
+
+
+def test_the_same_logical_install_serializes_identically_from_two_absolute_roots(
+    two_roots: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Given
+    root_a, root_b = two_roots
+    path_a, path_b = root_a / "comfy-build.yaml", root_b / "comfy-build.yaml"
+
+    # When
+    monkeypatch.chdir(root_a)
+    write_build_spec(path_a, _spec_for_root(root_a))
+    monkeypatch.chdir(root_b)
+    write_build_spec(path_b, _spec_for_root(root_b))
+
+    # Then
+    assert root_a != root_b
+    assert path_a.read_bytes() == path_b.read_bytes()
+
+
+def test_rendered_bytes_carry_no_absolute_path_or_machine_identity(
+    two_roots: tuple[Path, Path], masked_machine_identity: tuple[str, ...]
+) -> None:
+    # Given
+    root_a, root_b = two_roots
+
+    # When
+    output = serialize_build_spec(_spec_for_root(root_a), format="yaml")
+
+    # Then
+    assert _ABSOLUTE_PATH.search(f"localPath: {root_a.as_posix()}/models") is not None
+    assert _ABSOLUTE_PATH.search(output) is None
+    for leak in (str(root_a), str(root_b), root_a.name, root_b.parent.parent.name, *masked_machine_identity):
+        assert leak not in output
+
+
+def test_no_iso8601_timestamp_appears_outside_the_synced_revision_value(two_roots: tuple[Path, Path]) -> None:
+    # Given
+    root_a, _ = two_roots
+    output = serialize_build_spec(_spec_for_root(root_a), format="yaml")
+
+    # When
+    masked = re.sub(r"(?m)^syncedRevision:.*$", "syncedRevision:", output)
+
+    # Then
+    assert _ISO8601.search(output) is not None, "fixture must keep syncedRevision timestamp-shaped"
+    assert _SYNCED_REVISION not in masked
+    assert _ISO8601.search(masked) is None
+
+
+def test_model_and_node_order_equal_their_total_sort_keys(two_roots: tuple[Path, Path]) -> None:
+    # Given
+    root_a, _ = two_roots
+    spec = _spec_for_root(root_a)
+    models, nodes = spec["definition"]["models"], spec["definition"]["customNodes"]
+
+    # When
+    definition = canonicalize_build_spec(spec)["definition"]
+
+    # Then
+    assert models != sorted(models, key=_model_sort_key), "fixture must start unsorted"
+    assert nodes != sorted(nodes, key=_node_sort_key), "fixture must start unsorted"
+    assert definition["models"] == sorted(models, key=_model_sort_key)
+    assert definition["customNodes"] == sorted(nodes, key=_node_sort_key)
+
+
+def test_duplicate_display_names_with_distinct_ids_are_stable_across_every_permutation(
+    two_roots: tuple[Path, Path],
+) -> None:
+    # Given
+    root_a, _ = two_roots
+    spec = _spec_for_root(root_a)
+    orderings = list(permutations(spec["definition"]["customNodes"]))
+
+    # When
+    rendered = set()
+    for ordering in orderings:
+        spec["definition"]["customNodes"] = list(ordering)
+        rendered.add(serialize_build_spec(spec, format="yaml"))
+
+    # Then
+    assert len(orderings) == 24
+    assert len(rendered) == 1
+    names = [entry["name"] for entry in canonicalize_build_spec(spec)["definition"]["customNodes"]]
+    assert names.count("Essentials") == 2
+
+
+def test_pip_dependencies_keep_their_original_line_order_through_a_round_trip(tmp_path: Path) -> None:
+    # Given
+    path = tmp_path / "comfy-build.yaml"
+    write_build_spec(path, _spec_for_root(tmp_path))
+    first = path.read_text(encoding="utf-8")
+
+    # When
+    reloaded = read_build_spec(path)
+    write_build_spec(path, reloaded)
+
+    # Then
+    assert reloaded["definition"]["pipDependencies"] == _PIP_DEPENDENCIES
+    assert path.read_text(encoding="utf-8") == first
+    offsets = [first.index(f"    {line}") for line in _PIP_DEPENDENCIES.splitlines()]
+    assert offsets == sorted(offsets)
+
+
+def test_two_independent_constructions_emit_the_same_pip_dependencies(two_roots: tuple[Path, Path]) -> None:
+    # Given
+    root_a, root_b = two_roots
+
+    # When
+    first = _pip_block(serialize_build_spec(_spec_for_root(root_a), format="yaml"))
+    second = _pip_block(serialize_build_spec(_spec_for_root(root_b), format="yaml"))
+
+    # Then
+    assert first == second
+    assert "-e git+https://github.com/comfy-org/example-node.git@v1.2.3#egg=example-node" in first
+    assert first.count("--hash=sha256:") == 2
+
+
+@pytest.mark.parametrize("spec_format", ["yaml", "json"])
+def test_serializing_the_same_spec_twice_in_one_process_is_byte_stable(
+    two_roots: tuple[Path, Path], spec_format: SpecFormat
+) -> None:
+    # Given
+    root_a, _ = two_roots
+    spec = _spec_for_root(root_a)
+
+    # When
+    first = serialize_build_spec(spec, format=spec_format)
+    second = serialize_build_spec(spec, format=spec_format)
+
+    # Then
+    assert first == second

--- a/tests/comfy_cli/output/test_error_code_registry.py
+++ b/tests/comfy_cli/output/test_error_code_registry.py
@@ -206,6 +206,36 @@ def test_every_registered_code_is_raised(raised_codes):
     )
 
 
+def test_every_build_code_has_a_first_call_site(raised_codes):
+    """The ``build_*`` family is filled in one code at a time, under this rule:
+
+        Each error code is registered in the same change that introduces its
+        first call site. No change pre-registers codes for later ones.
+
+    Pre-registering is not a harmless head start. ``comfy discover`` publishes the
+    registry verbatim, so a code with no call site advertises a branch to agents
+    that nothing can ever take — a documented promise the CLI cannot keep.
+
+    :func:`test_every_registered_code_is_raised` already rejects an orphan anywhere
+    in the registry; this narrows that direction to the build family so the failure
+    names the rule that was broken instead of dropping a bare code into a flat list
+    shared with every other subsystem.
+
+    If this fails: move the registration into the change that raises the code.
+    """
+    BUILD_PREFIX = "build_"
+    build_codes = [c for c in error_codes.all_codes() if c.startswith(BUILD_PREFIX)]
+    # Guards the orphan check below against a silently empty enumeration.
+    assert build_codes, f"no {BUILD_PREFIX}* codes found in the registry — this guard would pass vacuously"
+
+    orphans = sorted(c for c in build_codes if c not in raised_codes)
+    assert not orphans, (
+        f"Registered with no call site under comfy_cli/: {orphans}\n"
+        "Each error code is registered in the same change that introduces its first call site. "
+        "Move the registration into the change that raises it, or wire up the call site now."
+    )
+
+
 def test_codes_match_pattern():
     """Every registered code is snake_case matching the documented pattern."""
     bad = [ec.code for ec in error_codes.REGISTRY if not error_codes.CODE_PATTERN.match(ec.code)]


### PR DESCRIPTION
**TL;DR:** The offline half of the `comfy-build.yaml` build spec — read/write, path resolution, target parsing, and structural diff — with no command wired to any of it yet. Three error codes land with the three call sites that raise them.

Stacked on #792 (which is stacked on #791). Review those first; this PR's diff is the 10 files below.

**What changed**

* **comfy_cli/command/build_spec.py** (new): read, write and schema-validate `comfy-build.yaml`. Serialization is deterministic — an unchanged spec round-trips byte-identically — so `status` and `pull` can diff a rewritten spec against the original without spurious churn. Raises `build_spec_invalid` and `build_spec_write_error`.
* **comfy_cli/command/build_paths.py** (new): resolve a `PATH` argument to a spec file — `<dir>/comfy-build.yaml` for a directory, the file itself for a `.yaml`/`.json` path. `BuildSpecNotFoundError` carries the exact absolute path probed in `details.path`, so an agent can retry against it without re-deriving the rules. Subclasses `ValueError`, not `FileNotFoundError`, so a broad `except OSError` around neighbouring file IO cannot swallow it. Raises `build_spec_not_found`.
* **comfy_cli/command/build_targets.py** (new): parse and normalize `os/gpu` build targets.
* **comfy_cli/command/build_diff.py** (new): structural diff between two specs — the engine `status` and `pull` report through later in the stack.
* **comfy_cli/error_codes.py**: registers exactly the three codes the modules above raise. Nothing is pre-registered for the commands still to come.
* **tests/comfy_cli/output/test_error_code_registry.py**: adds `test_every_build_code_has_a_first_call_site`. `comfy discover` publishes the registry verbatim, so a code with no call site advertises a branch to agents that nothing can ever take. This narrows the existing orphan check to the build family so a violation names the rule it broke.
* **tests** (4 new files): spec read/write and validation, serialization determinism, path resolution, and diff.

**One wording note:** two hints here are deliberately worded without naming `comfy build init` — that verb does not exist yet, and `test_no_mentions_of_nonexistent_commands` resolves every backticked command in prose against the live Typer tree. They are restored when `init` lands.

**Validation**

* `uv run --locked --extra dev pytest -q`: 6080 passed, 38 skipped. The one failure (`test_build.py::test_scan_custom_nodes_records_repo_and_ref`) reproduces identically on a clean `origin/main` checkout — pre-existing, not this change.
* `ruff check` / `ruff format --diff` clean at CI's pin (0.15.15).
* Differential: the four new test modules fail on `origin/main` (the modules under test do not exist) and pass here.
* No command surface changes: `comfy build --help` is byte-identical to `origin/main`, and `comfy discover` gains only the three registered codes.

**Contradicts:** nothing.