### PR TITLE
fix(knowledge): score capability wording so phrased picks stop missing

### DIFF
--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -185,8 +185,8 @@ def _tokens(s: str) -> frozenset[str]:
 
 def _short_key(key: str) -> bool:
     """A one-word key (filler aside) under MIN_SINGLE_TOKEN_CHARS never matches on wording."""
-    raw = [w for w in _split(key) if _stem(w) not in _FILLER_STEMS]
-    return len(raw) == 1 and len(raw[0]) < MIN_SINGLE_TOKEN_CHARS
+    raw = {w for w in _split(key) if _stem(w) not in _FILLER_STEMS}
+    return len(raw) == 1 and len(next(iter(raw))) < MIN_SINGLE_TOKEN_CHARS
 
 
 def _query_tokens(s: str) -> frozenset[str]:

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -509,10 +509,10 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
     key_words: dict[str, set[str]] = defaultdict(set)
     for words, _, cid in capability_tokens:
         key_words[cid] |= words
-    # Description words a query may share with a capability, minus the words its
-    # keys already carry, so context only ever counts what the keys did not.
+    # First sentence only: the rest of a description says what the row is *not*
+    # ("Never used to fix anatomy") and would pull those queries in.
     capability_context = {
-        cid: _tokens(desc) - key_words[cid]
+        cid: _tokens(re.split(r"(?<=[.;])\s", desc, maxsplit=1)[0]) - key_words[cid]
         for cid, cap in capabilities.items()
         if isinstance(desc := cap.get("description"), str)
     }

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -14,7 +14,6 @@ disturbing the explicit ``comfy knowledge`` verbs.
 from __future__ import annotations
 
 import hashlib
-import itertools
 import json
 import math
 import os
@@ -57,9 +56,11 @@ UNAVAILABLE_LOCALLY = "the templates or nodes this row resolves to are absent fr
 # naming a capability, model or gallery tag here would be a second copy of the
 # bundle's vocabulary, which then drifts every time comfy-knowledge is recompiled.
 _FILLER = frozenset(
-    "a an the of to for from with and or in on at by as is are be do it no not which where while "
+    "a an the of to for from with and or in on at by as is are be do it which where while "
     "my me some this that into make create generate".split()
 )
+# Cut a description here: what follows says what the row is *not*.
+_NEGATOR = re.compile(r"(?<=[.;])\s|\b(?:no|not|never|neither|nor|without|except)\b", re.IGNORECASE)
 # A one-word key must be at least this long to match on its own. Guards against a
 # future alias like "3d" dragging a capability into every query mentioning it.
 MIN_SINGLE_TOKEN_CHARS = 4
@@ -151,16 +152,26 @@ def _normalize(s: str) -> str:
 
 
 def _stem(word: str) -> str:
-    """Suffix strip so "editing", "edits" and "edit" agree, and "removal" meets "remove"."""
-    for suffix in ("ing", "ed", "es", "s", "al"):
-        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
-            word = word[: -len(suffix)]
-            break
+    """Suffix strip, repeated until nothing matches, so "editing", "edits" and "edit" agree.
+
+    Only inflections: "-al" is left alone so "musical" never lands on the alias "Music".
+    """
+    stripped = True
+    while stripped:
+        stripped = False
+        for suffix in ("ing", "ed", "es", "s"):
+            if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+                word = word[: -len(suffix)]
+                stripped = True
+                break
     return word[:-1] if word.endswith("e") and len(word) > 3 else word
 
 
