### PR TITLE
feat(build): add packaging, sync and Builder client primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ history.
 
 - The builder client module is now `comfy_cli.builder_api` (was
   `comfy_cli.distribution_api`), and its methods say build and release
-  (`create_build`, `list_releases`, ...), matching the builder's public API.
-  The `distribution-definition/0` schema id is unchanged.
+  (`create_build`, `create_release`, `list_releases`, ...), matching the
+  builder's public API. The `distribution-definition/0` schema id is unchanged.
 - `comfy build --json` payloads carry the builder's vocabulary: `buildId`,
   `releaseId`, and `builds` and `releases` arrays. The retired `distributionId`,
   `versionId`, `distributions` and `versions` keys are emitted alongside them
@@ -60,6 +60,10 @@ history.
 - The shipped `build_from_snapshot.json` schema now requires the `build` key
   the builder actually serves; it still required the pre-rename `distribution`
   key, so a valid `comfy build from-snapshot --json` payload failed validation.
+- `comfy build list` and `comfy build release list` show every row again. The
+  builder pages both reads, and the client took only the first page, so a
+  workspace or a build past one page lost its tail — silently, with no error
+  and nothing in the output to say rows were missing.
 
 ## [1.16.0] - 2026-08-10
 

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import requests
 
 from comfy_cli import credentials
-from comfy_cli.builder_pagination import cursor_pages
+from comfy_cli.builder_pagination import PAGE_LIMIT, cursor_pages
 from comfy_cli.http import request_json
 from comfy_cli.target import Target
 
@@ -193,7 +193,9 @@ class BuilderClient:
         The builder pages this read, so a workspace past one page silently lost
         its tail when only the first was taken."""
         builds: list[dict] = []
-        for page in cursor_pages(lambda cursor: self._get(("builds",), {"cursor": cursor}), "builds"):
+        for page in cursor_pages(
+            lambda cursor: self._get(("builds",), {"cursor": cursor, "limit": PAGE_LIMIT}), "builds"
+        ):
             builds.extend(page.get("builds", []))
         return builds
 
@@ -206,7 +208,10 @@ class BuilderClient:
         releases. A server that predates the version-to-release rename keys the
         list ``versions``, so both spellings parse."""
         releases: list[dict] = []
-        pages = cursor_pages(lambda cursor: self._get(("builds", build_id, "releases"), {"cursor": cursor}), "releases")
+        pages = cursor_pages(
+            lambda cursor: self._get(("builds", build_id, "releases"), {"cursor": cursor, "limit": PAGE_LIMIT}),
+            "releases",
+        )
         for page in pages:
             releases.extend(page.get("releases") or page.get("versions") or [])
         return releases

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import requests
 
 from comfy_cli import credentials
+from comfy_cli.builder_pagination import cursor_pages
 from comfy_cli.http import request_json
 from comfy_cli.target import Target
 
@@ -76,10 +77,22 @@ class BuilderClient:
         )
         return parsed or {}
 
-    def create_blob(self, kind: str, filename: str, sha256: str, size_bytes: int) -> tuple[str, str]:
-        """Mint a presigned upload. Returns (blobId, uploadUrl)."""
+    def create_blob(self, kind: str, filename: str, sha256: str, size_bytes: int) -> tuple[str, str | None]:
+        """Claim a blob id for these bytes. Returns ``(blobId, uploadUrl)``.
+
+        ``uploadUrl`` is ``None`` when the workspace already held these exact
+        bytes: the builder returns the id it already has and there is nothing
+        to transfer, which is what makes an interrupted multi-GB push cheap to
+        retry. Branch on the server's ``deduplicated`` flag rather than on the
+        URL being absent — a presigned PUT is signed create-only, so replaying
+        one against content that already exists fails rather than harmlessly
+        re-uploading.
+        """
         r = self._post(("blobs",), {"kind": kind, "filename": filename, "sha256": sha256, "sizeBytes": size_bytes})
-        return r["blobId"], r["uploadUrl"]
+        blob_id = r["blobId"]
+        if r.get("deduplicated") is True:
+            return blob_id, None
+        return blob_id, r["uploadUrl"]
 
     def upload_blob(self, upload_url: str, path: Path) -> None:
         """Stream a file to its presigned PUT URL (bytes go straight to storage).
@@ -119,7 +132,7 @@ class BuilderClient:
             body["description"] = description
         return self._post(("builds", "from-workflow"), body, timeout=_WORKFLOW_IMPORT_TIMEOUT)
 
-    def cut_version(self, build_id: str, targets: list[dict] | None = None) -> tuple[str, str]:
+    def create_release(self, build_id: str, targets: list[dict] | None = None) -> tuple[str, str]:
         """POST /v1/builds/{id}/releases: freeze the definition and enqueue a
         build. Returns (releaseId, statusUrl). A server that predates the
         version-to-release rename still answers with ``buildVersionId``, so
@@ -130,10 +143,10 @@ class BuilderClient:
         r = self._post(("builds", build_id, "releases"), body)
         return r.get("releaseId") or r["buildVersionId"], r["statusUrl"]
 
-    def get_version(self, version_id: str) -> dict:
+    def get_release(self, release_id: str) -> dict:
         """GET /v1/releases/{id}: poll a release's build status."""
         _, parsed = request_json(
-            self.target.url("releases", version_id), self.target, method="GET", max_bytes=_MAX_JSON
+            self.target.url("releases", release_id), self.target, method="GET", max_bytes=_MAX_JSON
         )
         return parsed or {}
 
@@ -175,31 +188,40 @@ class BuilderClient:
         return parsed or {}
 
     def list_builds(self) -> list[dict]:
-        """GET /v1/builds -> the caller's builds (summaries)."""
-        return self._get(("builds",)).get("builds", [])
+        """GET every cursor page from /v1/builds -> the caller's builds (summaries).
+
+        The builder pages this read, so a workspace past one page silently lost
+        its tail when only the first was taken."""
+        builds: list[dict] = []
+        for page in cursor_pages(lambda cursor: self._get(("builds",), {"cursor": cursor}), "builds"):
+            builds.extend(page.get("builds", []))
+        return builds
 
     def get_build(self, build_id: str) -> dict:
         """GET /v1/builds/{id} -> a build with its full definition."""
         return self._get(("builds", build_id))
 
     def list_releases(self, build_id: str) -> list[dict]:
-        """GET /v1/builds/{id}/releases -> the build's releases. A server
-        that predates the version-to-release rename keys the list ``versions``,
-        so both spellings parse."""
-        body = self._get(("builds", build_id, "releases"))
-        return body.get("releases") or body.get("versions") or []
+        """GET every cursor page from /v1/builds/{id}/releases -> the build's
+        releases. A server that predates the version-to-release rename keys the
+        list ``versions``, so both spellings parse."""
+        releases: list[dict] = []
+        pages = cursor_pages(lambda cursor: self._get(("builds", build_id, "releases"), {"cursor": cursor}), "releases")
+        for page in pages:
+            releases.extend(page.get("releases") or page.get("versions") or [])
+        return releases
 
-    def get_version_logs(self, version_id: str, *, os: str | None = None, gpu: str | None = None) -> dict:
+    def get_release_logs(self, release_id: str, *, os: str | None = None, gpu: str | None = None) -> dict:
         """GET /v1/releases/{id}/logs -> the build log for one target
         (``os``/``gpu`` select which; the builder picks a target when omitted).
-        Returns ``{versionId, os?, gpu?, log, truncated}``. Uses a larger response
+        Returns ``{releaseId, os?, gpu?, log, truncated}``. Uses a larger response
         cap than other reads because a build log can be several MiB."""
-        return self._get(("releases", version_id, "logs"), {"os": os, "gpu": gpu}, max_bytes=_MAX_LOG_JSON)
+        return self._get(("releases", release_id, "logs"), {"os": os, "gpu": gpu}, max_bytes=_MAX_LOG_JSON)
 
     def delete_build(self, build_id: str) -> None:
         """DELETE /v1/builds/{id} -> soft-delete. Idempotent (204 even when
         already gone); the builder returns 409 while a deployment still runs one of
-        its versions."""
+        its releases."""
         request_json(self.target.url("builds", build_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
 
     def validate_build(self, build_id: str) -> dict:
@@ -214,12 +236,28 @@ class BuilderClient:
         )
         return parsed or {}
 
-    def update_build(self, build_id: str, definition: dict, expected_updated_at: str | None) -> dict:
+    def update_build(
+        self,
+        build_id: str,
+        definition: dict,
+        expected_updated_at: str | None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> dict:
         """PATCH /v1/builds/{id} -> replace the stored definition. Returns
         the updated build. ``expected_updated_at`` is the ``updatedAt`` the
         caller last saw (optimistic concurrency); the builder rejects the save with
-        409 STALE if it is stale or missing, so pass the value from a fresh GET."""
+        409 STALE if it is stale or missing, so pass the value from a fresh GET.
+
+        ``name`` and ``description`` are the server's own existing fields: a
+        local spec owns them too, so a sync that could not carry them would leave
+        the two copies disagreeing with no way to reconcile."""
         body = {"definition": definition, "expectedUpdatedAt": expected_updated_at}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
         _, parsed = request_json(
             self.target.url("builds", build_id),
             self.target,
@@ -229,10 +267,10 @@ class BuilderClient:
         )
         return parsed or {}
 
-    def get_version_manifest(self, version_id: str) -> dict:
+    def get_release_manifest(self, release_id: str) -> dict:
         """GET /v1/releases/{id}/manifest -> the release's models and
         runtime policies."""
-        return self._get(("releases", version_id, "manifest"))
+        return self._get(("releases", release_id, "manifest"))
 
     def get_artifact_download(self, artifact_id: str) -> dict:
         """GET /v1/build-artifacts/{id}/download -> ``{downloadUrl, expiresAt?}``."""
