### PR TITLE
feat(nodes): hide deprecated classes from discovery and refuse them in add_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ history.
 
 ### Added
 
+- `comfy workflow add-node` and an `add_node` op in `comfy workflow apply`
+  refuse a class the catalog marks deprecated (`node_deprecated`), naming the
+  live class with the same display name when there is one. Pass
+  `--allow-deprecated` (or `"allow_deprecated": true` on the op) to add it
+  anyway.
+- `comfy nodes search` and `comfy nodes ls` hide deprecated classes by
+  default; `--include-deprecated` shows them.
+
 - `comfy-build`, the skill for building a custom ComfyUI environment on the
   developer platform, is now bundled with the CLI. `comfy skills show
   comfy-build` works, and an argument-free `comfy skills install` writes it on a

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -31,6 +31,15 @@ from comfy_cli.output.sanitize import sanitize_markup
 
 app = typer.Typer(no_args_is_help=True, help="Introspect ComfyUI node classes (inputs, outputs, categories).")
 
+IncludeDeprecatedOpt = Annotated[
+    bool,
+    typer.Option(
+        "--include-deprecated/--exclude-deprecated",
+        show_default=False,
+        help="Include classes the catalog marks deprecated (hidden by default, like the frontend's node library).",
+    ),
+]
+
 
 # ---------------------------------------------------------------------------
 # graph resolution — shared across ls/show/search
@@ -185,10 +194,7 @@ def ls_cmd(
         bool,
         typer.Option("--output-only", show_default=False, help="Only terminal output nodes."),
     ] = False,
-    exclude_deprecated: Annotated[
-        bool,
-        typer.Option("--exclude-deprecated", show_default=False, help="Exclude deprecated nodes."),
-    ] = False,
+    include_deprecated: IncludeDeprecatedOpt = False,
     limit: Annotated[
         int | None,
         typer.Option(show_default=False, help="Cap output to N rows."),
@@ -245,7 +251,7 @@ def ls_cmd(
             continue
         if output_only and not m.is_output_node:
             continue
-        if exclude_deprecated and m.deprecated:
+        if m.deprecated and not include_deprecated:
             continue
         nodes.append(m)
 
@@ -273,7 +279,7 @@ def ls_cmd(
             "cloud_disabled": cloud_disabled if cloud_disabled else None,
             "api_only": api_only if api_only else None,
             "output_only": output_only if output_only else None,
-            "exclude_deprecated": exclude_deprecated if exclude_deprecated else None,
+            "include_deprecated": include_deprecated if include_deprecated else None,
         },
         "total": total_matched,
         "count": len(nodes),
@@ -287,6 +293,7 @@ def ls_cmd(
                 # Paid partner-API node vs free open-weights node. JSON only —
                 # the pretty table is deliberately left unchanged.
                 "is_api_node": m.is_api_node,
+                **({"deprecated": True} if m.deprecated else {}),
             }
             for m in nodes
         ],
@@ -506,6 +513,7 @@ def search_cmd(
             ),
         ),
     ] = 0,
