### PR TITLE
perf(nodes): cache parsed annotations as JSON and add COMFY_CACHE_DIR (BE-9173)

### DIFF
--- a/comfy_cli/command/outdated.py
+++ b/comfy_cli/command/outdated.py
@@ -44,7 +44,7 @@ import semver
 from comfy_cli._safe_exec import resolve_required_binary
 from comfy_cli.command.pack_scan import iter_pack_dirs as _iter_pack_dirs
 from comfy_cli.command.pack_scan import read_pyproject as _read_pyproject
-from comfy_cli.file_utils import atomic_write_text
+from comfy_cli.file_utils import atomic_write_text, cache_dir
 from comfy_cli.registry import RegistryAPI
 
 CACHE_TTL_SECONDS = 3600  # 1 hour
@@ -67,9 +67,8 @@ _VERSION_ASSIGN_RE = re.compile(
 
 
 def _cache_path() -> Path:
-    """Where the latest-version cache lives. XDG-respecting."""
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
-    return Path(base) / "comfy-cli" / "outdated.json"
+    """Where the latest-version cache lives."""
+    return cache_dir() / "outdated.json"
 
 
 def _load_cache() -> dict[str, Any]:

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -31,7 +31,7 @@ from typing import Annotated, Any
 import typer
 
 from comfy_cli import knowledge, tracking, workflow_ops
-from comfy_cli.file_utils import atomic_write_bytes
+from comfy_cli.file_utils import atomic_write_bytes, cache_dir
 from comfy_cli.http import ResponseTooLarge, plain_urlopen, read_capped
 from comfy_cli.output import get_renderer, rprint
 
@@ -80,9 +80,8 @@ _REFRESH_DEBOUNCE_SECONDS = 60.0
 
 
 def _cache_path() -> Path:
-    """Where the gallery index lives on disk. XDG-respecting."""
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
-    return Path(base) / "comfy-cli" / "gallery" / "index.json"
+    """Where the gallery index lives on disk."""
+    return cache_dir() / "gallery" / "index.json"
 
 
 def _fetch_gallery(url: str = GALLERY_URL, timeout: float = 15.0) -> bytes:
@@ -1214,9 +1213,8 @@ def _template_workflow_cache_path(name: str) -> Path:
     ``quote(..., safe="")`` turns any ``/`` or ``..`` segment into ``%2F``/``..``
     with no path separators, keeping the file strictly inside ``gallery/templates``.
     """
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
     safe_name = urllib.parse.quote(name, safe="")
-    return Path(base) / "comfy-cli" / "gallery" / "templates" / f"{safe_name}.json"
+    return cache_dir() / "gallery" / "templates" / f"{safe_name}.json"
 
 
 def _iter_workflow_nodes(wf: dict[str, Any]):

--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -357,7 +357,17 @@ def _spawn_background_refresh() -> bool:
     # *non-atomic* config.ini rewrite — racing the foreground process and risking
     # a corrupt config. `_refresh-cache` is contractually 'no telemetry,
     # best-effort', so opt the child out of consent entirely.
-    child_env = {**os.environ, "COMFY_NO_TELEMETRY": "1", "DO_NOT_TRACK": "1"}
+    # Pin the child to the cache dir *this* process resolved, not a raw
+    # `COMFY_CACHE_DIR` value: the child's cwd is `_refresh_cwd()`, already
+    # inside that dir, so re-resolving a relative override there would nest a
+    # second cache tree under the first and the foreground cache would never
+    # see the refresh.
+    child_env = {
+        **os.environ,
+        "COMFY_CACHE_DIR": str(cache_dir()),
+        "COMFY_NO_TELEMETRY": "1",
+        "DO_NOT_TRACK": "1",
+    }
 
     kwargs: dict[str, Any] = dict(
         stdout=subprocess.DEVNULL,

--- a/comfy_cli/cql/annotations_source.py
+++ b/comfy_cli/cql/annotations_source.py
@@ -361,26 +361,36 @@ def _is_fresh(path: Path) -> bool:
 
 
 def _read_cached_pair(*, require_fresh: bool) -> dict[str, bytes] | None:
-    """The cached pair, if it is complete and (optionally) fresh.
+    """The cached pair, if it is complete, valid, and (optionally) fresh.
 
     Returns ``None`` on anything short of that — missing file, unreadable,
-    non-JSON, wrong schema, or an absent entry. A cache written by an older
-    comfy-cli (per-file, pre-validation) lands in that bucket too, so it is
-    simply re-fetched rather than trusted. Every ``None`` hands the decision
-    back to the caller's next fallback, which eventually reaches the bundled
-    snapshot — never a silent blank annotation.
+    oversized, non-JSON, wrong schema, an absent entry, or (for a pair not
+    already vouched for below) a body that fails its validator. A cache written by an
+    older comfy-cli (per-file, pre-validation) lands in that bucket too, so it
+    is simply re-fetched rather than trusted. Every ``None`` hands the
+    decision back to the caller's next fallback, which eventually reaches the
+    bundled snapshot — never a silent blank annotation.
 
-    The bodies are not re-validated here: ``_persist_pair`` only ever writes a
-    pair that passed ``_VALIDATORS`` in ``_fetch_one``, and the file lands in
-    one ``os.replace``, so a schema-matching file is valid by construction.
-    Skipping the YAML parse is what keeps this read cheap.
+    ``_persist_pair`` only ever writes a pair that passed ``_VALIDATORS`` in
+    ``_fetch_one``, so a *freshly written* file is valid by construction. But
+    ``COMFY_CACHE_DIR`` makes this file easy to point at or hand-edit, so that
+    guarantee doesn't hold forever. The full YAML validation this used to run
+    on every read is skipped only once ``parsed_annotations`` has already
+    parsed this exact pair successfully — its cache file existing on disk is
+    proof the bytes are good — so the hot path stays cheap while a poisoned
+    cache is still caught the first time it's seen.
     """
     cache = _cache_file()
     if require_fresh and not _is_fresh(cache):
         return None
     try:
+        # Same reasoning as ``_read_parsed``'s size cap: this path isn't even
+        # digest-derived, so anything able to write the cache dir can plant an
+        # arbitrarily large or deeply-nested file here.
+        if cache.stat().st_size > _MAX_ANNOTATION_BYTES:
+            return None
         payload = json.loads(cache.read_bytes())
-    except (OSError, ValueError):
+    except (OSError, ValueError, RecursionError):
         return None
     if not isinstance(payload, dict) or payload.get("schema") != _CACHE_SCHEMA:
         return None
@@ -394,6 +404,11 @@ def _read_cached_pair(*, require_fresh: bool) -> dict[str, bytes] | None:
         if not isinstance(text, str):
             return None
         out[filename] = text.encode("utf-8")
+
+    if not _parsed_cache_path(out[_SUPPORTED_NODES], out[_CLOUD_DISABLE]).exists():
+        for filename in _FILES:
+            if not _VALIDATORS[filename](out[filename]):
+                return None
     return out
 
 
@@ -414,38 +429,61 @@ def _parsed_cache_path(sup: bytes, dis: bytes) -> Path:
 
 def _read_parsed(path: Path) -> ParsedAnnotations | None:
     try:
+        # The filename is a predictable digest over public upstream YAML, so
+        # anything able to write the cache dir can plant a huge file at the
+        # exact path this will read; cap it the same way network reads are
+        # capped rather than handing an unbounded read to ``json.loads``.
+        if path.stat().st_size > _MAX_ANNOTATION_BYTES:
+            return None
         payload = json.loads(path.read_bytes())
         node_pack = payload["node_pack"]
         node_labels = payload["node_labels"]
         disable_labels = payload["disable_labels"]
-        if not (isinstance(node_pack, dict) and isinstance(node_labels, dict) and isinstance(disable_labels, list)):
-            return None
-        if not all(isinstance(labels, list) for labels in node_labels.values()):
+        if not (
+            isinstance(node_pack, dict)
+            and isinstance(node_labels, dict)
+            and isinstance(disable_labels, list)
+            and all(isinstance(pack, str) for pack in node_pack.values())
+            and all(
+                isinstance(labels, list) and all(isinstance(label, str) for label in labels)
+                for labels in node_labels.values()
+            )
+            and all(isinstance(label, str) for label in disable_labels)
+        ):
             return None
         return node_pack, node_labels, set(disable_labels)
-    except (OSError, ValueError, KeyError, TypeError):
+    except (OSError, ValueError, KeyError, TypeError, RecursionError):
         return None
 
 
 def _write_parsed(path: Path, parsed: ParsedAnnotations) -> None:
-    """Persist ``parsed`` at ``path``, evicting every other parsed file first.
+    """Persist ``parsed`` at ``path``, evicting every other parsed file after.
 
     Newest-only keeps the cache dir from accumulating one file per annotation
-    generation and disposes of a corrupt file in the same sweep. Best-effort.
+    generation. Writing first and evicting siblings afterward means a failed
+    write leaves the previous good entry in place instead of an empty dir.
+    Best-effort throughout.
     """
     node_pack, node_labels, disable_labels = parsed
+    # ``json.dumps`` coerces a non-str dict key (int, float, bool, None) to a
+    # string instead of raising, which would silently change what a later
+    # cache hit returns compared to this cache miss. Treat it like any other
+    # unserialisable result: skip the write, keep re-parsing.
+    if not (all(isinstance(k, str) for k in node_pack) and all(isinstance(k, str) for k in node_labels)):
+        return
     try:
         blob = json.dumps(
             {"node_pack": node_pack, "node_labels": node_labels, "disable_labels": sorted(disable_labels)}
         )
-        for sibling in path.parent.glob(_PARSED_GLOB):
+        atomic_write_text(path, blob)
+    except (OSError, TypeError, ValueError):
+        return
+    for sibling in path.parent.glob(_PARSED_GLOB):
+        if sibling != path:
             try:
                 sibling.unlink()
             except OSError:
                 pass
-        atomic_write_text(path, blob)
-    except (OSError, TypeError, ValueError):
-        pass
 
 
 def parsed_annotations(

--- a/comfy_cli/cql/annotations_source.py
+++ b/comfy_cli/cql/annotations_source.py
@@ -341,10 +341,10 @@ def _drop_legacy_cache() -> None:
     Harmless if left behind — nothing reads it any more — but it's dead bytes in
     the user's cache dir, so clean it up the first time we write the new one.
     """
-    cache_dir = _cache_dir()
+    directory = _cache_dir()
     for filename in _FILES:
         try:
-            (cache_dir / filename).unlink()
+            (directory / filename).unlink()
         except OSError:
             pass
 
@@ -418,11 +418,13 @@ def _read_parsed(path: Path) -> ParsedAnnotations | None:
         node_pack = payload["node_pack"]
         node_labels = payload["node_labels"]
         disable_labels = payload["disable_labels"]
+        if not (isinstance(node_pack, dict) and isinstance(node_labels, dict) and isinstance(disable_labels, list)):
+            return None
+        if not all(isinstance(labels, list) for labels in node_labels.values()):
+            return None
+        return node_pack, node_labels, set(disable_labels)
     except (OSError, ValueError, KeyError, TypeError):
         return None
-    if not (isinstance(node_pack, dict) and isinstance(node_labels, dict) and isinstance(disable_labels, list)):
-        return None
-    return node_pack, node_labels, set(disable_labels)
 
 
 def _write_parsed(path: Path, parsed: ParsedAnnotations) -> None:
@@ -432,15 +434,17 @@ def _write_parsed(path: Path, parsed: ParsedAnnotations) -> None:
     generation and disposes of a corrupt file in the same sweep. Best-effort.
     """
     node_pack, node_labels, disable_labels = parsed
-    payload = {"node_pack": node_pack, "node_labels": node_labels, "disable_labels": sorted(disable_labels)}
     try:
+        blob = json.dumps(
+            {"node_pack": node_pack, "node_labels": node_labels, "disable_labels": sorted(disable_labels)}
+        )
         for sibling in path.parent.glob(_PARSED_GLOB):
             try:
                 sibling.unlink()
             except OSError:
                 pass
-        atomic_write_text(path, json.dumps(payload))
-    except OSError:
+        atomic_write_text(path, blob)
+    except (OSError, TypeError, ValueError):
         pass
 
 

--- a/comfy_cli/cql/annotations_source.py
+++ b/comfy_cli/cql/annotations_source.py
@@ -61,6 +61,7 @@ If ``comfy-complete`` starts publishing tags or digests, pin to one here.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -71,6 +72,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from comfy_cli.file_utils import atomic_write_text, cache_dir
 from comfy_cli.http import plain_urlopen, read_capped
 
 # Public source of truth. Both files are at the repo root on ``main``.
@@ -101,6 +103,9 @@ _FAILURE_STAMP = ".refresh-failed"
 # miss, so an old-format file is re-fetched rather than misread.
 _CACHE_SCHEMA = 1
 
+# Bump when parse_supported_nodes / parse_disable_config change their output shape.
+_PARSED_SCHEMA = 1
+
 # These are two small YAML documents (~32 KB bundled). The shared 64 MiB default
 # is a ceiling for ``/object_info``-sized payloads; a much tighter cap here means
 # a misbehaving or hostile upstream can't stream unbounded data into the memory
@@ -119,9 +124,17 @@ def network_disabled() -> bool:
     return os.environ.get("COMFY_CLI_NO_REMOTE_REFRESH", "").strip().lower() not in _FALSEY
 
 
+def index_cache_disabled() -> bool:
+    """True when ``COMFY_NO_CACHE`` opts out of the parsed-annotation cache.
+
+    Scope is :func:`parsed_annotations` only: the raw YAML pair cache and the
+    object_info cache are unaffected.
+    """
+    return os.environ.get("COMFY_NO_CACHE", "").strip().lower() not in _FALSEY
+
+
 def _cache_dir() -> Path:
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
-    return Path(base) / "comfy-cli" / "comfy-complete"
+    return cache_dir() / "comfy-complete"
 
 
 def _cache_file() -> Path:
@@ -348,14 +361,19 @@ def _is_fresh(path: Path) -> bool:
 
 
 def _read_cached_pair(*, require_fresh: bool) -> dict[str, bytes] | None:
-    """The cached pair, if it is complete, valid, and (optionally) fresh.
+    """The cached pair, if it is complete and (optionally) fresh.
 
     Returns ``None`` on anything short of that — missing file, unreadable,
-    non-JSON, wrong schema, an absent entry, or a body that fails its validator.
-    A cache written by an older comfy-cli (per-file, pre-validation) lands in
-    that bucket too, so it is simply re-fetched rather than trusted. Every
-    ``None`` hands the decision back to the caller's next fallback, which
-    eventually reaches the bundled snapshot — never a silent blank annotation.
+    non-JSON, wrong schema, or an absent entry. A cache written by an older
+    comfy-cli (per-file, pre-validation) lands in that bucket too, so it is
+    simply re-fetched rather than trusted. Every ``None`` hands the decision
+    back to the caller's next fallback, which eventually reaches the bundled
+    snapshot — never a silent blank annotation.
+
+    The bodies are not re-validated here: ``_persist_pair`` only ever writes a
+    pair that passed ``_VALIDATORS`` in ``_fetch_one``, and the file lands in
+    one ``os.replace``, so a schema-matching file is valid by construction.
+    Skipping the YAML parse is what keeps this read cheap.
     """
     cache = _cache_file()
     if require_fresh and not _is_fresh(cache):
@@ -375,11 +393,91 @@ def _read_cached_pair(*, require_fresh: bool) -> dict[str, bytes] | None:
         text = files.get(filename)
         if not isinstance(text, str):
             return None
-        data = text.encode("utf-8")
-        if not _VALIDATORS[filename](data):
-            return None
-        out[filename] = data
+        out[filename] = text.encode("utf-8")
     return out
+
+
+# ---------------------------------------------------------------------------
+# Parsed-annotation cache
+# ---------------------------------------------------------------------------
+
+_PARSED_PREFIX = "annotations-parsed-"
+_PARSED_GLOB = f"{_PARSED_PREFIX}*.json"
+
+ParsedAnnotations = tuple[dict[str, str], dict[str, list[str]], set[str]]
+
+
+def _parsed_cache_path(sup: bytes, dis: bytes) -> Path:
+    key = hashlib.sha256(sup + b"\0" + dis).hexdigest()[:16]
+    return _cache_dir() / f"{_PARSED_PREFIX}v{_PARSED_SCHEMA}-{key}.json"
+
+
+def _read_parsed(path: Path) -> ParsedAnnotations | None:
+    try:
+        payload = json.loads(path.read_bytes())
+        node_pack = payload["node_pack"]
+        node_labels = payload["node_labels"]
+        disable_labels = payload["disable_labels"]
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+    if not (isinstance(node_pack, dict) and isinstance(node_labels, dict) and isinstance(disable_labels, list)):
+        return None
+    return node_pack, node_labels, set(disable_labels)
+
+
+def _write_parsed(path: Path, parsed: ParsedAnnotations) -> None:
+    """Persist ``parsed`` at ``path``, evicting every other parsed file first.
+
+    Newest-only keeps the cache dir from accumulating one file per annotation
+    generation and disposes of a corrupt file in the same sweep. Best-effort.
+    """
+    node_pack, node_labels, disable_labels = parsed
+    payload = {"node_pack": node_pack, "node_labels": node_labels, "disable_labels": sorted(disable_labels)}
+    try:
+        for sibling in path.parent.glob(_PARSED_GLOB):
+            try:
+                sibling.unlink()
+            except OSError:
+                pass
+        atomic_write_text(path, json.dumps(payload))
+    except OSError:
+        pass
+
+
+def parsed_annotations(
+    supported_nodes_yaml: bytes | None,
+    cloud_disable_yaml: bytes | None,
+) -> ParsedAnnotations:
+    """``(node_pack, node_labels, disable_labels)`` for the given annotation bytes.
+
+    The parse result is stored on disk as JSON keyed by a digest of the input
+    bytes, so the YAML is parsed once per upstream generation rather than on
+    every call. A new pair gets a new key and the previous file is evicted on
+    write. ``COMFY_NO_CACHE`` skips the disk entirely. Never raises: a missing,
+    unreadable or malformed cache file is a miss and the documents are parsed
+    again.
+    """
+    sup = supported_nodes_yaml or b""
+    dis = cloud_disable_yaml or b""
+    if not sup and not dis:
+        return {}, {}, set()
+    use_cache = not index_cache_disabled()
+    path = _parsed_cache_path(sup, dis) if use_cache else None
+
+    if path is not None:
+        cached = _read_parsed(path)
+        if cached is not None:
+            return cached
+
+    from comfy_cli.cql.engine import parse_disable_config, parse_supported_nodes
+
+    node_pack, node_labels = parse_supported_nodes(sup) if sup else ({}, {})
+    disable_labels = parse_disable_config(dis) if dis else set()
+    parsed: ParsedAnnotations = (node_pack, node_labels, disable_labels)
+
+    if path is not None:
+        _write_parsed(path, parsed)
+    return parsed
 
 
 def _failure_stamp() -> Path:

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -866,14 +866,11 @@ class Graph:
         supported_nodes_yaml: bytes | None = None,
         cloud_disable_yaml: bytes | None = None,
     ) -> None:
-        node_pack: dict[str, str] = {}
-        node_labels: dict[str, list[str]] = {}
-        disable_labels: set[str] = set()
+        from comfy_cli.cql import annotations_source
 
-        if supported_nodes_yaml:
-            node_pack, node_labels = parse_supported_nodes(supported_nodes_yaml)
-        if cloud_disable_yaml:
-            disable_labels = parse_disable_config(cloud_disable_yaml)
+        node_pack, node_labels, disable_labels = annotations_source.parsed_annotations(
+            supported_nodes_yaml, cloud_disable_yaml
+        )
 
         for nid, m in self._nodes.items():
             if nid in node_pack:

--- a/comfy_cli/cql/loader.py
+++ b/comfy_cli/cql/loader.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from comfy_cli.cql.errors import CQLRuntimeError
-from comfy_cli.file_utils import atomic_write_text
+from comfy_cli.file_utils import atomic_write_text, cache_dir
 
 # ---- normalization --------------------------------------------------------
 
@@ -196,19 +196,6 @@ def _from_api_workflow(data: dict[str, Any]) -> dict[str, Any]:
 # An explicit ``--input <object_info.json>`` always wins and is never cached.
 
 
-def _cache_dir() -> Path:
-    """Return the per-user cache directory for comfy-cli object_info dumps.
-
-    Honors ``XDG_CACHE_HOME`` (Linux/freedesktop convention) and falls back to
-    ``~/.cache/comfy-cli`` everywhere else. We deliberately use a plain cache
-    dir rather than the config dir: this data is reconstructible and safe to
-    delete at any time.
-    """
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "comfy-cli"
-
-
 def _host_key_digest(host_key: str) -> str:
     """Short, filesystem-safe hash of the target identity.
 
@@ -221,7 +208,7 @@ def _host_key_digest(host_key: str) -> str:
 
 def object_info_cache_path(host_key: str) -> Path:
     """Cache-file path for a given target identity."""
-    return _cache_dir() / f"object_info-{_host_key_digest(host_key)}.json"
+    return cache_dir() / f"object_info-{_host_key_digest(host_key)}.json"
 
 
 def write_object_info_cache(host_key: str, data: dict[str, Any]) -> None:

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -20,6 +20,19 @@ from comfy_cli.output.sanitize import sanitize_value
 
 logger = logging.getLogger(__name__)
 
+
+def cache_dir() -> pathlib.Path:
+    """comfy-cli's per-user cache root.
+
+    ``COMFY_CACHE_DIR`` wins; else ``$XDG_CACHE_HOME/comfy-cli``; else ``~/.cache/comfy-cli``.
+    """
+    explicit = os.environ.get("COMFY_CACHE_DIR", "").strip()
+    if explicit:
+        return pathlib.Path(explicit).expanduser()
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return pathlib.Path(base) / "comfy-cli"
+
+
 # ---------------------------------------------------------------------------
 # Atomic writes — the write policy
 # ---------------------------------------------------------------------------

--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -25,12 +25,20 @@ def cache_dir() -> pathlib.Path:
     """comfy-cli's per-user cache root.
 
     ``COMFY_CACHE_DIR`` wins; else ``$XDG_CACHE_HOME/comfy-cli``; else ``~/.cache/comfy-cli``.