@@ -240,7 +278,12 @@ class BuilderClient:
 
     def list_blobs(self, kind: str | None = None) -> list[dict]:
         """GET /v1/blobs -> the workspace's private uploaded content (summaries),
-        optionally filtered by ``kind`` (model | node_zip)."""
+        optionally filtered by ``kind`` (model | node_zip).
+
+        One page, no walk: this endpoint mints no cursor, so there is nothing to
+        follow. Pass the result through
+        :func:`comfy_cli.builder_pagination.blob_listing_is_clamped` to tell a
+        complete listing from one the server cut off at its page limit."""
         return self._get(("blobs",), {"kind": kind}).get("blobs", [])
 
     def list_base_images(self) -> list[dict]:
@@ -248,7 +291,7 @@ class BuilderClient:
         return self._get(("base-images",)).get("baseImages", [])
 
     def list_build_targets(self) -> list[dict]:
-        """GET /v1/build-targets -> the build targets a version can be cut for."""
+        """GET /v1/build-targets -> the build targets a release can be cut for."""
         return self._get(("build-targets",)).get("targets", [])
 
     def list_model_directories(self) -> list[str]:

--- a/comfy_cli/builder_pagination.py
+++ b/comfy_cli/builder_pagination.py
@@ -1,0 +1,68 @@
+"""Walking the builder's cursor listings without trusting the server's shape.
+
+Split out of ``builder_api`` because these are the rules for *following* a
+listing, not for speaking to any one endpoint: the client contributes the URL
+and the response key, and everything about when to stop lives here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Final
+
+import requests
+
+# The builder clamps a page to 100 rows, so this ceiling is tens of thousands of
+# builds — orders of magnitude past any real workspace. It bounds a *server*
+# that keeps handing back a cursor, not a listing anyone actually has.
+_MAX_LIST_PAGES: Final = 200
+# `list_blobs` is served as a single page with no cursor, so a clamped listing is
+# indistinguishable from a complete one except by its length: the builder returns
+# httpkit.DefaultPageLimit rows when the caller names no limit, and this client
+# names none. A page of exactly that many rows is the ceiling, not the whole set.
+_BLOB_PAGE_LIMIT: Final = 20
+
+
+class BuilderPaginationError(requests.RequestException):
+    """A cursor listing cannot be walked to its end without trusting the server.
+
+    Subclasses ``RequestException`` rather than ``ValueError`` so that
+    ``build._builder_call`` reports it as ``build_builder_error`` ("builder call
+    failed"), which is what it is. That wrapper's ``ValueError`` clause is
+    reserved for *caller* input mistakes and would relabel this
+    ``build_missing_input``, sending the user off to fix a flag that is fine.
+    """
+
+
+def cursor_pages(fetch: Callable[[str | None], dict], listing: str) -> Iterator[dict]:
+    """Yield every page of a builder cursor listing, or refuse to keep asking.
+
+    A cursor is followed only when the server returns it as a non-empty **str**.
+    ``nextCursor: 5`` or ``{"a": 1}`` is truthy and survives ``urlencode``, so an
+    untyped walk would page forever against a server whose shape drifted, with
+    the accumulated rows growing without bound — the failure this listing's
+    ``deploy_api.iter_deployments`` sibling already guards against.
+
+    A repeated cursor and an exceeded page cap raise rather than returning what
+    was collected so far: a short listing presented as complete is the silent
+    truncation this pagination was added to fix.
+    """
+    cursor: str | None = None
+    seen: set[str] = set()
+    for _ in range(_MAX_LIST_PAGES):
+        page = fetch(cursor)
+        yield page
+        next_cursor = page.get("nextCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            return
+        if next_cursor in seen:
+            raise BuilderPaginationError(f"builder repeated a {listing} page cursor; refusing to page in a circle")
+        seen.add(next_cursor)
+        cursor = next_cursor
+    raise BuilderPaginationError(f"builder {listing} listing did not end within {_MAX_LIST_PAGES} pages")
+
+
+def blob_listing_is_clamped(blobs: list[dict]) -> bool:
+    """Whether ``BuilderClient.list_blobs`` returned a full page, i.e. one the
+    server may have cut short."""
+    return len(blobs) >= _BLOB_PAGE_LIMIT

--- a/comfy_cli/builder_pagination.py
+++ b/comfy_cli/builder_pagination.py
@@ -16,6 +16,10 @@ import requests
 # builds — orders of magnitude past any real workspace. It bounds a *server*
 # that keeps handing back a cursor, not a listing anyone actually has.
 _MAX_LIST_PAGES: Final = 200
+# Sent explicitly: httpkit.ClampLimit falls back to 20 rows, not to its 100-row
+# ceiling, when the caller names no limit — so an unset limit pages at a fifth of
+# what `_MAX_LIST_PAGES` above was sized against, and fails at 4,000 rows.
+PAGE_LIMIT: Final = 100
 # `list_blobs` is served as a single page with no cursor, so a clamped listing is
 # indistinguishable from a complete one except by its length: the builder returns
 # httpkit.DefaultPageLimit rows when the caller names no limit, and this client

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -892,7 +892,9 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
     ``locate_bytes(upload) -> Path`` finds the local file for a model upload.
     node_zip uploads (hand-dropped local nodes) aren't packaged yet — raises
     NotImplementedError so the caller can surface a clear message. Returns
-    ``{buildId, distributionId, releaseId, versionId, statusUrl, uploaded}``."""
+    ``{buildId, distributionId, releaseId, versionId, statusUrl, uploaded}``,
+    where ``uploaded`` counts the blobs whose bytes actually moved — content the
+    workspace already holds is stitched in without a transfer."""
     definition = plan["definition"]
     # Preflight the whole upload list before any bytes move: an unsupported local
     # node, or a model whose file can't be found (missing --models-dir), must fail
@@ -906,10 +908,14 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
     uploaded = 0
     for u, path in prepared:
         blob_id, upload_url = client.create_blob("model", u["filename"], u["sha256"], u["sizeBytes"])
-        client.upload_blob(upload_url, path)
+        # No URL means the builder already holds these bytes and deduplicated the
+        # blob; PUTting to `None` raises MissingSchema and would fail the create
+        # over content already stored. The id still stitches in, only bytes skip.
+        if upload_url is not None:
+            client.upload_blob(upload_url, path)
+            uploaded += 1
         section, idx = u["slot"]
         definition[section][idx]["blobId"] = blob_id
-        uploaded += 1
     build_id = client.create_build(name, definition)
     try:
         version_id, status_url = client.create_release(build_id, targets)
@@ -1841,16 +1847,24 @@ def blob_upload_cmd(
     size_bytes = file_path.stat().st_size
     sha256 = _sha256_file(file_path)
     blob_id, upload_url = _builder_call(renderer, lambda: client.create_blob(kind, file_path.name, sha256, size_bytes))
-    _builder_call(renderer, lambda: client.upload_blob(upload_url, file_path))
+    # No URL means the builder already holds these bytes and deduplicated the blob.
+    # Re-running this command on a file already stored is the ordinary case, so it
+    # answers with the usable id rather than failing on a `None` URL.
+    transferred = upload_url is not None
+    if transferred:
+        _builder_call(renderer, lambda: client.upload_blob(upload_url, file_path))
     if renderer.is_pretty():
-        renderer.success(f"Uploaded {file_path.name} as {blob_id}")
+        if transferred:
+            renderer.success(f"Uploaded {file_path.name} as {blob_id}")
+        else:
+            renderer.success(f"{file_path.name} was already stored as {blob_id}")
         # A model entry needs the hash as well as the id, and the cut refuses one
         # that is not a real sha256, so both are printed rather than just the id.
         renderer.info(f'reference it as "blobId": "{blob_id}", "sha256": "{sha256}"')
     renderer.emit(
         {"blobId": blob_id, "kind": kind, "filename": file_path.name, "sha256": sha256, "sizeBytes": size_bytes},
         command="build blob upload",
-        changed=True,
+        changed=transferred,
     )
 
 

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -912,7 +912,7 @@ def execute_create(plan: dict, *, client, name: str, locate_bytes, targets=None)
         uploaded += 1
     build_id = client.create_build(name, definition)
     try:
-        version_id, status_url = client.cut_version(build_id, targets)
+        version_id, status_url = client.create_release(build_id, targets)
     except Exception as e:
         # The build now exists server-side; carry its id on the error so the
         # command can surface it (the user can then delete or retry it, not orphan it).
@@ -1510,7 +1510,7 @@ def version_create(
 ):
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    release_id, status_url = _builder_call(renderer, lambda: client.cut_version(build_id))
+    release_id, status_url = _builder_call(renderer, lambda: client.create_release(build_id))
     if renderer.is_pretty():
         renderer.success(f"Cut release {release_id}")
         renderer.print(f"  status: {status_url}")
@@ -1546,7 +1546,7 @@ def version_get(
 ):
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    version = _builder_call(renderer, lambda: client.get_version(version_id))
+    version = _builder_call(renderer, lambda: client.get_release(version_id))
     if renderer.is_pretty():
         renderer.console().print_json(json.dumps(version))
     renderer.emit(version, command="build release get")
@@ -1564,7 +1564,7 @@ def version_logs(
 ):
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    content = _builder_call(renderer, lambda: client.get_version_logs(version_id, os=os_target, gpu=gpu))
+    content = _builder_call(renderer, lambda: client.get_release_logs(version_id, os=os_target, gpu=gpu))
     # Mirror whichever spelling the builder returned, so either server generation
     # yields both keys.
     log_id = content.get("releaseId") or content.get("versionId")
@@ -1915,7 +1915,7 @@ def version_manifest(
 ):
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    manifest = _builder_call(renderer, lambda: client.get_version_manifest(version_id))
+    manifest = _builder_call(renderer, lambda: client.get_release_manifest(version_id))
     if renderer.is_pretty():
         renderer.console().print_json(json.dumps(manifest))
     renderer.emit(manifest, command="build release manifest")

--- a/comfy_cli/command/build_package.py
+++ b/comfy_cli/command/build_package.py
@@ -1,0 +1,200 @@
+"""Deterministic local custom-node packaging."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import tempfile
+import zipfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Final, NoReturn
+
+_EXCLUDED_DIRECTORIES: Final = frozenset({".git", "__pycache__"})
+_FIXED_MTIME: Final = (1980, 1, 1, 0, 0, 0)
+_FIXED_MODE: Final = stat.S_IFREG | 0o644
+# Bounds the resident cost of one member and of one hashing read. A node that
+# vendors a multi-GB weight file is the case this exists for.
+_CHUNK_BYTES: Final = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class NodePackageError(ValueError):
+    path: Path
+    reason: str
+
+    def __str__(self) -> str:
+        return f"cannot package {self.path}: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class NodePackage:
+    """One node's archive, its content identity, and what packaging left out.
+
+    Identity travels *with* the archive rather than being recomputed from the
+    path, so a caller can never pair one archive with another archive's digest.
+
+    ``archive_path`` is ``None`` when the caller named no destination: the
+    archive was still produced (there is no way to know a node's identity
+    without it) but into a file discarded on return, so a caller that wants only
+    ``sha256``/``size_bytes`` pays no disk and no memory for bytes it will not
+    send.
+    """
+
+    archive_path: Path | None
+    sha256: str
+    size_bytes: int
+    skipped_symlinks: tuple[str, ...]
+
+
+def _member_name(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _unreadable(root: Path, path: Path | str | None, error: OSError) -> NodePackageError:
+    """Turn any traversal or read failure into the packaging error contract.
+
+    A member that *holds content* and cannot be read aborts the archive rather
+    than shrinking it. A silently short archive would be hashed, written into
+    the spec as the node's ``localDigest``, and released — surfacing only as an
+    ImportError inside a deployed container, arbitrarily far from the
+    unreadable file that caused it.
+
+    This is about readability, not exhaustiveness: ``_package_files`` also
+    leaves out entries that carry no packageable bytes at all — sockets, FIFOs,
+    device nodes — and those are dropped without a report, because unlike a
+    symlink none of them can stand in for vendored code.
+    """
+    detail = error.strerror or str(error)
+    if path is None:
+        return NodePackageError(root, f"could not be read: {detail}")
+    target = Path(path)
+    if target == root:
+        return NodePackageError(root, f"could not be read: {detail}")
+    return NodePackageError(root, f"{_member_name(root, target)} could not be read: {detail}")
+
+
+def _package_files(root: Path) -> tuple[list[tuple[str, Path]], list[str]]:
+    """Return ``(members, skipped_symlinks)`` for *root*, or raise.
+
+    Symlinks are excluded from the archive by design (they are not portable
+    content), but they are *reported* rather than dropped in silence — a node
+    that vendors its dependencies through a symlink would otherwise package to
+    a near-empty zip and succeed.
+    """
+    members: list[tuple[str, Path]] = []
+    skipped: list[str] = []
+
+    def fail(error: OSError) -> NoReturn:
+        raise _unreadable(root, error.filename, error)
+
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True, onerror=fail, followlinks=False):
+        directory = Path(dirpath)
+        kept: list[str] = []
+        for name in sorted(dirnames):
+            if name in _EXCLUDED_DIRECTORIES:
+                continue
+            path = directory / name
+            try:
+                mode = os.lstat(path).st_mode
+            except OSError as error:
+                raise _unreadable(root, path, error) from error
+            if stat.S_ISLNK(mode):
+                skipped.append(_member_name(root, path))
+                continue
+            kept.append(name)
+        dirnames[:] = kept
+        for name in sorted(filenames):
+            if name.endswith(".pyc"):
+                continue
+            path = directory / name
+            try:
+                mode = os.lstat(path).st_mode
+            except OSError as error:
+                raise _unreadable(root, path, error) from error
+            if stat.S_ISLNK(mode):
+                skipped.append(_member_name(root, path))
+            elif stat.S_ISREG(mode):
+                members.append((_member_name(root, path), path))
+    members.sort(key=lambda member: member[0])
+    skipped.sort()
+    return members, skipped
+
+
+def _write_archive(root: Path, members: Sequence[tuple[str, Path]], stream: IO[bytes]) -> tuple[str, int]:
+    """Stream the archive into *stream* and return ``(sha256, size_bytes)``.
+
+    Two passes over one file rather than one pass over a buffer. The digest has
+    to cover the *finished* zip, and the writer seeks backwards to fix up each
+    member's header once its CRC and size are known, so bytes hashed on their
+    way in are not the bytes the archive ends up holding. Re-reading costs one
+    chunk of memory; buffering costs the whole archive, twice over once
+    ``getvalue()`` copies it.
+
+    Every field the determinism guarantee rests on is set here exactly as the
+    buffered ``writestr`` set it, so the digest is unchanged for identical
+    input — existing specs carry ``localDigest`` values minted the old way, and
+    a drifted digest would invalidate every stored ``blobId``.
+    """
+    with zipfile.ZipFile(stream, mode="w", compression=zipfile.ZIP_STORED) as archive:
+        for member_name, member_path in members:
+            info = zipfile.ZipInfo(member_name, date_time=_FIXED_MTIME)
+            info.compress_type = zipfile.ZIP_STORED
+            info.create_system = 3
+            info.external_attr = _FIXED_MODE << 16
+            try:
+                # `writestr` set this from the payload it was handed, and the
+                # zip64 decision reads it: left at 0 a member past 4 GiB aborts
+                # with a RuntimeError instead of widening its header.
+                info.file_size = member_path.stat().st_size
+                with member_path.open("rb") as source, archive.open(info, "w") as target:
+                    shutil.copyfileobj(source, target, _CHUNK_BYTES)
+            except OSError as error:
+                raise _unreadable(root, member_path, error) from error
+    size_bytes = stream.seek(0, os.SEEK_END)
+    stream.seek(0)
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: stream.read(_CHUNK_BYTES), b""):
+        digest.update(chunk)
+    return digest.hexdigest(), size_bytes
+
+
+def package_node(path: Path, destination: Path | None = None) -> NodePackage:
+    """Build one custom-node archive and its identity in a single pass.
+
+    The archive is never resident in memory. ``destination`` names where the
+    caller wants to keep it; with ``None`` it is still built — a node's identity
+    is the digest of its bytes, so there is no shortcut — but into a file that is
+    unlinked on return. ``prepare_push`` packages *every* local node before
+    uploading any of them, so an archive retained per node makes peak cost the
+    sum of the whole workspace's vendored content.
+    """
+    root = path.expanduser()
+    try:
+        mode = os.lstat(root).st_mode
+    except OSError as error:
+        raise _unreadable(root, root, error) from error
+    if stat.S_ISLNK(mode):
+        raise NodePackageError(root, "node root must not be a symlink")
+    if not stat.S_ISDIR(mode):
+        raise NodePackageError(root, "node root must be a directory")
+
+    members, skipped = _package_files(root)
+    if destination is None:
+        with tempfile.TemporaryFile(prefix="comfy-node-package-") as scratch:
+            sha256, size_bytes = _write_archive(root, members, scratch)
+        return NodePackage(None, sha256, size_bytes, tuple(skipped))
+    try:
+        stream = destination.open("wb+")
+    except OSError as error:
+        detail = error.strerror or str(error)
+        raise NodePackageError(root, f"archive could not be written to {destination}: {detail}") from error
+    with stream:
+        sha256, size_bytes = _write_archive(root, members, stream)
+    return NodePackage(destination, sha256, size_bytes, tuple(skipped))

--- a/comfy_cli/command/build_package.py
+++ b/comfy_cli/command/build_package.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import shutil
 import stat
 import tempfile
 import zipfile
@@ -80,13 +79,51 @@ def _unreadable(root: Path, path: Path | str | None, error: OSError) -> NodePack
     return NodePackageError(root, f"{_member_name(root, target)} could not be read: {detail}")
 
 
-def _package_files(root: Path) -> tuple[list[tuple[str, Path]], list[str]]:
+def _excluded_member(root: Path, destination: Path | None) -> frozenset[str]:
+    """The member name(s) *destination* occupies inside *root*, if any.
+
+    The tree is walked *before* the archive is opened, so a destination that
+    already exists under ``root`` would otherwise be collected as a member and
+    then truncated by ``open("wb+")`` — and ``_write_archive`` would read the
+    very file it is appending to, which never reaches EOF. The archive grows
+    until the disk does not.
+
+    Excluding it also makes a repeat packaging idempotent: the digest covers the
+    node's content rather than the output of the previous run. Nothing is
+    excluded when the destination is outside ``root`` — which is every caller in
+    the tree, since ``prepare_push`` packages into a ``TemporaryDirectory`` — so
+    no already-minted ``localDigest`` moves.
+
+    Matched on the resolved path so that a relative path, a ``..`` segment or a
+    symlinked parent cannot smuggle the destination past the comparison, *and*
+    on the literal one so that a destination lexically inside the root but
+    symlinked out of it is still recognised as the archive rather than reported
+    to the user as vendored content packaging left behind.
+    """
+    if destination is None:
+        return frozenset()
+    names: set[str] = set()
+    for root_path, destination_path in (
+        (os.path.realpath(root), os.path.realpath(destination)),
+        (root, destination),
+    ):
+        try:
+            names.add(Path(destination_path).relative_to(root_path).as_posix())
+        except ValueError:
+            continue
+    return frozenset(names)
+
+
+def _package_files(root: Path, excluded: frozenset[str] = frozenset()) -> tuple[list[tuple[str, Path]], list[str]]:
     """Return ``(members, skipped_symlinks)`` for *root*, or raise.
 
     Symlinks are excluded from the archive by design (they are not portable
     content), but they are *reported* rather than dropped in silence — a node
     that vendors its dependencies through a symlink would otherwise package to
     a near-empty zip and succeed.
+
+    ``excluded`` holds the member name(s) the archive is being written to; see
+    ``_excluded_member``.
     """
     members: list[tuple[str, Path]] = []
     skipped: list[str] = []
@@ -114,6 +151,10 @@ def _package_files(root: Path) -> tuple[list[tuple[str, Path]], list[str]]:
             if name.endswith(".pyc"):
                 continue
             path = directory / name
+            # Above the lstat on purpose: an unreadable *output* file is not
+            # this node's content, so it must not raise `_unreadable`.
+            if _member_name(root, path) in excluded:
+                continue
             try:
                 mode = os.lstat(path).st_mode
             except OSError as error:
@@ -125,6 +166,26 @@ def _package_files(root: Path) -> tuple[list[tuple[str, Path]], list[str]]:
     members.sort(key=lambda member: member[0])
     skipped.sort()
     return members, skipped
+
+
+def _copy_declared(source: IO[bytes], target: IO[bytes], declared: int) -> int:
+    """Copy from *source* to *target*, returning the byte count, never past *declared*.
+
+    Bounding the read is what stops a member that grows while it is being
+    archived from being followed forever: an unbounded copy against a file some
+    other writer is still extending never reaches EOF, and the archive grows
+    until the disk does. The caller compares the return against *declared*, so a
+    file that changed under packaging aborts rather than landing in the archive
+    at a length its header does not describe.
+    """
+    remaining = declared
+    while remaining > 0:
+        chunk = source.read(min(_CHUNK_BYTES, remaining))
+        if not chunk:
+            break
+        target.write(chunk)
+        remaining -= len(chunk)
+    return declared - remaining
 
 
 def _write_archive(root: Path, members: Sequence[tuple[str, Path]], stream: IO[bytes]) -> tuple[str, int]:
@@ -152,11 +213,19 @@ def _write_archive(root: Path, members: Sequence[tuple[str, Path]], stream: IO[b
                 # `writestr` set this from the payload it was handed, and the
                 # zip64 decision reads it: left at 0 a member past 4 GiB aborts
                 # with a RuntimeError instead of widening its header.
-                info.file_size = member_path.stat().st_size
+                # Held separately: closing the member writer rewrites
+                # `info.file_size` to whatever was actually written.
+                declared = member_path.stat().st_size
+                info.file_size = declared
                 with member_path.open("rb") as source, archive.open(info, "w") as target:
-                    shutil.copyfileobj(source, target, _CHUNK_BYTES)
+                    copied = _copy_declared(source, target, declared)
+                    still_reading = bool(source.read(1))
             except OSError as error:
                 raise _unreadable(root, member_path, error) from error
+            if copied != declared or still_reading:
+                raise NodePackageError(
+                    root, f"{_member_name(root, member_path)} changed size while it was being packaged"
+                )
     size_bytes = stream.seek(0, os.SEEK_END)
     stream.seek(0)
     digest = hashlib.sha256()
@@ -185,7 +254,7 @@ def package_node(path: Path, destination: Path | None = None) -> NodePackage:
     if not stat.S_ISDIR(mode):
         raise NodePackageError(root, "node root must be a directory")
 
-    members, skipped = _package_files(root)
+    members, skipped = _package_files(root, _excluded_member(root, destination))
     if destination is None:
         with tempfile.TemporaryFile(prefix="comfy-node-package-") as scratch:
             sha256, size_bytes = _write_archive(root, members, scratch)

--- a/comfy_cli/command/build_pull.py
+++ b/comfy_cli/command/build_pull.py
@@ -1,0 +1,250 @@
+"""Identity-preserving reconciliation for the build pull path."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Final, Literal, TypeAlias
+
+from typing_extensions import assert_never
+
+from comfy_cli.command.build_push import normalize_repository_identity
+from comfy_cli.command.build_spec import BuildSpecInvalidError, JsonObject, JsonValue
+
+IdentityTier: TypeAlias = Literal["sha256", "model_location", "blobId", "id", "repository", "name"]
+
+_MODEL_LOCAL_FIELDS: Final = frozenset({"source", "localPath", "blobId", "sha256", "sizeBytes"})
+_NODE_LOCAL_FIELDS: Final = frozenset({"source", "localPath", "blobId", "localDigest", "localSizeBytes"})
+_MODEL_KNOWN_FIELDS: Final = _MODEL_LOCAL_FIELDS | {"type", "filename", "sourceUri"}
+_NODE_KNOWN_FIELDS: Final = _NODE_LOCAL_FIELDS | {
+    "name",
+    "id",
+    "repository",
+    "gitRef",
+    "commit",
+    "registryVersion",
+    "sourceUri",
+}
+_DEFINITION_KNOWN_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "baseComfyVersion",
+        "baseImage",
+        "models",
+        "customNodes",
+        "pipDependencies",
+        "environment",
+        "modelPolicy",
+        "partnerNodePolicy",
+    }
+)
+
+
+def _entries(definition: JsonObject, collection: str, *, side: str) -> list[JsonObject]:
+    values = definition.get(collection, [])
+    if not isinstance(values, list):
+        raise BuildSpecInvalidError(f"{side} definition.{collection} must be a list")
+    entries: list[JsonObject] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, dict):
+            raise BuildSpecInvalidError(f"{side} definition.{collection}[{index}] must be a mapping")
+        entries.append(value)
+    return entries
+
+
+def _text(entry: JsonObject, field: str, *, location: str) -> str | None:
+    value = entry.get(field)
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise BuildSpecInvalidError(f"{location}.{field} must be a string or null")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _identity(entry: JsonObject, tier: IdentityTier, *, location: str) -> tuple[str, ...] | None:
+    match tier:
+        case "sha256" | "blobId" | "id" | "name":
+            value = _text(entry, tier, location=location)
+            return (value,) if value is not None else None
+        case "model_location":
+            model_type = _text(entry, "type", location=location)
+            filename = _text(entry, "filename", location=location)
+            return (model_type, filename) if model_type is not None and filename is not None else None
+        case "repository":
+            repository = _text(entry, "repository", location=location)
+            return (normalize_repository_identity(repository),) if repository is not None else None
+        case unreachable:
+            assert_never(unreachable)
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidates:
+    local: frozenset[int]
+    server: frozenset[int]
+
+
+@dataclass(frozen=True, slots=True)
+class _FieldPolicy:
+    known: frozenset[str]
+    local: frozenset[str]
+
+
+class _TieredMatcher:
+    """Mutable greedy-match accumulator; matched indexes leave every later tier."""
+
+    def __init__(self, local: list[JsonObject], server: list[JsonObject], collection: str) -> None:
+        self.local = local
+        self.server = server
+        self.collection = collection
+        self.local_unmatched = set(range(len(local)))
+        self.server_unmatched = set(range(len(server)))
+        self.local_by_server: dict[int, int] = {}
+
+    def candidates(self) -> _Candidates:
+        return _Candidates(frozenset(self.local_unmatched), frozenset(self.server_unmatched))
+
+    def groups(
+        self, tier: IdentityTier, candidates: _Candidates
+    ) -> tuple[dict[tuple[str, ...], list[int]], dict[tuple[str, ...], list[int]]]:
+        local: dict[tuple[str, ...], list[int]] = {}
+        server: dict[tuple[str, ...], list[int]] = {}
+        for index in candidates.local:
+            key = _identity(self.local[index], tier, location=f"local definition.{self.collection}[{index}]")
+            if key is not None:
+                local.setdefault(key, []).append(index)
+        for index in candidates.server:
+            key = _identity(self.server[index], tier, location=f"server definition.{self.collection}[{index}]")
+            if key is not None:
+                server.setdefault(key, []).append(index)
+        return local, server
+
+    def pair(self, local_index: int, server_index: int) -> None:
+        self.local_unmatched.remove(local_index)
+        self.server_unmatched.remove(server_index)
+        self.local_by_server[server_index] = local_index
+
+    def ambiguity(self, tier: IdentityTier, key: tuple[str, ...], candidates: _Candidates) -> BuildSpecInvalidError:
+        local = ", ".join(f"local definition.{self.collection}[{index}]" for index in sorted(candidates.local))
+        server = ", ".join(f"server definition.{self.collection}[{index}]" for index in sorted(candidates.server))
+        return BuildSpecInvalidError(
+            f"ambiguous pull identity at {self.collection}.{tier}={key!r}: {local or 'no local entry'}; "
+            f"{server or 'no server entry'}"
+        )
+
+    def run(self, tier: IdentityTier, candidates: _Candidates | None = None) -> None:
+        active = candidates or self.candidates()
+        local_groups, server_groups = self.groups(tier, active)
+        for key in sorted(local_groups.keys() & server_groups.keys()):
+            local_indexes = local_groups[key]
+            server_indexes = server_groups[key]
+            group = _Candidates(frozenset(local_indexes), frozenset(server_indexes))
+            if len(local_indexes) != 1 or len(server_indexes) != 1:
+                raise self.ambiguity(tier, key, group)
+            self.pair(local_indexes[0], server_indexes[0])
+
+
+def _match_models(local: list[JsonObject], server: list[JsonObject]) -> dict[int, int]:
+    matcher = _TieredMatcher(local, server, "models")
+    local_digests, server_digests = matcher.groups("sha256", matcher.candidates())
+    for digest in sorted(local_digests.keys() & server_digests.keys()):
+        local_group = frozenset(local_digests[digest])
+        server_group = frozenset(server_digests[digest])
+        if len(local_group) == 1 and len(server_group) == 1:
+            matcher.pair(next(iter(local_group)), next(iter(server_group)))
+            continue
+        matcher.run("model_location", _Candidates(local_group, server_group))
+        remaining = _Candidates(local_group & matcher.local_unmatched, server_group & matcher.server_unmatched)
+        if not remaining.local or not remaining.server:
+            continue
+        if len(remaining.local) == 1 and len(remaining.server) == 1:
+            matcher.pair(next(iter(remaining.local)), next(iter(remaining.server)))
+            continue
+        raise matcher.ambiguity("sha256", digest, remaining)
+    matcher.run("model_location")
+    return matcher.local_by_server
+
+
+def _match_nodes(local: list[JsonObject], server: list[JsonObject]) -> dict[int, int]:
+    matcher = _TieredMatcher(local, server, "customNodes")
+    for tier in ("blobId", "id", "repository", "name"):
+        matcher.run(tier)
+    return matcher.local_by_server
+
+
+def _merge_entry(
+    local: JsonObject,
+    server: JsonObject,
+    policy: _FieldPolicy,
+) -> JsonObject:
+    merged = deepcopy(server)
+    for key, value in local.items():
+        if key not in merged and (key not in policy.known or value is None):
+            merged[key] = deepcopy(value)
+    for field in policy.local:
+        if field in local:
+            merged[field] = deepcopy(local[field])
+        else:
+            merged.pop(field, None)
+    merged.pop("sourceUri", None)
+    local_source_uri = local.get("sourceUri")
+    if isinstance(local_source_uri, str) and local_source_uri.strip():
+        merged["sourceUri"] = local_source_uri
+    return merged
+
+
+def _merge_collection(
+    local: JsonObject, server: JsonObject, collection: Literal["models", "customNodes"]
+) -> list[JsonValue]:
+    local_entries = _entries(local, collection, side="local")
+    server_entries = _entries(server, collection, side="server")
+    match collection:
+        case "models":
+            matches = _match_models(local_entries, server_entries)
+            policy = _FieldPolicy(_MODEL_KNOWN_FIELDS, _MODEL_LOCAL_FIELDS)
+        case "customNodes":
+            matches = _match_nodes(local_entries, server_entries)
+            policy = _FieldPolicy(_NODE_KNOWN_FIELDS, _NODE_LOCAL_FIELDS)
+        case unreachable:
+            assert_never(unreachable)
+    return [
+        deepcopy(entry)
+        if server_index not in matches
+        else _merge_entry(local_entries[matches[server_index]], entry, policy)
+        for server_index, entry in enumerate(server_entries)
+    ]
+
+
+def merge_pull_definition(local: JsonObject, server: JsonObject) -> JsonObject:
+    """Merge a server-owned definition onto local authoring/cache fields by identity."""
+    merged = deepcopy(server)
+    for key, value in local.items():
+        if key not in _DEFINITION_KNOWN_FIELDS and key not in merged:
+            merged[key] = deepcopy(value)
+    merged["models"] = _merge_collection(local, server, "models")
+    merged["customNodes"] = _merge_collection(local, server, "customNodes")
+    return merged
+
+
+def merge_pulled_spec(local_spec: JsonObject, remote: JsonObject, build_id: str) -> JsonObject:
+    """Return the atomically writable local spec for one fetched Build."""
+    local_definition = local_spec.get("definition")
+    server_definition = remote.get("definition")
+    if not isinstance(local_definition, dict) or not isinstance(server_definition, dict):
+        raise BuildSpecInvalidError("both the local spec and fetched Build need a definition mapping")
+    name = remote.get("name")
+    description = remote.get("description")
+    revision = remote.get("updatedAt")
+    if not isinstance(name, str) or not isinstance(description, str) or not isinstance(revision, str) or not revision:
+        raise BuildSpecInvalidError("the fetched Build needs string name, description and updatedAt fields")
+    merged = deepcopy(local_spec)
+    merged.update(
+        {
+            "id": build_id,
+            "name": name,
+            "description": description,
+            "syncedRevision": revision,
+            "definition": merge_pull_definition(local_definition, server_definition),
+        }
+    )
+    return merged