-def _words(s: str) -> list[str]:
-    return [t for t in re.split(r"[^a-z0-9]+", s.lower()) if t and t not in _FILLER]
+_FILLER_STEMS = frozenset(map(_stem, _FILLER))
+
+
+def _split(s: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", s.lower())
 
 
 def _tokens(s: str) -> frozenset[str]:
@@ -169,13 +180,13 @@ def _tokens(s: str) -> frozenset[str]:
     Only generic English is listed in the filler — no capability, model or tag
     name — so this stays put while the bundle changes underneath it.
     """
-    return frozenset(_stem(w) for w in _words(s))
+    return frozenset(w for w in map(_stem, _split(s)) if w not in _FILLER_STEMS)
 
 
 def _query_tokens(s: str) -> frozenset[str]:
     """:func:`_tokens` plus each adjacent pair joined, so "lip sync" reaches the key ``lipsync``."""
-    words = _words(s)
-    return frozenset(_stem(w) for w in itertools.chain(words, (a + b for a, b in zip(words, words[1:]))))
+    words = _split(s)
+    return _tokens(s) | frozenset(_stem(a + b) for a, b in zip(words, words[1:]))
 
 
 def _normalized_map(keys: dict[str, str], *, ids: Collection[str] = ()) -> dict[str, str]:
@@ -509,10 +520,8 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
     key_words: dict[str, set[str]] = defaultdict(set)
     for words, _, cid in capability_tokens:
         key_words[cid] |= words
-    # First sentence only: the rest of a description says what the row is *not*
-    # ("Never used to fix anatomy") and would pull those queries in.
     capability_context = {
-        cid: _tokens(re.split(r"(?<=[.;])\s", desc, maxsplit=1)[0]) - key_words[cid]
+        cid: _tokens(_NEGATOR.split(desc, maxsplit=1)[0]) - key_words[cid]
         for cid, cap in capabilities.items()
         if isinstance(desc := cap.get("description"), str)
     }
@@ -591,7 +600,7 @@ def _resolve_tokens(bundle: Bundle, query: str) -> str | None:
     scored: dict[str, tuple[float, int, int, int]] = {}
     for key_words, key_norm, cid in bundle.capability_tokens:
         hit = key_words & words
-        if not hit or (len(hit) == 1 and len(next(iter(hit))) < MIN_SINGLE_TOKEN_CHARS):
+        if not hit or (len(key_words) == 1 and len(key_norm) < MIN_SINGLE_TOKEN_CHARS):
             continue
         context = len(bundle.capability_context.get(cid, frozenset()) & words)
         missing = len(key_words) - len(hit)

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -14,6 +14,7 @@ disturbing the explicit ``comfy knowledge`` verbs.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import math
 import os
@@ -21,6 +22,7 @@ import re
 import time
 import urllib.parse
 import urllib.request
+from collections import defaultdict
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -54,7 +56,10 @@ UNAVAILABLE_LOCALLY = "the templates or nodes this row resolves to are absent fr
 # Grammatical filler dropped before subset matching. Deliberately generic English:
 # naming a capability, model or gallery tag here would be a second copy of the
 # bundle's vocabulary, which then drifts every time comfy-knowledge is recompiled.
-_FILLER = frozenset("a an the of to for from with and or in on my me some this that into make create generate".split())
+_FILLER = frozenset(
+    "a an the of to for from with and or in on at by as is are be do it no not which where while "
+    "my me some this that into make create generate".split()
+)
 # A one-word key must be at least this long to match on its own. Guards against a
 # future alias like "3d" dragging a capability into every query mentioning it.
 MIN_SINGLE_TOKEN_CHARS = 4
@@ -82,9 +87,10 @@ class Bundle:
     # exact path decides it; a real id always keeps its own key.
     normalized_aliases: dict[str, str] = field(default_factory=dict)
     normalized_capabilities: dict[str, str] = field(default_factory=dict)
-    # (word set, capability id) for every capability id and alias, so an intent
-    # phrase reaches the row its own wording names. See :func:`_resolve_tokens`.
-    capability_tokens: tuple[tuple[frozenset[str], str], ...] = ()
+    # (word set, normalized key, capability id) for every capability id and alias,
+    # so an intent phrase reaches the row its own wording names. See :func:`_resolve_tokens`.
+    capability_tokens: tuple[tuple[frozenset[str], str, str], ...] = ()
+    capability_context: dict[str, frozenset[str]] = field(default_factory=dict)
 
 
 # One-element tuple so a memoized ``None`` is distinguishable from "not loaded yet".
@@ -144,13 +150,32 @@ def _normalize(s: str) -> str:
     return re.sub(r"[^a-z0-9]", "", s)
 
 
-def _tokens(s: str) -> frozenset[str]:
-    """Word set for subset matching, with grammatical filler dropped.
+def _stem(word: str) -> str:
+    """Suffix strip so "editing", "edits" and "edit" agree, and "removal" meets "remove"."""
+    for suffix in ("ing", "ed", "es", "s", "al"):
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+            word = word[: -len(suffix)]
+            break
+    return word[:-1] if word.endswith("e") and len(word) > 3 else word
 
-    Only generic English is listed here — no capability, model or tag name — so
-    this stays put while the bundle changes underneath it.
+
+def _words(s: str) -> list[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", s.lower()) if t and t not in _FILLER]
+
+
+def _tokens(s: str) -> frozenset[str]:
+    """Stemmed word set of a key or description, with grammatical filler dropped.
+
+    Only generic English is listed in the filler — no capability, model or tag
+    name — so this stays put while the bundle changes underneath it.
     """
-    return frozenset(t for t in re.split(r"[^a-z0-9]+", s.lower()) if t and t not in _FILLER)
+    return frozenset(_stem(w) for w in _words(s))
+
+
+def _query_tokens(s: str) -> frozenset[str]:
+    """:func:`_tokens` plus each adjacent pair joined, so "lip sync" reaches the key ``lipsync``."""
+    words = _words(s)
+    return frozenset(_stem(w) for w in itertools.chain(words, (a + b for a, b in zip(words, words[1:]))))
 
 
 def _normalized_map(keys: dict[str, str], *, ids: Collection[str] = ()) -> dict[str, str]:
@@ -478,6 +503,20 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
             if alias:
                 capability_keys.setdefault(alias, cid)
 
+    capability_tokens = tuple(
+        (words, _normalize(key), cid) for key, cid in capability_keys.items() if (words := _tokens(key))
+    )
+    key_words: dict[str, set[str]] = defaultdict(set)
+    for words, _, cid in capability_tokens:
+        key_words[cid] |= words
+    # Description words a query may share with a capability, minus the words its
+    # keys already carry, so context only ever counts what the keys did not.
+    capability_context = {
+        cid: _tokens(desc) - key_words[cid]
+        for cid, cap in capabilities.items()
+        if isinstance(desc := cap.get("description"), str)
+    }
+
     version = manifest.get("version") if manifest is not None else None
     return Bundle(
         version=version[:MAX_VERSION_CHARS] if isinstance(version, str) else "unknown",
@@ -494,7 +533,8 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
         model_capabilities=model_capabilities,
         normalized_aliases=_normalized_map(aliases, ids=models),
         normalized_capabilities=_normalized_map(capability_keys, ids=capabilities),
-        capability_tokens=tuple((words, cid) for key, cid in capability_keys.items() if (words := _tokens(key))),
+        capability_tokens=capability_tokens,
+        capability_context=capability_context,
     )
 
 
@@ -531,28 +571,40 @@ def _resolve_tokens(bundle: Bundle, query: str) -> str | None:
 
     Callers ask in sentences ("image to 3d model mesh") while the bundle is keyed
     on tags and ids ("Image to Model", "image-to-3d"), and :func:`_normalize`
-    only strips punctuation, so the exact path misses everything phrased. A key
-    matches when all of its words appear in the query, and the longest key wins
-    so a more specific capability is not outvoted by a broader one.
+    only strips punctuation, so the exact path misses everything phrased.
+
+    Each key scores by the share of its words the query contains. A full match
+    always counts. A partial one counts only when the query shares more words
+    with the capability's description than the key words it lacks, so "poster
+    with readable text" reaches ``text-in-image`` while "4K video generation"
+    reaches nothing. Among capabilities that score the same, the key spelled
+    out literally in the query wins ("text to image" over ``text-in-image``),
+    then the one whose description the query echoes.
 
     Ambiguity resolves to nothing rather than to a guess, matching
     :func:`_normalized_map`: a tie between two capabilities is not an answer.
     """
-    words = _tokens(query)
+    words = _query_tokens(query)
     if not words:
         return None
-    best: set[str] = set()
-    best_len = 0
-    for key_words, cid in bundle.capability_tokens:
-        if len(key_words) < best_len or not key_words <= words:
+    literal = _normalize(query)
+    scored: dict[str, tuple[float, int, int, int]] = {}
+    for key_words, key_norm, cid in bundle.capability_tokens:
+        hit = key_words & words
+        if not hit or (len(hit) == 1 and len(next(iter(hit))) < MIN_SINGLE_TOKEN_CHARS):
             continue
-        if len(key_words) == 1 and len(next(iter(key_words))) < MIN_SINGLE_TOKEN_CHARS:
+        context = len(bundle.capability_context.get(cid, frozenset()) & words)
+        missing = len(key_words) - len(hit)
+        if missing and context <= missing:
             continue
-        if len(key_words) > best_len:
-            best, best_len = {cid}, len(key_words)
-        else:
-            best.add(cid)
-    return next(iter(best)) if len(best) == 1 else None
+        score = (len(hit) / len(key_words), len(hit), len(key_norm) if key_norm in literal else 0, context)
+        if score > scored.get(cid, (0.0, 0, 0, 0)):
+            scored[cid] = score
+    if not scored:
+        return None
+    best = max(scored.values())
+    winners = [cid for cid, score in scored.items() if score == best]
+    return winners[0] if len(winners) == 1 else None
 
 
 def _text(value: Any) -> str | None:

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -59,8 +59,12 @@ _FILLER = frozenset(
     "a an the of to for from with and or in on at by as is are be do it which where while "
     "my me some this that into make create generate".split()
 )
-# Cut a description here: what follows says what the row is *not*.
-_NEGATOR = re.compile(r"(?<=[.;])\s|\b(?:no|not|never|neither|nor|without|except)\b", re.IGNORECASE)
+# A description counts as match context only up to its first sentence end or
+# negator, whichever comes first: what follows says what the row is *not*, or
+# how it routes. "e.g." and "No.1" are not ends.
+_CONTEXT_END = re.compile(
+    r"(?<=[a-z]{2}[.;])\s|\b(?:no|not|never|neither|nor|without|except)\b(?![.\d])", re.IGNORECASE
+)
 # A one-word key must be at least this long to match on its own. Guards against a
 # future alias like "3d" dragging a capability into every query mentioning it.
 MIN_SINGLE_TOKEN_CHARS = 4
@@ -159,12 +163,12 @@ def _stem(word: str) -> str:
     stripped = True
     while stripped:
         stripped = False
-        for suffix in ("ing", "ed", "es", "s"):
+        for suffix in ("ing", "ed", "s", "e"):
             if word.endswith(suffix) and len(word) - len(suffix) >= 3:
                 word = word[: -len(suffix)]
                 stripped = True
                 break
-    return word[:-1] if word.endswith("e") and len(word) > 3 else word
+    return word
 
 
 _FILLER_STEMS = frozenset(map(_stem, _FILLER))
@@ -175,12 +179,14 @@ def _split(s: str) -> list[str]:
 
 
 def _tokens(s: str) -> frozenset[str]:
-    """Stemmed word set of a key or description, with grammatical filler dropped.
-
-    Only generic English is listed in the filler — no capability, model or tag
-    name — so this stays put while the bundle changes underneath it.
-    """
+    """Stemmed word set of a key or description, with grammatical filler dropped."""
     return frozenset(w for w in map(_stem, _split(s)) if w not in _FILLER_STEMS)
+
+
+def _short_key(key: str) -> bool:
+    """A one-word key (filler aside) under MIN_SINGLE_TOKEN_CHARS never matches on wording."""
+    raw = [w for w in _split(key) if _stem(w) not in _FILLER_STEMS]
+    return len(raw) == 1 and len(raw[0]) < MIN_SINGLE_TOKEN_CHARS
 
 
 def _query_tokens(s: str) -> frozenset[str]:
@@ -515,13 +521,15 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
                 capability_keys.setdefault(alias, cid)
 
     capability_tokens = tuple(
-        (words, _normalize(key), cid) for key, cid in capability_keys.items() if (words := _tokens(key))
+        (words, _normalize(key), cid)
+        for key, cid in capability_keys.items()
+        if (words := _tokens(key)) and not _short_key(key)
     )
     key_words: dict[str, set[str]] = defaultdict(set)
     for words, _, cid in capability_tokens:
         key_words[cid] |= words
     capability_context = {
-        cid: _tokens(_NEGATOR.split(desc, maxsplit=1)[0]) - key_words[cid]
+        cid: _tokens(_CONTEXT_END.split(desc, maxsplit=1)[0]) - key_words[cid]
         for cid, cap in capabilities.items()
         if isinstance(desc := cap.get("description"), str)
     }
@@ -600,7 +608,7 @@ def _resolve_tokens(bundle: Bundle, query: str) -> str | None:
     scored: dict[str, tuple[float, int, int, int]] = {}
     for key_words, key_norm, cid in bundle.capability_tokens:
         hit = key_words & words
-        if not hit or (len(key_words) == 1 and len(key_norm) < MIN_SINGLE_TOKEN_CHARS):
+        if not hit:
             continue
         context = len(bundle.capability_context.get(cid, frozenset()) & words)
         missing = len(key_words) - len(hit)

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -318,6 +318,7 @@ class TestPhrasedQueries:
             "gamma delta. Never used for epsilon zeta.",
             "gamma delta with no epsilon zeta.",
             "gamma delta; not epsilon zeta",
+            "gamma delta, e.g. No.1 pick. Never used for epsilon zeta.",
         ],
     )
     def test_a_description_stops_counting_where_it_says_what_the_row_is_not(self, description):
@@ -335,7 +336,7 @@ class TestPhrasedQueries:
         assert knowledge._resolve_tokens(b, "backgrounds removed from these photos") == "cap"
 
     def test_a_four_letter_alias_ending_in_e_is_still_reachable(self):
-        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Pose"]}, "short": {"aliases": ["3D"]}}}
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Pose"]}, "short": {"aliases": ["3D", "Make 3D"]}}}
         b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
         assert knowledge._resolve_tokens(b, "pose estimation") == "cap"
         assert knowledge._resolve_tokens(b, "a 3d scene") is None
@@ -349,6 +350,8 @@ class TestPhrasedQueries:
             ("images", "image"),
             ("classes", "class"),
             ("generating", "generate"),
+            ("denoising", "denoise"),
+            ("denoised", "denoise"),
         ):
             assert knowledge._stem(a) == knowledge._stem(b), (a, b)
         assert knowledge._stem("3d") == "3d"

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -336,7 +336,10 @@ class TestPhrasedQueries:
         assert knowledge._resolve_tokens(b, "backgrounds removed from these photos") == "cap"
 
     def test_a_four_letter_alias_ending_in_e_is_still_reachable(self):
-        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Pose"]}, "short": {"aliases": ["3D", "Make 3D"]}}}
+        data = {
+            "models": {},
+            "capabilities": {"cap": {"aliases": ["Pose"]}, "short": {"aliases": ["3D", "Make 3D", "3D 3D"]}},
+        }
         b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
         assert knowledge._resolve_tokens(b, "pose estimation") == "cap"
         assert knowledge._resolve_tokens(b, "a 3d scene") is None

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -251,7 +251,7 @@ def _phrased_bundle() -> knowledge.Bundle:
         "text-to-video": {"description": "Make a clip from a prompt with no source image."},
         "upscale": {
             "aliases": ["Video Upscale"],
-            "description": "Add resolution or restore detail after generation or editing.",
+            "description": "Add resolution or restore detail after generation or editing. Never used to fix anatomy.",
         },
     }
     return knowledge._index(
@@ -291,6 +291,7 @@ class TestPhrasedQueries:
             ("dub video into another language with lip sync", "lipsync"),
             # Nothing in the table names these; they must stay misses, not resolve to the closest row.
             ("restore old damaged photo keep faces", None),
+            ("fix the anatomy in my image", None),
             ("camera control video", None),
             ("how do I load a checkpoint", None),
         ],
@@ -309,6 +310,14 @@ class TestPhrasedQueries:
         assert knowledge._resolve_tokens(b, "alpha gamma") is None
         assert knowledge._resolve_tokens(b, "alpha gamma delta") == "cap"
         assert knowledge._resolve_tokens(b, "gamma delta") is None
+
+    def test_only_the_first_sentence_of_a_description_counts(self):
+        cap = {"aliases": ["alpha beta"], "description": "gamma delta. Never used for epsilon zeta."}
+        b = knowledge._index(
+            {"models": {}, "capabilities": {"cap": cap}}, None, source="env", stale=False, path="x", mtime=0.0
+        )
+        assert knowledge._resolve_tokens(b, "alpha gamma delta") == "cap"
+        assert knowledge._resolve_tokens(b, "alpha epsilon zeta") is None
 
     def test_an_inflected_key_word_still_matches(self):
         data = {"models": {}, "capabilities": {"cap": {"aliases": ["Background Removal"]}}}

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -278,6 +278,7 @@ class TestPhrasedQueries:
             ("text to video with audio / sound", "text-to-video"),
             # A partial key match counts when the description supplies more words than the key lacks.
             ("poster with readable text", "text-in-image"),
+            ("a musical poster with readable text", "text-in-image"),
             ("poster with lots of small readable text typography", "text-in-image"),
             ("sound effects generation", "audio-generation"),
             ("4K video generation", None),
@@ -311,8 +312,16 @@ class TestPhrasedQueries:
         assert knowledge._resolve_tokens(b, "alpha gamma delta") == "cap"
         assert knowledge._resolve_tokens(b, "gamma delta") is None
 
-    def test_only_the_first_sentence_of_a_description_counts(self):
-        cap = {"aliases": ["alpha beta"], "description": "gamma delta. Never used for epsilon zeta."}
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "gamma delta. Never used for epsilon zeta.",
+            "gamma delta with no epsilon zeta.",
+            "gamma delta; not epsilon zeta",
+        ],
+    )
+    def test_a_description_stops_counting_where_it_says_what_the_row_is_not(self, description):
+        cap = {"aliases": ["alpha beta"], "description": description}
         b = knowledge._index(
             {"models": {}, "capabilities": {"cap": cap}}, None, source="env", stale=False, path="x", mtime=0.0
         )
@@ -320,15 +329,33 @@ class TestPhrasedQueries:
         assert knowledge._resolve_tokens(b, "alpha epsilon zeta") is None
 
     def test_an_inflected_key_word_still_matches(self):
-        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Background Removal"]}}}
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Remove Background"]}}}
         b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
-        assert knowledge._resolve_tokens(b, "remove the background from this photo") == "cap"
+        assert knowledge._resolve_tokens(b, "removing the background from this photo") == "cap"
+        assert knowledge._resolve_tokens(b, "backgrounds removed from these photos") == "cap"
+
+    def test_a_four_letter_alias_ending_in_e_is_still_reachable(self):
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Pose"]}, "short": {"aliases": ["3D"]}}}
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "pose estimation") == "cap"
+        assert knowledge._resolve_tokens(b, "a 3d scene") is None
 
     def test_stem_agrees_across_inflections(self):
-        for a, b in (("editing", "edit"), ("edits", "edit"), ("removal", "remove"), ("images", "image")):
+        for a, b in (
+            ("editing", "edit"),
+            ("edits", "edit"),
+            ("removed", "remove"),
+            ("removals", "removal"),
+            ("images", "image"),
+            ("classes", "class"),
+            ("generating", "generate"),
+        ):
             assert knowledge._stem(a) == knowledge._stem(b), (a, b)
         assert knowledge._stem("3d") == "3d"
+        assert knowledge._stem("musical") != knowledge._stem("music")
+        assert knowledge._tokens("generating an image") == knowledge._tokens("generate an image")
         assert knowledge._query_tokens("lip sync") >= {"lip", "sync", "lipsync"}
+        assert "lipsync" not in knowledge._query_tokens("lip or sync")
 
 
 class TestScalarGuards:

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -230,6 +230,98 @@ class TestLookup:
         assert entry["tier"] == "canon"
 
 
+def _phrased_bundle() -> knowledge.Bundle:
+    """The real bundle's capability keys and descriptions, minus the picks."""
+    capabilities = {
+        "audio-generation": {
+            "aliases": ["Text to Audio", "Music", "Audio"],
+            "description": "Music, text-to-speech and sound effects. Neither is the native audio track of a clip.",
+        },
+        "image-edit": {"description": "Change an existing still by instruction (instruct-edit)."},
+        "inpaint": {
+            "description": "Remove or replace part of an image. Prompt-remove and mask-fill are different fetches."
+        },
+        "lipsync": {"description": "A still plus audio becomes a talking clip, or dubbing existing footage."},
+        "text-in-image": {
+            "description": "Stills where in-image text must be readable: posters, signs, UI, typography."
+        },
+        "text-to-image": {
+            "description": "Make a still image from a prompt with no source image. The photorealism row."
+        },
+        "text-to-video": {"description": "Make a clip from a prompt with no source image."},
+        "upscale": {
+            "aliases": ["Video Upscale"],
+            "description": "Add resolution or restore detail after generation or editing.",
+        },
+    }
+    return knowledge._index(
+        {"models": {}, "capabilities": capabilities}, None, source="env", stale=False, path="x", mtime=0.0
+    )
+
+
+class TestPhrasedQueries:
+    """The three defects behind ``knowledge pick``'s miss rate, and the misses that must stay misses."""
+
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            # A tie on {text, image} breaks on the key spelled out literally, or on description words.
+            ("fast cheap text to image drafts for A/B testing", "text-to-image"),
+            ("fast local text to image with accurate object binding", "text-to-image"),
+            ("image with accurate text and typography", "text-in-image"),
+            ("generate image with readable Chinese text local", "text-in-image"),
+            ("text image", None),
+            # lipsync versus the alias "Audio": the longer literal key wins.
+            ("lipsync talking portrait from photo and audio", "lipsync"),
+            ("make a portrait speak my audio (lipsync talking avatar)", "lipsync"),
+            # text-to-video versus "Text to Audio": same rule.
+            ("text to video with audio / sound", "text-to-video"),
+            # A partial key match counts when the description supplies more words than the key lacks.
+            ("poster with readable text", "text-in-image"),
+            ("poster with lots of small readable text typography", "text-in-image"),
+            ("sound effects generation", "audio-generation"),
+            ("4K video generation", None),
+            ("generate image keeping multiple reference photos consistent", None),
+            ("a video", None),
+            # Stemming and joined adjacent words.
+            ("keep the same character while editing an image", "image-edit"),
+            # "removal" is only in inpaint's description, never a key, so this stays a canon gap.
+            ("remove the background from this photo", None),
+            ("lip sync video to new speech", "lipsync"),
+            ("dub video into another language with lip sync", "lipsync"),
+            # Nothing in the table names these; they must stay misses, not resolve to the closest row.
+            ("restore old damaged photo keep faces", None),
+            ("camera control video", None),
+            ("how do I load a checkpoint", None),
+        ],
+    )
+    def test_resolves_the_capability_the_phrase_names(self, query, expected):
+        assert knowledge._resolve_tokens(_phrased_bundle(), query) == expected
+
+    def test_every_id_still_resolves_to_itself(self):
+        b = _phrased_bundle()
+        for cid in b.capabilities:
+            assert knowledge.pick(b, cid)["id"] == cid
+
+    def test_a_partial_match_needs_its_description_to_out_vote_the_missing_words(self):
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["alpha beta"], "description": "gamma delta"}}}
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "alpha gamma") is None
+        assert knowledge._resolve_tokens(b, "alpha gamma delta") == "cap"
+        assert knowledge._resolve_tokens(b, "gamma delta") is None
+
+    def test_an_inflected_key_word_still_matches(self):
+        data = {"models": {}, "capabilities": {"cap": {"aliases": ["Background Removal"]}}}
+        b = knowledge._index(data, None, source="env", stale=False, path="x", mtime=0.0)
+        assert knowledge._resolve_tokens(b, "remove the background from this photo") == "cap"
+
+    def test_stem_agrees_across_inflections(self):
+        for a, b in (("editing", "edit"), ("edits", "edit"), ("removal", "remove"), ("images", "image")):
+            assert knowledge._stem(a) == knowledge._stem(b), (a, b)
+        assert knowledge._stem("3d") == "3d"
+        assert knowledge._query_tokens("lip sync") >= {"lip", "sync", "lipsync"}
+
+
 class TestScalarGuards:
     def test_non_string_routing_values_are_emitted_as_null(self):
         """Routing is copied straight out of the bundle, and the block schema allows


### PR DESCRIPTION
Companion to cloud PR #7609 / BE-9929. The hosted agent calls `comfy knowledge pick` with the user's own phrasing; this fixes the three matcher defects behind its miss rate.

## What changed in `_resolve_tokens`

Same three passes (exact, `_normalize`, wording). The wording pass now scores instead of demanding every key word:

1. **Tie-break by literal key and by description.** `text-in-image` and `text-to-image` both reduce to `{text, image}`. Among keys that score the same, the key spelled out literally in the query wins (`"text to image"` → `text-to-image`), then the capability whose description shares more words with the query (`"typography"`, `"readable"` → `text-in-image`). No signal → still `None`.
2. **Partial key matches, gated by evidence.** A key missing words counts only when the query shares more description words with that capability than the key words it lacks. `"poster with readable text"` hits `text-in-image` (missing `image`, shares `poster`, `readable`). `"4K video generation"` stays a miss (one shared word, `generation`, is not enough). Threshold chosen from the replay: allowing one shared word produced four wrong hits, all on `upscale`.
3. **Stemming and adjacent-word joining.** A small suffix strip (`ing`, `ed`, `s`, `e`, repeated to a fixed point) makes `editing`/`edit` and `removed`/`remove` agree. `-al` is deliberately not stripped: it would send `musical` onto the alias `Music`. Adjacent query words are joined before filler removal, so `"lip sync"` reaches the key `lipsync` and `"lip or sync"` does not.

Description words are indexed at load time from the bundle's own `description` field, minus the capability's key words, so no vocabulary lives in the matcher. The description is cut at the first sentence end or negator (`no`, `not`, `never`, `neither`, `nor`, `without`, `except`), because what follows says what a row is *not*: with the whole description indexed, `"fix anatomy in my image"` resolved to `upscale` on the strength of "Never used to fix anatomy", and `"image to video with a source clip"` resolved to `text-to-video` on "with no source image".

`log_query`, the envelope, `resolve`, `attach()` and the canon are untouched. No fallback to the closest capability: a miss is still a miss.

## Replay

100 `list_model_picks` queries from eval run `run_3e91922d97784821be2c96bf9a0debcf`, against the vendored bundle (`~/ComfyCode/cloud/services/agent/knowledge/knowledge.json`, `COMFY_KNOWLEDGE_FILE` set to it).

| | total | hit | miss | distinct hit / distinct queries |
|---|---|---|---|---|
| before | 100 | 68 | 32 | 38 / 69 |
| after | 100 | 84 | 16 | 54 / 69 |

The before row is the spec's baseline (`hit=68 miss=32`), reproduced against `origin/main` (`c1fa1f4`).

Every flip, for a human to check:

| query | before | after |
|---|---|---|
| `dense poster with lots of small readable text and precise typography` | – | text-in-image |
| `dub video into another language with lip sync` | – | lipsync |
| `fast cheap text to image drafts for A/B testing` | – | text-to-image |
| `fast local text to image with accurate object binding` | – | text-to-image |
| `generate image with readable Chinese text local` | – | text-in-image |
| `image with accurate text and typography` | – | text-in-image |
| `keep the same character while editing an image` | – | image-edit |
| `lip sync video to new speech` | – | lipsync |
| `lipsync talking portrait from photo and audio` | – | lipsync |
| `make a portrait speak my audio (lipsync talking avatar)` | – | lipsync |
| `poster with lots of small readable text typography` | – | text-in-image |
| `poster with readable Chinese text` | – | text-in-image |
| `poster with readable text` | – | text-in-image |
| `sound effects generation` | – | audio-generation |
| `sound effects generation from text` | – | audio-generation |
| `talking photo lip sync from portrait and audio` | audio-generation | lipsync |
| `text to video with audio / sound` | – | text-to-video |

No query that hit before now misses. One wrong hit (`talking photo lip sync…` → `audio-generation`) is corrected.

Still missing (16 of 100, 15 distinct), none of which names a capability key, so they are curation gaps for `comfy-knowledge` aliases rather than matcher work: `3D view from a single photo`, `4K video generation`, `camera control video`, `camera control video generation`, `consistent characters across shots`, `consistent characters and camera control in video generation`, `edit product photo, change background and enrich colors`, `edit product photos keeping the same character consistent across edits`, `generate image keeping multiple reference photos consistent`, `multi-reference brand-consistent image from several reference photos`, `photorealistic product photography still, luxury object on surface`, `product videos with motion control at scale on a budget`, `restore old damaged photo keep faces`, `restore old damaged photo keep faces looking like real people`, `restyle a portrait photo into a watercolor painting while keeping the face recognizable`.

All twelve ids still resolve to themselves with a non-empty pick list (`True True`).

## Tests

`TestPhrasedQueries` in `tests/comfy_cli/test_knowledge_attach.py`: a table over the spec's examples for each defect plus the misses that must stay misses, against a bundle with the real keys and descriptions. Existing matcher tests unchanged and green.

`ruff check`, `ruff format --check` (0.15.15) clean. Full suite: 6119 passed, 1 failed (`test_from_workflow_refuses_a_workflow_nested_past_the_parser_limit`, fails identically on clean `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE8LztmLiy7j1AZfbPNXok