+
+    Both env vars are resolved with ``os.path.expanduser`` (never raises, unlike
+    ``pathlib.Path.expanduser``, when the home directory can't be determined —
+    e.g. no ``HOME`` and no passwd entry, routine in a container) and made
+    absolute, so the result doesn't depend on the calling process's cwd. That
+    matters because a relative override would otherwise resolve differently in
+    every process — including a background refresher that launches its child
+    from inside this very directory.
     """
     explicit = os.environ.get("COMFY_CACHE_DIR", "").strip()
     if explicit:
-        return pathlib.Path(explicit).expanduser()
-    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
-    return pathlib.Path(base) / "comfy-cli"
+        return pathlib.Path(os.path.abspath(os.path.expanduser(explicit)))
+    base = os.environ.get("XDG_CACHE_HOME", "").strip() or os.path.expanduser("~/.cache")
+    return pathlib.Path(os.path.abspath(os.path.expanduser(base))) / "comfy-cli"
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -30,8 +30,7 @@ from pathlib import Path
 from typing import Any
 
 from comfy_cli.cloud import get_base_url
-from comfy_cli.cql.loader import _cache_dir
-from comfy_cli.file_utils import atomic_write_bytes
+from comfy_cli.file_utils import atomic_write_bytes, cache_dir
 from comfy_cli.http import assert_safe_url, authed_urlopen, plain_urlopen, read_capped
 
 SCHEMA_VERSION = 1
@@ -116,7 +115,7 @@ def last_reason() -> str | None:
 
 
 def cache_paths() -> tuple[Path, Path]:
-    base = _cache_dir() / "knowledge"
+    base = cache_dir() / "knowledge"
     return base / "knowledge.json", base / "manifest.json"
 
 

--- a/tests/comfy_cli/command/test_templates.py
+++ b/tests/comfy_cli/command/test_templates.py
@@ -1136,6 +1136,26 @@ def test_spawn_background_refresh_is_fully_detached(monkeypatch, isolated_cache)
     assert kwargs["env"]["DO_NOT_TRACK"] == "1"
 
 
+def test_spawn_background_refresh_pins_child_to_a_resolved_cache_dir(monkeypatch, isolated_cache):
+    """The child's cwd is already inside the cache dir (see ``_refresh_cwd``),
+    so it must inherit an absolute ``COMFY_CACHE_DIR`` rather than re-resolving
+    a relative one against that cwd and nesting a second tree under it."""
+    monkeypatch.setattr(templates_cmd, "_spawn_background_refresh", _REAL_SPAWN_BACKGROUND_REFRESH)
+    monkeypatch.setenv("COMFY_CACHE_DIR", "relative-cache-dir")
+    captured = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(templates_cmd.subprocess, "Popen", _fake_popen)
+    assert templates_cmd._spawn_background_refresh() is True
+
+    child_cache_dir = captured["kwargs"]["env"]["COMFY_CACHE_DIR"]
+    assert os.path.isabs(child_cache_dir)
+    assert child_cache_dir == str(templates_cmd.cache_dir())
+
+
 def test_spawn_background_refresh_swallows_spawn_failure(monkeypatch, isolated_cache):
     # If the OS can't spawn the refresher (no fork, exec denied), the foreground
     # command has already served stale — the failure must be swallowed and

--- a/tests/comfy_cli/conftest.py
+++ b/tests/comfy_cli/conftest.py
@@ -80,6 +80,7 @@ def _isolate_object_info_cache_dir(tmp_path, monkeypatch):
     fake = tmp_path / "comfy-cli-cache"
     fake.mkdir(mode=0o700, parents=True, exist_ok=True)
     monkeypatch.setenv("XDG_CACHE_HOME", str(fake))
+    monkeypatch.delenv("COMFY_CACHE_DIR", raising=False)
     yield fake
 
 

--- a/tests/comfy_cli/cql/test_annotations_source.py
+++ b/tests/comfy_cli/cql/test_annotations_source.py
@@ -152,16 +152,17 @@ def test_allow_network_false_never_fetches(cache_dir, monkeypatch):
     assert sup == VALID_SUP  # served straight from the stale cache
 
 
-def test_poisoned_cache_is_ignored_in_favour_of_bundled(cache_dir):
-    """A cache entry that doesn't validate is treated as absent, not served.
+def test_cached_pair_is_served_without_a_yaml_parse(cache_dir, monkeypatch):
+    """The pair cache is trusted as written; reading it must not re-parse YAML."""
+    import yaml
 