--- a/comfy_cli/command/build_pull.py
+++ b/comfy_cli/command/build_pull.py
@@ -10,9 +10,20 @@ from typing_extensions import assert_never
 
 from comfy_cli.command.build_push import normalize_repository_identity
 from comfy_cli.command.build_spec import BuildSpecInvalidError, JsonObject, JsonValue
+from comfy_cli.command.build_validation import MODEL_SOURCES, NODE_SOURCES
 
 IdentityTier: TypeAlias = Literal["sha256", "model_location", "blobId", "id", "repository", "name"]
 
+_SIZE_FIELDS: Final = frozenset({"sizeBytes", "localSizeBytes"})
+# Metadata describing whatever the entry's source resolves to, rather than the
+# entry itself, and which the builder therefore enforces against it. `sizeBytes`
+# is deliberately absent: the builder's Model carries no size column, so pairing
+# it with a source states nothing, and restricting it would only delete a size
+# the scanner knew. A node's git coordinates *are* such a claim — `_project_node`
+# keeps them on the wire when `repository` wins — though nothing fills them
+# today, both sitting outside `_NODE_LOCAL_FIELDS`.
+_MODEL_SOURCE_DEPENDENT: Final = frozenset({"sha256"})
+_NODE_SOURCE_DEPENDENT: Final = frozenset({"gitRef", "commit"})
 _MODEL_LOCAL_FIELDS: Final = frozenset({"source", "localPath", "blobId", "sha256", "sizeBytes"})
 _NODE_LOCAL_FIELDS: Final = frozenset({"source", "localPath", "blobId", "localDigest", "localSizeBytes"})
 _MODEL_KNOWN_FIELDS: Final = _MODEL_LOCAL_FIELDS | {"type", "filename", "sourceUri"}
@@ -88,6 +99,11 @@ class _Candidates:
 class _FieldPolicy:
     known: frozenset[str]
     local: frozenset[str]
+    sources: frozenset[str]
+    # Metadata that describes the bytes a source points at rather than the entry
+    # itself, and so is only meaningful paired with the source it was taken from.
+    source_dependent: frozenset[str]
+    fillable: frozenset[str]
 
 
 class _TieredMatcher:
@@ -172,24 +188,72 @@ def _match_nodes(local: list[JsonObject], server: list[JsonObject]) -> dict[int,
     return matcher.local_by_server
 
 
+def _states(entry: JsonObject, field: str) -> bool:
+    """Whether *entry* makes a usable statement about *field*.
+
+    A text field has to be a non-blank string — the guard the pre-merge
+    ``sourceUri`` handling already applied. Carrying a ``"   "`` or a stray
+    number through a pull writes a spec that fails ``project_wire_definition``
+    on the very next push, which is a worse outcome than dropping it here.
+    """
+    value = entry.get(field)
+    if field in _SIZE_FIELDS:
+        return isinstance(value, int) and not isinstance(value, bool)
+    return isinstance(value, str) and bool(value.strip())
+
+
 def _merge_entry(
     local: JsonObject,
     server: JsonObject,
     policy: _FieldPolicy,
 ) -> JsonObject:
+    """Merge one server entry onto its local match, by who owns the entry.
+
+    Only a ``source: "local"`` entry is described by bytes on this machine, so
+    only there do the local ``blobId``/digest/size fields outrank the server's.
+    For any other source the server holds the entry's content identity, and
+    letting local win reverted a server-side switch from a private blob to a
+    public ``sourceUri`` on the next push, or dropped the server's blob
+    reference and hash under a local public entry.
+
+    The non-local side *fills* rather than replaces, so re-owning these fields
+    cannot itself delete authoring data — with one exclusion that matters. The
+    source fields are a precedence group, not independent values:
+    ``project_wire_definition`` emits the first of ``MODEL_SOURCES`` /
+    ``NODE_SOURCES`` an entry names and drops the rest. Filling a stale local
+    ``blobId`` beside a server ``sourceUri`` would therefore not merely add a
+    field, it would *outrank* the server's and reinstate the exact revert this
+    merge exists to prevent. So once the server names any source, local fills
+    none of them; a server that names no source at all is the only case where
+    absence is not a statement.
+
+    ``source_dependent`` travels in that same group. ``sha256`` describes the
+    bytes a source points at, not the entry, so pairing a local hash with a
+    source the server has since changed states an integrity claim that was never
+    true — and the builder enforces it, failing the pull's damage at deploy
+    staging with a checksum mismatch rather than here. Dropping a hash is safe
+    (it is optional); keeping a wrong one is not.
+    """
     merged = deepcopy(server)
     for key, value in local.items():
         if key not in merged and (key not in policy.known or value is None):
             merged[key] = deepcopy(value)
-    for field in policy.local:
-        if field in local:
+    if local.get("source") == "local":
+        for field in policy.local:
+            if field in local:
+                merged[field] = deepcopy(local[field])
+            else:
+                merged.pop(field, None)
+        merged.pop("sourceUri", None)
+        if _states(local, "sourceUri"):
+            merged["sourceUri"] = deepcopy(local["sourceUri"])
+        return merged
+    fillable = policy.fillable
+    if any(_states(merged, field) for field in policy.sources):
+        fillable -= policy.sources | policy.source_dependent
+    for field in sorted(fillable):
+        if _states(local, field) and not _states(merged, field):
             merged[field] = deepcopy(local[field])
-        else:
-            merged.pop(field, None)
-    merged.pop("sourceUri", None)
-    local_source_uri = local.get("sourceUri")
-    if isinstance(local_source_uri, str) and local_source_uri.strip():
-        merged["sourceUri"] = local_source_uri
     return merged
 
 
@@ -201,10 +265,26 @@ def _merge_collection(
     match collection:
         case "models":
             matches = _match_models(local_entries, server_entries)
-            policy = _FieldPolicy(_MODEL_KNOWN_FIELDS, _MODEL_LOCAL_FIELDS)
+            policy = _FieldPolicy(
+                _MODEL_KNOWN_FIELDS,
+                _MODEL_LOCAL_FIELDS,
+                frozenset(MODEL_SOURCES),
+                _MODEL_SOURCE_DEPENDENT,
+                # `sourceUri` is fillable for both, though only a model's is a
+                # *source*: a node has no public resolution path, so nothing here
+                # writes one and it can outrank nothing. It stays fillable so a
+                # hand-authored one is carried rather than silently deleted.
+                _MODEL_LOCAL_FIELDS | {"sourceUri"},
+            )
         case "customNodes":
             matches = _match_nodes(local_entries, server_entries)
-            policy = _FieldPolicy(_NODE_KNOWN_FIELDS, _NODE_LOCAL_FIELDS)
+            policy = _FieldPolicy(
+                _NODE_KNOWN_FIELDS,
+                _NODE_LOCAL_FIELDS,
+                frozenset(NODE_SOURCES),
+                _NODE_SOURCE_DEPENDENT,
+                _NODE_LOCAL_FIELDS | {"sourceUri"},
+            )
         case unreachable:
             assert_never(unreachable)
     return [

--- a/comfy_cli/command/build_push.py
+++ b/comfy_cli/command/build_push.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Final, Literal, Protocol
 from urllib.parse import urlsplit
 
+from typing_extensions import assert_never
+
 from comfy_cli.command.build_package import package_node
 from comfy_cli.command.build_paths import BuildPaths, resolve_local_path
 from comfy_cli.command.build_spec import BuildSpecInvalidError, JsonObject, JsonValue
@@ -187,23 +189,45 @@ def prepare_push(
 
 
 def pending_uploads(preparation: PushPreparation) -> tuple[PushUpload, ...]:
-    models = _entries(preparation.definition, "models")
+    """The planned uploads whose bytes the builder does not already hold.
+
+    Read against the *current* definition rather than the plan, because
+    ``upload_assets`` writes each ``blobId`` back into it as the blob lands. A
+    node archive was previously exempt from that re-read, so asking a second
+    time — after a partial run, or simply to count what is left — reported every
+    completed node as still pending.
+    """
+    definition = preparation.definition
+    entries = {collection: _entries(definition, collection) for collection in ("models", "customNodes")}
     return tuple(
         upload
         for upload in preparation.uploads
-        if upload.kind == "node_zip"
-        or (not _has_text(models[upload.index], "blobId") and not _has_text(models[upload.index], "sourceUri"))
+        if _still_unresolved(entries[upload.collection][upload.index], upload.kind)
     )
+
+
+def _still_unresolved(entry: JsonObject, kind: Literal["model", "node_zip"]) -> bool:
+    """Whether *entry* still needs its bytes uploaded.
+
+    The two kinds resolve differently, exactly as ``prepare_push`` plans them: a
+    model is satisfied by a public ``sourceUri`` as well as a ``blobId``, while a
+    packaged node archive is only ever satisfied by a ``blobId``.
+    """
+    if _has_text(entry, "blobId"):
+        return False
+    match kind:
+        case "model":
+            return not _has_text(entry, "sourceUri")
+        case "node_zip":
+            return True
+        case unreachable:
+            assert_never(unreachable)
 
 
 def unresolved_models(preparation: PushPreparation) -> list[JsonObject]:
     models = _entries(preparation.definition, "models")
     indexes = {upload.index for upload in preparation.uploads if upload.kind == "model"}
-    return [
-        model
-        for index, model in enumerate(models)
-        if index in indexes and not _has_text(model, "blobId") and not _has_text(model, "sourceUri")
-    ]
+    return [model for index, model in enumerate(models) if index in indexes and _still_unresolved(model, "model")]
 
 
 def spec_without_stale_source_uris(original: JsonObject, preparation: PushPreparation) -> JsonObject:

--- a/comfy_cli/command/build_push.py
+++ b/comfy_cli/command/build_push.py
@@ -1,0 +1,304 @@
+"""Local cache reconciliation and upload planning for the build push path."""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal, Protocol
+from urllib.parse import urlsplit
+
+from comfy_cli.command.build_package import package_node
+from comfy_cli.command.build_paths import BuildPaths, resolve_local_path
+from comfy_cli.command.build_spec import BuildSpecInvalidError, JsonObject, JsonValue
+from comfy_cli.command.build_validation import project_wire_definition
+
+_SCP_REPOSITORY: Final = re.compile(r"^(?P<user>[^@/]+)@(?P<host>[^:/]+):(?P<path>.+)$")
+
+
+class ModelDigest(Protocol):
+    def __call__(self, path: Path) -> str: ...
+
+
+class BlobClient(Protocol):
+    def create_blob(self, kind: str, filename: str, sha256: str, size_bytes: int) -> tuple[str, str | None]: ...
+
+    def upload_blob(self, upload_url: str, path: Path) -> None: ...
+
+
+class Persist(Protocol):
+    def __call__(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PushUpload:
+    """One blob this push still owes the builder, and the file that holds it.
+
+    ``path`` is the bytes to PUT: the model file itself for a ``model``, the
+    packaged archive for a ``node_zip``. It is ``None`` only when the plan was
+    drawn without a ``package_dir`` — `--dry-run` and `pull` want the count and
+    the byte total, and materializing archives neither will send is the memory
+    cost this planner exists to avoid.
+    """
+
+    kind: Literal["model", "node_zip"]
+    collection: Literal["models", "customNodes"]
+    index: int
+    filename: str
+    sha256: str
+    size_bytes: int
+    path: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class SkippedSymlink:
+    """One symlink packaging left out of a node archive, and where it lives.
+
+    ``location`` points into the **local** spec's definition, which is the order
+    `init`, `update` and `push` go on to report. It is not portable to a
+    definition assembled somewhere else: `build pull` ships the server's node
+    order and omits local nodes the server lacks, so it must renumber these rows
+    against what it actually emits (``build._relocate_skipped_symlinks``).
+    ``local_path`` needs no such fixup and identifies the node either way.
+    """
+
+    location: str
+    local_path: str
+    member: str
+
+    def as_row(self) -> JsonObject:
+        return {"location": self.location, "localPath": self.local_path, "member": self.member}
+
+
+@dataclass(frozen=True, slots=True)
+class PushPreparation:
+    spec: JsonObject
+    uploads: tuple[PushUpload, ...]
+    stale_source_uri_models: tuple[int, ...]
+    skipped_symlinks: tuple[SkippedSymlink, ...] = ()
+
+    @property
+    def definition(self) -> JsonObject:
+        definition = self.spec["definition"]
+        if not isinstance(definition, dict):
+            raise BuildSpecInvalidError("definition must be a mapping")
+        return definition
+
+
+@dataclass(frozen=True, slots=True)
+class PublicNodeIdentity:
+    kind: Literal["registry", "repository"]
+    value: str
+    version: str | None = None
+
+
+def _entries(definition: JsonObject, collection: str) -> list[JsonObject]:
+    values = definition.get(collection, [])
+    if not isinstance(values, list):
+        raise BuildSpecInvalidError(f"definition.{collection} must be a list")
+    entries: list[JsonObject] = []
+    for index, value in enumerate(values):
+        if not isinstance(value, dict):
+            raise BuildSpecInvalidError(f"definition.{collection}[{index}] must be a mapping")
+        entries.append(value)
+    return entries
+
+
+def _local_path(entry: JsonObject, root: Path, *, location: str) -> Path:
+    value = entry.get("localPath")
+    if not isinstance(value, str) or not value:
+        raise BuildSpecInvalidError(f"{location}.localPath is required when source is 'local'")
+    return resolve_local_path(root, value, entry=location)
+
+
+def _has_text(entry: JsonObject, key: str) -> bool:
+    value = entry.get(key)
+    return isinstance(value, str) and bool(value.strip())
+
+
+def prepare_push(
+    spec: JsonObject, paths: BuildPaths, model_digest: ModelDigest, *, package_dir: Path | None = None
+) -> PushPreparation:
+    """Reconcile the spec against local bytes and plan what still has to upload.
+
+    ``package_dir`` is the scratch directory node archives are written into, and
+    naming one is what makes the returned plan *uploadable*. Callers that want
+    only the reconciled spec and the upload totals — `--dry-run`, and `pull`,
+    which reads ``spec`` and never ``uploads`` — leave it unset, and every
+    archive is discarded as soon as its digest is known.
+    """
+    prepared = deepcopy(spec)
+    definition = prepared.get("definition")
+    if not isinstance(definition, dict):
+        raise BuildSpecInvalidError("definition must be a mapping")
+    uploads: list[PushUpload] = []
+    stale_source_uris: list[int] = []
+    skipped_symlinks: list[SkippedSymlink] = []
+
+    for index, model in enumerate(_entries(definition, "models")):
+        if model.get("source") != "local":
+            continue
+        location = f"definition.models[{index}]"
+        path = _local_path(model, paths.models_dir, location=location)
+        try:
+            digest = model_digest(path)
+            size = path.stat().st_size
+        except OSError as error:
+            raise BuildSpecInvalidError(f"{location} could not be read: {error}") from error
+        if model.get("sha256") != digest:
+            model.pop("blobId", None)
+            if "sourceUri" in model:
+                stale_source_uris.append(index)
+                model.pop("sourceUri", None)
+        model["sha256"] = digest
+        model["sizeBytes"] = size
+        if not _has_text(model, "blobId") and not _has_text(model, "sourceUri"):
+            uploads.append(
+                PushUpload("model", "models", index, str(model.get("filename") or path.name), digest, size, path)
+            )
+
+    for index, node in enumerate(_entries(definition, "customNodes")):
+        if node.get("source") != "local":
+            continue
+        location = f"definition.customNodes[{index}]"
+        path = _local_path(node, paths.custom_nodes_dir, location=location)
+        # One build, one identity: packaging twice lets the directory change
+        # between calls and pairs these bytes with another archive's digest.
+        # `NodePackageError` propagates: it already names the node directory the
+        # user must fix, which a `BuildSpecInvalidError` here would relabel with
+        # the spec file's path at the call site.
+        package = package_node(path, package_dir / f"node-{index}.zip" if package_dir is not None else None)
+        digest, size = package.sha256, package.size_bytes
+        # `_local_path` above already proved localPath is a non-empty str.
+        local_path = str(node["localPath"])
+        skipped_symlinks.extend(SkippedSymlink(location, local_path, member) for member in package.skipped_symlinks)
+        if node.get("localDigest") != digest:
+            node.pop("blobId", None)
+        node["localDigest"] = digest
+        node["localSizeBytes"] = size
+        if not _has_text(node, "blobId"):
+            name = str(node.get("name") or f"node-{index}")
+            uploads.append(
+                PushUpload("node_zip", "customNodes", index, f"{name}.zip", digest, size, package.archive_path)
+            )
+
+    return PushPreparation(prepared, tuple(uploads), tuple(stale_source_uris), tuple(skipped_symlinks))
+
+
+def pending_uploads(preparation: PushPreparation) -> tuple[PushUpload, ...]:
+    models = _entries(preparation.definition, "models")
+    return tuple(
+        upload
+        for upload in preparation.uploads
+        if upload.kind == "node_zip"
+        or (not _has_text(models[upload.index], "blobId") and not _has_text(models[upload.index], "sourceUri"))
+    )
+
+
+def unresolved_models(preparation: PushPreparation) -> list[JsonObject]:
+    models = _entries(preparation.definition, "models")
+    indexes = {upload.index for upload in preparation.uploads if upload.kind == "model"}
+    return [
+        model
+        for index, model in enumerate(models)
+        if index in indexes and not _has_text(model, "blobId") and not _has_text(model, "sourceUri")
+    ]
+
+
+def spec_without_stale_source_uris(original: JsonObject, preparation: PushPreparation) -> JsonObject:
+    cleaned = deepcopy(original)
+    definition = cleaned.get("definition")
+    if not isinstance(definition, dict):
+        raise BuildSpecInvalidError("definition must be a mapping")
+    models = _entries(definition, "models")
+    for index in preparation.stale_source_uri_models:
+        models[index].pop("sourceUri", None)
+    return cleaned
+
+
+def upload_assets(preparation: PushPreparation, client: BlobClient, persist: Persist | None = None) -> int:
+    """Upload every pending blob, checkpointing each id the moment it lands.
+
+    The spec file is this command's resume store — ``prepare_push`` skips any
+    entry that already carries a ``blobId`` — so *when* it is written decides
+    whether an interrupted push resumes or starts over. ``persist`` is the
+    caller's atomic write of the reconciled spec, and it runs per blob rather
+    than once at the end because the builder mints a fresh id per
+    ``create_blob`` for content it does not already hold, so an id lost with the
+    process is not merely re-uploaded — it orphans the bytes stored under the
+    first one.
+
+    Returns the number of blobs whose bytes were actually transferred. A
+    builder that already holds the content answers ``create_blob`` with the
+    existing id and no upload URL, so the pending count is an upper bound.
+    """
+    uploaded = 0
+    uploads = pending_uploads(preparation)
+    definition = preparation.definition
+    for upload in uploads:
+        if upload.path is None:
+            # A ValueError, not a BuildSpecInvalidError: `build._builder_call`
+            # wraps this call and maps the former to a CLI error, while the
+            # latter is not in its taxonomy and would escape as a traceback.
+            raise ValueError(
+                f"{upload.filename} was planned without an archive to upload; "
+                "prepare_push needs a package_dir to materialize node archives"
+            )
+        blob_id, upload_url = client.create_blob(upload.kind, upload.filename, upload.sha256, upload.size_bytes)
+        if upload_url is not None:
+            client.upload_blob(upload_url, upload.path)
+            uploaded += 1
+        _entries(definition, upload.collection)[upload.index]["blobId"] = blob_id
+        if persist is not None:
+            persist()
+    return uploaded
+
+
+def normalize_repository_identity(repository: str) -> str:
+    raw = repository.strip()
+    scp = _SCP_REPOSITORY.fullmatch(raw)
+    if scp is not None:
+        host = scp.group("host").lower()
+        path = scp.group("path")
+    else:
+        try:
+            parsed = urlsplit(raw)
+            host = (parsed.hostname or "").lower()
+            port = parsed.port
+        except ValueError:
+            return raw.rstrip("/").removesuffix(".git")
+        if not host:
+            return raw.rstrip("/").removesuffix(".git")
+        host += f":{port}" if port is not None else ""
+        path = parsed.path
+    normalized_path = path.strip("/").removesuffix(".git")
+    return f"https://{host}/{normalized_path}"
+
+
+def public_node_projection(definition: JsonObject) -> list[JsonObject]:
+    original = _entries(definition, "customNodes")
+    node_values: list[JsonValue] = [node for node in original]
+    projected = project_wire_definition({"customNodes": node_values})
+    wire = _entries(projected, "customNodes")
+    return [
+        node
+        for source, node in zip(original, wire)
+        if source.get("source") != "local" and (_has_text(node, "registryVersion") or _has_text(node, "repository"))
+    ]
+
+
+def public_node_identities(nodes: list[JsonObject]) -> set[PublicNodeIdentity]:
+    identities: set[PublicNodeIdentity] = set()
+    for index, node in enumerate(nodes):
+        if _has_text(node, "registryVersion"):
+            node_id = node.get("id")
+            version = node.get("registryVersion")
+            if not isinstance(node_id, str) or not node_id.strip() or not isinstance(version, str):
+                raise BuildSpecInvalidError(f"public customNodes[{index}] needs id + registryVersion")
+            identities.add(PublicNodeIdentity("registry", node_id, version))
+        elif _has_text(node, "repository"):
+            repository = node["repository"]
+            assert isinstance(repository, str)
+            identities.add(PublicNodeIdentity("repository", normalize_repository_identity(repository)))
+    return identities

--- a/comfy_cli/command/build_validation.py
+++ b/comfy_cli/command/build_validation.py
@@ -12,8 +12,8 @@ from comfy_cli.command.build_paths import BuildPaths, resolve_local_path
 from comfy_cli.command.build_spec import SPEC_SCHEMA, BuildSpecInvalidError, JsonObject, JsonValue
 
 _AUTHORING_FIELDS: Final = frozenset({"source", "localPath", "localDigest", "localSizeBytes"})
-_MODEL_SOURCES: Final = ("blobId", "sourceUri")
-_NODE_SOURCES: Final = ("blobId", "registryVersion", "repository")
+MODEL_SOURCES: Final = ("blobId", "sourceUri")
+NODE_SOURCES: Final = ("blobId", "registryVersion", "repository")
 MODEL_RESOLVE_BATCH_SIZE: Final = 32
 
 
@@ -82,11 +82,11 @@ def _set_sources(entry: JsonObject, fields: tuple[str, ...], *, location: str) -
 
 
 def _project_model(entry: JsonObject, *, location: str) -> JsonObject:
-    sources = _set_sources(entry, _MODEL_SOURCES, location=location)
+    sources = _set_sources(entry, MODEL_SOURCES, location=location)
     projected = deepcopy(entry)
-    for field in (*_AUTHORING_FIELDS, *_MODEL_SOURCES):
+    for field in (*_AUTHORING_FIELDS, *MODEL_SOURCES):
         projected.pop(field, None)
-    for winner in _MODEL_SOURCES:
+    for winner in MODEL_SOURCES:
         if winner in sources:
             projected[winner] = sources[winner]
             break
@@ -94,11 +94,11 @@ def _project_model(entry: JsonObject, *, location: str) -> JsonObject:
 
 
 def _project_node(entry: JsonObject, *, location: str) -> JsonObject:
-    sources = _set_sources(entry, _NODE_SOURCES, location=location)
+    sources = _set_sources(entry, NODE_SOURCES, location=location)
     projected = deepcopy(entry)
-    for field in (*_AUTHORING_FIELDS, *_NODE_SOURCES):
+    for field in (*_AUTHORING_FIELDS, *NODE_SOURCES):
         projected.pop(field, None)
-    for winner in _NODE_SOURCES:
+    for winner in NODE_SOURCES:
         if winner not in sources:
             continue
         projected[winner] = sources[winner]
@@ -180,7 +180,7 @@ def _validate_authoring_definition(definition: JsonObject, paths: BuildPaths) ->
 
 
 def _validate_wire_sources(original: JsonObject, projected: JsonObject, collection: str) -> None:
-    fields = _MODEL_SOURCES if collection == "models" else _NODE_SOURCES
+    fields = MODEL_SOURCES if collection == "models" else NODE_SOURCES
     originals = _entries(original, collection)
     wire_entries = _entries(projected, collection)
     for index, (authoring_entry, wire_entry) in enumerate(zip(originals, wire_entries)):

--- a/comfy_cli/command/build_validation.py
+++ b/comfy_cli/command/build_validation.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Final, Literal, Protocol
+
+from typing_extensions import assert_never
+
+from comfy_cli.command.build_paths import BuildPaths, resolve_local_path
+from comfy_cli.command.build_spec import SPEC_SCHEMA, BuildSpecInvalidError, JsonObject, JsonValue
+
+_AUTHORING_FIELDS: Final = frozenset({"source", "localPath", "localDigest", "localSizeBytes"})
+_MODEL_SOURCES: Final = ("blobId", "sourceUri")
+_NODE_SOURCES: Final = ("blobId", "registryVersion", "repository")
+MODEL_RESOLVE_BATCH_SIZE: Final = 32
+
+
+class ModelLookupState(str, Enum):
+    CANDIDATE_FOUND = "candidate_found"
+    NONE_FOUND = "none_found"
+    LOOKUP_ERROR = "lookup_error"
+    NOT_LOOKUPABLE = "not_lookupable"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelLookup:
+    index: int
+    filename: str | None
+    state: ModelLookupState
+    candidates: tuple[JsonObject, ...] = ()
+    error: str | None = None
+
+    def as_json(self) -> JsonObject:
+        result: JsonObject = {
+            "entry": f"definition.models[{self.index}]",
+            "filename": self.filename,
+            "state": self.state.value,
+        }
+        if self.candidates:
+            result["candidates"] = [deepcopy(candidate) for candidate in self.candidates]
+        if self.error is not None:
+            result["error"] = self.error
+        return result
+
+
+class ModelResolver(Protocol):
+    def __call__(self, filenames: list[str]) -> list[JsonObject]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class LocalPathContext:
+    location: str
+    root: Path
+    kind: Literal["model", "node"]
+
+
+def _entries(definition: JsonObject, collection: str) -> list[JsonObject]:
+    value = definition.get(collection, [])
+    if not isinstance(value, list):
+        raise BuildSpecInvalidError(f"definition.{collection} must be a list")
+    entries: list[JsonObject] = []
+    for index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            raise BuildSpecInvalidError(f"definition.{collection}[{index}] must be a mapping")
+        entries.append(entry)
+    return entries
+
+
+def _set_sources(entry: JsonObject, fields: tuple[str, ...], *, location: str) -> dict[str, str]:
+    sources: dict[str, str] = {}
+    for field in fields:
+        value = entry.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise BuildSpecInvalidError(f"{location}.{field} must be a string or null")
+        if value.strip():
+            sources[field] = value
+    return sources
+
+
+def _project_model(entry: JsonObject, *, location: str) -> JsonObject:
+    sources = _set_sources(entry, _MODEL_SOURCES, location=location)
+    projected = deepcopy(entry)
+    for field in (*_AUTHORING_FIELDS, *_MODEL_SOURCES):
+        projected.pop(field, None)
+    for winner in _MODEL_SOURCES:
+        if winner in sources:
+            projected[winner] = sources[winner]
+            break
+    return projected
+
+
+def _project_node(entry: JsonObject, *, location: str) -> JsonObject:
+    sources = _set_sources(entry, _NODE_SOURCES, location=location)
+    projected = deepcopy(entry)
+    for field in (*_AUTHORING_FIELDS, *_NODE_SOURCES):
+        projected.pop(field, None)
+    for winner in _NODE_SOURCES:
+        if winner not in sources:
+            continue
+        projected[winner] = sources[winner]
+        if winner in {"blobId", "registryVersion"}:
+            projected.pop("gitRef", None)
+            projected.pop("commit", None)
+        break
+    return projected
+
+
+def project_wire_definition(definition: JsonObject) -> JsonObject:
+    """Return the exclusion-based builder wire copy using D-I source precedence."""
+    projected = deepcopy(definition)
+    if "models" in definition:
+        projected["models"] = [
+            _project_model(entry, location=f"definition.models[{index}]")
+            for index, entry in enumerate(_entries(definition, "models"))
+        ]
+    if "customNodes" in definition:
+        projected["customNodes"] = [
+            _project_node(entry, location=f"definition.customNodes[{index}]")
+            for index, entry in enumerate(_entries(definition, "customNodes"))
+        ]
+    return projected
+
+
+def _required_string(entry: JsonObject, field: str, *, location: str) -> str:
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise BuildSpecInvalidError(f"{location}.{field} must be a non-empty string")
+    return value
+
+
+def _optional_string(entry: JsonObject, field: str, *, location: str) -> str | None:
+    value = entry.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise BuildSpecInvalidError(f"{location}.{field} must be a string or null")
+    return value
+
+
+def _validate_local_path(entry: JsonObject, context: LocalPathContext) -> None:
+    local_path = _optional_string(entry, "localPath", location=context.location)
+    source = _optional_string(entry, "source", location=context.location)
+    if local_path is None:
+        if source == "local":
+            raise BuildSpecInvalidError(f"{context.location}.localPath is required when source is 'local'")
+        return
+    if not local_path.strip():
+        raise BuildSpecInvalidError(f"{context.location}.localPath must be a non-empty string")
+    resolved = resolve_local_path(context.root, local_path, entry=context.location)
+    match context.kind:
+        case "model":
+            correct_kind = resolved.is_file()
+            expected = "file"
+        case "node":
+            correct_kind = resolved.is_dir()
+            expected = "directory"
+        case unreachable:
+            assert_never(unreachable)
+    if not correct_kind:
+        raise BuildSpecInvalidError(f"{context.location}.localPath must resolve to a {expected}: {local_path!r}")
+
+
+def _validate_authoring_definition(definition: JsonObject, paths: BuildPaths) -> None:
+    schema = definition.get("schema")
+    if schema is not None and not isinstance(schema, str):
+        raise BuildSpecInvalidError("definition.schema must be a string or null")
+    for index, model in enumerate(_entries(definition, "models")):
+        location = f"definition.models[{index}]"
+        _required_string(model, "type", location=location)
+        _optional_string(model, "filename", location=location)
+        _validate_local_path(model, LocalPathContext(location, paths.models_dir, "model"))
+    for index, node in enumerate(_entries(definition, "customNodes")):
+        location = f"definition.customNodes[{index}]"
+        _required_string(node, "name", location=location)
+        _validate_local_path(node, LocalPathContext(location, paths.custom_nodes_dir, "node"))
+
+
+def _validate_wire_sources(original: JsonObject, projected: JsonObject, collection: str) -> None:
+    fields = _MODEL_SOURCES if collection == "models" else _NODE_SOURCES
+    originals = _entries(original, collection)
+    wire_entries = _entries(projected, collection)
+    for index, (authoring_entry, wire_entry) in enumerate(zip(originals, wire_entries)):
+        effective = _set_sources(wire_entry, fields, location=f"definition.{collection}[{index}]")
+        if len(effective) > 1:
+            raise BuildSpecInvalidError(f"definition.{collection}[{index}] has multiple effective builder sources")
+        if effective or authoring_entry.get("source") == "local":
+            continue
+        raise BuildSpecInvalidError(f"definition.{collection}[{index}] has no effective builder source")
+
+
+def validate_local_build_spec(spec: JsonObject, paths: BuildPaths) -> JsonObject:
+    """Run authoring validation, then return the validated normalized wire copy."""
+    if spec.get("schema") != SPEC_SCHEMA:
+        raise BuildSpecInvalidError(f"unsupported build spec schema {spec.get('schema')!r}; expected {SPEC_SCHEMA!r}")
+    definition: JsonValue = spec.get("definition")
+    if not isinstance(definition, dict):
+        raise BuildSpecInvalidError("definition must be a mapping")
+    _validate_authoring_definition(definition, paths)
+    projected = project_wire_definition(definition)
+    _validate_wire_sources(definition, projected, "models")
+    _validate_wire_sources(definition, projected, "customNodes")
+    return projected
+
+
+def _lookup_result(index: int, filename: str, response: JsonValue | None) -> ModelLookup:
+    location = f"definition.models[{index}]"
+    if not isinstance(response, dict):
+        return ModelLookup(index, filename, ModelLookupState.LOOKUP_ERROR, error="lookup returned no result")
+    echoed = response.get("filename")
+    if echoed != filename:
+        return ModelLookup(
+            index,
+            filename,
+            ModelLookupState.LOOKUP_ERROR,
+            error=f"lookup returned {echoed!r} for {location}",
+        )
+    error = response.get("error")
+    if error is not None:
+        if not isinstance(error, str):
+            return ModelLookup(
+                index, filename, ModelLookupState.LOOKUP_ERROR, error="lookup returned a malformed error"
+            )
+        if error.strip():
+            return ModelLookup(index, filename, ModelLookupState.LOOKUP_ERROR, error=error)
+    candidates = response.get("candidates")
+    if not isinstance(candidates, list):
+        return ModelLookup(index, filename, ModelLookupState.LOOKUP_ERROR, error="lookup returned malformed candidates")
+    parsed: list[JsonObject] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            return ModelLookup(
+                index, filename, ModelLookupState.LOOKUP_ERROR, error="lookup returned a malformed candidate"
+            )
+        parsed.append(candidate)
+    state = ModelLookupState.CANDIDATE_FOUND if parsed else ModelLookupState.NONE_FOUND
+    return ModelLookup(index, filename, state, candidates=tuple(parsed))
+
+
+def lookup_public_model_sources(definition: JsonObject, resolver: ModelResolver) -> list[ModelLookup]:
+    """Resolve lookupable model filenames in 32-item batches and restore spec order."""
+    models = _entries(definition, "models")
+    lookupable: list[tuple[int, str]] = []
+    results: dict[int, ModelLookup] = {}
+    for index, model in enumerate(models):
+        filename = model.get("filename")
+        if isinstance(filename, str) and filename.strip():
+            lookupable.append((index, filename))
+        else:
+            results[index] = ModelLookup(index, None, ModelLookupState.NOT_LOOKUPABLE)
+
+    for start in range(0, len(lookupable), MODEL_RESOLVE_BATCH_SIZE):
+        batch = lookupable[start : start + MODEL_RESOLVE_BATCH_SIZE]
+        response = resolver([filename for _, filename in batch])
+        for offset, (index, filename) in enumerate(batch):
+            item = response[offset] if offset < len(response) else None
+            results[index] = _lookup_result(index, filename, item)
+    return [results[index] for index in range(len(models))]

--- a/tests/comfy_cli/command/test_build.py
+++ b/tests/comfy_cli/command/test_build.py
@@ -390,7 +390,7 @@ class _FakeBuilder:
         self.created = (name, definition)
         return "dist-123"
 
-    def cut_version(self, build_id, targets=None):
+    def create_release(self, build_id, targets=None):
         self.cut = (build_id, targets)
         return "ver-456", "https://status.example/ver-456"
 
@@ -535,7 +535,7 @@ def test_builder_client_endpoints_and_parsing(monkeypatch):
     c = BuilderClient("https://builder.test/", "jwt-token")
     assert c.create_blob("model", "f.safetensors", "hash", 5) == ("b1", "https://put")
     assert c.create_build("n", {"models": [], "customNodes": []}) == "d1"
-    assert c.cut_version("d1") == ("v1", "https://s")
+    assert c.create_release("d1") == ("v1", "https://s")
     results = c.resolve_models(["a.safetensors"])
     assert results[0]["candidates"][0]["sourceUri"] == "https://u"
     # URLs carry the /v1 prefix, and the JWT rides on the cloud target
@@ -569,7 +569,7 @@ def test_builder_client_read_endpoints(monkeypatch):
     assert c.list_builds() == [{"id": "d1", "name": "n"}]
     assert c.get_build("d1")["definition"] == {"models": []}
     assert c.list_releases("d1") == [{"id": "v1", "status": "complete"}]
-    logs = c.get_version_logs("v1", os="linux", gpu="nvidia")
+    logs = c.get_release_logs("v1", os="linux", gpu="nvidia")
     assert logs["log"] == "hello" and logs["truncated"] is False
     # reads are GETs under /v1, and the log target selector rides as query params
     assert ("GET", "https://builder.test/v1/builds") in calls
@@ -625,7 +625,7 @@ def test_builder_client_reference_and_update_endpoints(monkeypatch):
     assert c.list_model_directories() == ["checkpoints", "vae"]
     assert c.list_blobs() == [{"blobId": "b1", "filename": "m.safetensors"}]
     assert c.update_build("d1", {"models": []}, "2026-08-01T00:00:00Z")["id"] == "d1"
-    assert c.get_version_manifest("v1")["models"][0]["filename"] == "ae"
+    assert c.get_release_manifest("v1")["models"][0]["filename"] == "ae"
     assert c.get_artifact_download("a1")["downloadUrl"] == "https://dl"
     # update is a PATCH carrying the definition AND the expectedUpdatedAt guard the
     # builder requires (a missing one 409s STALE); the rest are GETs under /v1
@@ -779,7 +779,7 @@ def test_upload_blob_sends_generation_match_header(monkeypatch, tmp_path):
     assert captured["allow_redirects"] is False
 
 
-def test_get_version_logs_uses_large_cap(monkeypatch):
+def test_get_release_logs_uses_large_cap(monkeypatch):
     seen = {}
 
     def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
@@ -789,7 +789,7 @@ def test_get_version_logs_uses_large_cap(monkeypatch):
     monkeypatch.setattr("comfy_cli.builder_api.request_json", fake_request_json)
     from comfy_cli.builder_api import BuilderClient
 
-    BuilderClient("https://builder.test/", "jwt").get_version_logs("v1")
+    BuilderClient("https://builder.test/", "jwt").get_release_logs("v1")
     # the builder caps a served log at 8 MiB; the client cap must sit above that
     assert seen["max_bytes"] > 8 * 1024 * 1024
 
@@ -1165,7 +1165,7 @@ class _ImportingBuilder:
         self.created_with = definition
         return "dist-1"
 
-    def cut_version(self, build_id, targets=None):
+    def create_release(self, build_id, targets=None):
         return ("ver-1", "status-url")
 
 
@@ -1669,7 +1669,7 @@ def test_build_version_alias_hidden_from_build_help():
     assert "version" not in listed
 
 
-def test_cut_version_falls_back_to_buildversionid(monkeypatch):
+def test_create_release_falls_back_to_buildversionid(monkeypatch):
     """A not-yet-upgraded builder answers the cut with buildVersionId; the
     client still parses the id so the CLI works against either generation."""
 
@@ -1681,7 +1681,7 @@ def test_cut_version_falls_back_to_buildversionid(monkeypatch):
     from comfy_cli.builder_api import BuilderClient
 
     c = BuilderClient("https://builder.test/", "jwt")
-    assert c.cut_version("d1") == ("v1", "https://s")
+    assert c.create_release("d1") == ("v1", "https://s")
 
 
 # --- review follow-ups --------------------------------------------------------

--- a/tests/comfy_cli/command/test_build.py
+++ b/tests/comfy_cli/command/test_build.py
@@ -384,6 +384,10 @@ class _FakeBuilder:
         return f"blob-{filename}", f"https://put.example/{filename}"
 
     def upload_blob(self, upload_url, path):
+        # The real client hands the URL to `requests.put`, which rejects `None`.
+        # A fake that accepted it would let a deduplicated blob regress silently.
+        if upload_url is None:
+            raise requests.exceptions.MissingSchema("Invalid URL 'None': No scheme supplied.")
         self.uploaded.append((upload_url, str(path)))
 
     def create_build(self, name, definition, description=None):
@@ -393,6 +397,15 @@ class _FakeBuilder:
     def create_release(self, build_id, targets=None):
         self.cut = (build_id, targets)
         return "ver-456", "https://status.example/ver-456"
+
+
+class _DeduplicatingBuilder(_FakeBuilder):
+    """A builder that already holds every blob offered to it, so ``create_blob``
+    answers with the existing id and no upload URL."""
+
+    def create_blob(self, kind, filename, sha256, size_bytes):
+        self.blobs_created.append(filename)
+        return f"blob-{filename}", None
 
 
 def test_execute_create_uploads_stitches_and_cuts():
@@ -440,6 +453,42 @@ def test_execute_create_preflights_uploads_before_moving_bytes():
         build.execute_create(plan, client=fake, name="demo", locate_bytes=lambda u: Path("/tmp/x"))
     assert fake.blobs_created == [], "no model should upload when a later node makes the create unsupported"
     assert fake.created is None
+
+
+def test_execute_create_stitches_a_deduplicated_blob_without_uploading_it():
+    """A builder that already holds the bytes answers with the id it has and no
+    upload URL. Sending them anyway PUTs to ``None`` — ``requests`` raises
+    ``MissingSchema`` — and fails the whole create over content already stored,
+    which is exactly the retry this deduplication exists to make cheap."""
+    scan_def = {
+        "models": [{"type": "vae", "filename": "ae.safetensors", "sha256": "h", "sizeBytes": 5, "source": "local"}],
+        "customNodes": [],
+    }
+    plan = build.plan_create(scan_def)
+    fake = _DeduplicatingBuilder()
+
+    result = build.execute_create(plan, client=fake, name="demo", locate_bytes=lambda u: Path("/tmp/ae.safetensors"))
+
+    assert fake.uploaded == [], "a blob the builder already holds has nothing to transfer"
+    assert result["uploaded"] == 0, "`uploaded` counts bytes that moved, not blobs stitched"
+    assert plan["definition"]["models"][0]["blobId"] == "blob-ae.safetensors"
+    assert fake.cut[0] == "dist-123", "the create must still reach the release"
+
+
+def test_blob_upload_reports_the_id_when_the_builder_already_holds_the_bytes(monkeypatch, tmp_path, capsys):
+    """Re-running `comfy build blob upload` on a stored file is the ordinary case:
+    it must answer with the usable id rather than fail on a ``None`` upload URL."""
+    target = tmp_path / "ae.safetensors"
+    target.write_bytes(b"VAE")
+    client = _DeduplicatingBuilder()
+    monkeypatch.setattr(build, "_builder_client", lambda renderer, url: client)
+
+    build.blob_upload_cmd(path=str(target))
+
+    assert client.uploaded == [], "nothing to PUT when the builder deduplicated the blob"
+    out = capsys.readouterr().out
+    assert "blob-ae.safetensors" in out
+    assert "None" not in out, "a None upload URL must never reach the user"
 
 
 class _FakeResolver:

--- a/tests/comfy_cli/command/test_build.py
+++ b/tests/comfy_cli/command/test_build.py
@@ -599,11 +599,13 @@ def test_builder_client_read_endpoints(monkeypatch):
 
     def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
         calls.append((method, url))
-        if url.endswith("/v1/builds"):
+        # The paged reads carry a `?limit=`, so route on the path, not the URL.
+        path = url.split("?", 1)[0]
+        if path.endswith("/v1/builds"):
             return 200, {"builds": [{"id": "d1", "name": "n"}]}
-        if url.endswith("/v1/builds/d1"):
+        if path.endswith("/v1/builds/d1"):
             return 200, {"id": "d1", "name": "n", "definition": {"models": []}}
-        if url.endswith("/v1/builds/d1/releases"):
+        if path.endswith("/v1/builds/d1/releases"):
             # A not-yet-upgraded builder still keys the list `versions`; the
             # client parses that spelling as well as `releases`.
             return 200, {"versions": [{"id": "v1", "status": "complete"}]}
@@ -621,7 +623,7 @@ def test_builder_client_read_endpoints(monkeypatch):
     logs = c.get_release_logs("v1", os="linux", gpu="nvidia")
     assert logs["log"] == "hello" and logs["truncated"] is False
     # reads are GETs under /v1, and the log target selector rides as query params
-    assert ("GET", "https://builder.test/v1/builds") in calls
+    assert ("GET", "https://builder.test/v1/builds?limit=100") in calls
     assert any("/logs?" in u and "os=linux" in u and "gpu=nvidia" in u for _, u in calls)
 
 
@@ -1610,9 +1612,11 @@ class _FakeBuilderHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler's spelling)
-        if self.path == "/v1/builds":
+        # The paged reads carry a `?limit=`, so route the listings on the path.
+        route = self.path.split("?", 1)[0]
+        if route == "/v1/builds":
             return self._reply(200, {"builds": [{"id": "dist-1", "name": "portrait"}]})
-        if self.path == "/v1/builds/dist-1/releases":
+        if route == "/v1/builds/dist-1/releases":
             return self._reply(200, {"releases": [{"id": "rel-9", "status": "complete"}]})
         if self.path.startswith("/v1/releases/rel-9/logs"):
             return self._reply(200, {"releaseId": "rel-9", "os": "linux", "log": "pip install ok", "truncated": False})

--- a/tests/comfy_cli/command/test_build_package.py
+++ b/tests/comfy_cli/command/test_build_package.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from comfy_cli.command.build_package import NodePackageError, package_node
+from comfy_cli.command.build_package import NodePackageError, _copy_declared, package_node
 
 posix_permissions = pytest.mark.skipif(
     sys.platform == "win32" or getattr(os, "geteuid", lambda: -1)() == 0,
@@ -139,8 +139,6 @@ def test_package_has_exact_members_and_fixed_metadata(tmp_path: Path) -> None:
     (node / "__pycache__" / "cached.pyc").write_bytes(b"cache")
     (node / "root.pyc").write_bytes(b"cache")
     (node / "target.txt").write_text("target", encoding="utf-8")
-    os.symlink(node / "target.txt", node / "linked.txt")
-    os.symlink(node / "nested", node / "linked-dir")
 
     # When
     archive = _archive_bytes(node, tmp_path / "node.zip")
@@ -155,6 +153,66 @@ def test_package_has_exact_members_and_fixed_metadata(tmp_path: Path) -> None:
             assert stat.S_IMODE(member.external_attr >> 16) == 0o644
 
 
+def test_a_destination_inside_the_root_is_not_packaged_into_itself(tmp_path: Path) -> None:
+    # Given a stale archive from a previous run sitting in the node's own tree
+    node = _node_tree(tmp_path)
+    destination = node / "dist.zip"
+    destination.write_bytes(b"STALE" * 1000)
+
+    # When
+    package = package_node(node, destination)
+
+    # Then it packages the node's content, never the archive it is writing
+    with zipfile.ZipFile(destination) as archive:
+        assert archive.namelist() == ["__init__.py", "nested/data.txt"]
+    assert package.size_bytes == destination.stat().st_size
+
+
+def test_repeated_packaging_into_the_root_is_idempotent(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    destination = node / "dist.zip"
+
+    # When the same destination is packaged twice, the second run sees the first
+    first = package_node(node, destination).sha256
+    second = package_node(node, destination).sha256
+
+    # Then
+    assert first == second
+
+
+def test_a_leftover_archive_does_not_change_the_nodes_identity(tmp_path: Path) -> None:
+    # Given the digest `push` mints, packaging a clean tree into a temp dir
+    node = _node_tree(tmp_path)
+    expected = package_node(node, tmp_path / "outside.zip").sha256
+
+    # When a previous run left its archive inside the node and it is packaged again
+    destination = node / "dist.zip"
+    destination.write_bytes(b"STALE" * 1000)
+
+    # Then the node still hashes to what `push` would compute for it
+    assert package_node(node, destination).sha256 == expected
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
+def test_a_destination_symlinked_out_of_the_root_is_not_reported_as_skipped(tmp_path: Path) -> None:
+    # Given a destination lexically inside the node but pointing outside it
+    node = _node_tree(tmp_path)
+    outside = tmp_path / "elsewhere.zip"
+    outside.write_bytes(b"SEED")
+    destination = node / "dist.zip"
+    os.symlink(outside, destination)
+
+    # When
+    package = package_node(node, destination)
+
+    # Then the archive it is writing is not vendored content it left behind
+    assert package.skipped_symlinks == ()
+    with zipfile.ZipFile(outside) as archive:
+        assert archive.namelist() == ["__init__.py", "nested/data.txt"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
 def test_symlinked_node_root_is_rejected(tmp_path: Path) -> None:
     # Given
     node = _node_tree(tmp_path)
@@ -180,6 +238,7 @@ def test_identity_describes_the_archive_it_is_returned_with(tmp_path: Path) -> N
     assert package.size_bytes == len(written)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privileges on Windows")
 def test_skipped_symlinks_are_reported_rather_than_dropped_in_silence(tmp_path: Path) -> None:
     # Given
     node = _node_tree(tmp_path)
@@ -196,6 +255,71 @@ def test_skipped_symlinks_are_reported_rather_than_dropped_in_silence(tmp_path: 
     with zipfile.ZipFile(destination) as archive:
         assert "linked.txt" not in archive.namelist()
         assert "vendor/data.txt" not in archive.namelist()
+
+
+def test_the_member_copy_stops_at_the_declared_length(tmp_path: Path) -> None:
+    """The bound is what terminates a read against a file still being written.
+
+    An archive member that aliases the archive itself — a hardlink defeats the
+    path-based exclusion — reads back every byte the writer just appended and
+    never reaches EOF. Only the declared length ends it; the size check that
+    follows can never run otherwise.
+    """
+
+    # Given a source that never reports EOF, as a growing member does not.
+    # Capped so an unbounded reader fails the test instead of wedging the run.
+    class _Endless(io.RawIOBase):
+        def __init__(self) -> None:
+            self.reads = 0
+
+        def readable(self) -> bool:
+            return True
+
+        def read(self, size: int = -1) -> bytes:
+            self.reads += 1
+            assert self.reads <= 8, "the copy read past the declared length"
+            return b"X" * (size if size and size > 0 else 1)
+
+    target = io.BytesIO()
+
+    # When
+    copied = _copy_declared(_Endless(), target, 4096)
+
+    # Then
+    assert copied == 4096
+    assert target.getvalue() == b"X" * 4096
+
+
+@pytest.mark.parametrize(("declared", "actual"), [(50, 100), (200, 100)], ids=["grew", "shrank"])
+def test_a_member_that_changes_size_while_packaging_aborts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, declared: int, actual: int
+) -> None:
+    """A member whose length moved under packaging aborts rather than landing torn.
+
+    A digest taken over a torn read is not reproducible, which is the whole
+    point of ``localDigest``. This pins only the size comparison — the bound that
+    lets the comparison run at all is pinned by
+    ``test_the_member_copy_stops_at_the_declared_length``.
+    """
+    # Given a file whose real length disagrees with the one packaging recorded
+    node = _node_tree(tmp_path)
+    moving = node / "moving.bin"
+    moving.write_bytes(b"X" * actual)
+    real_stat = Path.stat
+
+    def fake_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+        result = real_stat(self, *args, **kwargs)  # type: ignore[arg-type]
+        if self == moving:
+            fields = list(result)
+            fields[6] = declared
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+
+    # When / Then
+    with pytest.raises(NodePackageError, match="moving.bin changed size while it was being packaged"):
+        package_node(node, tmp_path / "node.zip")
 
 
 @posix_permissions

--- a/tests/comfy_cli/command/test_build_package.py
+++ b/tests/comfy_cli/command/test_build_package.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import stat
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.command.build_package import NodePackageError, package_node
+
+posix_permissions = pytest.mark.skipif(
+    sys.platform == "win32" or getattr(os, "geteuid", lambda: -1)() == 0,
+    reason="needs POSIX mode bits that root ignores",
+)
+
+
+def _node_tree(root: Path) -> Path:
+    node = root / "node"
+    (node / "nested").mkdir(parents=True)
+    (node / "__init__.py").write_bytes(b"NODE")
+    (node / "nested" / "data.txt").write_bytes(b"DATA")
+    return node
+
+
+def _archive_bytes(node: Path, destination: Path) -> bytes:
+    package = package_node(node, destination)
+    assert package.archive_path == destination
+    return destination.read_bytes()
+
+
+def _buffered_archive(root: Path) -> bytes:
+    """The pre-streaming implementation, kept here as an independent oracle.
+
+    Specs already in the wild carry ``localDigest`` values this exact algorithm
+    minted, and a digest that drifted would invalidate every ``blobId`` stored
+    beside them. Pinning that against a second call to the code under test would
+    prove only that it agrees with itself, so the guarantee is pinned against a
+    reimplementation of the old algorithm over the same input.
+    """
+    members = sorted((path.relative_to(root).as_posix(), path) for path in root.rglob("*") if path.is_file())
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, mode="w", compression=zipfile.ZIP_STORED) as archive:
+        for member_name, member_path in members:
+            info = zipfile.ZipInfo(member_name, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.create_system = 3
+            info.external_attr = (stat.S_IFREG | 0o644) << 16
+            archive.writestr(info, member_path.read_bytes())
+    return output.getvalue()
+
+
+def test_package_is_byte_identical_across_repeated_builds(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+
+    # When
+    first = _archive_bytes(node, tmp_path / "first.zip")
+    second = _archive_bytes(node, tmp_path / "second.zip")
+
+    # Then
+    assert first == second
+
+
+def test_streaming_to_a_destination_reproduces_the_buffered_digest(tmp_path: Path) -> None:
+    """`localDigest` values minted before packaging streamed must still verify."""
+    # Given: a tree whose member order differs between path sort and name sort,
+    # which is where a rewritten walk would silently reorder the archive.
+    node = _node_tree(tmp_path)
+    (node / "a").mkdir()
+    (node / "a" / "b.txt").write_bytes(b"NESTED")
+    (node / "a.txt").write_bytes(b"SIBLING")
+    expected = _buffered_archive(node)
+    destination = tmp_path / "node.zip"
+
+    # When
+    package = package_node(node, destination)
+
+    # Then
+    assert destination.read_bytes() == expected
+    assert package.sha256 == hashlib.sha256(expected).hexdigest()
+    assert package.size_bytes == len(expected)
+
+
+def test_packaging_without_a_destination_retains_no_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Identity needs the bytes; keeping them is what `prepare_push` cannot afford."""
+    # Given
+    node = _node_tree(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(scratch))
+    expected = hashlib.sha256(_buffered_archive(node)).hexdigest()
+
+    # When
+    package = package_node(node)
+
+    # Then
+    assert package.archive_path is None
+    assert package.sha256 == expected
+    assert list(scratch.iterdir()) == []
+
+
+def test_content_identity_is_independent_of_absolute_root(tmp_path: Path) -> None:
+    # Given
+    first_node = _node_tree(tmp_path / "first")
+    second_node = _node_tree(tmp_path / "different" / "depth")
+
+    # When
+    first = package_node(first_node).sha256
+    second = package_node(second_node).sha256
+
+    # Then
+    assert first == second
+
+
+def test_content_identity_changes_when_file_content_changes(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    before = package_node(node).sha256
+
+    # When
+    (node / "nested" / "data.txt").write_bytes(b"CHANGED")
+    after = package_node(node).sha256
+
+    # Then
+    assert after != before
+
+
+def test_package_has_exact_members_and_fixed_metadata(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    (node / ".git").mkdir()
+    (node / ".git" / "config").write_text("secret", encoding="utf-8")
+    (node / "__pycache__").mkdir()
+    (node / "__pycache__" / "cached.pyc").write_bytes(b"cache")
+    (node / "root.pyc").write_bytes(b"cache")
+    (node / "target.txt").write_text("target", encoding="utf-8")
+    os.symlink(node / "target.txt", node / "linked.txt")
+    os.symlink(node / "nested", node / "linked-dir")
+
+    # When
+    archive = _archive_bytes(node, tmp_path / "node.zip")
+
+    # Then
+    with zipfile.ZipFile(io.BytesIO(archive)) as package:
+        assert package.namelist() == ["__init__.py", "nested/data.txt", "target.txt"]
+        for member in package.infolist():
+            assert member.compress_type == zipfile.ZIP_STORED
+            assert member.date_time == (1980, 1, 1, 0, 0, 0)
+            assert stat.S_IFMT(member.external_attr >> 16) == stat.S_IFREG
+            assert stat.S_IMODE(member.external_attr >> 16) == 0o644
+
+
+def test_symlinked_node_root_is_rejected(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    linked_root = tmp_path / "linked-node"
+    os.symlink(node, linked_root)
+
+    # When / Then
+    with pytest.raises(ValueError, match="node root.*symlink"):
+        package_node(linked_root)
+
+
+def test_identity_describes_the_archive_it_is_returned_with(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    destination = tmp_path / "node.zip"
+
+    # When
+    package = package_node(node, destination)
+
+    # Then
+    written = destination.read_bytes()
+    assert package.sha256 == hashlib.sha256(written).hexdigest()
+    assert package.size_bytes == len(written)
+
+
+def test_skipped_symlinks_are_reported_rather_than_dropped_in_silence(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    (node / "target.txt").write_text("target", encoding="utf-8")
+    os.symlink(node / "target.txt", node / "linked.txt")
+    os.symlink(node / "nested", node / "vendor")
+
+    # When
+    destination = tmp_path / "node.zip"
+    package = package_node(node, destination)
+
+    # Then
+    assert package.skipped_symlinks == ("linked.txt", "vendor")
+    with zipfile.ZipFile(destination) as archive:
+        assert "linked.txt" not in archive.namelist()
+        assert "vendor/data.txt" not in archive.namelist()
+
+
+@posix_permissions
+def test_an_untraversable_directory_aborts_instead_of_shrinking_the_archive(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    vendor = node / "vendor"
+    vendor.mkdir()
+    (vendor / "lib.py").write_bytes(b"LIB")
+    os.chmod(vendor, 0o000)
+
+    # When / Then
+    try:
+        with pytest.raises(NodePackageError, match="vendor could not be read"):
+            package_node(node)
+    finally:
+        os.chmod(vendor, 0o700)
+
+
+@posix_permissions
+def test_an_unreadable_file_raises_the_packaging_error_rather_than_escaping(tmp_path: Path) -> None:
+    # Given
+    node = _node_tree(tmp_path)
+    secret = node / "nested" / "secret.py"
+    secret.write_bytes(b"SECRET")
+    os.chmod(secret, 0o000)
+
+    # When / Then
+    try:
+        with pytest.raises(NodePackageError, match="nested/secret.py could not be read"):
+            package_node(node)
+    finally:
+        os.chmod(secret, 0o600)

--- a/tests/comfy_cli/command/test_build_pull_merge.py
+++ b/tests/comfy_cli/command/test_build_pull_merge.py
@@ -1,0 +1,232 @@
+"""Who owns an entry's content identity when a pull merges server onto local.
+
+An entry whose ``source`` is ``local`` is described by bytes on this machine, so
+its ``blobId``/digest/size are authoring data the server cannot know better.
+Every other source is the server's to describe: letting local win there reverted
+a server-side switch from a private blob to a public ``sourceUri`` on the next
+push, and dropped the server's blob reference and hash under a local public
+entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from comfy_cli.command.build_pull import merge_pull_definition
+from comfy_cli.command.build_validation import project_wire_definition
+
+
+def _definition(model: dict) -> dict:
+    return {"models": [model], "customNodes": []}
+
+
+def _merged_model(local: dict, server: dict) -> dict:
+    merged = merge_pull_definition(_definition(local), _definition(server))
+    assert len(merged["models"]) == 1
+    return merged["models"][0]
+
+
+def _wire_model(merged_model: dict) -> dict:
+    return project_wire_definition(_definition(merged_model))["models"][0]
+
+
+_LOCATION = {"type": "checkpoints", "filename": "m.safetensors"}
+
+
+def test_a_local_entry_keeps_its_own_blob_digest_and_size() -> None:
+    # Given a locally-authored model the server describes differently
+    local = {**_LOCATION, "source": "local", "localPath": "m.safetensors", "blobId": "local-blob", "sha256": "a" * 64}
+    server = {**_LOCATION, "blobId": "server-blob", "sha256": "b" * 64, "sizeBytes": 2}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then the bytes on this machine remain the truth
+    assert merged["blobId"] == "local-blob"
+    assert merged["sha256"] == "a" * 64
+    assert merged["source"] == "local"
+    assert merged["localPath"] == "m.safetensors"
+
+
+def test_a_local_entry_still_drops_a_server_sourceuri_it_does_not_carry() -> None:
+    # Given
+    local = {**_LOCATION, "source": "local", "localPath": "m.safetensors", "sha256": "a" * 64}
+    server = {**_LOCATION, "sha256": "a" * 64, "sourceUri": "https://cdn.test/m.safetensors"}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert "sourceUri" not in merged
+
+
+def test_a_non_local_entry_keeps_the_servers_sourceuri() -> None:
+    """The regression: a server-side switch from private blob to public URI.
+
+    Asserted on the *wire* copy, because that is where reverting happens.
+    ``MODEL_SOURCES`` is a precedence group — ``project_wire_definition`` emits
+    the first source an entry names and drops the rest — so merely keeping the
+    server's ``sourceUri`` proves nothing while a stale local ``blobId`` sits
+    beside it outranking it.
+    """
+    # Given
+    local = {**_LOCATION, "source": "url", "blobId": "stale-blob"}
+    server = {**_LOCATION, "sourceUri": "https://cdn.test/m.safetensors"}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert merged["sourceUri"] == "https://cdn.test/m.safetensors"
+    assert "blobId" not in merged
+    assert _wire_model(merged) == {**_LOCATION, "sourceUri": "https://cdn.test/m.safetensors"}
+
+
+def test_a_non_local_node_keeps_the_servers_registry_version() -> None:
+    """The node shape of the same revert, which loses more when it happens.
+
+    ``_project_node`` also drops ``gitRef``/``commit`` once ``blobId`` wins, so a
+    refilled stale blob takes the git coordinates down with the registry pin.
+    """
+    # Given
+    local = {"name": "n", "id": "pkg", "source": "registry", "blobId": "stale-node-blob"}
+    server = {"name": "n", "id": "pkg", "registryVersion": "1.2.3"}
+
+    # When
+    merged = merge_pull_definition({"models": [], "customNodes": [local]}, {"models": [], "customNodes": [server]})
+    node = merged["customNodes"][0]
+
+    # Then
+    assert node["registryVersion"] == "1.2.3"
+    assert "blobId" not in node
+    assert project_wire_definition(merged)["customNodes"][0] == {"name": "n", "id": "pkg", "registryVersion": "1.2.3"}
+
+
+def test_a_non_local_entry_keeps_the_servers_blob_and_hash() -> None:
+    # Given a public local entry pulled over a server-held blob
+    local = {**_LOCATION, "source": "url", "blobId": "stale-blob", "sha256": "a" * 64, "sizeBytes": 1}
+    server = {**_LOCATION, "blobId": "server-blob", "sha256": "b" * 64, "sizeBytes": 2}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then the server's reference survives instead of being clobbered
+    assert merged["blobId"] == "server-blob"
+    assert merged["sha256"] == "b" * 64
+    assert merged["sizeBytes"] == 2
+
+
+def test_a_non_local_entry_keeps_its_authoring_fields() -> None:
+    # Given a server that describes none of the local authoring data
+    local = {**_LOCATION, "source": "url", "localPath": "vendor/m.safetensors"}
+    server = {**_LOCATION, "sourceUri": "https://cdn.test/m.safetensors"}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then re-owning content identity does not delete what only local knows
+    assert merged["source"] == "url"
+    assert merged["localPath"] == "vendor/m.safetensors"
+
+
+@pytest.mark.parametrize("field", ["blobId", "sha256", "sizeBytes", "sourceUri"])
+def test_a_non_local_entry_fills_a_field_the_server_named_no_source_for(field: str) -> None:
+    """Server-owned means server-wins-if-present, never server-wins-by-absence.
+
+    The server stores several definition shapes through ``ToMap``, whose
+    ``omitempty`` drops empty fields entirely. The server entry here names *no*
+    source at all, which is the only case where that absence is safe to fill —
+    a server naming one is covered by the two revert tests above.
+    """
+    # Given
+    value = {"blobId": "local-blob", "sha256": "a" * 64, "sizeBytes": 7, "sourceUri": "https://cdn.test/m"}[field]
+    local = {**_LOCATION, "source": "url", field: value}
+    server = dict(_LOCATION)
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert merged[field] == value
+
+
+@pytest.mark.parametrize("changed_to", ["https://cdn.test/NEW.safetensors", None], ids=["new_uri", "server_blob"])
+def test_a_changed_source_does_not_keep_the_hash_of_the_old_one(changed_to: str | None) -> None:
+    """A hash describes the bytes a source resolves to, so the two move together.
+
+    Keeping the local ``sha256`` beside a source the server has since changed
+    states an integrity claim that was never true, and the builder enforces it —
+    the pull's damage would surface as a checksum mismatch at deploy staging,
+    far from the command that wrote it. Dropping the hash is safe; it is
+    optional and the builder recomputes.
+    """
+    # Given a local entry whose source and hash were taken together
+    local = {**_LOCATION, "source": "url", "sourceUri": "https://cdn.test/OLD.safetensors", "sha256": "a" * 64}
+    server = {**_LOCATION, "sourceUri": changed_to} if changed_to else {**_LOCATION, "blobId": "server-blob"}
+
+    # When the server has moved the entry to a different source and states no hash
+    merged = _merged_model(local, server)
+
+    # Then the stale hash does not ride along with the new source
+    assert "sha256" not in merged
+    wire = _wire_model(merged)
+    assert "sha256" not in wire
+    assert wire == {**_LOCATION, ("sourceUri" if changed_to else "blobId"): changed_to or "server-blob"}
+
+
+def test_a_server_that_names_no_source_still_keeps_the_hash() -> None:
+    # Given a server that names no source at all, so nothing contradicts the hash
+    local = {**_LOCATION, "source": "url", "sha256": "a" * 64}
+    server = dict(_LOCATION)
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert merged["sha256"] == "a" * 64
+
+
+def test_even_an_unchanged_source_drops_a_hash_the_server_omits() -> None:
+    """Matching source *strings* does not make the local hash describe them.
+
+    The local ``sha256`` is the digest of the file on this machine, not of what
+    the URI serves. The one flow that pairs the two — ``resolve_models_via_builder``
+    — only assigns a ``sourceUri`` once it has confirmed the candidate's hash
+    equals the local one, and it sends both together, so a server that holds
+    that pairing hands the hash back and this fill never fires.
+
+    Left over, an equal string is exactly the renamed-fine-tune hazard: two
+    different files published under one URL. Dropping the hash means "do not
+    verify" — weaker, but never wrong; the builder treats an absent hash as
+    optional and `comfy build update` restores it from disk on the next scan.
+    """
+    # Given local and server naming the very same source, server stating no hash
+    uri = "https://cdn.test/m.safetensors"
+    local = {**_LOCATION, "source": "url", "sourceUri": uri, "sha256": "a" * 64}
+    server = {**_LOCATION, "sourceUri": uri}
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert "sha256" not in merged
+    assert merged["sourceUri"] == uri
+
+
+@pytest.mark.parametrize("blank", ["   ", "", 123, [], None])
+def test_a_pull_does_not_carry_an_unusable_sourceuri_through(blank: object) -> None:
+    """A value the wire projection would reject must not reach the spec.
+
+    ``project_wire_definition`` raises on a non-string ``sourceUri``, so writing
+    one here leaves the workspace failing its own validation on the next push.
+    """
+    # Given
+    local = {**_LOCATION, "source": "local", "localPath": "m.safetensors", "sourceUri": blank}
+    server = dict(_LOCATION)
+
+    # When
+    merged = _merged_model(local, server)
+
+    # Then
+    assert "sourceUri" not in merged
+    assert _wire_model(merged) == _LOCATION

--- a/tests/comfy_cli/command/test_build_push_uploads.py
+++ b/tests/comfy_cli/command/test_build_push_uploads.py
@@ -1,0 +1,137 @@
+"""What `pending_uploads` still owes the builder after blobs start landing.
+
+`upload_assets` writes each ``blobId`` back into the definition as its blob
+lands, and that definition — not the plan drawn before the first PUT — is the
+record of what is left. A node archive used to be exempt from that re-read, so
+asking a second time reported every completed node as still pending.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.command.build_push import (
+    PushPreparation,
+    PushUpload,
+    pending_uploads,
+    upload_assets,
+)
+
+
+def _preparation(models: list[dict], nodes: list[dict], uploads: tuple[PushUpload, ...]) -> PushPreparation:
+    spec = {"definition": {"models": models, "customNodes": nodes}}
+    return PushPreparation(spec, uploads, ())
+
+
+class _RecordingClient:
+    def __init__(self, upload_url: str | None = "https://blobs.test/put") -> None:
+        self.upload_url = upload_url
+        self.created: list[tuple[str, str]] = []
+        self.uploaded: list[str] = []
+
+    def create_blob(self, kind: str, filename: str, sha256: str, size_bytes: int) -> tuple[str, str | None]:
+        self.created.append((kind, filename))
+        return f"blob-{filename}", self.upload_url
+
+    def upload_blob(self, upload_url: str, path: Path) -> None:
+        self.uploaded.append(upload_url)
+
+
+def test_a_node_archive_that_already_landed_is_no_longer_pending(tmp_path: Path) -> None:
+    # Given a node whose blob landed on an earlier run
+    archive = tmp_path / "node-0.zip"
+    archive.write_bytes(b"ZIP")
+    uploads = (PushUpload("node_zip", "customNodes", 0, "n.zip", "d" * 64, 3, archive),)
+    preparation = _preparation([], [{"source": "local", "blobId": "blob-n.zip"}], uploads)
+
+    # When / Then
+    assert pending_uploads(preparation) == ()
+
+
+def test_a_node_archive_without_a_blob_is_still_pending(tmp_path: Path) -> None:
+    # Given
+    archive = tmp_path / "node-0.zip"
+    archive.write_bytes(b"ZIP")
+    uploads = (PushUpload("node_zip", "customNodes", 0, "n.zip", "d" * 64, 3, archive),)
+    preparation = _preparation([], [{"source": "local"}], uploads)
+
+    # When / Then
+    assert pending_uploads(preparation) == uploads
+
+
+def test_a_node_archive_is_not_resolved_by_a_sourceuri(tmp_path: Path) -> None:
+    """Only a ``blobId`` satisfies a packaged archive.
+
+    ``prepare_push`` plans a local node on ``blobId`` alone — a model is the one
+    kind a public ``sourceUri`` can stand in for — so reading both fields here
+    would drop an upload the plan still owes.
+    """
+    # Given
+    archive = tmp_path / "node-0.zip"
+    archive.write_bytes(b"ZIP")
+    uploads = (PushUpload("node_zip", "customNodes", 0, "n.zip", "d" * 64, 3, archive),)
+    preparation = _preparation([], [{"source": "local", "sourceUri": "https://example.test/n.zip"}], uploads)
+
+    # When / Then
+    assert pending_uploads(preparation) == uploads
+
+
+@pytest.mark.parametrize("resolved_by", ["blobId", "sourceUri"])
+def test_a_resolved_model_is_no_longer_pending(tmp_path: Path, resolved_by: str) -> None:
+    # Given
+    model_file = tmp_path / "m.safetensors"
+    model_file.write_bytes(b"MODEL")
+    uploads = (PushUpload("model", "models", 0, "m.safetensors", "a" * 64, 5, model_file),)
+    resolved = {"blobId": "blob-1", "sourceUri": "https://example.test/m"}[resolved_by]
+    preparation = _preparation([{"source": "local", resolved_by: resolved}], [], uploads)
+
+    # When / Then
+    assert pending_uploads(preparation) == ()
+
+
+def test_a_second_pass_after_uploading_owes_the_builder_nothing(tmp_path: Path) -> None:
+    """The regression: re-asking after a completed run must not requeue.
+
+    A repeated ``create_blob`` for content the builder already stored mints a
+    *fresh* id, orphaning the bytes held under the first one.
+    """
+    # Given
+    archive = tmp_path / "node-0.zip"
+    archive.write_bytes(b"ZIP")
+    model_file = tmp_path / "m.safetensors"
+    model_file.write_bytes(b"MODEL")
+    uploads = (
+        PushUpload("model", "models", 0, "m.safetensors", "a" * 64, 5, model_file),
+        PushUpload("node_zip", "customNodes", 0, "n.zip", "d" * 64, 3, archive),
+    )
+    preparation = _preparation([{"source": "local"}], [{"source": "local"}], uploads)
+    client = _RecordingClient()
+
+    # When
+    assert upload_assets(preparation, client) == 2
+    remaining = pending_uploads(preparation)
+
+    # Then
+    assert remaining == ()
+    assert upload_assets(preparation, client) == 0
+    assert client.created == [("model", "m.safetensors"), ("node_zip", "n.zip")]
+
+
+def test_a_deduplicated_blob_is_recorded_without_being_uploaded(tmp_path: Path) -> None:
+    # Given a builder that already holds the content and returns no upload URL
+    archive = tmp_path / "node-0.zip"
+    archive.write_bytes(b"ZIP")
+    uploads = (PushUpload("node_zip", "customNodes", 0, "n.zip", "d" * 64, 3, archive),)
+    preparation = _preparation([], [{"source": "local"}], uploads)
+    client = _RecordingClient(upload_url=None)
+
+    # When
+    transferred = upload_assets(preparation, client)
+
+    # Then
+    assert transferred == 0
+    assert client.uploaded == []
+    assert preparation.definition["customNodes"][0]["blobId"] == "blob-n.zip"
+    assert pending_uploads(preparation) == ()

--- a/tests/comfy_cli/test_builder_api.py
+++ b/tests/comfy_cli/test_builder_api.py
@@ -29,6 +29,7 @@ from typing import Any
 import pytest
 
 from comfy_cli.builder_api import BuilderClient
+from comfy_cli.builder_pagination import PAGE_LIMIT
 
 # Transcribed from the pre-rename source, NOT imported from builder_api — an
 # imported constant would make the cap assertions recompute themselves.
@@ -135,7 +136,7 @@ _WIRE = [
         new_name="list_builds",
         legacy_name="list_distributions",
         http_method="GET",
-        url=f"{_BASE}/v1/builds",
+        url=f"{_BASE}/v1/builds?limit=100",
     ),
     Wire(
         new_name="get_build",
@@ -149,7 +150,7 @@ _WIRE = [
         legacy_name="list_distribution_versions",
         args=("d1",),
         http_method="GET",
-        url=f"{_BASE}/v1/builds/d1/releases",
+        url=f"{_BASE}/v1/builds/d1/releases?limit=100",
     ),
     Wire(
         new_name="get_release_logs",
@@ -302,7 +303,41 @@ def test_a_paged_list_read_follows_the_cursor_to_the_end(monkeypatch, method, ar
     client = BuilderClient(_BASE_URL, "jwt-token")
 
     assert getattr(client, method)(*args) == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
-    assert seen == [f"{_BASE}{path}", f"{_BASE}{path}?cursor=c1", f"{_BASE}{path}?cursor=c2"]
+    assert seen == [
+        f"{_BASE}{path}?limit=100",
+        f"{_BASE}{path}?cursor=c1&limit=100",
+        f"{_BASE}{path}?cursor=c2&limit=100",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "path", "key"),
+    [
+        pytest.param("list_builds", (), "/v1/builds", "builds", id="list_builds"),
+        pytest.param("list_releases", ("d1",), "/v1/builds/d1/releases", "releases", id="list_releases"),
+    ],
+)
+def test_a_paged_list_read_asks_for_the_servers_largest_page(monkeypatch, method, args, path, key):
+    """Naming no limit is not the same as asking for the maximum.
+
+    ``httpkit.ClampLimit`` falls back to 20 rows rather than to its 100-row
+    ceiling, so an unset limit pages at a fifth of what ``_MAX_LIST_PAGES`` was
+    sized against — five times the round trips, and a hard "listing did not end"
+    failure at 4,000 rows instead of 20,000.
+    """
+    seen: list[str] = []
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        seen.append(url)
+        return 200, {key: []}
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", fake_request_json)
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    getattr(client, method)(*args)
+
+    assert seen == [f"{_BASE}{path}?limit={PAGE_LIMIT}"]
+    assert PAGE_LIMIT == 100
 
 
 # --- older-generation builder fallbacks (pre-#770 response spellings) ---------

--- a/tests/comfy_cli/test_builder_api.py
+++ b/tests/comfy_cli/test_builder_api.py
@@ -1,0 +1,342 @@
+"""Wire-contract proof for ``BuilderClient``.
+
+Todo 13 renamed eleven client methods from distribution/version vocabulary to
+build/release vocabulary. That rename is **CLI-side only**: every REST path,
+HTTP verb, request body and response-size cap must be byte-identical to what
+the pre-rename method produced — with one deliberate exception. PR #770 moved
+the builder's own release endpoints server-side (``POST /v1/builds/{id}/versions``
+-> ``.../releases``; ``GET /v1/build-versions/{id}``, ``/logs`` and ``/manifest``
+-> ``GET /v1/releases/{id}...``), so the five release rows below are transcribed
+from that migration rather than from the pre-rename source. Todo 14 deliberately
+extends ``update_build`` with the server's existing ``name`` and ``description``
+fields; that row pins the extended body while every other row remains the
+rename-equivalence proof.
+
+The oracle here is deliberately *independent of the code under test*: every
+expected verb / URL / body / cap below is transcribed from the pre-rename
+implementation (``git show HEAD:comfy_cli/distribution_api.py``, the file this
+module was renamed from in Todo 3) — or, for the release rows, from #770's
+post-migration paths — not recomputed from today's source. So a method that
+quietly moved to a different path, changed a JSON field name, or lost its raised
+log cap fails here even though its Python name is right.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from comfy_cli.builder_api import BuilderClient
+
+# Transcribed from the pre-rename source, NOT imported from builder_api — an
+# imported constant would make the cap assertions recompute themselves.
+_MAX_JSON = 5 * 1024 * 1024
+_MAX_LOG_JSON = 32 * 1024 * 1024
+
+# The trailing slash is deliberate: the client rstrips it, and the pre-rename
+# client did too, so every expected URL below carries exactly one.
+_BASE_URL = "https://builder.test/"
+_BASE = "https://builder.test"
+
+
+class _Recorder:
+    """Stands in for the shared ``request_json`` seam, recording each request.
+
+    Answers with one superset envelope so every method's own response parsing
+    still runs (``create_build`` reads ``id``, ``create_release`` reads
+    ``releaseId``/``statusUrl``, the list reads take their own key).
+
+    ``releaseId``/``releases`` are the post-#770 spellings and ``buildVersionId``/
+    ``versions`` the pre-rename ones. Both are present so the superset stays
+    honest, but the dedicated fallback tests below are what pin the older
+    spellings — this envelope alone would let a client that ignored them pass.
+    """
+
+    _ENVELOPE = {
+        "id": "d1",
+        "releaseId": "v1",
+        "buildVersionId": "v1",
+        "statusUrl": "https://status.example/v1",
+        "builds": [],
+        "releases": [],
+        "versions": [],
+        "blobs": [],
+        "results": [],
+        "downloadUrl": "https://dl.example/a1",
+    }
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        self.calls.append({"method": method, "url": url, "body": body, "max_bytes": max_bytes, "target": target})
+        return 200, dict(self._ENVELOPE)
+
+
+@pytest.fixture
+def recorder(monkeypatch) -> _Recorder:
+    rec = _Recorder()
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", rec)
+    return rec
+
+
+@dataclass(frozen=True)
+class Wire:
+    """One method call and its exact current request contract."""
+
+    new_name: str
+    legacy_name: str | None
+    http_method: str
+    url: str
+    body: dict | None = None
+    max_bytes: int = _MAX_JSON
+    args: tuple = ()
+    kwargs: dict = field(default_factory=dict)
+
+
+# Every row's expected verb/url/body/cap comes from the pre-rename method of the
+# same index — see the module docstring. `legacy_name` is the identifier that
+# produced it, and is asserted GONE so this table cannot pass un-renamed code.
+_WIRE = [
+    Wire(
+        new_name="create_build",
+        legacy_name="create_distribution",
+        args=("n", {"models": [], "customNodes": []}),
+        http_method="POST",
+        url=f"{_BASE}/v1/builds",
+        body={"name": "n", "definition": {"models": [], "customNodes": []}},
+    ),
+    Wire(
+        new_name="create_build",
+        legacy_name="create_distribution",
+        args=("n", {"models": []}, "a description"),
+        http_method="POST",
+        url=f"{_BASE}/v1/builds",
+        body={"name": "n", "definition": {"models": []}, "description": "a description"},
+    ),
+    Wire(
+        new_name="create_release",
+        legacy_name="cut_version",
+        args=("d1", [{"os": "linux", "gpu": "nvidia"}]),
+        http_method="POST",
+        url=f"{_BASE}/v1/builds/d1/releases",
+        body={"targets": [{"os": "linux", "gpu": "nvidia"}]},
+    ),
+    Wire(
+        new_name="get_release",
+        legacy_name="get_version",
+        args=("v1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/releases/v1",
+    ),
+    Wire(
+        new_name="list_builds",
+        legacy_name="list_distributions",
+        http_method="GET",
+        url=f"{_BASE}/v1/builds",
+    ),
+    Wire(
+        new_name="get_build",
+        legacy_name="get_distribution",
+        args=("d1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/builds/d1",
+    ),
+    Wire(
+        new_name="list_releases",
+        legacy_name="list_distribution_versions",
+        args=("d1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/builds/d1/releases",
+    ),
+    Wire(
+        new_name="get_release_logs",
+        legacy_name="get_version_logs",
+        args=("v1",),
+        kwargs={"os": "linux", "gpu": "nvidia"},
+        http_method="GET",
+        url=f"{_BASE}/v1/releases/v1/logs?os=linux&gpu=nvidia",
+        max_bytes=_MAX_LOG_JSON,
+    ),
+    Wire(
+        # No selector: the pre-rename `_get` dropped empty params, leaving a bare
+        # /logs URL with no `?`.
+        new_name="get_release_logs",
+        legacy_name="get_version_logs",
+        args=("v1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/releases/v1/logs",
+        max_bytes=_MAX_LOG_JSON,
+    ),
+    Wire(
+        new_name="delete_build",
+        legacy_name="delete_distribution",
+        args=("d1",),
+        http_method="DELETE",
+        url=f"{_BASE}/v1/builds/d1",
+    ),
+    Wire(
+        # The pre-rename validate sent no body at all — only the verb and path.
+        new_name="validate_build",
+        legacy_name="validate_distribution",
+        args=("d1",),
+        http_method="POST",
+        url=f"{_BASE}/v1/builds/d1/validate",
+    ),
+    Wire(
+        new_name="update_build",
+        legacy_name="update_distribution",
+        args=("d1", {"models": []}, "2026-08-01T00:00:00Z"),
+        kwargs={"name": "Renamed", "description": "Synced description"},
+        http_method="PATCH",
+        url=f"{_BASE}/v1/builds/d1",
+        body={
+            "definition": {"models": []},
+            "expectedUpdatedAt": "2026-08-01T00:00:00Z",
+            "name": "Renamed",
+            "description": "Synced description",
+        },
+    ),
+    Wire(
+        new_name="get_release_manifest",
+        legacy_name="get_version_manifest",
+        args=("v1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/releases/v1/manifest",
+    ),
+    Wire(
+        # NOT renamed (its command is gone, the API stays available) — pinned so a
+        # future sweep that renames it by association is caught here.
+        new_name="get_artifact_download",
+        legacy_name=None,
+        args=("a1",),
+        http_method="GET",
+        url=f"{_BASE}/v1/build-artifacts/a1/download",
+    ),
+]
+
+_IDS = [f"{w.new_name}{'-' + '-'.join(w.kwargs) if w.kwargs else ''}-{i}" for i, w in enumerate(_WIRE)]
+
+
+@pytest.mark.parametrize("wire", _WIRE, ids=_IDS)
+def test_renamed_method_emits_the_pre_rename_request(recorder, wire: Wire):
+    """Given a renamed client method, When it is called, Then the request it hands
+    the HTTP layer is byte-identical to the pre-rename method's."""
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    getattr(client, wire.new_name)(*wire.args, **wire.kwargs)
+
+    assert len(recorder.calls) == 1
+    call = recorder.calls[0]
+    assert call["method"] == wire.http_method
+    assert call["url"] == wire.url
+    assert call["body"] == wire.body
+    assert call["max_bytes"] == wire.max_bytes
+
+
+@pytest.mark.parametrize("wire", _WIRE, ids=_IDS)
+def test_request_rides_the_clients_own_cloud_target(recorder, wire: Wire):
+    """The recording seam also captures the Target that built the URL: it must
+    stay the client's own /v1-prefixed cloud target carrying the Bearer."""
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    getattr(client, wire.new_name)(*wire.args, **wire.kwargs)
+
+    target = recorder.calls[0]["target"]
+    assert target is client.target
+    assert target.is_cloud and target.path_prefix == "/v1"
+    assert target.base_url == _BASE and target.auth_token == "jwt-token"
+
+
+@pytest.mark.parametrize("legacy_name", sorted({w.legacy_name for w in _WIRE if w.legacy_name}))
+def test_the_legacy_method_name_is_gone(legacy_name: str):
+    """Without this the wire table above would pass just as happily against the
+    un-renamed client, since it only ever calls the NEW names."""
+    assert not hasattr(BuilderClient, legacy_name)
+
+
+def test_no_client_method_keeps_distribution_or_version_vocabulary():
+    stale = [
+        name
+        for name in vars(BuilderClient)
+        if not name.startswith("_") and ("distribution" in name or "version" in name)
+    ]
+    assert stale == []
+
+
+def test_get_artifact_download_survives_the_rename():
+    """Its command was removed in Todo 3, but the underlying API stays available."""
+    assert callable(BuilderClient.get_artifact_download)
+
+
+# --- paged list reads ---------------------------------------------------------
+#
+# The builder pages both list endpoints. Taking only the first page loses the
+# tail of any workspace or build past one page, silently and without an error,
+# so both reads follow ``nextCursor`` to exhaustion.
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "path", "key"),
+    [
+        pytest.param("list_builds", (), "/v1/builds", "builds", id="list_builds"),
+        pytest.param("list_releases", ("d1",), "/v1/builds/d1/releases", "releases", id="list_releases"),
+    ],
+)
+def test_a_paged_list_read_follows_the_cursor_to_the_end(monkeypatch, method, args, path, key):
+    pages = [
+        {key: [{"id": "a"}], "nextCursor": "c1"},
+        {key: [{"id": "b"}], "nextCursor": "c2"},
+        {key: [{"id": "c"}]},
+    ]
+    seen: list[str] = []
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        assert url.startswith(f"{_BASE}{path}")
+        seen.append(url)
+        return 200, pages[len(seen) - 1]
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", fake_request_json)
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    assert getattr(client, method)(*args) == [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    assert seen == [f"{_BASE}{path}", f"{_BASE}{path}?cursor=c1", f"{_BASE}{path}?cursor=c2"]
+
+
+# --- older-generation builder fallbacks (pre-#770 response spellings) ---------
+#
+# #770 renamed the builder's own response keys along with its paths. The client
+# reads the new spelling first and the old one second, so a builder that has not
+# been upgraded yet still works. The superset envelope in ``_Recorder`` carries
+# both keys and therefore cannot prove the second half — these two do.
+
+
+def test_create_release_falls_back_to_buildversionid(monkeypatch):
+    """A not-yet-upgraded builder answers the cut with ``buildVersionId`` instead
+    of ``releaseId``; the client still parses the id out of it."""
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        assert url == f"{_BASE}/v1/builds/d1/releases"
+        return 202, {"buildVersionId": "v1", "statusUrl": "https://s"}
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", fake_request_json)
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    assert client.create_release("d1", [{"os": "linux", "gpu": "nvidia"}]) == ("v1", "https://s")
+
+
+def test_list_releases_falls_back_to_the_versions_key(monkeypatch):
+    """The same generation gap on the list read: an older builder keys the page
+    ``versions``. A single page (no ``nextCursor``) keeps this pinned on the key
+    rather than on the cursor loop."""
+
+    def fake_request_json(url, target, *, method="GET", body=None, max_bytes, timeout=30.0):
+        assert url.startswith(f"{_BASE}/v1/builds/d1/releases")
+        return 200, {"versions": [{"id": "v1"}]}
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", fake_request_json)
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    assert client.list_releases("d1") == [{"id": "v1"}]


### PR DESCRIPTION
<details><summary><b>Stack of 7 — review bottom-up</b> (this is 801)</summary>

1. #801 — `feat(build)`: packaging, sync and Builder client primitives — base `main` &nbsp;&nbsp;**← this PR**
2. #802 — `feat(build)!`: replace the legacy build and distribution surface **(breaking)**
3. #803 — `feat(deploy)`: the deployment control plane
4. #804 — `feat(deploy)`: the asset and job data-plane clients
5. #805 — `feat(deploy)`: `comfy deploy run`
6. #810 — `fix(build)`: a pull no longer deletes definition data silently
7. #824 — `fix(cli)`: unbreak the interactive pickers and Go timestamp parsing on 3.10

Each PR is based on the branch below it, so its own diff is only its commit. Merge in order.

Rebased onto `main` @ `c1fa1f4`. The original bottom PR (#800, raising the Python floor to 3.11) was closed — see that thread for why; the stack is 3.10-compatible instead.
</details>

**TL;DR:** The second offline build layer — packaging, spec-to-wire projection, and push/pull reconciliation — plus three `BuilderClient` corrections. Still no command wired to any of it.

Bottom of a five-PR stack, based directly on `main`.

**What changed**

* **build_package.py** (new): stage a custom node into an uploadable package.
* **build_validation.py** (new): project the authoring spec onto the builder wire format (D-I source precedence, authoring-only fields excluded) and validate it.
* **build_push.py / build_pull.py** (new): local-cache reconciliation and upload planning, and the identity-preserving merge that keeps local asset identities when a remote Build is fetched over the local spec.

`BuilderClient` changes in three ways:

* **Release vocabulary**: #770 moved the builder's own release endpoints server-side; the four client methods still spelled *version* now match — `cut_version` → `create_release`, `get_version` → `get_release`, and the same for the logs and manifest reads — with their call sites in `comfy_cli/command/build.py` following through.
* **Pagination**: `list_builds` and `list_releases` follow `nextCursor` to exhaustion. The builder pages both, and taking one page dropped the tail of any workspace past it, silently.
* **`update_build`** can now carry the server's existing `name` and `description`, which a local spec owns too and a sync had no way to send.

**Deliberately not here:** the non-empty targets guard on `create_release`. Today's `comfy build release create` takes no `--target` and relies on the server default, so refusing an empty list would break it. The guard arrives with `comfy build push`, which computes its own targets.

Adds no error codes — none of these modules raise one that is not already registered. Two module docstrings avoid naming `comfy build push` / `pull`, since those verbs do not exist yet and the help-string guard resolves every mention against the live Typer tree.

**Python 3.10 compatibility:** `build_validation.py` and `build_pull.py` import `assert_never` from `typing_extensions` rather than `typing`, matching the pattern #798 established in `build_spec.py`. `typing-extensions>=4.7` is already a declared runtime dependency. The declared floor stays `>=3.10`.

**Validation**

* CI (`build` job, Python 3.10) at this commit: **6185 passed, 38 skipped, 0 failed**.
* A local run shows one extra failure, `test_scan_custom_nodes_records_repo_and_ref`, which is **environmental, not from this change**: a `url.git@github.com:.insteadOf https://github.com/` rewrite makes the fixture read back a `git@` remote where it wrote an `https://` one. It reproduces on a clean `main` checkout, and CI confirms it does not occur on runners. The next PR up replaces that surface anyway.
* `ruff check .` / `ruff format --diff .` clean at CI's pin (0.15.15).

**Contradicts:** nothing.
