### PR TITLE
feat(knowledge): attach the model's fits block to each pick (BE-10154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ history.
 
 ### Added
 
+- `comfy knowledge pick` attaches each pick's model `fits` block (VRAM per
+  variant, credit rate, max refs) when the bundle carries one, so a size or
+  price constraint can be checked against a number rather than the caveat text.
 - `comfy-build`, the skill for building a custom ComfyUI environment on the
   developer platform, is now bundled with the CLI. `comfy skills show
   comfy-build` works, and an argument-free `comfy skills install` writes it on a

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -193,17 +193,18 @@ def pick_cmd(
         model_id = p.get("model")
         model_id = model_id if isinstance(model_id, str) else None
         row = bundle.models.get(model_id) or {}
-        picks.append(
-            {
-                "rank": knowledge.pick_rank(p),
-                "model": model_id,
-                "route": _text(p.get("route")),
-                "template": _text(p.get("template")),
-                "caveat": _text(p.get("caveat")),
-                "status": _text(row.get("status")),
-                "superseded_by": _text(row.get("superseded_by")),
-            }
-        )
+        entry = {
+            "rank": knowledge.pick_rank(p),
+            "model": model_id,
+            "route": _text(p.get("route")),
+            "template": _text(p.get("template")),
+            "caveat": _text(p.get("caveat")),
+            "status": _text(row.get("status")),
+            "superseded_by": _text(row.get("superseded_by")),
+        }
+        if "fits" in p:
+            entry["fits"] = p["fits"]
+        picks.append(entry)
     payload = {
         "capability": capability_id,
         "zero_hit": False,

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -13,6 +13,7 @@ disturbing the explicit ``comfy knowledge`` verbs.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import math
@@ -262,8 +263,18 @@ def pick(bundle: Bundle, capability: str) -> dict | None:
     # The key resolved through spelling and wording is the answer; a row that
     # omits its own ``id`` must not send the caller back to the raw phrase.
     out["id"] = cap_id
-    out["picks"] = sorted(picks, key=_rank_key)
+    out["picks"] = [_with_fits(bundle, p) for p in sorted(picks, key=_rank_key)]
     return out
+
+
+def _with_fits(bundle: Bundle, p: dict) -> dict:
+    """The pick plus its model row's ``fits`` block, copied so the bundle stays untouched."""
+    model = p.get("model")
+    row = bundle.models.get(model) if isinstance(model, str) else None
+    fits = row.get("fits") if row is not None else None
+    if not isinstance(fits, dict):
+        return p
+    return {**p, "fits": copy.deepcopy(fits)}
 
 
 def pick_rank(p: dict) -> int | float | None:

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -53,7 +53,8 @@
           "template": { "type": ["string", "null"] },
           "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
-          "superseded_by": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." }
+          "superseded_by": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
+          "fits": { "type": "object", "description": "The model row's fits block (vram_gb per variant, a credit rate, max_refs, source), present only when the row carries one." }
         }
       }
     }

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -15,6 +15,7 @@ with a guard that fails the test if reached.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import os
@@ -605,6 +606,42 @@ class TestIndex:
         assert [p["model"] for p in knowledge.pick(b, "c")["picks"]] == ["z", "y", "x"]
         assert b.as_of == "1970-01-01T00:00:00Z"
 
+    def test_pick_attaches_the_model_fits(self):
+        fits = {"vram_gb": {"fp8": 12, "bf16": 24}, "credits_per_image": 0.5, "max_refs": 3, "source": "measured"}
+        data = {
+            "models": {"a": {"id": "a", "fits": fits}, "b": {"id": "b"}, "c": {"id": "c", "fits": "12 GB"}},
+            "capabilities": {
+                "cap": {
+                    "picks": [
+                        {"model": "a", "rank": 1, "caveat": "fits"},
+                        {"model": "b", "rank": 2},
+                        {"model": "c", "rank": 3},
+                        {"model": "ghost", "rank": 4},
+                    ]
+                }
+            },
+        }
+        b = knowledge._index(data, None, source="env", stale=False, path="p", mtime=0.0)
+        picks = knowledge.pick(b, "cap")["picks"]
+        assert [p["model"] for p in picks] == ["a", "b", "c", "ghost"]
+        assert picks[0] == {"model": "a", "rank": 1, "caveat": "fits", "fits": fits}
+        # No fits on the row, a non-dict fits, and a model the bundle lacks all pass through untouched.
+        assert picks[1:] == data["capabilities"]["cap"]["picks"][1:]
+        assert all("fits" not in p for p in picks[1:])
+
+    def test_pick_copies_fits_instead_of_touching_the_bundle(self):
+        data = {
+            "models": {"a": {"id": "a", "fits": {"vram_gb": {"fp8": 12}}}},
+            "capabilities": {"cap": {"picks": [{"model": "a", "rank": 1}]}},
+        }
+        snapshot = copy.deepcopy(data)
+        b = knowledge._index(data, None, source="env", stale=False, path="p", mtime=0.0)
+        top = knowledge.pick(b, "cap")["picks"][0]
+        top["fits"]["vram_gb"]["fp8"] = 0
+        top["fits"]["extra"] = True
+        assert data == snapshot
+        assert "fits" not in b.capabilities["cap"]["picks"][0]
+
 
 # ---------------------------------------------------------------------------
 # CLI
@@ -835,6 +872,20 @@ class TestCli:
         assert env["data"]["description"] is None and env["data"]["as_of"] is None
         top = env["data"]["picks"][0]
         assert [top[k] for k in ("route", "template", "caveat", "status", "superseded_by")] == [None] * 5