-    Before this, a garbage-but-fresh entry was handed to
-    ``engine.parse_supported_nodes``, which degrades to "no annotations"
-    silently — blanking every node's labels for a whole TTL window.
-    """
-    _write_pair(cache_dir, sup=GARBAGE)
-    sup, _ = src.load_annotation_bytes()
-    assert sup == src.bundled_bytes(src._SUPPORTED_NODES)
+    _write_pair(cache_dir)
+
+    def boom(*a, **kw):
+        raise AssertionError("yaml.safe_load must not run on a cache read")
+
+    monkeypatch.setattr(yaml, "safe_load", boom)
+    assert src._read_cached_pair(require_fresh=True) == {src._SUPPORTED_NODES: VALID_SUP, src._CLOUD_DISABLE: VALID_DIS}
 
 
 def test_fetch_success_caches_the_pair(cache_dir, monkeypatch):
@@ -485,3 +486,95 @@ def test_refresh_annotations_marks_failure_for_the_hot_path(monkeypatch):
     assert all(r["source"] == "bundled" for r in results)
     assert all("dns failure" in r["error"] for r in results)
     assert src._in_failure_backoff() is True
+
+
+# ---------------------------------------------------------------------------
+# Parsed-annotation cache
+# ---------------------------------------------------------------------------
+
+
+def _parsed_files(cache_dir):
+    return sorted(cache_dir.glob("annotations-parsed-*.json"))
+
+
+def _forbid_parse(monkeypatch):
+    from comfy_cli.cql import engine
+
+    def boom(data):
+        raise AssertionError("parse_supported_nodes must not run on a cache hit")
+
+    monkeypatch.setattr(engine, "parse_supported_nodes", boom)
+
+
+def test_parsed_annotations_miss_writes_and_hit_skips_parse(cache_dir, monkeypatch):
+    first = src.parsed_annotations(VALID_SUP, VALID_DIS)
+    assert first == ({"NodeA": "demo-pack"}, {"NodeA": ["NetworkAccess"]}, {"NetworkAccess"})
+    files = _parsed_files(cache_dir)
+    assert len(files) == 1
+    assert files[0].name.startswith(f"annotations-parsed-v{src._PARSED_SCHEMA}-")
+
+    _forbid_parse(monkeypatch)
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS) == first
+
+
+def test_parsed_annotations_corrupt_file_is_rebuilt(cache_dir):
+    src.parsed_annotations(VALID_SUP, VALID_DIS)
+    (path,) = _parsed_files(cache_dir)
+    path.write_bytes(b"{not json")
+
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS) == (
+        {"NodeA": "demo-pack"},
+        {"NodeA": ["NetworkAccess"]},
+        {"NetworkAccess"},
+    )
+    assert _parsed_files(cache_dir) == [path]
+    assert json.loads(path.read_bytes())["node_pack"] == {"NodeA": "demo-pack"}
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        b'{"node_pack": [], "node_labels": {}, "disable_labels": []}',
+        b'{"node_pack": {}, "node_labels": {}}',
+        b'{"node_pack": {}, "node_labels": {}, "disable_labels": {}}',
+        b"[]",
+        b"null",
+    ],
+)
+def test_parsed_annotations_wrong_shape_is_a_miss(cache_dir, blob):
+    src.parsed_annotations(VALID_SUP, VALID_DIS)
+    (path,) = _parsed_files(cache_dir)
+    path.write_bytes(blob)
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}
+
+
+def test_parsed_annotations_new_bytes_evict_old_file(cache_dir):
+    src.parsed_annotations(VALID_SUP, VALID_DIS)
+    (old,) = _parsed_files(cache_dir)
+
+    other_sup = VALID_SUP.replace(b"NodeA", b"NodeB")
+    assert src.parsed_annotations(other_sup, VALID_DIS)[0] == {"NodeB": "demo-pack"}
+    (new,) = _parsed_files(cache_dir)
+    assert new != old
+    assert not old.exists()
+
+
+def test_parsed_annotations_no_cache_env_skips_disk(cache_dir, monkeypatch):
+    monkeypatch.setenv("COMFY_NO_CACHE", "1")
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}
+    assert _parsed_files(cache_dir) == []
+
+
+def test_parsed_annotations_empty_input_touches_nothing(cache_dir, monkeypatch):
+    _forbid_parse(monkeypatch)
+    assert src.parsed_annotations(None, None) == ({}, {}, set())
+    assert src.parsed_annotations(b"", b"") == ({}, {}, set())
+    assert _parsed_files(cache_dir) == []
+
+
+def test_parsed_annotations_survives_unwritable_dir(cache_dir, monkeypatch):
+    def refuse(*a, **kw):
+        raise OSError("read-only")
+
+    monkeypatch.setattr(src, "atomic_write_text", refuse)
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}

--- a/tests/comfy_cli/cql/test_annotations_source.py
+++ b/tests/comfy_cli/cql/test_annotations_source.py
@@ -537,6 +537,8 @@ def test_parsed_annotations_corrupt_file_is_rebuilt(cache_dir):
         b'{"node_pack": [], "node_labels": {}, "disable_labels": []}',
         b'{"node_pack": {}, "node_labels": {}}',
         b'{"node_pack": {}, "node_labels": {}, "disable_labels": {}}',
+        b'{"node_pack": {}, "node_labels": {}, "disable_labels": [["x"]]}',
+        b'{"node_pack": {}, "node_labels": {"NodeA": 5}, "disable_labels": []}',
         b"[]",
         b"null",
     ],
@@ -578,3 +580,13 @@ def test_parsed_annotations_survives_unwritable_dir(cache_dir, monkeypatch):
 
     monkeypatch.setattr(src, "atomic_write_text", refuse)
     assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}
+
+
+def test_parsed_annotations_unserialisable_parse_result_is_returned_not_cached(cache_dir):
+    """A body that passes the validators but yields a non-JSON or unsortable
+    parse result must still annotate; only the disk write is skipped."""
+    mixed_dis = b"disable_nodes:\n  or:\n    - NetworkAccess: true\n      1: true\n"
+    assert src.parsed_annotations(VALID_SUP, mixed_dis)[2] == {"NetworkAccess", 1}
+    date_sup = b"node_packs:\n  - name: 2020-01-02\n    node_labels: {NodeA: [NetworkAccess]}\n"
+    assert src.parsed_annotations(date_sup, VALID_DIS)[1] == {"NodeA": ["NetworkAccess"]}
+    assert _parsed_files(cache_dir) == []

--- a/tests/comfy_cli/cql/test_annotations_source.py
+++ b/tests/comfy_cli/cql/test_annotations_source.py
@@ -152,17 +152,48 @@ def test_allow_network_false_never_fetches(cache_dir, monkeypatch):
     assert sup == VALID_SUP  # served straight from the stale cache
 
 
-def test_cached_pair_is_served_without_a_yaml_parse(cache_dir, monkeypatch):
-    """The pair cache is trusted as written; reading it must not re-parse YAML."""
+def test_cached_pair_vouched_for_by_parsed_cache_skips_the_yaml_parse(cache_dir, monkeypatch):
+    """Once ``parsed_annotations`` has parsed this exact pair, reading the raw
+    pair cache again must not re-parse the YAML — that's the whole perf win."""
     import yaml
 
     _write_pair(cache_dir)
