### PR TITLE
feat(knowledge): fetch the bundle from the cloud knowledge channel by default (BE-8952)

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,10 +631,11 @@ custom_nodes:
 
 Discovery commands can attach a `knowledge` block to their `--json` output: which
 model a name refers to, whether it is deprecated, ranked picks per capability,
-and known pitfalls. It is **off unless you point the CLI at a bundle**, so a
-default install never emits the block.
+and known pitfalls. A signed-in install (`comfy cloud login`) fetches the bundle
+from the cloud knowledge channel on its own. Signed out, the fetch fails quietly
+and no block is emitted.
 
-Turn it on with either of:
+Point the CLI at a different bundle with either of:
 
 ```
 export COMFY_KNOWLEDGE_URL=https://.../knowledge.json   # fetched and cached
@@ -655,8 +656,8 @@ Turn it off again:
 export COMFY_KNOWLEDGE_DISABLE=1
 ```
 
-Clearing `COMFY_KNOWLEDGE_URL` is *not* an off switch. Once a bundle is cached it
-keeps being served, stale or not. `COMFY_KNOWLEDGE_DISABLE` suppresses envelope
+Signing out is *not* an off switch. Once a bundle is cached it keeps being
+served, stale or not. `COMFY_KNOWLEDGE_DISABLE` suppresses envelope
 enrichment outright; the `comfy knowledge` verbs keep working under it, since
 those are you asking for the bundle directly.
 
@@ -683,9 +684,9 @@ comfy tracking disable
 When tracking is on, we use Mixpanel to understand usage patterns and know where
 to prioritize our efforts.
 
-**One event carries text you typed.** If a curated knowledge bundle is configured
-— it is not by default, and needs `COMFY_KNOWLEDGE_URL` or `COMFY_KNOWLEDGE_FILE`
-— then `comfy nodes search`, `comfy templates ls`, `comfy generate schema`,
+**One event carries text you typed.** If a curated knowledge bundle is loaded
+(a signed-in install fetches one on its own), then `comfy nodes search`,
+`comfy templates ls`, `comfy generate schema`,
 `comfy generate list` and `comfy models search` send the search terms you typed
 and which curated entries they matched. This tells us what people look for and fail
 to find. It needs both the bundle and your tracking consent, so with either one

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ Discovery commands can attach a `knowledge` block to their `--json` output: whic
 model a name refers to, whether it is deprecated, ranked picks per capability,
 and known pitfalls. A signed-in install (`comfy cloud login`) fetches the bundle
 from the cloud knowledge channel on its own. Signed out, the fetch fails quietly
-and no block is emitted.
+and no block is emitted unless a bundle is already cached.
 
 Point the CLI at a different bundle with either of:
 

--- a/comfy_cli/cloud/command.py
+++ b/comfy_cli/cloud/command.py
@@ -25,7 +25,7 @@ from typing import Annotated, Any
 import typer
 from rich import markup as rich_markup
 
-from comfy_cli import tracking
+from comfy_cli import knowledge, tracking
 from comfy_cli.auth import store
 from comfy_cli.cloud import CLIENT_ID, CLIENT_NAME, CONFIG_KEY_BASE_URL, get_base_url, get_resource_url, get_scopes
 from comfy_cli.cloud.oauth import OAuthError, run_login
@@ -133,6 +133,10 @@ def login_cmd(
         token_type=result.tokens.token_type,
         expires_at=result.tokens.expires_at,
     )
+
+    # Fill the knowledge cache while the user is online and freshly signed
+    # in, so the cache-only attach path has a bundle on a brand-new install.
+    knowledge.refresh_if_stale()
 
     if renderer.is_pretty():
         from comfy_cli.output.branding import welcome_banner

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -41,13 +41,22 @@ def _text(value: Any) -> str | None:
     return value if isinstance(value, str) else None
 
 
+_UNAVAILABLE_HINTS = {
+    knowledge.REASON_SIGNED_OUT: "sign in with `comfy cloud login` so the bundle can be fetched, or set COMFY_KNOWLEDGE_FILE to a knowledge.json",
+    knowledge.REASON_FETCH_FAILED: "check COMFY_KNOWLEDGE_URL, or set COMFY_KNOWLEDGE_FILE to a knowledge.json",
+    knowledge.REASON_ENV_FILE: "check the COMFY_KNOWLEDGE_FILE path",
+}
+
+
 def _require_bundle(renderer) -> knowledge.Bundle:
     bundle = knowledge.load_bundle()
     if bundle is None:
+        reason = knowledge.last_reason()
+        hint = _UNAVAILABLE_HINTS.get(reason, "set COMFY_KNOWLEDGE_FILE to a knowledge.json")
         renderer.error(
             code="knowledge_unavailable",
-            message="no knowledge bundle is loaded",
-            hint="sign in with `comfy cloud login` so the bundle can be fetched, or set COMFY_KNOWLEDGE_FILE to a knowledge.json; see `comfy knowledge status`",
+            message=f"no knowledge bundle is loaded: {reason}",
+            hint=f"{hint}; see `comfy knowledge status`",
         )
         raise typer.Exit(code=1)
     return bundle
@@ -58,7 +67,10 @@ def _require_bundle(renderer) -> knowledge.Bundle:
 def status_cmd(
     refresh: Annotated[
         bool,
-        typer.Option("--refresh", help="Re-fetch the bundle, ignoring the cache TTL."),
+        typer.Option(
+            "--refresh",
+            help="Reload the bundle, ignoring the cache TTL (re-reads COMFY_KNOWLEDGE_FILE when set, else re-fetches).",
+        ),
     ] = False,
 ):
     renderer = get_renderer()

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -24,11 +24,10 @@ app = typer.Typer(no_args_is_help=True, help="Inspect the curated model-knowledg
 
 
 def _env_context() -> dict[str, Any]:
-    url = os.environ.get(knowledge.ENV_URL, "").strip()
     return {
         "env_file": os.environ.get(knowledge.ENV_FILE, "").strip() or None,
         # Userinfo, query and fragment can carry a token; the path still shows which bundle is configured.
-        "url": tracking._scrub_value(url) if url else None,
+        "url": tracking._scrub_value(knowledge.bundle_url()),
         "ttl_seconds": knowledge.ttl_seconds(),
         "cache_path": str(knowledge.cache_paths()[0]),
     }
@@ -48,7 +47,7 @@ def _require_bundle(renderer) -> knowledge.Bundle:
         renderer.error(
             code="knowledge_unavailable",
             message="no knowledge bundle is loaded",
-            hint="set COMFY_KNOWLEDGE_FILE to a knowledge.json, or COMFY_KNOWLEDGE_URL to fetch one; see `comfy knowledge status`",
+            hint="sign in with `comfy cloud login` so the bundle can be fetched, or set COMFY_KNOWLEDGE_FILE to a knowledge.json; see `comfy knowledge status`",
         )
         raise typer.Exit(code=1)
     return bundle
@@ -59,7 +58,7 @@ def _require_bundle(renderer) -> knowledge.Bundle:
 def status_cmd(
     refresh: Annotated[
         bool,
-        typer.Option("--refresh", help="Re-fetch from COMFY_KNOWLEDGE_URL, ignoring the cache TTL."),
+        typer.Option("--refresh", help="Re-fetch the bundle, ignoring the cache TTL."),
     ] = False,
 ):
     renderer = get_renderer()

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -77,7 +77,7 @@ REASON_SIGNED_OUT = (
     "fetch from the cloud knowledge channel failed and no cached bundle exists; "
     "the usual cause is being signed out (run `comfy cloud login`)"
 )
-REASON_FETCH_FAILED = "fetch failed and no cached bundle exists"
+REASON_FETCH_FAILED = "fetch from COMFY_KNOWLEDGE_URL failed and no cached bundle exists"
 
 
 @dataclass(frozen=True)
@@ -405,7 +405,9 @@ def _http_get(url: str) -> bytes:
     if url.startswith(get_base_url().rstrip("/") + "/"):
         from comfy_cli.target import resolve_target
 
-        opened = authed_urlopen(url, resolve_target(where="cloud"), timeout=FETCH_TIMEOUT_SECONDS)
+        # Best-effort background fetch: a spurious refresh failure must not log the user out.
+        target = resolve_target(where="cloud", allow_clear=False)
+        opened = authed_urlopen(url, target, timeout=FETCH_TIMEOUT_SECONDS)
     else:
         req = urllib.request.Request(url, headers={"User-Agent": "comfy-cli"})
         opened = plain_urlopen(req, timeout=FETCH_TIMEOUT_SECONDS)

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -3,7 +3,8 @@
 The bundle (``knowledge.json`` + optional ``manifest.json``) is produced by
 the curated knowledge bundle repo. It reaches this process by one of three routes,
 tried in order: an explicit ``COMFY_KNOWLEDGE_FILE``, the per-user cache, or a
-fetch from ``COMFY_KNOWLEDGE_URL``. A missing or broken bundle is a normal
+fetch from ``COMFY_KNOWLEDGE_URL``, which defaults to the knowledge channel
+under the cloud base URL. A missing or broken bundle is a normal
 state: every entry point here returns ``None`` rather than raising, and nothing
 is written to stdout or stderr. :func:`attach` is how discovery commands add a
 capped ``knowledge`` block to their payload; it is fail-open for the same reason.
@@ -39,6 +40,7 @@ ENV_FILE = "COMFY_KNOWLEDGE_FILE"
 ENV_URL = "COMFY_KNOWLEDGE_URL"
 ENV_TTL = "COMFY_KNOWLEDGE_TTL"
 ENV_DISABLE = "COMFY_KNOWLEDGE_DISABLE"
+DEFAULT_URL_PATH = "/api/knowledge/knowledge.json"
 DEFAULT_TTL_SECONDS = 24 * 60 * 60
 FETCH_TIMEOUT_SECONDS = 10.0
 MAX_BUNDLE_BYTES = 16 * 1024 * 1024
@@ -71,7 +73,10 @@ _CONTEXT_END = re.compile(
 MIN_SINGLE_TOKEN_CHARS = 4
 
 REASON_ENV_FILE = "COMFY_KNOWLEDGE_FILE is set but could not be loaded"
-REASON_NO_URL = "no cache and COMFY_KNOWLEDGE_URL is not set"
+REASON_SIGNED_OUT = (
+    "fetch from the cloud knowledge channel failed and no cached bundle exists; "
+    "the usual cause is being signed out (run `comfy cloud login`)"
+)
 REASON_FETCH_FAILED = "fetch failed and no cached bundle exists"
 
 
@@ -131,11 +136,27 @@ def ttl_seconds() -> float:
     return max(ttl, 0.0) if math.isfinite(ttl) else DEFAULT_TTL_SECONDS
 
 
+def default_url() -> str:
+    """``knowledge.json`` under the cloud base URL, derived on every call.
+
+    Never stored: :func:`_http_get` attaches credentials only under
+    ``get_base_url()``, which resolves per invocation, so a remembered
+    production URL would silently fetch unauthenticated for anyone pointed at
+    another environment.
+    """
+    return get_base_url().rstrip("/") + DEFAULT_URL_PATH
+
+
+def bundle_url() -> str:
+    """``COMFY_KNOWLEDGE_URL`` when set, else :func:`default_url`."""
+    return os.environ.get(ENV_URL, "").strip() or default_url()
+
+
 def load_bundle(*, force_fetch: bool = False, cache_only: bool = False) -> Bundle | None:
     """Return the indexed bundle, or ``None`` when no usable bundle exists.
 
     Memoized per process; ``force_fetch=True`` re-runs the load and skips the
-    cache TTL gate so a fetch happens whenever ``COMFY_KNOWLEDGE_URL`` is set.
+    cache TTL gate so a fetch happens unless ``COMFY_KNOWLEDGE_FILE`` is set.
     ``cache_only=True`` never touches the network: env file, then any cache
     (fresh or stale), else ``None``. The memo is shared, except that a
     cache-only miss is not memoized so a later full load can still fetch.
@@ -309,9 +330,9 @@ def _load(*, force_fetch: bool, cache_only: bool = False) -> tuple[Bundle | None
         if bundle is not None:
             return bundle, None
 
-    url = os.environ.get(ENV_URL, "").strip()
-    if url and not cache_only:
-        bundle = _fetch(url, knowledge_path, manifest_path)
+    explicit_url = os.environ.get(ENV_URL, "").strip()
+    if not cache_only:
+        bundle = _fetch(explicit_url or default_url(), knowledge_path, manifest_path)
         if bundle is not None:
             return bundle, None
 
@@ -319,7 +340,7 @@ def _load(*, force_fetch: bool, cache_only: bool = False) -> tuple[Bundle | None
     bundle = _load_file(knowledge_path, manifest_path, source=source, stale=not fresh)
     if bundle is not None:
         return bundle, None
-    return None, (REASON_FETCH_FAILED if url else REASON_NO_URL)
+    return None, (REASON_FETCH_FAILED if explicit_url else REASON_SIGNED_OUT)
 
 
 def _cache_is_fresh(path: Path) -> bool:
@@ -903,9 +924,9 @@ def attach(
     exactly as it was.
 
     ``COMFY_KNOWLEDGE_DISABLE`` suppresses the block entirely. A cached bundle
-    keeps being read once it exists, stale or not, so clearing
-    ``COMFY_KNOWLEDGE_URL`` is not an off switch and this is. Following
-    ``DO_NOT_TRACK``, any value but empty or ``"0"`` disables.
+    keeps being read once it exists, stale or not, and the default URL means a
+    signed-in install fetches one without being asked, so this is the only off
+    switch. Following ``DO_NOT_TRACK``, any value but empty or ``"0"`` disables.
     """
     try:
         disable = os.environ.get(ENV_DISABLE, "")

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -13,7 +13,7 @@
     "as_of": { "type": ["string", "null"], "description": "ISO-8601 UTC timestamp: file mtime (status) or the capability's as_of, null when the capability has none (pick)." },
     "path": { "type": "string", "description": "File the bundle bytes were read from (status)." },
     "env_file": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_FILE (status)." },
-    "url": { "type": ["string", "null"], "description": "Value of COMFY_KNOWLEDGE_URL with userinfo, query and fragment removed (status)." },
+    "url": { "type": ["string", "null"], "description": "URL a fetch uses: COMFY_KNOWLEDGE_URL, else knowledge.json under the cloud base URL; userinfo, query and fragment removed (status)." },
     "ttl_seconds": { "type": "number", "description": "Cache TTL in effect (status)." },
     "cache_path": { "type": "string", "description": "Where a fetched bundle is cached (status)." },
     "counts": {

--- a/comfy_cli/target.py
+++ b/comfy_cli/target.py
@@ -51,7 +51,12 @@ class Target:
 
 
 def resolve_target(
-    *, where: str | None, host: str | None = None, port: int | None = None, config: Any = None
+    *,
+    where: str | None,
+    host: str | None = None,
+    port: int | None = None,
+    config: Any = None,
+    allow_clear: bool = True,
 ) -> Target:
     """Pick a Target based on ``--where`` plus host/port (for local).
 
@@ -60,6 +65,10 @@ def resolve_target(
     auto-detect (``cloud`` if credentials exist, else ``local``).
     The ``config`` arg is honored if passed; otherwise
     we instantiate a ``ConfigManager`` to read the persisted key.
+
+    ``allow_clear=False`` is forwarded to :func:`resolve_cloud_credential` so a
+    best-effort background caller cannot wipe the stored session on a failed
+    token refresh.
     """
     from comfy_cli import where as where_module
 
@@ -92,7 +101,7 @@ def resolve_target(
         # when the token isn't near expiry (no network), and the client/loader
         # still force-refresh *reactively* on a server 401 as a backstop.
         base_url = get_base_url()
-        cred = resolve_cloud_credential(purpose="cloud", base_url=base_url, refresh=True)
+        cred = resolve_cloud_credential(purpose="cloud", base_url=base_url, refresh=True, allow_clear=allow_clear)
         token = cred.value if cred is not None and cred.kind == "oauth" else None
         api_key = cred.value if cred is not None and cred.kind == "api_key" else None
 

--- a/tests/comfy_cli/cloud/test_login_command.py
+++ b/tests/comfy_cli/cloud/test_login_command.py
@@ -57,6 +57,52 @@ def _no_tracking(monkeypatch):
     monkeypatch.setattr("comfy_cli.tracking.track_event", lambda *a, **k: None)
 
 
+@pytest.fixture(autouse=True)
+def _knowledge_warm(monkeypatch):
+    """Record the post-login knowledge warm instead of fetching a bundle."""
+    calls: list[None] = []
+    monkeypatch.setattr(command.knowledge, "refresh_if_stale", lambda: calls.append(None))
+    return calls
+
+
+def test_login_warms_the_knowledge_cache_after_saving_the_session(monkeypatch, capsys, _knowledge_warm):
+    order: list[str] = []
+
+    def fake_run_login(**kwargs):
+        kwargs["on_url_ready"](_AUTHORIZE_URL)
+        return _login_result()
+
+    real_save = command.store.save_cloud_session
+
+    def save_then_record(**kwargs):
+        order.append("save")
+        return real_save(**kwargs)
+
+    monkeypatch.setattr(command, "run_login", fake_run_login)
+    monkeypatch.setattr(command.store, "save_cloud_session", save_then_record)
+    monkeypatch.setattr(command.knowledge, "refresh_if_stale", lambda: order.append("warm"))
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud login", version="test"))
+
+    command.login_cmd(no_browser=True, timeout=300)
+
+    assert order == ["save", "warm"]
+    assert _parse_lines(capsys.readouterr().out)[-1]["ok"] is True
+
+
+def test_login_timeout_does_not_warm_the_knowledge_cache(monkeypatch, capsys, _knowledge_warm):
+    def fake_run_login(**kwargs):
+        kwargs["on_url_ready"](_AUTHORIZE_URL)
+        raise oauth.OAuthError("timed out")
+
+    monkeypatch.setattr(command, "run_login", fake_run_login)
+    set_renderer(Renderer(mode=OutputMode.JSON, command="cloud login", version="test"))
+
+    with pytest.raises(typer.Exit):
+        command.login_cmd(no_browser=True, timeout=1)
+
+    assert _knowledge_warm == []
+
+
 def test_json_login_emits_login_url_event_before_envelope(monkeypatch, capsys):
     """`comfy --json cloud login --no-browser` streams a `login_url` event
     (carrying the authorize URL) ahead of the final, session-redacted envelope."""

--- a/tests/comfy_cli/cloud/test_login_command.py
+++ b/tests/comfy_cli/cloud/test_login_command.py
@@ -89,7 +89,7 @@ def test_login_warms_the_knowledge_cache_after_saving_the_session(monkeypatch, c
     assert _parse_lines(capsys.readouterr().out)[-1]["ok"] is True
 
 
-def test_login_timeout_does_not_warm_the_knowledge_cache(monkeypatch, capsys, _knowledge_warm):
+def test_login_timeout_does_not_warm_the_knowledge_cache(monkeypatch, _knowledge_warm):
     def fake_run_login(**kwargs):
         kwargs["on_url_ready"](_AUTHORIZE_URL)
         raise oauth.OAuthError("timed out")

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -362,13 +362,15 @@ class TestAuthRouting:
         def fake_authed(url, target, **kw):
             seen["url"] = url
             seen["target_kind"] = target.kind
+            # A failed token refresh during this background fetch must not wipe the stored session.
+            seen["allow_clear"] = target.allow_clear
             return self._fake_resp(b'{"models": {}}')
 
         monkeypatch.setattr(knowledge, "authed_urlopen", fake_authed)
         monkeypatch.setattr(knowledge, "plain_urlopen", lambda *a, **kw: pytest.fail("plain opener used"))
         url = f"{get_base_url()}/api/knowledge/knowledge.json"
         assert knowledge._http_get(url) == b'{"models": {}}'
-        assert seen == {"url": url, "target_kind": "cloud"}
+        assert seen == {"url": url, "target_kind": "cloud", "allow_clear": False}
 
     def test_signed_out_401_on_the_default_url_degrades_quietly(self, monkeypatch):
         import comfy_cli.target
@@ -816,6 +818,16 @@ class TestCli:
         rc, env = _run(["resolve", "x"], capsys)
         assert rc == 1
         assert env["error"]["code"] == "knowledge_unavailable"
+        assert "comfy cloud login" in env["error"]["hint"]
+
+    def test_resolve_after_explicit_url_failure_points_at_the_url(self, monkeypatch, capsys):
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
+        rc, env = _run(["resolve", "x"], capsys)
+        assert rc == 1
+        assert env["error"]["code"] == "knowledge_unavailable"
+        assert knowledge.REASON_FETCH_FAILED in env["error"]["message"]
+        assert "COMFY_KNOWLEDGE_URL" in env["error"]["hint"]
+        assert "comfy cloud login" not in env["error"]["hint"]
 
     def test_pick_hit(self, tmp_path, monkeypatch, capsys):
         _env_bundle(tmp_path, monkeypatch)

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -2,7 +2,8 @@
 
 Contract under test:
   * load order: ``COMFY_KNOWLEDGE_FILE`` (authoritative, never cached) >
-    fresh cache > ``COMFY_KNOWLEDGE_URL`` fetch > stale cache > nothing.
+    fresh cache > fetch (``COMFY_KNOWLEDGE_URL``, else the cloud default) >
+    stale cache > nothing.
   * a broken or missing bundle returns ``None``; nothing here raises.
   * manifest ``schema_version`` and ``sha256`` reject a mismatched bundle.
   * the index is a tolerant reader: unknown keys/fields are ignored.
@@ -21,6 +22,7 @@ import json
 import os
 import shutil
 import time
+import urllib.error
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -218,15 +220,39 @@ class TestLoadOrder:
         monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
         assert knowledge.load_bundle().source == "stale-cache"
 
-    def test_no_cache_no_url_is_none(self):
+    def test_no_cache_and_no_url_fetches_the_default_and_reports_signed_out(self, monkeypatch):
+        calls = _fake_http(monkeypatch, knowledge_bytes=None)
         assert knowledge.load_bundle() is None
-        assert knowledge.last_reason() == knowledge.REASON_NO_URL
+        assert knowledge.last_reason() == knowledge.REASON_SIGNED_OUT
+        assert calls == [knowledge.default_url()]
 
     def test_no_cache_failed_fetch_is_none(self, monkeypatch):
         _fake_http(monkeypatch, knowledge_bytes=None)
         monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/knowledge.json")
         assert knowledge.load_bundle() is None
         assert knowledge.last_reason() == knowledge.REASON_FETCH_FAILED
+
+    def test_default_url_follows_the_cloud_base_url(self, monkeypatch):
+        monkeypatch.setenv("COMFY_CLOUD_BASE_URL", "https://staging.example/")
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        assert knowledge.load_bundle().source == "fetch"
+        assert calls == [
+            "https://staging.example/api/knowledge/knowledge.json",
+            "https://staging.example/api/knowledge/manifest.json",
+        ]
+
+    def test_explicit_url_overrides_the_default(self, monkeypatch):
+        monkeypatch.setenv("COMFY_CLOUD_BASE_URL", "https://staging.example")
+        monkeypatch.setenv(knowledge.ENV_URL, "https://example.com/k/knowledge.json")
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes(), manifest_bytes=None)
+        assert knowledge.load_bundle().source == "fetch"
+        assert calls == ["https://example.com/k/knowledge.json", "https://example.com/k/manifest.json"]
+
+    def test_env_file_skips_the_default_fetch(self, tmp_path, monkeypatch):
+        _env_bundle(tmp_path, monkeypatch)
+        calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes())
+        assert knowledge.load_bundle().source == "env"
+        assert calls == []
 
     def test_unsafe_url_is_a_fetch_failure(self, monkeypatch):
         calls = _fake_http(monkeypatch, knowledge_bytes=FIXTURE_KNOWLEDGE.read_bytes())
@@ -343,6 +369,23 @@ class TestAuthRouting:
         url = f"{get_base_url()}/api/knowledge/knowledge.json"
         assert knowledge._http_get(url) == b'{"models": {}}'
         assert seen == {"url": url, "target_kind": "cloud"}
+
+    def test_signed_out_401_on_the_default_url_degrades_quietly(self, monkeypatch):
+        import comfy_cli.target
+
+        monkeypatch.setattr(knowledge, "_http_get", _REAL_HTTP_GET)
+        monkeypatch.setattr(comfy_cli.target, "resolve_target", lambda **kw: SimpleNamespace(kind="cloud", **kw))
+        seen: list[str] = []
+
+        def unauthorized(url, target, **kw):
+            seen.append(url)
+            raise urllib.error.HTTPError(url, 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr(knowledge, "authed_urlopen", unauthorized)
+        monkeypatch.setattr(knowledge, "plain_urlopen", lambda *a, **kw: pytest.fail("plain opener used"))
+        assert knowledge.load_bundle() is None
+        assert knowledge.last_reason() == knowledge.REASON_SIGNED_OUT
+        assert seen == [knowledge.default_url()]
 
     def test_lookalike_host_does_not_get_credentials(self, monkeypatch):
         from comfy_cli.cloud import get_base_url
@@ -694,7 +737,7 @@ class TestCli:
         assert data["version"] == "0.1.0-fixture"
         assert data["schema_version"] == 1
         assert data["env_file"] == str(path)
-        assert data["url"] is None
+        assert data["url"] == knowledge.default_url()
         assert data["ttl_seconds"] == knowledge.DEFAULT_TTL_SECONDS
         assert data["counts"] == {"models": 5, "capabilities": 2, "aliases": 23, "deprecations": 2}
         _validate(data)
@@ -705,7 +748,8 @@ class TestCli:
         assert env["ok"] is True
         data = env["data"]
         assert data["loaded"] is False
-        assert data["reason"]
+        assert data["reason"] == knowledge.REASON_SIGNED_OUT
+        assert data["url"] == knowledge.default_url()
         assert data["cache_path"].endswith(os.path.join("knowledge", "knowledge.json"))
         _validate(data)
 

--- a/tests/comfy_cli/test_local_address.py
+++ b/tests/comfy_cli/test_local_address.py
@@ -200,6 +200,22 @@ def test_resolve_target_local_flag_beats_env(monkeypatch):
     assert target.port == 8188
 
 
+def test_resolve_target_cloud_forwards_allow_clear(monkeypatch):
+    import comfy_cli.credentials
+    from comfy_cli.target import resolve_target
+
+    seen: dict = {}
+
+    def fake_resolve(**kwargs):
+        seen.update(kwargs)
+        return None
+
+    monkeypatch.setattr(comfy_cli.credentials, "resolve_cloud_credential", fake_resolve)
+    target = resolve_target(where="cloud", allow_clear=False)
+    assert target.kind == "cloud"
+    assert seen["allow_clear"] is False
+
+
 def test_jobs_resolver_honors_env(monkeypatch):
     from comfy_cli.command.jobs import _resolve_host_port
 


### PR DESCRIPTION
## Summary

- With `COMFY_KNOWLEDGE_URL` and `COMFY_KNOWLEDGE_FILE` both unset, the loader now fetches `knowledge.json` from `/api/knowledge/knowledge.json` under the cloud base URL, so a stock signed-in install loads a bundle with no configuration.
- The URL is derived from `get_base_url()` on every call and never stored, because `_http_get` only attaches credentials to URLs under that base and the base resolves per invocation from `COMFY_CLOUD_BASE_URL`, the persisted `cloud_base_url`, then `cloud.comfy.org`.
- An explicit `COMFY_KNOWLEDGE_URL` still wins. `COMFY_KNOWLEDGE_FILE` still skips the fetch entirely.
- `REASON_NO_URL` was unreachable and is replaced by `REASON_SIGNED_OUT`, which names the usual cause of a failed default fetch. `comfy knowledge status` reports it together with the effective URL.
- Cache, TTL and validation are unchanged. Env-only, no persisted config key.

## Login warm

`comfy cloud login` now calls `knowledge.refresh_if_stale()` after the session is saved. The attach path loads cache-only, so without this a fresh install had no knowledge block until the user ran a knowledge command. The warm skips when the cache is fresh or `COMFY_KNOWLEDGE_FILE` is set, and swallows every failure, so login cannot break because of it.

## Tests

- New: default URL follows the cloud base URL, explicit env var overrides it, `COMFY_KNOWLEDGE_FILE` bypasses the fetch, signed-out 401 degrades to `loaded=false` with the new reason and no exception.
- Login: warm runs after `save_cloud_session`, and never runs when login fails.
- Knowledge suites: `266 passed`. `ruff check .`: `All checks passed!`. `ruff format --check`: clean on touched files.

## First-run cost

With an empty cache against production: 0.69s wall, one `GET /api/knowledge/knowledge.json` request. The manifest fetch is skipped when the first request fails.

## Production check

Blocked on deploy. The endpoint returns 404 because cloud#7674 is merged but not yet deployed. Output was `loaded: false` with the signed-out reason, no exception, exit 0.

Closes BE-8952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbcMMxBQyYjRk32iKtqnMX