+        _validate(env["data"])
+
+    def test_pick_payload_carries_fits_verbatim(self, tmp_path, monkeypatch, capsys):
+        fits = {"vram_gb": {"fp8": 12}, "credits_per_sec": 0.02, "max_refs": 1, "source": "measured"}
+        models = {"x": {"id": "x", "fits": fits}, "y": {"id": "y"}}
+        cap = {"id": "c", "picks": [{"model": "x", "rank": 1}, {"model": "y", "rank": 2}]}
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps({"models": models, "capabilities": {"c": cap}}))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        rc, env = _run(["pick", "c"], capsys)
+        assert rc == 0
+        x, y = env["data"]["picks"]
+        assert x["fits"] == fits
+        assert "fits" not in y
         _validate(env["data"])
 
     def test_resolve_pretty_tolerates_malformed_row_fields(self, tmp_path, monkeypatch, pretty_no_stdout):


### PR DESCRIPTION
Linear: BE-10154

## Why

The hosted agent's `list_model_picks` tool runs `comfy knowledge pick`. Each pick it gets back carries one prose `caveat` and no numbers, so a user constraint like "12 GB GPU" or "cheap" has to be matched against caveat wording. In staging eval run `run_cd086941fbb140398a8dacc5b03027fb`, five cases failed that way: `creative-rec-model-wan-02`, `creative-rec-model-qwen-edit-02`, `creative-rec-model-character-lock-01`, `creative-rec-model-cheap-music-01`, `creative-rec-model-z-image-02`.

The companion comfy-knowledge PR (also BE-10154) adds an optional `fits` object to model rows: `{vram_gb: {variant: number}, credits_per_sec | credits_per_image | credits_per_1k_tokens: number, max_refs: int, source: str}`. With `fits` on the pick, the agent compares a number.

## Change

- `knowledge.pick()` looks up each pick's model row by `pick["model"]`. When that row carries a `fits` object, the returned pick gets a deep copy of it under `fits`. The bundle is never mutated.
- A pick whose model has no `fits`, whose model is not in the bundle, or whose `fits` is not an object is returned unchanged, with no `fits` key at all.
- `comfy --json knowledge pick` passes `fits` through verbatim, only when present. The human table is unchanged (the block is nested, so it does not fit a column).
- `comfy_cli/schemas/knowledge.json` documents the new optional `fits` property on picks. Nothing is required, so callers that do not know `fits` see the same shape as before.
- CHANGELOG entry under Unreleased.

This is additive and safe to ship before the canon PR. A bundle with no `fits` on any model row produces byte-identical output.

## Tests

`tests/comfy_cli/test_knowledge.py`:

- `test_pick_attaches_the_model_fits`: a pick whose model has `fits` gets it attached; a pick whose model lacks `fits` has no key; a non-dict `fits` is skipped; a model missing from the bundle leaves the pick unchanged.
- `test_pick_copies_fits_instead_of_touching_the_bundle`: mutating the returned `fits` leaves the bundle's model row and pick dict untouched.
- `test_pick_payload_carries_fits_verbatim`: the `--json` envelope carries `fits` on the pick that has one, omits it on the pick that does not, and still validates against the schema.

## Verification

```
$ uv run --extra dev pytest tests/comfy_cli/test_knowledge.py -q
86 passed in 0.89s

$ uv run --extra dev ruff check comfy_cli/knowledge.py comfy_cli/command/knowledge.py tests/comfy_cli/test_knowledge.py
All checks passed!
$ uv run --extra dev ruff format --check comfy_cli/knowledge.py comfy_cli/command/knowledge.py tests/comfy_cli/test_knowledge.py
3 files already formatted
```

Full suite: `46 failed, 6085 passed, 39 skipped`. The same 46 fail on a clean `origin/main` checkout (`test_renderer` ANSI-escape cases, `tests/uv`, `cloud/test_login_command`, `command/generate`, `command/test_build`, and a few others), none in the knowledge tests. Likewise `ruff check .` reports 21 pre-existing errors on `origin/main` in files this PR does not touch (mostly `comfy_cli/workflow_to_api.py`).

End to end, against the comfy-knowledge worktree's compiled bundle that already carries `fits` (`COMFY_KNOWLEDGE_FILE=.../dist/internal/knowledge.json comfy --json knowledge pick image-edit`), trimmed to rank, model, fits:

```
{"rank": 1, "model": "qwen-image-edit", "fits": {"source": "notion:canvas-craft §4 Qwen-Image-Edit", "vram_gb": {"fp8": 16, "int8": 12}}}
{"rank": 2, "model": "flux-2", "fits": {"max_refs": 8, "source": "notion:canvas-craft §4 FLUX family", "vram_gb": {"dev_fp8": 24, "klein_4b": 8, "klein_9b": 16}}}
{"rank": 3, "model": "grok-image"}
{"rank": 4, "model": "gpt-image-2"}
{"rank": 5, "model": "nano-banana", "fits": {"credits_per_1k_tokens": 7.6, "source": "notion:canvas-craft §4 Nano Banana family"}}
{"rank": 6, "model": "seedream", "fits": {"credits_per_image": 9.5, "max_refs": 10, "source": "notion:canvas-craft §4 Seedream"}}
{"rank": 7, "model": "firered-image-edit"}
{"rank": 8, "model": "flux-1-kontext"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNBcQtoHyF4g6ysDCftDt6