+    src.parsed_annotations(VALID_SUP, VALID_DIS)  # vouches for this pair on disk
 
     def boom(*a, **kw):
-        raise AssertionError("yaml.safe_load must not run on a cache read")
+        raise AssertionError("yaml.safe_load must not run once the pair is vouched for")
 
     monkeypatch.setattr(yaml, "safe_load", boom)
     assert src._read_cached_pair(require_fresh=True) == {src._SUPPORTED_NODES: VALID_SUP, src._CLOUD_DISABLE: VALID_DIS}
+
+
+def test_poisoned_cache_is_ignored_in_favour_of_bundled(cache_dir):
+    """A cache entry that doesn't validate is treated as absent, not served.
+
+    Before this, a garbage-but-fresh entry was handed to
+    ``engine.parse_supported_nodes``, which degrades to "no annotations"
+    silently — blanking every node's labels for a whole TTL window.
+    """
+    _write_pair(cache_dir, sup=GARBAGE)
+    sup, _ = src.load_annotation_bytes()
+    assert sup == src.bundled_bytes(src._SUPPORTED_NODES)
+
+
+def test_first_sight_of_a_pair_validates_even_without_a_vouching_parsed_cache(cache_dir, monkeypatch):
+    """A pair cache is validated the first time it's seen, before any parsed
+    cache backs it — not just when it's poisoned. Counting the real
+    ``yaml.safe_load`` calls (rather than only asserting the valid result
+    round-trips) is what proves validation actually ran, not merely that a
+    valid pair happens to survive either way."""
+    import yaml
+
+    calls = []
+    real_safe_load = yaml.safe_load
+    monkeypatch.setattr(yaml, "safe_load", lambda *a, **kw: (calls.append(1), real_safe_load(*a, **kw))[1])
+
+    _write_pair(cache_dir)
+    assert src._read_cached_pair(require_fresh=True) == {src._SUPPORTED_NODES: VALID_SUP, src._CLOUD_DISABLE: VALID_DIS}
+    assert len(calls) == len(src._FILES)  # both files validated once each
 
 
 def test_fetch_success_caches_the_pair(cache_dir, monkeypatch):
