### PR TITLE
fix(cql): link-only dynamic-combo sub-inputs own no widget slot (BE-10291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,20 @@ history.
 
 ### Fixed
 
+- Connection-only sub-inputs of a `COMFY_DYNAMICCOMBO_V3` option (a nested
+  `COMFY_AUTOGROW_V3` image list, a `GEMINI_INPUT_FILES` link, a bare
+  `IMAGE` / `VIDEO` / `AUDIO` socket) no longer count as widget slots in
+  `comfy nodes widget-catalog` or in the node `comfy workflow add-node`
+  materialises. They never own a `widgets_values` entry on the canvas, so
+  counting them put phantom slots in front of `seed` on every dynamic-combo
+  partner node: an added `GeminiNanoBanana2V2` carried 11 values where the
+  frontend writes 9 and converted with its `seed` landing in `system_prompt`,
+  and through the catalog a canvas-built MiniMax H3 node's `seed` position read
+  as `model.reference_images`. `widget_order_default`, `widget_defaults` and
+  `widget_order_for_node` now name the same slots. **`catalog_version` changes**
+  for the affected classes (41 in the cloud catalog); consumers pinning the
+  catalog re-pin. (BE-10291)
+
 - The shipped `build_from_snapshot.json` schema now requires the `build` key
   the builder actually serves; it still required the pre-rename `distribution`
   key, so a valid `comfy build from-snapshot --json` payload failed validation.

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -628,7 +628,9 @@ def _dynamic_sub_widget_defaults(base: str, options: list, selected: Any = _FIRS
     selected key — as ``widget_order_for_node`` does — keeps the widget order
     aligned to ``widgets_values`` when a node picks an option whose sub-widget
     count differs from the default. An unknown key expands to nothing, matching
-    the converter's ``_dynamic_combo_sub_inputs``."""
+    the converter's ``_dynamic_combo_sub_inputs``. Connection-only sub-inputs
+    are skipped (they have no ``widgets_values`` slot), matching
+    ``_expand_widget_entries``."""
     if not options:
         return {}
     if selected is _FIRST_KEY:
@@ -646,7 +648,19 @@ def _dynamic_sub_widget_defaults(base: str, options: list, selected: Any = _FIRS
         if not isinstance(section_def, dict):
             continue
         for sub_name, spec in section_def.items():
-            _t, _e, enum_values, opts, _declared, _dyn = _parse_input_spec(spec)
+            type_id, is_enum, enum_values, opts, _declared, _dyn = _parse_input_spec(spec)
+            # Connection-only sub-inputs (an IMAGE / VIDEO / AUDIO socket, a
+            # nested COMFY_AUTOGROW_V3 list, GEMINI_INPUT_FILES, ...) own no
+            # ``widgets_values`` slot: the frontend renders them as sockets and
+            # never serializes a value for them. Counting them here put phantom
+            # slots in front of ``seed`` on every dynamic-combo partner node
+            # (GeminiNanoBanana2V2 wrote 11 values where the frontend writes 9),
+            # so ``add-node`` output, the widget catalog and
+            # ``widget_order_for_node`` disagreed with each other and with the
+            # canvas. Same predicate ``_port_from_spec`` / ``_expand_widget_entries``
+            # use, so every widget-order surface skips the same ports.
+            if _is_link(type_id, is_enum, opts.force_input):
+                continue
             default = opts.default
             if default is None and enum_values:
                 default = enum_values[0]

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -723,3 +723,31 @@ rebuilds the executable graph — the API prompt — not the canvas decoration.
 
 **No change to §§2-8.** No op kind was added, removed, or re-scoped;
 `FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS` are untouched.
+
+## 14. Amendment v1.5 — 2026-08-27 (link-only dynamic-combo sub-inputs own no slot)
+
+### 14.1 Every order surface skips socket sub-inputs of a dynamic combo
+
+A `COMFY_DYNAMICCOMBO_V3` option may declare sub-inputs that the frontend
+renders as sockets, not widgets: a nested `COMFY_AUTOGROW_V3` list
+(`GeminiNanoBanana2V2.model.images`, `MinimaxHailuo03ReferenceNode
+.model.reference_images`), a `GEMINI_INPUT_FILES` link, a bare `IMAGE` /
+`VIDEO` / `AUDIO`. The canvas never serialises a `widgets_values` entry for
+them. `widget_order_for_node` already skipped them; `widget_order_default`
+(the exported **widget catalog**, pinned by `catalog_version`) and
+`widget_defaults` (what `add_node` materialises) did not. So an `add_node` of
+a dynamic-combo partner node wrote phantom `null` slots in front of `seed`
+(11 values for Nano Banana 2 against the frontend's 9), the API conversion
+of that node shifted every later widget by the phantom count, and a consumer
+mapping names to indexes through the catalog read a canvas-built node's `seed`
+position as `model.reference_images`. All three surfaces now share the
+`_is_link` predicate `_port_from_spec` uses. **`catalog_version` hashes
+change** for every class whose selected option carries a socket sub-input
+(41 classes in the cloud catalog at the time of writing); consumers pinning
+the catalog re-pin with this SHA and re-mint minted documents per the
+doc-host procedure.
+
+**No change to §§2-8.** No op kind was added, removed, or re-scoped;
+`FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS` are untouched. `add_node`'s
+op shape is unchanged; only the length of the `widgets_values` it stamps into
+`op.node` differs for the affected classes.

--- a/tests/comfy_cli/cql/test_dynamic_combo_link_subs.py
+++ b/tests/comfy_cli/cql/test_dynamic_combo_link_subs.py
@@ -1,0 +1,172 @@
+"""Connection-only dynamic-combo sub-inputs own no ``widgets_values`` slot.
+
+A ``COMFY_DYNAMICCOMBO_V3`` option can declare sub-inputs that are sockets, not
+widgets: a nested ``COMFY_AUTOGROW_V3`` image list (``GeminiNanoBanana2V2
+.model.images``, ``MinimaxHailuo03ReferenceNode.model.reference_images``), a
+``GEMINI_INPUT_FILES`` link, a bare ``IMAGE`` / ``VIDEO`` / ``AUDIO``. The
+frontend renders those as sockets and never writes a value for them, so the
+canvas serialises Nano Banana 2 as 9 values (``seed`` at index 5) and MiniMax
+H3 as 8.
+
+``_dynamic_sub_widget_defaults`` used to emit an entry for every sub-input
+regardless, and it feeds ``widget_order_default`` (the exported widget catalog
+the CRDT doc host maps names to indexes with) and ``widget_defaults`` (what
+``add-node`` materialises). The per-node path ``widget_order_for_node`` already
+skipped links. Result: ``add-node`` wrote 11 values for Nano Banana 2 with two
+``null`` phantoms in front of ``seed``; converting that node gave
+``response_modalities: null, system_prompt: 42, temperature: "fixed"``; and
+through the catalog a UI-built MiniMax H3 node's ``seed`` position was read as
+``model.reference_images`` (PM-273 / BE-10291).
+
+Fixtures: ``dynamic_combo_link_subs_object_info.json`` is the cloud catalog
+entry for the affected classes; ``dynamic_combo_link_subs_frontend_nodes.json``
+is the node as the frontend serialised it in the gallery template for each
+class (``api_google_nano_banana2_image_edit``, ``api_minimax_h3_r2v``,
+``api_seedance2_5_r2v``) — the ground truth the CLI must agree with.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli import workflow_ops
+from comfy_cli.cql.engine import Graph
+from comfy_cli.workflow_to_api import convert_ui_to_api
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+NESTED_LINK_CLASSES = ["GeminiNanoBanana2V2", "MinimaxHailuo03ReferenceNode", "ByteDance2ReferenceNodeV2"]
+
+
+@pytest.fixture(scope="module")
+def object_info() -> dict:
+    return json.loads((_FIXTURES / "dynamic_combo_link_subs_object_info.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def graph(object_info: dict) -> Graph:
+    return Graph.from_object_info(object_info)
+
+
+@pytest.fixture(scope="module")
+def frontend_nodes() -> dict:
+    return json.loads((_FIXTURES / "dynamic_combo_link_subs_frontend_nodes.json").read_text())
+
+
+def _empty_workflow() -> dict:
+    return {"nodes": [], "links": [], "groups": [], "version": 0.4, "last_node_id": 0, "last_link_id": 0}
+
+
+class TestLinkSubInputsOwnNoSlot:
+    @pytest.mark.parametrize("class_type", NESTED_LINK_CLASSES)
+    def test_catalog_order_names_no_link_sub_input(self, graph: Graph, class_type: str):
+        order = graph.widget_order_default(class_type)
+        m = graph.node(class_type)
+        assert m is not None
+        # Every dotted entry must be a widget-like sub-port of the selected option.
+        link_subs = {
+            f"{p.name}.{sub}"
+            for p in m.inputs
+            if p.dynamic_options
+            for opt in p.dynamic_options[:1]
+            for section in ("required", "optional")
+            for sub, spec in (opt.get("inputs", {}).get(section) or {}).items()
+            if isinstance(spec, list)
+            and isinstance(spec[0], str)
+            and (spec[0].startswith("COMFY_AUTOGROW") or spec[0] in {"IMAGE", "VIDEO", "AUDIO", "GEMINI_INPUT_FILES"})
+        }
+        assert link_subs, f"fixture for {class_type} no longer carries a link-typed sub-input"
+        assert not link_subs & set(order), (
+            f"{class_type}: link sub-inputs leaked into widget_order: {link_subs & set(order)}"
+        )
+
+    @pytest.mark.parametrize("class_type", NESTED_LINK_CLASSES)
+    def test_every_widget_order_surface_agrees(self, graph: Graph, class_type: str):
+        """The catalog order, the add-node defaults and the value-aware order
+        must name the same slots in the same positions for a fresh node."""
+        order = graph.widget_order_default(class_type)
+        defaults = graph.widget_defaults(class_type)
+        assert list(defaults) == order
+        assert graph.widget_order_for_node(class_type, [defaults[n] for n in order]) == order
+
+    def test_all_classes_self_consistent(self, graph: Graph, object_info: dict):
+        for class_type in object_info:
+            order = graph.widget_order_default(class_type)
+            assert list(graph.widget_defaults(class_type)) == order, class_type
+
+
+class TestAgreesWithFrontendSerialisation:
+    @pytest.mark.parametrize("class_type", NESTED_LINK_CLASSES)
+    def test_seed_index_matches_the_canvas(self, graph: Graph, frontend_nodes: dict, class_type: str):
+        """A frontend-authored node stores ``seed`` where the catalog says it is —
+        the property the CRDT doc host relies on when it maps names to indexes."""
+        node = frontend_nodes[class_type]
+        values = node["widgets_values"]
+        catalog = graph.widget_order_default(class_type)
+        per_node = graph.widget_order_for_node(class_type, values)
+        assert catalog.index("seed") == per_node.index("seed")
+        assert isinstance(values[catalog.index("seed")], int)
+        # The frontend may omit trailing optional widgets it did not know about
+        # (older frontends), but it never writes MORE slots than the catalog names.
+        assert len(values) <= len(catalog)
+        assert per_node[: len(values)] == catalog[: len(values)]
+
+    def test_set_widget_on_a_ui_built_node_hits_the_seed_slot(self, graph: Graph, frontend_nodes: dict):
+        node = frontend_nodes["MinimaxHailuo03ReferenceNode"]
+        wf = _empty_workflow()
+        wf["nodes"].append(
+            {
+                "id": 4,
+                "type": "MinimaxHailuo03ReferenceNode",
+                "pos": [0, 0],
+                "size": [300, 300],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [dict(i) for i in node["inputs"]],
+                "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": []}],
+                "properties": {},
+                "widgets_values": list(node["widgets_values"]),
+            }
+        )
+        wf["last_node_id"] = 4
+        before = list(node["widgets_values"])
+        wf, _op = workflow_ops.set_widget(wf, graph, 4, "seed", 4242)
+        after = wf["nodes"][0]["widgets_values"]
+        assert len(after) == len(before)
+        assert after[5] == 4242  # the frontend's seed position
+        assert after[:5] == before[:5] and after[6:] == before[6:]
+
+
+class TestAddNodeMatchesTheCanvas:
+    def test_add_node_writes_the_frontend_slot_count(self, graph: Graph, frontend_nodes: dict):
+        wf, op = workflow_ops.add_node(_empty_workflow(), graph, "GeminiNanoBanana2V2")
+        values = op["node"]["widgets_values"]
+        order = graph.widget_order_default("GeminiNanoBanana2V2")
+        assert len(values) == len(order)
+        assert None not in values[: order.index("seed") + 1], "phantom null slots in front of seed"
+        assert values[order.index("seed")] == 42
+
+    def test_add_node_converts_with_every_widget_in_its_own_field(self, graph: Graph, object_info: dict):
+        wf, op = workflow_ops.add_node(_empty_workflow(), graph, "GeminiNanoBanana2V2")
+        wf, _ = workflow_ops.set_widget(wf, graph, op["node_id"], "seed", 777)
+        api = convert_ui_to_api(wf, object_info)
+        inputs = api[str(op["node_id"])]["inputs"]
+        assert inputs["seed"] == 777
+        assert inputs["response_modalities"] == "IMAGE"
+        assert inputs["temperature"] == 1
+        assert inputs["top_p"] == 0.95
+        assert isinstance(inputs["system_prompt"], str)
+        # Socket-only sub-inputs never become API keys with widget values.
+        assert "model.images" not in inputs and "model.files" not in inputs
+
+    def test_add_node_minimax_h3_converts_clean(self, graph: Graph, object_info: dict):
+        wf, op = workflow_ops.add_node(_empty_workflow(), graph, "MinimaxHailuo03ReferenceNode")
+        api = convert_ui_to_api(wf, object_info)
+        inputs = api[str(op["node_id"])]["inputs"]
+        assert inputs["seed"] == 42
+        assert inputs["watermark"] is False
+        assert "model.reference_images" not in inputs

--- a/tests/comfy_cli/fixtures/dynamic_combo_link_subs_frontend_nodes.json
+++ b/tests/comfy_cli/fixtures/dynamic_combo_link_subs_frontend_nodes.json
@@ -1,0 +1,113 @@
+{
+ "GeminiNanoBanana2V2": {
+  "frontendVersion": "1.42.15",
+  "inputs": [
+   {
+    "name": "model.images.image_1",
+    "type": "IMAGE",
+    "link": 22
+   },
+   {
+    "name": "model.images.image_2",
+    "type": "IMAGE",
+    "link": null
+   },
+   {
+    "name": "model.files",
+    "type": "GEMINI_INPUT_FILES",
+    "link": null
+   }
+  ],
+  "widgets_values": [
+   "Edit the image: change the man's white tank top and light pink corduroy pants to an unbuttoned cream-colored linen button-down shirt and white linen shorts; change his hairstyle to wavy medium-length hair; add round tortoiseshell sunglasses on his nose; change the dog's plain collar to a blue and white striped sailor collar and add a small straw sun hat on the dog; change the background to a sunny beach with warm golden sand and the ocean in the distance; keep the man's kneeling pose, the dog's sitting posture, and their interaction identical to the original image.\n",
+   "Nano Banana 2 (Gemini 3.1 Flash Image)",
+   "auto",
+   "1K",
+   "MINIMAL",
+   191918952969076,
+   "randomize",
+   "IMAGE",
+   "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests."
+  ]
+ },
+ "MinimaxHailuo03ReferenceNode": {
+  "frontendVersion": "1.47.11",
+  "inputs": [
+   {
+    "name": "model.reference_images.image_1",
+    "type": "IMAGE",
+    "link": 4
+   },
+   {
+    "name": "model.reference_images.image_2",
+    "type": "IMAGE",
+    "link": null
+   },
+   {
+    "name": "model.reference_videos.video_1",
+    "type": "VIDEO",
+    "link": null
+   },
+   {
+    "name": "model.reference_audios.audio_1",
+    "type": "AUDIO",
+    "link": null
+   }
+  ],
+  "widgets_values": [
+   "MiniMax H3",
+   "Use the uploaded 9-panel storyboard image as the exact visual reference.Create a single continuous cinematic shot of a golden-hour tennis match on a red clay court. Follow the storyboard from left to right, top to bottom, as one smooth unbroken sequence.A Black male player in a yellow polo, yellow shorts, and sporty sunglasses plays against a female player with braided hair, a beige tank top, and a light blue tennis skirt. Preserve their faces, outfits, court, lighting, and color palette exactly as shown.The sequence should move naturally through these moments:1. male player overhead smash2. female player sprinting across the court3. male player backhand follow-through4. extreme close-up of the male player's sunglasses and sweat5. female player jumping to hit the ball6. female player forehand contact with the yellow tennis ball7. male player low lunge on clay8. both players meeting at the net and shaking handsCinematic sports film style, golden hour sunlight, warm orange tones, photoreal, sharp focus, shallow depth of field, smooth steadicam movement, no cuts, no text, no logos, no broadcast graphics.",
+   "768P",
+   "adaptive",
+   5,
+   42,
+   "randomize",
+   false
+  ]
+ },
+ "ByteDance2ReferenceNodeV2": {
+  "frontendVersion": "1.49.6",
+  "inputs": [
+   {
+    "name": "model.reference_images.image_1",
+    "type": "IMAGE",
+    "link": 18
+   },
+   {
+    "name": "model.reference_images.image_2",
+    "type": "IMAGE",
+    "link": null
+   },
+   {
+    "name": "model.reference_videos.video_1",
+    "type": "VIDEO",
+    "link": null
+   },
+   {
+    "name": "model.reference_audios.audio_1",
+    "type": "AUDIO",
+    "link": null
+   },
+   {
+    "name": "model.reference_assets.asset_1",
+    "type": "STRING",
+    "link": null
+   }
+  ],
+  "widgets_values": [
+   "Seedance 2.5",
+   "The crimson marble Medusa statue comes alive, opening her eyes and looking at the camera while the red typography in the background simultaneously dissolves away letter by letter into drifting red particles. The snakes in her hair rise and sway. Both the statue and the background text animate together, poster layout otherwise unchanged, cinematic, no black frames.",
+   "720p",
+   "adaptive",
+   5,
+   true,
+   "reference",
+   "mp4",
+   true,
+   false,
+   0,
+   "randomize",
+   false
+  ]
+ }
+}

--- a/tests/comfy_cli/fixtures/dynamic_combo_link_subs_object_info.json
+++ b/tests/comfy_cli/fixtures/dynamic_combo_link_subs_object_info.json
@@ -1,0 +1,1607 @@
+{
+ "GeminiNanoBanana2V2": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "tooltip": "Text prompt describing the image to generate or the edits to apply. Include any constraints, styles, or details the model should follow.",
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "tooltip": "If set to 'auto', matches your input image's aspect ratio; if no image is provided, a 16:9 square is usually generated.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Target output resolution.",
+            "multiselect": false,
+            "options": [
+             "1K",
+             "2K",
+             "4K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "tooltip": "Optional reference image(s). Up to 14 images total.",
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {
+            "tooltip": "Optional file(s) to use as context for the model. Accepts inputs from the Gemini Generate Content Input Files node."
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Nano Banana 2 Lite",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "tooltip": "If set to 'auto', matches your input image's aspect ratio; if no image is provided, a 16:9 square is usually generated.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Target output resolution.",
+            "multiselect": false,
+            "options": [
+             "1K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "tooltip": "Optional reference image(s). Up to 14 images total.",
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {
+            "tooltip": "Optional file(s) to use as context for the model. Accepts inputs from the Gemini Generate Content Input Files node."
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "tooltip": "When the seed is fixed to a specific value, the model makes a best effort to provide the same response for repeated requests. Deterministic output isn't guaranteed. Also, changing the model or parameter settings, such as the temperature, can cause variations in the response even when you use the same seed value. By default, a random seed value is used.",
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE",
+       "IMAGE+TEXT"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "system_prompt": [
+     "STRING",
+     {
+      "tooltip": "Foundational instructions that dictate an AI's behavior.",
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ],
+    "temperature": [
+     "FLOAT",
+     {
+      "tooltip": "Controls randomness in generation. Lower is more focused/deterministic.",
+      "advanced": true,
+      "default": 1.0,
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.01
+     }
+    ],
+    "top_p": [
+     "FLOAT",
+     {
+      "tooltip": "Nucleus sampling threshold. Lower is more focused, higher more diverse.",
+      "advanced": true,
+      "default": 0.95,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "response_modalities"
+   ],
+   "optional": [
+    "system_prompt",
+    "temperature",
+    "top_p"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING",
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING",
+   "thought_image"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   "First image from the model's thinking process. Only available with thinking_level HIGH and IMAGE+TEXT modality."
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiNanoBanana2V2",
+  "display_name": "Nano Banana 2",
+  "description": "Generate or edit images synchronously via Google Vertex API.",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $contains(widgets.model, \"lite\")\n                    ? {\"type\":\"usd\",\"usd\": 0.0408, \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                    : (\n                        $r := $lookup(widgets, \"model.resolution\");\n                        $prices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n                        {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                      )\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "MinimaxHailuo03ReferenceNode": {
+  "input": {
+   "required": {
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "tooltip": "Model to use for video generation.",
+      "options": [
+       {
+        "key": "MiniMax H3",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "tooltip": "Text prompt for video generation.",
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Resolution of the output video.",
+            "multiselect": false,
+            "options": [
+             "768P",
+             "2K"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "tooltip": "Aspect ratio of the output video.",
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "adaptive",
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "tooltip": "Duration of the output video in seconds (4-15).",
+            "default": 5,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "tooltip": "Subject or style reference images, referred to in the prompt as 'Image 1'..'Image 9' in connection order. Up to 9 images.",
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "tooltip": "Motion or scene reference videos, referred to in the prompt as 'Video 1'..'Video 3' in connection order. Up to 3 videos, 2-15 seconds each, 15 seconds in total.",
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "tooltip": "Audio references, referred to in the prompt as 'Audio 1'..'Audio 3' in connection order. Up to 3 clips, 2-15 seconds each, 15 seconds in total. Cannot be used without a reference image or video.",
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "tooltip": "Random seed. The same request with the same seed gives similar, but not guaranteed identical, results.",
+      "default": 42,
+      "min": 0,
+      "max": 4294967295,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ],
+    "watermark": [
+     "BOOLEAN",
+     {
+      "tooltip": "Whether to add an AIGC watermark to the video.",
+      "advanced": true,
+      "default": false
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "watermark"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "MinimaxHailuo03ReferenceNode",
+  "display_name": "MiniMax H3 Reference to Video",
+  "description": "Generate video conditioned on reference images, videos, and audio using the MiniMax H3 model. Refer to the references in the prompt by their order: 'Image 1', 'Image 2', 'Video 1', 'Audio 1', and so on.",
+  "python_module": "comfy_api_nodes.nodes_minimax",
+  "category": "partner/video/MiniMax",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.duration",
+      "type": "INT"
+     }
+    ],
+    "inputs": [],
+    "input_groups": [
+     "model.reference_images",
+     "model.reference_videos"
+    ]
+   },
+   "expr": "\n                (\n                  $dur := $lookup(widgets, \"model.duration\");\n                  $rate := $lookup(widgets, \"model.resolution\") = \"768p\" ? 0.1287 : 0.1859;\n                  $imgsRaw := $lookup(inputGroups, \"model.reference_images\");\n                  $imgs := $imgsRaw ? $imgsRaw : 0;\n                  $vidsRaw := $lookup(inputGroups, \"model.reference_videos\");\n                  $vids := $vidsRaw ? $vidsRaw : 0;\n                  $base := $dur * $rate + ($imgs > 5 ? ($imgs - 5) * 0.0572 : 0);\n                  $vids > 0\n                    ? {\"type\": \"range_usd\", \"min_usd\": $base + $vids * 2 * $rate,\n                       \"max_usd\": $base + 15 * $rate, \"format\": {\"approximate\": true}}\n                    : {\"type\": \"usd\", \"usd\": $base}\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "ByteDance2ReferenceNodeV2": {
+  "input": {
+   "required": {
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "tooltip": "Seedance 2.5 for the newest model, videos up to 30 seconds and mp4/mov output; Seedance 2.0 for maximum quality and 4k; Fast for speed optimization; Mini for the fastest, lowest-cost generation.",
+      "options": [
+       {
+        "key": "Seedance 2.5",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "tooltip": "Text prompt for video generation. Put spoken lines in double quotes to steer the generated dialogue.",
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Resolution of the output video.",
+            "default": "720p",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "tooltip": "Aspect ratio of the output video.",
+            "default": "16:9",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "tooltip": "Duration of the output video in seconds (4-30).",
+            "default": 5,
+            "min": 4,
+            "max": 30,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "tooltip": "Enable audio generation for the output video.",
+            "default": true
+           }
+          ],
+          "task_type": [
+           "COMBO",
+           {
+            "tooltip": "What to do with the reference media. Every value except auto is validated when the task is submitted, so mismatched settings fail before generation starts. auto: the model infers the task from the prompt and inputs, and settings that conflict with its reading fail only after generation has started. reference: generate a new video guided by the reference images, videos, and audio. edit: change a connected reference video (add, remove, replace); the output keeps the source clip's own length and aspect ratio, and the duration and ratio widgets are ignored. extend: continue a connected reference video forward or backward; the prompt should say 'extend forward', 'extend backward', or 'continue', the aspect ratio follows the source clip, and the output contains only the newly generated segment of the duration you set, not the source clip.",
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "reference",
+             "edit",
+             "extend"
+            ]
+           }
+          ],
+          "output_format": [
+           "COMBO",
+           {
+            "tooltip": "Container format of the output video.",
+            "default": "mp4",
+            "multiselect": false,
+            "options": [
+             "mp4"
+            ]
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14",
+              "image_15",
+              "image_16",
+              "image_17",
+              "image_18",
+              "image_19",
+              "image_20",
+              "image_21",
+              "image_22",
+              "image_23",
+              "image_24",
+              "image_25",
+              "image_26",
+              "image_27",
+              "image_28",
+              "image_29",
+              "image_30"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3",
+              "video_4",
+              "video_5",
+              "video_6",
+              "video_7",
+              "video_8",
+              "video_9",
+              "video_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3",
+              "audio_4",
+              "audio_5",
+              "audio_6",
+              "audio_7",
+              "audio_8",
+              "audio_9",
+              "audio_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9",
+              "asset_10",
+              "asset_11",
+              "asset_12",
+              "asset_13",
+              "asset_14",
+              "asset_15",
+              "asset_16",
+              "asset_17",
+              "asset_18",
+              "asset_19",
+              "asset_20",
+              "asset_21",
+              "asset_22",
+              "asset_23",
+              "asset_24",
+              "asset_25",
+              "asset_26",
+              "asset_27",
+              "asset_28",
+              "asset_29",
+              "asset_30"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically downscale reference videos that exceed the model's pixel budget for the selected resolution. Aspect ratio is preserved; videos already within limits are untouched.",
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically upscale reference videos that are below the model's minimum pixel count for the selected resolution. Aspect ratio is preserved; videos already meeting the minimum are untouched. Note: upscaling a low-resolution source does not add real detail and may produce lower-quality generations.",
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "tooltip": "Text prompt for video generation.",
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Resolution of the output video.",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p",
+             "4k"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "tooltip": "Aspect ratio of the output video.",
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "tooltip": "Duration of the output video in seconds (4-15).",
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "tooltip": "Enable audio generation for the output video.",
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically downscale reference videos that exceed the model's pixel budget for the selected resolution. Aspect ratio is preserved; videos already within limits are untouched.",
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically upscale reference videos that are below the model's minimum pixel count for the selected resolution. Aspect ratio is preserved; videos already meeting the minimum are untouched. Note: upscaling a low-resolution source does not add real detail and may produce lower-quality generations.",
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Fast",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "tooltip": "Text prompt for video generation.",
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Resolution of the output video.",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "tooltip": "Aspect ratio of the output video.",
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "tooltip": "Duration of the output video in seconds (4-15).",
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "tooltip": "Enable audio generation for the output video.",
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically downscale reference videos that exceed the model's pixel budget for the selected resolution. Aspect ratio is preserved; videos already within limits are untouched.",
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically upscale reference videos that are below the model's minimum pixel count for the selected resolution. Aspect ratio is preserved; videos already meeting the minimum are untouched. Note: upscaling a low-resolution source does not add real detail and may produce lower-quality generations.",
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Mini",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "tooltip": "Text prompt for video generation.",
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "tooltip": "Resolution of the output video.",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "tooltip": "Aspect ratio of the output video.",
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "tooltip": "Duration of the output video in seconds (4-15).",
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "tooltip": "Enable audio generation for the output video.",
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically downscale reference videos that exceed the model's pixel budget for the selected resolution. Aspect ratio is preserved; videos already within limits are untouched.",
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "tooltip": "Automatically upscale reference videos that are below the model's minimum pixel count for the selected resolution. Aspect ratio is preserved; videos already meeting the minimum are untouched. Note: upscaling a low-resolution source does not add real detail and may produce lower-quality generations.",
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "tooltip": "Seed controls whether the node should re-run; results are non-deterministic regardless of seed.",
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ],
+    "watermark": [
+     "BOOLEAN",
+     {
+      "tooltip": "Whether to add a watermark to the video.",
+      "advanced": true,
+      "default": false
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "watermark"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ByteDance2ReferenceNodeV2",
+  "display_name": "ByteDance Seedance 2.5 Reference to Video",
+  "description": "Generate, edit, or extend video using Seedance 2.5 or 2.0 with reference images, videos, and audio. Supports multimodal reference, video editing, and video extension.",
+  "python_module": "comfy_api_nodes.nodes_bytedance",
+  "category": "partner/video/ByteDance",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.ratio",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.duration",
+      "type": "INT"
+     },
+     {
+      "name": "model.task_type",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": [
+     "model.reference_videos"
+    ]
+   },
+   "expr": "\n(\n  $m := widgets.model;\n  $res := $lookup(widgets, \"model.resolution\");\n  $ratio := $lookup(widgets, \"model.ratio\");\n  $dur := $lookup(widgets, \"model.duration\");\n  $auto := $lookup(widgets, \"model.task_type\") = \"edit\";\n  $hasVideo := $exists(inputGroups) and $lookup(inputGroups, \"model.reference_videos\") > 0;\n  $ready := $type($m) = \"string\" and $type($res) = \"string\" and ($auto or $type($dur) = \"number\");\n  $ready ? (\n    $contains($m, \"2.5\") ? (\n      $is480 := $res = \"480p\";\n      $is1080 := $res = \"1080p\";\n      $perFrame := $ratio = \"1:1\"  ? ($is480 ? 400      : $is1080 ? 2025      : 900) :\n                   $ratio = \"4:3\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"3:4\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"21:9\" ? ($is480 ? 418.5    : $is1080 ? 2037.9648 : 904.3945) :\n                                     ($is480 ? 400.3125 : $is1080 ? 2025      : 900);\n      $price := $is1080\n        ? ($hasVideo ? 0.01001 : 0.016731)\n        : ($hasVideo ? 0.009152 : 0.015301);\n      $costFor := function($d) { $floor($perFrame * (24 * $d + 1)) / 1000 * $price };\n      $lo := $costFor($auto ? 4 : $dur);\n      $hi := $costFor(($auto ? 30 : $dur) + ($hasVideo ? 30 : 0));\n      $lo = $hi\n        ? {\"type\": \"usd\", \"usd\": $lo, \"format\": {\"approximate\": true}}\n        : {\"type\": \"range_usd\", \"min_usd\": $lo, \"max_usd\": $hi, \"format\": {\"approximate\": true}}\n    ) : (\n      $rate := $res = \"4k\"    ? 195200 :\n               $res = \"1080p\" ? 48800 :\n               $res = \"720p\"  ? 21600 : 10044;\n      $noVideoPrice := $res = \"4k\"    ? 0.00572 :\n                       $res = \"1080p\" ? 0.011011 :\n                       $contains($m, \"mini\") ? 0.005005 :\n                       $contains($m, \"fast\") ? 0.008008 : 0.01001;\n      $videoPrice := $res = \"4k\"    ? 0.003432 :\n                     $res = \"1080p\" ? 0.006721 :\n                     $contains($m, \"mini\") ? 0.003003 :\n                     $contains($m, \"fast\") ? 0.004719 : 0.006149;\n      $hasVideo\n        ? {\"type\": \"range_usd\",\n           \"min_usd\": $ceil($dur * 5 / 3) * $rate * $videoPrice / 1000,\n           \"max_usd\": (15 + $dur) * $rate * $videoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n        : {\"type\": \"usd\", \"usd\": $dur * $rate * $noVideoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n    )\n  ) : undefined\n)\n"
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "LoadImage": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "MASK"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "MASK"
+  ],
+  "name": "LoadImage",
+  "display_name": "Load Image",
+  "description": "",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "load image",
+   "open image",
+   "import image",
+   "image input",
+   "upload image",
+   "read image",
+   "image loader"
+  ],
+  "essentials_category": "Basics"
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "description": "",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ }
+}


### PR DESCRIPTION
Closes BE-10291 · parent PM-273 (agent can't wire Load Image / Video into dynamic / auto-grow inputs).

## Problem

`_dynamic_sub_widget_defaults` (`comfy_cli/cql/engine.py`) emitted an entry for **every** sub-input of the selected `COMFY_DYNAMICCOMBO_V3` option, including sockets the frontend never serialises a value for: a nested `COMFY_AUTOGROW_V3` list (`GeminiNanoBanana2V2.model.images`, `MinimaxHailuo03ReferenceNode.model.reference_images`), `GEMINI_INPUT_FILES`, bare `IMAGE` / `VIDEO` / `AUDIO`.

It feeds two surfaces: `widget_order_default` (the exported widget catalog the CRDT doc host maps names→indexes with) and `widget_defaults` (what `add-node` materialises). The per-node path `widget_order_for_node` already skipped links, so the CLI disagreed with itself and with the canvas.

Reproduced on main with the cloud `object_info`:

| | frontend (template) | CLI before | CLI after |
|---|---|---|---|
| `GeminiNanoBanana2V2` widgets_values | 9 (seed @5) | 11 (null, null @5-6; seed @7) | 9 (+2 trailing optional) |
| `MinimaxHailuo03ReferenceNode` | 8 (seed @5) | 11 (seed @8) | 8 |
| API conversion of an added NB2 node | | `response_modalities: null, system_prompt: 42, temperature: "fixed", top_p: "IMAGE"` | every widget in its own field |
| catalog `widget_order` for MiniMax H3 | | `[…, model.duration, model.reference_images, model.reference_videos, model.reference_audios, seed, …]` | `[…, model.duration, seed, …]` |

Through the catalog, a canvas-built MiniMax H3 node's `seed` position was read as `model.reference_images` and a `seed` write landed past the array. That is the "reference image force-mapped onto seed" report on PM-273.

## Change

Skip sub-inputs `_is_link` rejects, the same predicate `_port_from_spec` / `_expand_widget_entries` use, so `widget_order_default`, `widget_defaults` and `widget_order_for_node` name the same slots. One branch, no new predicate.

## Tests

`tests/comfy_cli/cql/test_dynamic_combo_link_subs.py` (14 cases) against two new fixtures: the cloud catalog entries for the three headline classes, and the nodes exactly as the frontend serialised them in the gallery templates (`api_google_nano_banana2_image_edit`, `api_minimax_h3_r2v`, `api_seedance2_5_r2v`).

- catalog order / add-node defaults / per-node order agree for every class in the fixture
- the frontend-authored node stores `seed` where the catalog says it is
- `set-widget seed` on a canvas-built MiniMax H3 node hits index 5 and nothing else
- `add-node` writes the frontend slot count and converts with every widget in its own field

`tests/comfy_cli/cql`, `test_nodes_widget_catalog.py`, `test_workflow_to_api.py`, `test_op_vocabulary_contract.py`: 476 passed. (The full suite has ~24 pre-existing failures on main in `test_host_port` / `test_broken_pipe` / `test_build` / stderr-cleanliness tests that fail identically on an unpatched checkout in my environment; none touch this code.)

## Rollout

**`catalog_version` changes** for 41 classes in the cloud catalog (37 partner, 4 core). Same procedure as #809 / BE-10283: bump the pin in `services/agent/Dockerfile` **and** `cli-runner.Dockerfile` together and re-mint minted documents (`cmd/crdt-cohort -remint` or the automatic re-mint on `catalog_mismatch`). Suggest landing this in the same pin bump as #809's follow-up so prod re-mints once. Recorded as op-vocabulary amendment v1.5 (`docs/op-vocabulary-v1.md` §14) and in `CHANGELOG.md`.

Does not address the sibling defect BE-10290 (nested auto-grow slots still cannot be grown by `connect`; that is `workflow_ops._resolve_input_target` and the doc host's slot minting, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sf4GiQuvSuNSvPFA8X643E