+    include_deprecated: IncludeDeprecatedOpt = False,
     input_path: Annotated[
         str | None,
         typer.Option("--input", show_default=False, help="Path to a local object_info JSON (offline mode)."),
@@ -547,8 +555,9 @@ def search_cmd(
     q = query.lower()
     tokens = q.split()
     q_joined = "".join(tokens)
+    catalog = [m for m in graph.all_nodes() if include_deprecated or not m.deprecated]
     scored: list[tuple[int, Any]] = []
-    for m in graph.all_nodes() if tokens else ():
+    for m in catalog if tokens else ():
         name_l = m.id.lower()
         display_l = m.display_name.lower()
         desc_l = m.description.lower()
@@ -583,7 +592,7 @@ def search_cmd(
         # in a colliding bucket is surfaced — a pack may register both
         # 'LoadImage' and 'loadimage', and dropping one hides a real suggestion.
         by_lower: dict[str, list[Any]] = {}
-        for m in graph.all_nodes():
+        for m in catalog:
             by_lower.setdefault(m.id.lower(), []).append(m)
         close = difflib.get_close_matches(q_joined, list(by_lower), n=max(1, limit), cutoff=0.6) if q_joined else []
         candidates = [m for name_l in close for m in by_lower[name_l]]
@@ -614,6 +623,7 @@ def search_cmd(
                 # share a display name and differ only here (MiniMax H3). JSON
                 # only; the pretty table is deliberately left unchanged.
                 "is_api_node": m.is_api_node,
+                **({"deprecated": True} if m.deprecated else {}),
                 **({"close_match": True} if close_match else {}),
             }
             for m in matched

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -144,6 +144,12 @@ def add_node_cmd(
         str | None,
         typer.Option("--at", show_default=False, help="Canvas position 'x,y' for the new node."),
     ] = None,
+    allow_deprecated: Annotated[
+        bool,
+        typer.Option(
+            "--allow-deprecated", show_default=False, help="Add the node even though the catalog marks it deprecated."
+        ),
+    ] = False,
     actor: ActorOpt = "cli",
     base_version: BaseVersionOpt = 0,
     stdout: StdoutOpt = False,
@@ -169,8 +175,22 @@ def add_node_cmd(
             raise typer.Exit(code=1) from e
     try:
         workflow, op = workflow_ops.add_node(
-            workflow, graph, class_type, pos=pos, actor=actor, base_version=base_version
+            workflow,
+            graph,
+            class_type,
+            pos=pos,
+            actor=actor,
+            base_version=base_version,
+            allow_deprecated=allow_deprecated,
         )
+    except workflow_ops.DeprecatedNodeType as e:
+        renderer.error(
+            code=e.code,
+            message=str(e),
+            hint=e.hint,
+            details={"requested": e.class_type, "replacement": e.replacement},
+        )
+        raise typer.Exit(code=1) from e
     except workflow_ops.UnknownNodeType as e:
         # Same envelope shape as `nodes show` so a caller can self-correct from
         # the error alone. (The old hint pointed at `comfy nodes types`, which
@@ -693,6 +713,14 @@ def apply_cmd(
         # with the hint naming the standalone command to run instead.
         renderer.error(code=e.code, message=f"batch failed: {e}", hint=e.hint)
         raise typer.Exit(code=1) from e
+    except workflow_ops.DeprecatedNodeType as e:
+        renderer.error(
+            code=e.code,
+            message=f"batch failed: {e}",
+            hint=e.hint,
+            details={"requested": e.class_type, "replacement": e.replacement},
+        )
+        raise typer.Exit(code=1) from e
     except (ValueError, KeyError) as e:
         # Atomic batch: nothing is written if any spec fails. Same error code
         # and exit in both ack modes — `--ack summary` only ADDS a structured
@@ -862,6 +890,19 @@ def foreach_cmd(
                 else ""
             ),
             details={"written": written} if written else None,
+        )
+        raise typer.Exit(code=1) from e
+    except workflow_ops.DeprecatedNodeType as e:
+        renderer.error(
+            code=e.code,
+            message=f"foreach failed: {e}",
+            hint=e.hint
+            + (
+                f" ({len(written)} workflow(s) were already written to {out} — delete them or re-run)"
+                if written
+                else ""
+            ),
+            details={"requested": e.class_type, "replacement": e.replacement, "written": written},
         )
         raise typer.Exit(code=1) from e
     except (workflow_ops.RecipeError, ValueError, KeyError) as e:

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -953,7 +953,9 @@ class Graph:
             while changed:
                 changed = False
                 for m in self._nodes.values():
-                    if not m.can_apply(free):
+                    # Same rule as the producer index: a deprecated loader
+                    # must not make its type look obtainable.
+                    if m.deprecated or not m.can_apply(free):
                         continue
                     for t in m.output_types():
                         if t != "*" and t not in free:

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -840,11 +840,17 @@ class Graph:
                 continue
             m = _parse_morphism(node_id, raw)
             g._nodes[m.id] = m
+            # A deprecated class stays addressable by name (show, validate,
+            # edits on a graph that already holds it) but is never a
+            # discovery answer: upstream/downstream/path/free-producer all
+            # read these indexes.
             for t in m.output_types():
-                g._producers[t].append(m)
+                if not m.deprecated:
+                    g._producers[t].append(m)
                 g._types.add(t)
             for t in m.input_link_types():
-                g._consumers[t].append(m)
+                if not m.deprecated:
+                    g._consumers[t].append(m)
                 g._types.add(t)
         # Sort indexes for deterministic output
         for t in g._producers:

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -718,6 +718,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "see `details.close_matches` or run `comfy nodes search`",
     ),
     ErrorCode(
+        "node_deprecated",
+        "`workflow add-node` (or an `add_node` op in a batch) named a class the catalog marks deprecated. "
+        "Nothing was added. `details.replacement` names the live class with the same display name when "
+        "one exists.",
+        "add `details.replacement` instead, or pass --allow-deprecated "
+        '(`"allow_deprecated": true` on the op) when the user asked for that exact node',
+    ),
+    ErrorCode(
         "path_bounds_invalid",
         "`comfy nodes path` was given `--max-depth` or `--max-paths` below 1. Such a bound admits no "
         "path at all, so the search is refused rather than returning an empty result that would read "

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -211,7 +211,7 @@ mechanism by complexity and reuse — not as a quality ranking:
    before choosing (swap `video`/`VIDEO` for the media type at hand):
    ```bash
    comfy --json templates ls --type video --limit 10        # working exemplar graphs
-   comfy --json nodes ls --produces VIDEO --exclude-deprecated
+   comfy --json nodes ls --produces VIDEO
    comfy --json nodes ls --category "partner/video*"       # partner providers
    ```
 
@@ -512,7 +512,7 @@ comfy --json nodes ls --category "loaders*"      # glob on category path
 comfy --json nodes ls --pack comfyui-impact-pack # nodes from a specific pack
 comfy --json nodes ls --api-only                 # only partner-API nodes
 comfy --json nodes ls --output-only              # terminal output nodes (SaveImage, etc.)
-comfy --json nodes ls --exclude-deprecated       # skip deprecated nodes
+comfy --json nodes ls --include-deprecated       # deprecated nodes are hidden by default
 comfy --json nodes ls --cloud-disabled           # what cloud refuses to run
 comfy --json nodes upstream KSampler             # what feeds in
 comfy --json nodes downstream CheckpointLoaderSimple  # what follows
@@ -524,7 +524,7 @@ comfy --json nodes categories                    # full category tree
 Combine flags to narrow results:
 
 ```bash
-comfy --json nodes ls --produces VIDEO --exclude-deprecated --limit 10
+comfy --json nodes ls --produces VIDEO --limit 10
 comfy --json nodes ls --pack core --produces MASK --limit 5
 ```
 
@@ -1131,7 +1131,7 @@ Hard-won lessons per domain. Not a tutorial — a reference card.
   speech. Concatenating such clips raw drifts the voice progressively out of sync
   — trim each clip to its own audio length (+ a small freeze-held breath beat)
   before concat; never butt-join the raw clips.
-- Survey first: `comfy nodes ls --produces VIDEO --exclude-deprecated`, `comfy nodes ls --category "partner/video*"`, `comfy templates ls --type video` — compare OSS, partner-API, and gallery before choosing
+- Survey first: `comfy nodes ls --produces VIDEO`, `comfy nodes ls --category "partner/video*"`, `comfy templates ls --type video` — compare OSS, partner-API, and gallery before choosing
 
 ## Audio
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -198,6 +198,40 @@ class UnknownNodeType(ValueError):
         super().__init__(msg)
 
 
+class DeprecatedNodeType(ValueError):
+    """add_node was given a class the catalog marks ``deprecated``.
+
+    ``replacement`` is the live class with the same display name, when one
+    exists (ComfyUI retires a node by suffixing its display name with
+    "(DEPRECATED)" or "(Legacy)" and registering the successor under the
+    bare name).
+    """
+
+    code = "node_deprecated"
+
+    def __init__(self, class_type: str, *, replacement: str | None):
+        self.class_type = class_type
+        self.replacement = replacement
+        use = f"use {replacement!r} instead" if replacement else "run `comfy nodes search <text>` for a live class"
+        self.hint = (
+            f'{use}; to add {class_type!r} anyway set "allow_deprecated": true on the add_node op '
+            "(or pass --allow-deprecated to `comfy workflow add-node`)"
+        )
+        super().__init__(f"{class_type!r} is deprecated")
+
+
+_DEPRECATED_DISPLAY_SUFFIX = re.compile(r"\s*\((?:deprecated|legacy)\)\s*$", re.I)
+
+
+def _deprecated_replacement(graph, m) -> str | None:
+    want = _DEPRECATED_DISPLAY_SUFFIX.sub("", m.display_name).strip().lower()
+    live = [n for n in graph.all_nodes() if not n.deprecated and n.display_name.strip().lower() == want]
+    # A free node and a paid partner node can share a display name; never
+    # answer a free class with one that bills credits (or vice versa).
+    live.sort(key=lambda n: n.is_api_node != m.is_api_node)
+    return live[0].id if live else None
+
+
 def _find(workflow: dict, node_id: Any) -> dict | None:
     for n in workflow.get("nodes") or []:
         if isinstance(n, dict) and n.get("id") == node_id:
@@ -477,6 +511,7 @@ def add_node(
     mode: int = 0,
     actor: str = "cli",
     base_version: int = 0,
+    allow_deprecated: bool = False,
 ) -> tuple[dict, dict]:
     m = graph.node(class_type)
     if m is None:
@@ -488,6 +523,8 @@ def add_node(
 
         names = [n.id for n in graph.all_nodes()]
         raise UnknownNodeType(class_type, close_matches=difflib.get_close_matches(class_type, names, n=5, cutoff=0.6))
+    if m.deprecated and not allow_deprecated:
+        raise DeprecatedNodeType(class_type, replacement=_deprecated_replacement(graph, m))
     size = layout.estimate_size(
         len([p for p in m.inputs if p.is_link]),
         len(m.outputs),
@@ -1060,8 +1097,8 @@ def replace_ops(old: dict, new: dict, *, actor: str = "cli", base_version: int =
                 class_type=original.get("type"),
                 pos=pos,
                 node=node,
-                # spec keys
-                **{"at": pos, "as": alias},
+                # spec keys; the node already existed, so a deprecated class replays
+                **{"at": pos, "as": alias, "allow_deprecated": True},
             )
         )
 
@@ -1379,6 +1416,9 @@ def capture_recipe(workflow: dict, graph, name: str = "captured", lift: dict | N
         alias = alias_by_sid[str(n["id"])]
         class_type = n.get("type")
         add: dict[str, Any] = {"op": "add_node", "class_type": class_type, "as": alias}
+        m = graph.node(class_type)
+        if m is not None and m.deprecated:
+            add["allow_deprecated"] = True
         if n.get("pos"):
             add["at"] = n["pos"]
         if n.get("mode"):
@@ -1516,6 +1556,7 @@ def apply_specs(
                         mode=spec.get("mode") or 0,
                         actor=actor,
                         base_version=base_version,
+                        allow_deprecated=bool(spec.get("allow_deprecated")),
                     )
                     alias = spec.get("as")
                     if alias:
@@ -1554,9 +1595,9 @@ def apply_specs(
             except KeyError as e:
                 raise ValueError(f"spec #{i} ({kind}) is missing required field {e}") from e
             ops.append(op)
-    except NotBatchableError:
-        # Already carries the registered code, the standalone command, and the
-        # nothing-was-applied statement — don't wrap it into a generic hint.
+    except (NotBatchableError, DeprecatedNodeType):
+        # Already carries a registered code and a hint that says what to do
+        # instead — don't wrap it into a generic hint.
         raise
     except (ValueError, KeyError) as e:
         err = _rehint_discarded_batch(e, pre_batch_hint)

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -225,11 +225,12 @@ _DEPRECATED_DISPLAY_SUFFIX = re.compile(r"\s*\((?:deprecated|legacy)\)\s*$", re.
 
 def _deprecated_replacement(graph, m) -> str | None:
     want = _DEPRECATED_DISPLAY_SUFFIX.sub("", m.display_name).strip().lower()
-    live = [n for n in graph.all_nodes() if not n.deprecated and n.display_name.strip().lower() == want]
     # A free node and a paid partner node can share a display name; never
     # answer a free class with one that bills credits (or vice versa).
-    live.sort(key=lambda n: n.is_api_node != m.is_api_node)
-    return live[0].id if live else None
+    for n in graph.all_nodes():
+        if not n.deprecated and n.is_api_node == m.is_api_node and n.display_name.strip().lower() == want:
+            return n.id
+    return None
 
 
 def _find(workflow: dict, node_id: Any) -> dict | None:

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -64,7 +64,9 @@ the node is minted with — `0` always (default, omitted), `1` on-event, `2` mut
 dropped them rebuilt a different API prompt. Minted op fields beyond the
 envelope: `node_id` (mint_id int), `class_type`, `pos`, `node` (the complete
 node object — replay inserts it verbatim; a nonzero mode is stamped into it and
-echoed as an op-level `mode` field).
+echoed as an op-level `mode` field). `allow_deprecated` is optional and spec-only
+(never minted into the op): a `class_type` the catalog marks `deprecated` is
+refused with `node_deprecated` unless it is `true`.
 
 * Idempotency: re-applying the same `op_id` is a no-op; independently, replaying
   an `add_node` whose `node_id` already exists in the graph is a no-op.

--- a/tests/comfy_cli/command/test_deprecated_nodes.py
+++ b/tests/comfy_cli/command/test_deprecated_nodes.py
@@ -52,6 +52,39 @@ def _object_info_with_deprecated() -> dict[str, Any]:
         "deprecated": True,
         "python_module": "nodes",
     }
+    # Deprecated free class whose only same-name live twin is a paid partner
+    # node: no replacement may be offered.
+    info["OldFreeUpscale"] = {
+        "input": {"required": {"image": "IMAGE"}},
+        "input_order": {"required": ["image"]},
+        "output": ["IMAGE"],
+        "output_name": ["IMAGE"],
+        "category": "image/upscale",
+        "display_name": "Upscale (Legacy)",
+        "deprecated": True,
+        "python_module": "nodes",
+    }
+    info["PaidUpscale"] = {
+        "input": {"required": {"image": "IMAGE"}},
+        "input_order": {"required": ["image"]},
+        "output": ["IMAGE"],
+        "output_name": ["IMAGE"],
+        "category": "partner/image",
+        "display_name": "Upscale",
+        "api_node": True,
+        "python_module": "comfy_api_nodes",
+    }
+    # Deprecated loader that is the ONLY producer of its type.
+    info["OldLoader"] = {
+        "input": {"required": {"name": [["a"]]}},
+        "input_order": {"required": ["name"]},
+        "output": ["OLDTHING"],
+        "output_name": ["OLDTHING"],
+        "category": "loaders",
+        "display_name": "Old Loader",
+        "deprecated": True,
+        "python_module": "nodes",
+    }
     info["OldSampler"] = {
         "input": {"required": {"model": "MODEL"}},
         "input_order": {"required": ["model"]},
@@ -114,6 +147,13 @@ class TestAddNode:
         assert env["error"]["details"]["replacement"] is None
         assert "nodes search" in env["error"]["hint"]
 
+    def test_no_replacement_across_billing_class(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(workflow_cmd.app, ["add-node", str(path), "OldFreeUpscale"], capsys)
+        assert env["error"]["code"] == "node_deprecated"
+        assert env["error"]["details"]["replacement"] is None
+        assert "PaidUpscale" not in env["error"]["hint"]
+
     def test_allow_deprecated_adds(self, patched_graph, tmp_path, capsys):
         path = _write(tmp_path, _base_workflow())
         env = _run(workflow_cmd.app, ["add-node", str(path), "ImageBatch", "--allow-deprecated"], capsys)
@@ -169,6 +209,11 @@ class TestDiscovery:
         env = _run(nodes_cmd.app, ["search", "OldSamplr"], capsys)
         assert env["ok"] is True
         assert "OldSampler" not in _names(env)
+
+    def test_deprecated_only_producer_is_not_free(self):
+        g = _graph()
+        assert "OLDTHING" not in g.free_types()
+        assert g._free_producer("OLDTHING", g.free_types()) is None
 
     def test_ls_hides_deprecated_by_default(self, patched_graph, capsys):
         env = _run(nodes_cmd.app, ["ls", "--category", "image/batch"], capsys)

--- a/tests/comfy_cli/command/test_deprecated_nodes.py
+++ b/tests/comfy_cli/command/test_deprecated_nodes.py
@@ -1,0 +1,222 @@
+"""Deprecated node classes: hidden from discovery, refused by add_node.
+
+ComfyUI marks a retired class with ``deprecated: true`` in object_info and
+suffixes its display name with "(DEPRECATED)" / "(Legacy)"; the successor is
+registered under the bare display name (``ImageBatch`` -> ``BatchImagesNode``).
+The frontend hides such classes from its node library by default. The agent
+kept building on ``ImageBatch`` (BE-7684) because ``nodes search`` ranked it
+like any live class and ``add-node`` accepted it, so:
+
+  * ``nodes search`` / ``nodes ls`` drop deprecated rows unless
+    ``--include-deprecated`` is passed.
+  * ``workflow add-node`` and an ``add_node`` op in ``workflow apply`` refuse
+    a deprecated class with ``code=node_deprecated`` and name the live
+    replacement; ``--allow-deprecated`` / ``"allow_deprecated": true`` adds it
+    anyway for a user who asked for that exact node.
+
+Editing a deprecated node that is ALREADY on the graph is untouched: connect
+and set_widget never go through add_node.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import pytest
+from test_workflow_edit import (  # type: ignore[import-not-found]
+    _base_workflow,
+    _force_json_renderer,
+    _object_info,
+    _write,
+    reset_singleton,  # noqa: F401  (autouse fixture)
+)
+from typer.testing import CliRunner
+
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.command import workflow_edit
+from comfy_cli.cql.engine import Graph
+
+
+def _object_info_with_deprecated() -> dict[str, Any]:
+    info = copy.deepcopy(_object_info())
+    info["ImageBatch"] = {
+        "input": {"required": {"image1": "IMAGE", "image2": "IMAGE"}},
+        "input_order": {"required": ["image1", "image2"]},
+        "output": ["IMAGE"],
+        "output_name": ["IMAGE"],
+        "category": "image/batch",
+        "display_name": "Batch Images (DEPRECATED)",
+        "deprecated": True,
+        "python_module": "nodes",
+    }
+    info["OldSampler"] = {
+        "input": {"required": {"model": "MODEL"}},
+        "input_order": {"required": ["model"]},
+        "output": ["LATENT"],
+        "output_name": ["LATENT"],
+        "category": "sampling",
+        "display_name": "Old Sampler",
+        "deprecated": True,
+        "python_module": "nodes",
+    }
+    return info
+
+
+def _graph() -> Graph:
+    return Graph.from_object_info(_object_info_with_deprecated())
+
+
+@pytest.fixture
+def patched_graph(monkeypatch):
+    monkeypatch.setattr(workflow_edit, "_get_graph", lambda *a, **kw: _graph())
+    monkeypatch.setattr(nodes_cmd, "_get_graph", lambda *a, **kw: _graph())
+
+
+def _run(app, args: list[str], capsys) -> dict[str, Any]:
+    _force_json_renderer()
+    result = CliRunner().invoke(app, args, standalone_mode=False)
+    captured = capsys.readouterr().out
+    if not captured.strip():
+        captured = result.stdout or ""
+    for line in reversed(captured.strip().splitlines()):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={captured[:600]})")
+
+
+def _names(env: dict) -> list[str]:
+    return [r["name"] for r in env["data"]["rows"]]
+
+
+class TestAddNode:
+    def test_refused_with_replacement(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(workflow_cmd.app, ["add-node", str(path), "ImageBatch"], capsys)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "node_deprecated", err
+        assert err["details"] == {"requested": "ImageBatch", "replacement": "BatchImagesNode"}
+        assert "BatchImagesNode" in err["hint"]
+        assert "allow_deprecated" in err["hint"]
+        # Atomic: the file is untouched.
+        assert json.loads(path.read_text())["last_node_id"] == _base_workflow()["last_node_id"]
+
+    def test_refused_without_replacement_points_at_search(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(workflow_cmd.app, ["add-node", str(path), "OldSampler"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "node_deprecated"
+        assert env["error"]["details"]["replacement"] is None
+        assert "nodes search" in env["error"]["hint"]
+
+    def test_allow_deprecated_adds(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(workflow_cmd.app, ["add-node", str(path), "ImageBatch", "--allow-deprecated"], capsys)
+        assert env["ok"] is True, env
+        assert any(n["type"] == "ImageBatch" for n in json.loads(path.read_text())["nodes"])
+
+    def test_live_class_unaffected(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        env = _run(workflow_cmd.app, ["add-node", str(path), "BatchImagesNode"], capsys)
+        assert env["ok"] is True, env
+
+
+class TestApplyBatch:
+    def test_batch_refused(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        ops = _write(tmp_path, [{"op": "add_node", "class_type": "ImageBatch", "as": "b"}], "ops.json")
+        env = _run(workflow_cmd.app, ["apply", str(path), "--ops", str(ops)], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "node_deprecated", env
+        assert env["error"]["details"]["replacement"] == "BatchImagesNode"
+
+    def test_batch_allow_deprecated_adds(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, _base_workflow())
+        ops = _write(
+            tmp_path, [{"op": "add_node", "class_type": "ImageBatch", "as": "b", "allow_deprecated": True}], "ops.json"
+        )
+        env = _run(workflow_cmd.app, ["apply", str(path), "--ops", str(ops)], capsys)
+        assert env["ok"] is True, env
+        assert any(n["type"] == "ImageBatch" for n in json.loads(path.read_text())["nodes"])
+
+
+class TestDiscovery:
+    def test_search_hides_deprecated_by_default(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["search", "batch images"], capsys)
+        assert env["ok"] is True
+        assert _names(env) == ["BatchImagesNode"]
+
+    def test_search_include_deprecated(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["search", "batch images", "--include-deprecated"], capsys)
+        assert set(_names(env)) == {"BatchImagesNode", "ImageBatch"}
+        flags = {r["name"]: r.get("deprecated") for r in env["data"]["rows"]}
+        assert flags == {"BatchImagesNode": None, "ImageBatch": True}
+
+    def test_downstream_and_path_skip_deprecated(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["downstream", "VAEDecode"], capsys)
+        assert env["ok"] is True
+        assert "ImageBatch" not in _names(env)
+        env = _run(nodes_cmd.app, ["path", "IMAGE", "IMAGE", "--emit-ops"], capsys)
+        assert env["ok"] is True
+        assert "ImageBatch" not in json.dumps(env["data"])
+
+    def test_search_close_match_fallback_skips_deprecated(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["search", "OldSamplr"], capsys)
+        assert env["ok"] is True
+        assert "OldSampler" not in _names(env)
+
+    def test_ls_hides_deprecated_by_default(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["ls", "--category", "image/batch"], capsys)
+        assert _names(env) == ["BatchImagesNode"]
+        assert env["data"]["filter"]["include_deprecated"] is None
+
+    def test_ls_include_deprecated(self, patched_graph, capsys):
+        env = _run(nodes_cmd.app, ["ls", "--category", "image/batch", "--include-deprecated"], capsys)
+        assert set(_names(env)) == {"BatchImagesNode", "ImageBatch"}
+        assert env["data"]["filter"]["include_deprecated"] is True
+
+
+class TestExistingDeprecatedNodeReplays:
+    """A deprecated class already on a graph is not the caller's choice, so the
+    op batches that reproduce that graph must still apply."""
+
+    def _workflow_with_image_batch(self) -> dict:
+        wf = _base_workflow()
+        wf["nodes"].append(
+            {
+                "id": 9,
+                "type": "ImageBatch",
+                "pos": [300, 300],
+                "inputs": [
+                    {"name": "image1", "type": "IMAGE", "link": None},
+                    {"name": "image2", "type": "IMAGE", "link": None},
+                ],
+                "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+                "widgets_values": [],
+            }
+        )
+        wf["last_node_id"] = 9
+        return wf
+
+    def test_capture_then_apply(self, patched_graph, tmp_path, capsys):
+        src = _write(tmp_path, self._workflow_with_image_batch(), "src.json")
+        recipe = tmp_path / "recipe.json"
+        env = _run(workflow_cmd.app, ["capture", str(src), "--out", str(recipe)], capsys)
+        assert env["ok"] is True, env
+        empty = _write(tmp_path, {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}, "empty.json")
+        env = _run(workflow_cmd.app, ["apply", str(empty), "--ops", str(recipe)], capsys)
+        assert env["ok"] is True, env
+        assert any(n["type"] == "ImageBatch" for n in json.loads(empty.read_text())["nodes"])
+
+    def test_replace_ops_apply(self, patched_graph, tmp_path, capsys):
+        from comfy_cli import workflow_ops
+
+        empty = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        ops = workflow_ops.replace_ops(empty, self._workflow_with_image_batch())
+        wf, applied, _ = workflow_ops.apply_specs(copy.deepcopy(empty), _graph(), ops)
+        assert any(n["type"] == "ImageBatch" for n in wf["nodes"])

--- a/tests/comfy_cli/command/test_pretty_print_sanitize.py
+++ b/tests/comfy_cli/command/test_pretty_print_sanitize.py
@@ -251,7 +251,7 @@ def test_nodes_ls_is_inert(pretty, hostile_object_info):
         cloud_disabled=False,
         api_only=False,
         output_only=False,
-        exclude_deprecated=False,
+        include_deprecated=False,
         limit=None,
         input_path=None,
         host=None,


### PR DESCRIPTION
Fixes [BE-7684](https://linear.app/comfyorg/issue/BE-7684) — the comfy-agent kept building on `ImageBatch` and the retired partner nodes (`GeminiNode`, `OpenAIGPTImage1`, …).

## Why here and not `object_info`

The agent bakes `object_info.json` and hands it to comfy-cli. The same file feeds ingest's `NodeValidator`, so deleting deprecated entries would 400 every existing workflow that contains one, and it would break `set_widget` on deprecated nodes already on the canvas. The catalog's own `deprecated: true` flag is the full list (112 of 3698 classes, all 19 old partner nodes included), so no hand-maintained list is needed.

## What changes

- `nodes search` / `nodes ls` hide deprecated classes by default, matching the frontend node library. `--include-deprecated` shows them and rows then carry `deprecated: true`. `ls` keeps `--exclude-deprecated` as the negative spelling; the payload filter key is now `include_deprecated`.
- The graph's producer/consumer indexes skip deprecated classes, so `upstream`, `downstream`, `path` and `path --emit-ops` never suggest one. `graph.node()` / `all_nodes()` / `show` / validation are unchanged.
- `workflow add-node` and an `add_node` op in `apply` / `foreach` refuse a deprecated class with `code=node_deprecated`. `details.replacement` and the hint name the live class with the same display name (suffix `(DEPRECATED)` / `(Legacy)` stripped; a free class is never answered with a paid partner class). That covers 20 pairs including `ImageBatch → BatchImagesNode`, `GeminiNode → GeminiNodeV2`, `OpenAIGPTImage1 → OpenAIGPTImageNodeV2`.
- Escape hatch for a user who wants that exact node: `add-node --allow-deprecated`, or `"allow_deprecated": true` on the op.
- `capture` and `replace_ops` stamp `allow_deprecated` on classes already present, so reproducing an existing workflow (and `templates fetch --emit-ops`) still applies.

Editing a deprecated node already on the graph is untouched: `connect` and `set_widget` never go through `add_node`.

Follow-up in `cloud`: bump the pin, keep `deprecated` in the `show_node` digest, expose `allow_deprecated` on the agent's `add_node` / `apply_ops` tools.

## Testing

- `tests/comfy_cli/command/test_deprecated_nodes.py` (new, 16 tests): add-node refusal with/without replacement, `--allow-deprecated`, batch refusal and opt-in, search/ls default hide + `--include-deprecated`, close-match fallback, downstream/path, capture→apply and `replace_ops` round trips on a graph holding `ImageBatch`.
- Full suite: `6140 passed, 2 failed` — both failures (`test_build.py::test_from_workflow_refuses_a_workflow_nested_past_the_parser_limit`, `test_run_json.py::TestErrorPathCoverage::test_object_info_timeout_routes_to_connection_error`) reproduce unchanged on `origin/main`.
- `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTNsAw3HyPbqm9w23qPeZ8