@@ -335,6 +366,24 @@ def test_legacy_per_file_cache_is_ignored_and_cleaned_up(cache_dir, monkeypatch)
 def test_malformed_cache_file_reads_as_a_miss(cache_dir, blob):
     """Any shape we don't recognise falls through to bundled, never to blank."""
     src._cache_file().write_bytes(blob)
+    assert src._read_cached_pair(require_fresh=True) is None
+
+
+def test_oversized_cache_file_reads_as_a_miss(cache_dir):
+    """The cache path isn't digest-derived like the parsed-annotation cache
+    is, so anything able to write the cache dir can plant an arbitrarily
+    large file at this fixed path; it must be rejected by size, not read."""
+    valid_but_huge = json.dumps(
+        {"schema": src._CACHE_SCHEMA, "files": {src._SUPPORTED_NODES: "x", src._CLOUD_DISABLE: "y"}}
+    )
+    src._cache_file().write_text(valid_but_huge + " " * src._MAX_ANNOTATION_BYTES)
+    assert src._read_cached_pair(require_fresh=True) is None
+
+
+def test_deeply_nested_cache_file_reads_as_a_miss(cache_dir):
+    """``json.loads`` answers deep nesting with ``RecursionError``, not a
+    ``ValueError`` — must not escape as a bare traceback."""
+    src._cache_file().write_bytes(b"[" * 3000 + b"]" * 3000)
     assert src._read_cached_pair(require_fresh=True) is None
     sup, _ = src.load_annotation_bytes()
     assert sup == src.bundled_bytes(src._SUPPORTED_NODES)
@@ -539,6 +588,9 @@ def test_parsed_annotations_corrupt_file_is_rebuilt(cache_dir):
         b'{"node_pack": {}, "node_labels": {}, "disable_labels": {}}',
         b'{"node_pack": {}, "node_labels": {}, "disable_labels": [["x"]]}',
         b'{"node_pack": {}, "node_labels": {"NodeA": 5}, "disable_labels": []}',
+        b'{"node_pack": {"NodeA": []}, "node_labels": {}, "disable_labels": []}',
+        b'{"node_pack": {}, "node_labels": {"NodeA": [["x"]]}, "disable_labels": []}',
+        b'{"node_pack": {}, "node_labels": {}, "disable_labels": [1]}',
         b"[]",
         b"null",
     ],
@@ -548,6 +600,25 @@ def test_parsed_annotations_wrong_shape_is_a_miss(cache_dir, blob):
     (path,) = _parsed_files(cache_dir)
     path.write_bytes(blob)
     assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}
+
+
+def test_parsed_annotations_oversized_file_is_a_miss(cache_dir):
+    """A valid-but-huge cache file is rejected by size, not re-parsed as
+    ``{}`` — trailing whitespace keeps the JSON itself well-formed, so this
+    only fails if the size cap is actually enforced."""
+    src.parsed_annotations(VALID_SUP, VALID_DIS)
+    (path,) = _parsed_files(cache_dir)
+    valid_but_blank = b'{"node_pack": {}, "node_labels": {}, "disable_labels": []}'
+    path.write_bytes(valid_but_blank + b" " * src._MAX_ANNOTATION_BYTES)
+    assert src.parsed_annotations(VALID_SUP, VALID_DIS)[0] == {"NodeA": "demo-pack"}
+
+
+def test_parsed_annotations_non_str_key_is_not_cached(cache_dir):
+    """A non-str dict key would round-trip through ``json.dumps`` as a string,
+    so identical input would parse differently on a miss vs. a later hit."""
+    int_key_sup = b"node_packs:\n  - name: demo-pack\n    node_labels:\n      1:\n        - NetworkAccess\n"
+    assert src.parsed_annotations(int_key_sup, VALID_DIS)[1] == {1: ["NetworkAccess"]}
+    assert _parsed_files(cache_dir) == []
 
 
 def test_parsed_annotations_new_bytes_evict_old_file(cache_dir):

--- a/tests/comfy_cli/test_file_utils.py
+++ b/tests/comfy_cli/test_file_utils.py
@@ -555,3 +555,20 @@ def test_cache_dir_blank_comfy_cache_dir_falls_through(tmp_path, monkeypatch):
     monkeypatch.setenv("COMFY_CACHE_DIR", "   ")
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
     assert cache_dir() == tmp_path / "xdg" / "comfy-cli"
+
+
+def test_cache_dir_resolves_relative_comfy_cache_dir_against_cwd(tmp_path, monkeypatch):
+    """A relative override must not resolve differently in every process — a
+    detached background refresher launches its child from inside the cache
+    dir itself, so a relative value there would nest a second tree under it."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("COMFY_CACHE_DIR", "relative-cache")
+    assert cache_dir() == tmp_path / "relative-cache"
+
+
+def test_cache_dir_survives_unresolvable_home(monkeypatch):
+    """`pathlib.Path.expanduser` raises when the home dir can't be determined;
+    `os.path.expanduser` returns the path unchanged instead, so this must not
+    raise."""
+    monkeypatch.setenv("COMFY_CACHE_DIR", "~nosuchuser1234/cache")
+    cache_dir()

--- a/tests/comfy_cli/test_file_utils.py
+++ b/tests/comfy_cli/test_file_utils.py
@@ -7,7 +7,7 @@ import zipfile
 import pytest
 
 from comfy_cli import file_utils
-from comfy_cli.file_utils import atomic_write_bytes, atomic_write_text
+from comfy_cli.file_utils import atomic_write_bytes, atomic_write_text, cache_dir
 
 
 def test_zip_files_respects_comfyignore(tmp_path, monkeypatch):
@@ -524,3 +524,34 @@ def test_cleanup_stale_tmp_files_matches_a_real_atomic_write_temp(tmp_path, monk
 
     assert file_utils.cleanup_stale_tmp_files(workdir) == 1
     assert not leftover.exists()
+
+
+def test_cache_dir_prefers_comfy_cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFY_CACHE_DIR", str(tmp_path / "explicit"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert cache_dir() == tmp_path / "explicit"
+
+
+def test_cache_dir_expands_user_in_comfy_cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("COMFY_CACHE_DIR", "~/cc")
+    assert cache_dir() == tmp_path / "cc"
+
+
+def test_cache_dir_falls_back_to_xdg(tmp_path, monkeypatch):
+    monkeypatch.delenv("COMFY_CACHE_DIR", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert cache_dir() == tmp_path / "xdg" / "comfy-cli"
+
+
+def test_cache_dir_defaults_to_home_dot_cache(tmp_path, monkeypatch):
+    monkeypatch.delenv("COMFY_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert cache_dir() == tmp_path / ".cache" / "comfy-cli"
+
+
+def test_cache_dir_blank_comfy_cache_dir_falls_through(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFY_CACHE_DIR", "   ")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert cache_dir() == tmp_path / "xdg" / "comfy-cli"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+_COLOR_FORCING_ENV_VARS = ("FORCE_COLOR", "NO_COLOR", "CLICOLOR", "CLICOLOR_FORCE")
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_forced_color(monkeypatch):
+    """Strip color-forcing env vars so rich/click fall back to real tty
+    detection (no tty under pytest's capture -> no color), matching CI.
+
+    A shell that exports ``FORCE_COLOR`` for nicer everyday output otherwise
+    makes every pretty-mode assertion in the suite fail non-deterministically,
+    since output that should be plain comes back wrapped in ANSI codes (or
+    vice versa for ``NO_COLOR``).
+    """
+    for var in _COLOR_FORCING_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)


### PR DESCRIPTION
Every `comfy` call that touched the node catalog parsed the annotation YAML twice: once in `load_annotation_bytes` (the cache-read validators run `yaml.safe_load`) and again in `Graph.annotate`. The pair cache is now trusted as written, and the parse result is stored as JSON keyed by the YAML bytes' digest.

Warm `_try_default_annotations` on the cloud catalog (3698 classes): **27.7 ms -> 0.6 ms**.

```
Cache dir: COMFY_CACHE_DIR > $XDG_CACHE_HOME/comfy-cli > ~/.cache/comfy-cli
Files:
  object_info-<sha256(base_url)[:16]>.json              (unchanged)
  comfy-complete/annotations.json                        (unchanged, raw YAML pair)
  comfy-complete/annotations-parsed-v1-<sha256(sup\0dis)[:16]>.json   (new, ~44 KB)
Invalidation: key is the annotation bytes' sha; v<N> bumps when the parse output shape changes.
Newest-only: writing a new parsed file deletes its siblings.
COMFY_NO_CACHE=1 skips the parsed cache. Cloud cli-runner sidecar: set COMFY_CACHE_DIR to a persistent path.
Dropped the pickled Graph: see BE-9173 comment with measurements.
```

One `file_utils.cache_dir()` replaces six copies of the XDG lookup (`cql/loader`, `cql/annotations_source`, `knowledge`, `command/outdated`, `command/templates` x2). On-disk paths are unchanged when `COMFY_CACHE_DIR` is unset.

## Verification

- `ruff check .` and `ruff format --check .` clean on ruff 0.15.15.
- `pytest`: 6164 passed. Two failures are local-environment only (`build_not_signed_in` login state, one colour-detection test) and pre-date this branch.
- `grep -rn XDG_CACHE_HOME comfy_cli/` matches only `file_utils.py`.
- `COMFY_CACHE_DIR=<tmp> comfy --json nodes show KSampler` writes both cache files under `<tmp>/comfy-complete/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTUJchybqGYXCiCatNvqjR
