### PR TITLE
fix(print): promoted widgets print at the host address; auto-grow groups print as links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ history.
 
 ### Fixed
 
+- Promoted subgraph widgets are edited where the frontend reads them. The
+  frontend (ADR 0009) keeps a promoted widget's value on the HOST instance
+  (`widgets_values` positional over the widget-backed subgraph inputs) and
+  runs that value over the interior default; `set-widget 57.width` used to
+  follow the legacy `proxyWidgets` route into the interior node, so the edit
+  neither ran nor showed on the canvas. `set-widget`, `set-slot` and `vary`
+  now write the host value for `<instance>.<input>`, redirect an interior
+  address that backs a promotion (`57/13.width`) to the same host value
+  (`redirected_from` on the op), follow an outside link feeding the promoted
+  input to its primitive (`PrimitiveInt`/`PrimitiveString*`/legacy
+  `PrimitiveNode`, through `Reroute`s) and refuse — naming the driver — when
+  a non-primitive node computes the value. Unpromoted interior widgets still
+  write the definition. The op carries `promoted.value_index` and the
+  materialized `host_widgets_values`.
+- `comfy workflow connect` wires an outside node to a promoted widget
+  (`PrimitiveInt.INT → 57.width`): the definition declares the input, so it
+  is materialized on the instance (with the frontend's `widget` marker) and
+  linked, type-checked against the declared input type.
+- `comfy workflow slots` advertises promoted widgets at the instance address
+  with the value the frontend runs (host value, else interior default), flags
+  widgets fed by a link (`linked_from`), keeps unpromoted interior widgets
+  reachable at `<instance>/<inner>.<widget>` (nested instances included), and
+  no longer advertises the interior address behind a promotion.
+- `convert_ui_to_api` (`comfy run`, `validate`) applies host-owned promoted
+  values onto the expanded interior nodes — a post-migration template whose
+  host prompt differs from the interior default (`audio_minimax_music_3`:
+  interior caption `''`) was submitted with the interior value. Precedence
+  matches the frontend: outside link, then host value, then interior.
 - `comfy workflow connect` can wire a Load Image / Load Video / Load Audio
   into an auto-grow group nested under a dynamic combo (`GeminiNanoBanana2V2`
   `model.images`, `MinimaxHailuo03ReferenceNode` / `ByteDance2ReferenceNodeV2`

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2638,6 +2638,23 @@ def _node_widget_slots(node: dict, prefix: str, graph: Graph) -> list[dict]:
         }
         if entry.port.enum_values:
             slot["enum"] = list(entry.port.enum_values)
+        # A widget converted to an input and wired: the link supplies the value
+        # at run time and the stored widget value is inert — say so, so a
+        # caller edits the source instead (the same rule promoted widgets
+        # follow across a subgraph boundary).
+        linked = next(
+            (
+                i.get("link")
+                for i in node.get("inputs") or []
+                if isinstance(i, dict)
+                and isinstance(i.get("widget"), dict)
+                and i["widget"].get("name") == entry.name
+                and i.get("link") is not None
+            ),
+            None,
+        )
+        if linked is not None:
+            slot["linked_from"] = linked
         slots.append(slot)
     return slots
 
@@ -2669,7 +2686,9 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
         seen_addrs.add(addr)
         slots.append(slot)
 
-    def walk(nodes: list, prefix: str, depth: int) -> None:
+    from comfy_cli.cql import promoted as _promoted
+
+    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]]) -> None:
         if depth > _MAX_SUBGRAPH_DEPTH:
             return
         for node in nodes:
@@ -2681,23 +2700,30 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             sg = defs_by_id.get(node_type)
             if sg is None:
                 for slot in _node_widget_slots(node, node_path, graph):
-                    add(slot)
+                    if (node_id, slot["name"]) not in exclude:
+                        add(slot)
                 continue
 
-            # Subgraph instance. A *curated* template (every declared proxy input
-            # resolves to a live interior widget) keeps its clean, hand-picked
-            # parameter view — we surface only its declared inputs and do NOT
-            # recurse, so the agent sees the intended surface. When the proxies
-            # are missing or dangling (the norm for fetched gallery templates,
-            # whose proxyWidgets point at deleted interior ids) we recurse into
-            # the definition so the real editable inner inputs are reachable.
-            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph)
+            # Subgraph instance. Its promoted widgets are advertised at the
+            # instance address (``57.width``) — the value the frontend runs
+            # lives on the host (cql.promoted), so the interior widget behind
+            # a promotion is NOT advertised: ``57/13.width`` is exactly the
+            # "layer 2" address whose edits the surface overrides. Every
+            # other interior widget is reachable at ``<instance>/<inner>.<w>``
+            # (recursing for nested instances). A legacy template whose
+            # curated surface comes entirely from ``proxyWidgets`` (nothing
+            # linked) keeps its hand-picked view without recursion.
+            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow)
             for slot in declared:
-                add(slot)
-            if not fully_curated:
-                walk(sg.get("nodes") or [], node_path, depth + 1)
+                if (node_id, slot["name"]) not in exclude:
+                    add(slot)
+            promoted = [p for p in _promoted.promoted_inputs(sg, defs_by_id) if p.is_widget]
+            if fully_curated and not promoted:
+                continue
+            hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
+            walk(sg.get("nodes") or [], node_path, depth + 1, hidden)
 
-    walk(workflow.get("nodes") or [], "", 0)
+    walk(workflow.get("nodes") or [], "", 0, set())
     return slots
 
 
@@ -2709,41 +2735,97 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
 _UNRESOLVED = object()
 
 
-def _declared_subgraph_slots(instance: dict, sg: dict, instance_id: str, graph: Graph) -> tuple[list[dict], bool]:
-    """Build slots for a subgraph instance's curated proxy inputs.
+def _declared_subgraph_slots(
+    instance: dict, sg: dict, instance_id: str, graph: Graph, workflow: dict | None = None
+) -> tuple[list[dict], bool]:
+    """Build slots for a subgraph instance's promoted inputs.
+
+    A declared input that a boundary link feeds into an interior widget is a
+    promoted WIDGET (``cql.promoted``): its address is ``<instance>.<name>``
+    and its current value is the one the frontend runs — the host instance's
+    own value when materialized, else the interior default. When an outside
+    link feeds the instance input, the slot says so (``linked_from``): a
+    write must then go to that source node. Socket-only inputs (``VIDEO``…)
+    are link slots, not widget slots. A declared input the definition does
+    not back with a link falls back to the legacy ``proxyWidgets`` route.
 
     Returns ``(slots, fully_curated)`` where ``fully_curated`` is True only when
-    the instance declares at least one input and EVERY declared input resolves
-    to a real interior widget value (so the curated surface is complete and the
-    caller can skip recursion).
+    at least one widget slot exists and EVERY one resolved to a value (so the
+    curated surface is complete and the caller can skip recursion).
     """
+    from comfy_cli.cql import promoted as _promoted
+
     declared: list[dict] = []
-    inputs = sg.get("inputs") or []
     any_declared = False
     all_resolved = True
-    for inp in inputs:
+    defs = _subgraph_defs_by_id(workflow) if workflow is not None else {}
+    promoted_by_name = {p.name: p for p in _promoted.promoted_inputs(sg, defs)}
+    for inp in sg.get("inputs") or []:
         if not isinstance(inp, dict):
             continue
         inp_name = inp.get("name", "")
         if not inp_name:
             continue
+        pi = promoted_by_name.get(inp_name)
+        linked_from = None
+        if pi is not None and pi.is_widget and workflow is not None:
+            current = _promoted.host_value(instance, pi)
+            if current is _promoted.UNSET:
+                current = _promoted.source_value(workflow, sg, pi, graph, defs)
+            if current is _promoted.UNSET:
+                current = _UNRESOLVED
+            linked_from = _promoted.external_link(instance, inp_name)
+        elif pi is not None and pi.is_widget:
+            current = _UNRESOLVED
+        else:
+            legacy = _resolve_proxy_value(instance, sg, inp_name, graph)
+            if legacy is _UNRESOLVED and pi is not None and not pi.is_widget and pi.source_node is None:
+                # Declared but unbacked and unproxied — a socket or a dangling
+                # declaration. Not a widget slot either way.
+                continue
+            current = legacy
         any_declared = True
-        current = _resolve_proxy_value(instance, sg, inp_name, graph)
         if current is _UNRESOLVED:
             all_resolved = False
             continue
         inp_type = inp.get("type", {})
-        declared.append(
-            {
-                "address": f"{instance_id}.{inp_name}",
-                "name": inp_name,
-                "type": inp_type if isinstance(inp_type, str) else str(inp_type),
-                "current_value": current,
-                "instance_id": instance_id,
-                "node_type": instance.get("type", ""),
-            }
-        )
+        slot = {
+            "address": f"{instance_id}.{inp_name}",
+            "name": inp_name,
+            "type": inp_type if isinstance(inp_type, str) else str(inp_type),
+            "current_value": current,
+            "instance_id": instance_id,
+            "node_type": instance.get("type", ""),
+        }
+        if linked_from is not None:
+            slot["linked_from"] = linked_from
+        declared.append(slot)
     return declared, (any_declared and all_resolved)
+
+
+def promoted_source_port(sg: dict, pi: Any, defs: dict[str, dict], graph: Graph) -> tuple[str, Port | None]:
+    """``(interior class, Port)`` of the concrete widget behind promoted input
+    ``pi`` — the schema a host value is validated against."""
+    from comfy_cli.cql import promoted as _promoted
+
+    target = _promoted.deepest_source(sg, pi, defs)
+    if target is None:
+        return "", None
+    path, widget = target
+    current_sg = sg
+    node: dict | None = None
+    for seg in path:
+        node = next((n for n in current_sg.get("nodes") or [] if str(n.get("id")) == seg), None)
+        if node is None:
+            return "", None
+        nxt = defs.get(str(node.get("type", "")))
+        if nxt is not None:
+            current_sg = nxt
+    class_type = str(node.get("type", "")) if node else ""
+    m = graph.node(class_type)
+    if m is None:
+        return class_type, None
+    return class_type, next((p for p in m.inputs if p.name == widget), None)
 
 
 def _resolve_proxy_value(instance: dict, subgraph: dict, input_name: str, graph: Graph):
@@ -3109,50 +3191,42 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
     # Always split on the FIRST dot so multi-dot input names are preserved.
     node_path, input_name = addr.split(".", 1)
     segments = node_path.split(_SUBGRAPH_PATH_SEP)
-
     defs_by_id = _subgraph_defs_by_id(workflow)
 
-    # --- Nested form: descend the subgraph path and write the interior widget. ---
-    if len(segments) > 1:
-        # _resolve_node_path forks every shared definition along the path (each
-        # non-terminal hop) before the terminal write, so sibling instances at
-        # any nesting depth stay independent.
-        target = _resolve_node_path(workflow, segments, defs_by_id)
-        return _write_widget(target, input_name, value, graph, extend=False)
+    from comfy_cli.cql import promoted as _promoted
 
-    instance_id = segments[0]
-    nodes = workflow.get("nodes") or []
-    instance = next((n for n in nodes if isinstance(n, dict) and str(n.get("id", "")) == instance_id), None)
-    if instance is None:
-        raise ValueError(f"node {instance_id} not found in workflow")
-
-    node_type = instance.get("type", "")
-    sg = defs_by_id.get(node_type)
-
-    # --- Curated subgraph proxy input (legacy ``<id>.<declaredInput>``). ---
-    if sg is not None:
-        proxy = (instance.get("properties") or {}).get("proxyWidgets") or []
-        interior_id = None
-        for entry in proxy:
-            if not isinstance(entry, list) or len(entry) < 2:
-                continue
-            name = entry[1] if isinstance(entry[1], str) else str(entry[1])
-            if name == input_name:
-                interior_id = str(entry[0])
-                break
-        if interior_id is None:
-            raise ValueError(
-                f"no proxyWidget mapping for {addr}; "
-                f"address an interior input directly, e.g. {instance_id}/<innerId>.<input> "
-                f"(run `comfy workflow slots` to list them)"
-            )
-        inode = next(
-            (n for n in (sg.get("nodes") or []) if isinstance(n, dict) and str(n.get("id", "")) == interior_id),
-            None,
-        )
-        if inode is None:
-            raise ValueError(f"interior node {interior_id} not found in subgraph")
-        return _write_widget(inode, input_name, value, graph, extend=False)
-
-    # --- Direct mode: regular top-level node. ---
-    return _write_widget(instance, input_name, value, graph, extend=True)
+    # One resolution for every address form — the same one set-widget uses —
+    # so a promoted widget's value lands on the host (or the outside node that
+    # feeds it), an unpromoted interior widget lands in the definition, and a
+    # plain node lands on itself. See ``cql.promoted.resolve_write``.
+    target = _promoted.resolve_write(workflow, graph, segments, input_name)
+    if target.kind == "host":
+        # Fork every shared definition along the path before writing so a
+        # nested host's siblings stay independent (a top-level host has no
+        # non-terminal hop and is not forked — its values are its own).
+        instance = _resolve_node_path(workflow, target.segments, defs_by_id)
+        sg = _subgraph_defs_by_id(workflow).get(str(instance.get("type", "")))
+        pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
+        _class, port = promoted_source_port(sg, pi, _subgraph_defs_by_id(workflow), graph)
+        warnings: list[dict] = []
+        if port is not None:
+            err = port.validate_shape(value)
+            if err:
+                raise ValueError(err)
+            warnings = [dict(w, field=addr) for w in port.validate_catalog(value)]
+        _promoted.set_host_value(workflow, instance, target.widget, value, graph)
+        return warnings
+    if target.kind == "interior":
+        inner = _resolve_node_path(workflow, target.segments, defs_by_id)
+        return _write_widget(inner, target.widget, value, graph, extend=False)
+    if target.kind == "legacy_primitive":
+        node = target.node
+        values = node.get("widgets_values")
+        values = list(values) if isinstance(values, list) else []
+        if not values:
+            values.append(None)
+        values[0] = value
+        node["widgets_values"] = values
+        return []
+    # --- Direct mode: a regular top-level node (or the primitive feeding a promoted input). ---
+    return _write_widget(target.node, target.widget, value, graph, extend=True)

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2688,7 +2688,7 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
 
     from comfy_cli.cql import promoted as _promoted
 
-    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]]) -> None:
+    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]], scope: dict) -> None:
         if depth > _MAX_SUBGRAPH_DEPTH:
             return
         for node in nodes:
@@ -2713,7 +2713,7 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             # (recursing for nested instances). A legacy template whose
             # curated surface comes entirely from ``proxyWidgets`` (nothing
             # linked) keeps its hand-picked view without recursion.
-            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow)
+            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow, scope)
             for slot in declared:
                 if (node_id, slot["name"]) not in exclude:
                     add(slot)
@@ -2721,9 +2721,9 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             if fully_curated and not promoted:
                 continue
             hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
-            walk(sg.get("nodes") or [], node_path, depth + 1, hidden)
+            walk(sg.get("nodes") or [], node_path, depth + 1, hidden, sg)
 
-    walk(workflow.get("nodes") or [], "", 0, set())
+    walk(workflow.get("nodes") or [], "", 0, set(), workflow)
     return slots
 
 
@@ -2736,7 +2736,12 @@ _UNRESOLVED = object()
 
 
 def _declared_subgraph_slots(
-    instance: dict, sg: dict, instance_id: str, graph: Graph, workflow: dict | None = None
+    instance: dict,
+    sg: dict,
+    instance_id: str,
+    graph: Graph,
+    workflow: dict | None = None,
+    scope: dict | None = None,
 ) -> tuple[list[dict], bool]:
     """Build slots for a subgraph instance's promoted inputs.
 
@@ -2774,7 +2779,10 @@ def _declared_subgraph_slots(
                 current = _promoted.source_value(workflow, sg, pi, graph, defs)
             if current is _promoted.UNSET:
                 current = _UNRESOLVED
-            linked_from = _promoted.external_link(instance, inp_name)
+            # Only a LIVE link counts (the workflow's for a top-level instance,
+            # the containing definition's for a nested one); a dangling id is
+            # what the frontend drops on load, so the host value runs.
+            linked_from = _promoted.live_external_link(scope if scope is not None else workflow, instance, inp_name)
         elif pi is not None and pi.is_widget:
             current = _UNRESOLVED
         else:

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -261,16 +261,28 @@ def source_value(workflow: dict, sg: dict, pi: PromotedInput, graph, defs: dict[
     return _interior_widget_value(inner, str(pi.source_widget), graph)
 
 
+def effective_value_for(
+    workflow: dict, instance: dict, sg: dict, pi: PromotedInput, graph, defs: dict[str, dict]
+) -> Any:
+    """:func:`effective_value` for a caller that already holds the resolved
+    ``PromotedInput`` and the definition index — the host value when
+    materialized, else the interior source value (:data:`UNSET` when even that
+    cannot be read). No name lookup, no re-walk of ``promoted_inputs``: a
+    renderer iterating every promoted input of every instance calls this once
+    per widget without re-deriving what its own loop produced."""
+    value = host_value(instance, pi)
+    if value is not UNSET:
+        return value
+    return source_value(workflow, sg, pi, graph, defs)
+
+
 def _effective(workflow: dict, instance: dict, sg: dict, name: str, graph, defs: dict[str, dict]) -> Any:
     pi = find_promoted(sg, defs, name)
     if pi is None:
         raise ValueError(f"{name!r} is not a promoted input of subgraph {sg.get('id')}")
     if not pi.is_widget:
         raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
-    value = host_value(instance, pi)
-    if value is not UNSET:
-        return value
-    return source_value(workflow, sg, pi, graph, defs)
+    return effective_value_for(workflow, instance, sg, pi, graph, defs)
 
 
 def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -162,9 +162,36 @@ def instance_input(instance: dict, name: str) -> dict | None:
 
 
 def external_link(instance: dict, name: str) -> Any:
-    """The link id feeding the instance's input ``name`` from outside, else None."""
+    """The RAW link id serialized on the instance's input ``name``, else None.
+    Prefer :func:`live_external_link`: a serialized id whose link no longer
+    exists is one the frontend drops on load, i.e. the input is unlinked."""
     entry = instance_input(instance, name)
     return None if entry is None else entry.get("link")
+
+
+def link_exists(scope: dict, link_id: Any) -> bool:
+    """Whether ``link_id`` is a live link in ``scope`` — the workflow (top-level
+    links are ``[id, src, slot, dst, slot, type]`` arrays) or a subgraph
+    definition (interior links are ``{"id": …}`` dicts)."""
+    for link in scope.get("links") or []:
+        if isinstance(link, dict):
+            if link.get("id") == link_id:
+                return True
+        elif isinstance(link, (list, tuple)) and link and link[0] == link_id:
+            return True
+    return False
+
+
+def live_external_link(scope: dict, instance: dict, name: str) -> Any:
+    """The link id feeding the instance's input ``name`` from outside, if that
+    link exists in ``scope`` (the workflow for a top-level instance, the
+    containing definition for a nested one); else None. A dangling id is
+    treated as unlinked everywhere — ``set-widget``, ``slots`` and the
+    converter must agree on what runs."""
+    link_id = external_link(instance, name)
+    if link_id is None or not link_exists(scope, link_id):
+        return None
+    return link_id
 
 
 def _quarantine_entries(instance: dict) -> list[dict]:
@@ -478,8 +505,8 @@ def resolve_write(
                 f"promoted input {widget!r} on subgraph node {node_str} is a link input ({pi.type}), not a widget — "
                 f"wire it with `comfy workflow connect <file> <node>.<output> {node_str}.{widget}`"
             )
-        link_id = external_link(node, widget)
-        if link_id is not None and _link_exists(workflow, link_id):
+        link_id = live_external_link(workflow, node, widget)
+        if link_id is not None:
             return trace_upstream_write(workflow, graph, link_id, given, redirected_from=redirected_from or given)
         # No link, or a dangling link id the frontend drops on load: the host
         # value is what runs.
@@ -493,10 +520,6 @@ def resolve_write(
         f"promoted widgets: {', '.join(names) if names else '(none)'} "
         f"(or address an interior widget directly, e.g. {node_str}/<innerId>.<input>)"
     )
-
-
-def _link_exists(workflow: dict, link_id: Any) -> bool:
-    return any(isinstance(x, (list, tuple)) and x and x[0] == link_id for x in workflow.get("links") or [])
 
 
 def trace_upstream_write(

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -94,7 +94,9 @@ def promoted_inputs(sg: dict, defs: dict[str, dict], depth: int = 0) -> list[Pro
             continue
         name = str(inp.get("name") or "")
         type_id = inp.get("type")
-        type_str = type_id if isinstance(type_id, str) else str(type_id)
+        # A missing or non-string declared type is UNKNOWN (""), never the
+        # repr of whatever was there — callers treat "" as "accept the source".
+        type_str = type_id if isinstance(type_id, str) else ""
         source: tuple[str, str, str | None, bool] | None = None
         for link_id in inp.get("linkIds") or []:
             if not isinstance(link_id, (int, str)):

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -1,0 +1,544 @@
+"""Promoted subgraph widgets — the host-owned value model.
+
+The frontend (``ComfyUI_frontend`` ADR 0009 *"Subgraph promoted widgets use
+linked inputs"*, ``SubgraphNode.ts``) represents a promoted widget as a
+**linked subgraph input**:
+
+* the subgraph definition declares the input (``definitions.subgraphs[].inputs``);
+* a boundary link (origin ``-10``, the subgraph input node) feeds it into an
+  interior node's widget-backed input (an ``inputs[]`` entry carrying a
+  ``widget`` marker), or into a nested subgraph instance's own promoted input;
+* the HOST instance owns the value: ``widgets_values[i]`` on the instance is
+  consumed positionally by the i-th subgraph input that resolves to a widget
+  (``_applyPromotedWidgetValues`` on load, ``serializeFromStoreState`` on
+  save). Socket-only inputs (``VIDEO``, ``MODEL``, an unlinked declaration)
+  own no slot.
+
+The interior widget is only a schema/default provider — *"the host/exterior
+value wins over the interior/source value during repair, persistence, and
+prompt serialization"*. ``properties.proxyWidgets`` is legacy load-time input
+the frontend consumes on migration; it is honored here only as a fallback for
+a name the definition does not declare as an input.
+
+Everything in this module is a pure function over workflow JSON. It never
+mutates a subgraph definition: a promoted value is edited on the instance,
+so sibling instances of a shared definition stay independent by construction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: LiteGraph's id for the virtual subgraph *input* node inside a definition.
+SUBGRAPH_INPUT_NODE_ID = -10
+
+#: Recursion cap for nested promotion chains (an inner instance promoting a
+#: deeper instance's input). Mirrors the frontend's own bounded traversal.
+_MAX_NESTED_PROMOTION_DEPTH = 32
+
+#: Sentinel: "no value is materialized here" (distinct from a stored ``None``).
+UNSET: Any = object()
+
+
+@dataclass(frozen=True)
+class PromotedInput:
+    """One declared subgraph input, as the host instance sees it.
+
+    ``value_index`` is the position in the host's ``widgets_values`` (``None``
+    for a socket-only input). ``source_node``/``source_input`` name the
+    interior input the first resolving boundary link targets;
+    ``source_widget`` is that input's widget name (``None`` when the source is
+    a nested instance's promoted input — ``nested`` is then ``True``).
+    """
+
+    name: str
+    type: str
+    index: int
+    value_index: int | None
+    source_node: str | None = None
+    source_input: str | None = None
+    source_widget: str | None = None
+    nested: bool = False
+
+    @property
+    def is_widget(self) -> bool:
+        return self.value_index is not None
+
+
+def defs_by_id(workflow: dict) -> dict[str, dict]:
+    """Subgraph definitions keyed by id (with the engine's unique-name fallback)."""
+    from comfy_cli.cql.engine import _subgraph_defs_by_id
+
+    return _subgraph_defs_by_id(workflow)
+
+
+def promoted_inputs(sg: dict, defs: dict[str, dict], depth: int = 0) -> list[PromotedInput]:
+    """Every declared input of definition ``sg`` in declaration order, with the
+    host value slot each widget-backed one owns — the frontend's own rule
+    (``SubgraphNode._resolveInputWidget``): walk the input's ``linkIds`` in
+    order and take the first boundary link whose interior target is a
+    widget-backed input, or a nested instance's promoted widget input."""
+    inner = {str(n.get("id")): n for n in sg.get("nodes") or [] if isinstance(n, dict)}
+    # Only hashable ids can be looked up; a malformed (list/dict) id is skipped
+    # rather than crashing conversion of the whole workflow.
+    links = {
+        link.get("id"): link
+        for link in sg.get("links") or []
+        if isinstance(link, dict) and isinstance(link.get("id"), (int, str))
+    }
+    out: list[PromotedInput] = []
+    value_index = 0
+    for idx, inp in enumerate(sg.get("inputs") or []):
+        if not isinstance(inp, dict):
+            continue
+        name = str(inp.get("name") or "")
+        type_id = inp.get("type")
+        type_str = type_id if isinstance(type_id, str) else str(type_id)
+        source: tuple[str, str, str | None, bool] | None = None
+        for link_id in inp.get("linkIds") or []:
+            if not isinstance(link_id, (int, str)):
+                continue
+            link = links.get(link_id)
+            if not isinstance(link, dict):
+                continue
+            target = inner.get(str(link.get("target_id")))
+            if target is None:
+                continue
+            target_inputs = target.get("inputs") or []
+            slot = link.get("target_slot")
+            entry = target_inputs[slot] if isinstance(slot, int) and 0 <= slot < len(target_inputs) else None
+            if not isinstance(entry, dict):
+                continue
+            inner_def = defs.get(str(target.get("type", "")))
+            if inner_def is not None:
+                # The target is itself a subgraph instance: its input entry
+                # carries a widget marker when promoted, but the concrete
+                # widget lives deeper — resolve through its own promotion.
+                if depth < _MAX_NESTED_PROMOTION_DEPTH:
+                    inner_by_name = {p.name: p for p in promoted_inputs(inner_def, defs, depth + 1)}
+                    inner_pi = inner_by_name.get(str(entry.get("name")))
+                    if inner_pi is not None and inner_pi.is_widget:
+                        source = (str(target.get("id")), str(entry.get("name")), None, True)
+                        break
+                continue
+            marker = entry.get("widget")
+            if marker:
+                widget_name = marker.get("name") if isinstance(marker, dict) else None
+                source = (str(target.get("id")), str(entry.get("name")), str(widget_name or entry.get("name")), False)
+                break
+        if source is None:
+            out.append(PromotedInput(name=name, type=type_str, index=idx, value_index=None))
+            continue
+        node_id, input_name, widget_name, nested = source
+        out.append(
+            PromotedInput(
+                name=name,
+                type=type_str,
+                index=idx,
+                value_index=value_index,
+                source_node=node_id,
+                source_input=input_name,
+                source_widget=widget_name,
+                nested=nested,
+            )
+        )
+        value_index += 1
+    return out
+
+
+def find_promoted(sg: dict, defs: dict[str, dict], name: str) -> PromotedInput | None:
+    return next((p for p in promoted_inputs(sg, defs) if p.name == name), None)
+
+
+def instance_input(instance: dict, name: str) -> dict | None:
+    """The instance's serialized ``inputs[]`` entry for subgraph input ``name``."""
+    for entry in instance.get("inputs") or []:
+        if isinstance(entry, dict) and entry.get("name") == name:
+            return entry
+    return None
+
+
+def external_link(instance: dict, name: str) -> Any:
+    """The link id feeding the instance's input ``name`` from outside, else None."""
+    entry = instance_input(instance, name)
+    return None if entry is None else entry.get("link")
+
+
+def _quarantine_entries(instance: dict) -> list[dict]:
+    raw = (instance.get("properties") or {}).get("proxyWidgetErrorQuarantine")
+    return [e for e in raw if isinstance(e, dict)] if isinstance(raw, list) else []
+
+
+def host_value(instance: dict, pi: PromotedInput) -> Any:
+    """The value the host instance materialized for ``pi``, or :data:`UNSET`.
+
+    Order is the frontend's (``_applyPromotedWidgetValues``): a quarantined
+    legacy entry's ``hostValue`` for this name first, then the positional
+    ``widgets_values`` slot.
+    """
+    if not pi.is_widget:
+        return UNSET
+    for entry in reversed(_quarantine_entries(instance)):
+        original = entry.get("originalEntry")
+        if (
+            isinstance(original, list)
+            and len(original) >= 2
+            and str(original[0]) == "-1"
+            and original[1] == pi.name
+            and "hostValue" in entry
+        ):
+            return entry["hostValue"]
+    values = instance.get("widgets_values")
+    if isinstance(values, list) and pi.value_index < len(values):
+        return values[pi.value_index]
+    return UNSET
+
+
+def _interior_widget_value(node: dict, widget: str, graph) -> Any:
+    """Read ``widget`` off an interior node's positional ``widgets_values``."""
+    from comfy_cli.cql.engine import _widgets_as_positional
+
+    node_type = str(node.get("type", ""))
+    values = _widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    order = graph.widget_order_for_node(node_type, values) if graph is not None else []
+    if widget in order:
+        idx = order.index(widget)
+        return values[idx] if idx < len(values) else None
+    return UNSET
+
+
+def source_value(workflow: dict, sg: dict, pi: PromotedInput, graph, defs: dict[str, dict] | None = None) -> Any:
+    """The interior value ``pi`` falls back to when the host has none: the
+    interior widget, or — through a nested instance — that instance's own
+    effective value. :data:`UNSET` when the source cannot be read."""
+    if pi.source_node is None:
+        return UNSET
+    defs = defs if defs is not None else defs_by_id(workflow)
+    inner = next((n for n in sg.get("nodes") or [] if str(n.get("id")) == pi.source_node), None)
+    if inner is None:
+        return UNSET
+    if pi.nested:
+        # The frontend seeds a host widget promoted THROUGH an inner instance
+        # from the deepest concrete widget (``_resolveNestedPromotedSource`` →
+        # ``resolveConcretePromotedWidget``), not from the inner host's value.
+        inner_def = defs.get(str(inner.get("type", "")))
+        if inner_def is None or pi.source_input is None:
+            return UNSET
+        inner_pi = find_promoted(inner_def, defs, pi.source_input)
+        if inner_pi is None:
+            return UNSET
+        return source_value(workflow, inner_def, inner_pi, graph, defs)
+    return _interior_widget_value(inner, str(pi.source_widget), graph)
+
+
+def _effective(workflow: dict, instance: dict, sg: dict, name: str, graph, defs: dict[str, dict]) -> Any:
+    pi = find_promoted(sg, defs, name)
+    if pi is None:
+        raise ValueError(f"{name!r} is not a promoted input of subgraph {sg.get('id')}")
+    if not pi.is_widget:
+        raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
+    value = host_value(instance, pi)
+    if value is not UNSET:
+        return value
+    return source_value(workflow, sg, pi, graph, defs)
+
+
+def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
+    """The value the frontend runs for promoted input ``name`` on ``instance``
+    when nothing outside feeds it: the host value if materialized, else the
+    interior source value (:data:`UNSET` if even that cannot be read).
+
+    Raises ``ValueError`` for a name the definition does not declare, or one
+    that is a socket-only input.
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    return _effective(workflow, instance, sg, name, graph, defs)
+
+
+def set_host_value(workflow: dict, instance: dict, name: str, value: Any, graph) -> Any:
+    """Write ``value`` as the host-owned value of promoted input ``name``.
+
+    Materializes the host's ``widgets_values`` to one entry per widget-backed
+    input (in declaration order, seeded from each input's current effective
+    value) so the positional array the frontend restores stays aligned, then
+    sets the one slot. A quarantined legacy ``hostValue`` for the same name is
+    rewritten too, because the frontend reads it first. The interior
+    definition is never touched. Returns the previous effective value.
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    pis = promoted_inputs(sg, defs)
+    pi = next((p for p in pis if p.name == name), None)
+    if pi is None:
+        raise ValueError(f"{name!r} is not a promoted input of subgraph node {instance.get('id')}")
+    if not pi.is_widget:
+        raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
+    old = _effective(workflow, instance, sg, name, graph, defs)
+    widget_backed = [p for p in pis if p.is_widget]
+    current = instance.get("widgets_values")
+    values = list(current) if isinstance(current, list) else []
+    for other in widget_backed:
+        if other.value_index >= len(values):
+            seeded = host_value(instance, other)
+            if seeded is UNSET:
+                seeded = source_value(workflow, sg, other, graph, defs)
+            values.append(None if seeded is UNSET else seeded)
+    values[pi.value_index] = value
+    instance["widgets_values"] = values
+    for entry in _quarantine_entries(instance):
+        original = entry.get("originalEntry")
+        if isinstance(original, list) and len(original) >= 2 and str(original[0]) == "-1" and original[1] == name:
+            if "hostValue" in entry:
+                entry["hostValue"] = value
+    return None if old is UNSET else old
+
+
+def deepest_source(sg: dict, pi: PromotedInput, defs: dict[str, dict]) -> tuple[list[str], str] | None:
+    """``(interior node path, widget name)`` of the concrete widget behind
+    ``pi`` — through any chain of nested instances. ``None`` when unresolvable."""
+    path: list[str] = []
+    current_sg, current = sg, pi
+    for _ in range(_MAX_NESTED_PROMOTION_DEPTH):
+        if current.source_node is None:
+            return None
+        path.append(current.source_node)
+        if not current.nested:
+            return path, str(current.source_widget)
+        inner = next((n for n in current_sg.get("nodes") or [] if str(n.get("id")) == current.source_node), None)
+        inner_def = defs.get(str(inner.get("type", ""))) if inner is not None else None
+        if inner_def is None or current.source_input is None:
+            return None
+        nxt = find_promoted(inner_def, defs, current.source_input)
+        if nxt is None:
+            return None
+        current_sg, current = inner_def, nxt
+    return None
+
+
+def host_widgets_values(instance: dict) -> list[Any]:
+    values = instance.get("widgets_values")
+    return list(values) if isinstance(values, list) else []
+
+
+# --------------------------------------------------------------------------- #
+# Where a widget write lands
+# --------------------------------------------------------------------------- #
+
+#: Frontend virtual nodes that pass a value through (``Reroute``) or hold one
+#: without a server schema (``PrimitiveNode``, ``widgets_values[0]``).
+REROUTE_TYPE = "Reroute"
+LEGACY_PRIMITIVE_TYPE = "PrimitiveNode"
+_MAX_REROUTE_HOPS = 64
+
+
+@dataclass
+class WriteTarget:
+    """The place a ``set-widget``/``set-slot`` address resolves to.
+
+    ``kind`` is ``top`` (an ordinary node's widget — possibly the SOURCE node a
+    promoted input is wired from), ``host`` (a subgraph instance's own value
+    for a promoted input; ``segments`` is the instance path, one segment when
+    top-level), ``interior`` (an unpromoted interior widget; ``segments`` is
+    the interior node path), or ``legacy_primitive`` (a schema-less frontend
+    ``PrimitiveNode``). ``redirected_from`` is the address the caller gave when
+    it was not the effective one.
+    """
+
+    kind: str
+    node: dict | None = None
+    widget: str | None = None
+    segments: list[str] | None = None
+    redirected_from: str | None = None
+
+
+def _find_top(workflow: dict, node_id: Any) -> dict | None:
+    for n in workflow.get("nodes") or []:
+        if isinstance(n, dict) and (n.get("id") == node_id or str(n.get("id")) == str(node_id)):
+            return n
+    return None
+
+
+def _navigate(workflow: dict, segments: list[str], defs: dict[str, dict]) -> dict:
+    node = _find_top(workflow, segments[0])
+    if node is None:
+        raise ValueError(f"node {segments[0]} not found in workflow")
+    for seg in segments[1:]:
+        sg = defs.get(str(node.get("type", "")))
+        if sg is None:
+            raise ValueError(f"node {node.get('id')} is not a subgraph; cannot descend to {seg!r}")
+        node = next((n for n in sg.get("nodes") or [] if isinstance(n, dict) and str(n.get("id")) == str(seg)), None)
+        if node is None:
+            raise ValueError(f"interior node {seg} not found in subgraph {sg.get('id')}")
+    return node
+
+
+def legacy_proxy_interior(instance: dict, widget: str) -> str | None:
+    """The interior node id a legacy ``proxyWidgets`` entry routes ``widget`` to."""
+    for entry in (instance.get("properties") or {}).get("proxyWidgets") or []:
+        if isinstance(entry, list) and len(entry) >= 2 and str(entry[1]) == widget and str(entry[0]) != "-1":
+            return str(entry[0])
+    return None
+
+
+def resolve_write(
+    workflow: dict, graph, segments: list[str], widget: str, *, redirected_from: str | None = None
+) -> WriteTarget:
+    """Resolve a widget address to the place whose value the graph runs.
+
+    * ``<instance>.<promoted>`` — the host instance's own value (ADR 0009)…
+      unless an outside link feeds that input, in which case the write follows
+      the link to its source (a primitive's single widget, through reroutes);
+      a source that is not a primitive is refused by name, because no widget
+      write could take effect.
+    * ``<instance>/<inner>.<widget>`` whose interior input is fed by the
+      subgraph input node (``-10``) — the same host value, so it redirects
+      there (``redirected_from`` records the given address). An interior
+      widget fed by another interior node is refused the same way.
+    * any other interior widget — written in the definition, as before.
+    * a promoted name the definition does not declare as an input but the
+      legacy ``proxyWidgets`` still route — the interior, as before.
+    """
+    defs = defs_by_id(workflow)
+    if len(segments) > 1:
+        target = _navigate(workflow, segments, defs)
+        parent = _navigate(workflow, segments[:-1], defs)
+        parent_def = defs.get(str(parent.get("type", "")))
+        target_def = defs.get(str(target.get("type", "")))
+        given = f"{'/'.join(segments)}.{widget}"
+        entry = next(
+            (
+                i
+                for i in target.get("inputs") or []
+                if isinstance(i, dict)
+                and (
+                    (isinstance(i.get("widget"), dict) and i["widget"].get("name") == widget)
+                    or (i.get("name") == widget and (i.get("widget") or target_def is not None))
+                )
+            ),
+            None,
+        )
+        link_id = entry.get("link") if entry is not None else None
+        if link_id is not None and parent_def is not None:
+            link = next(
+                (x for x in parent_def.get("links") or [] if isinstance(x, dict) and x.get("id") == link_id), None
+            )
+            if link is not None and link.get("origin_id") == SUBGRAPH_INPUT_NODE_ID:
+                sg_inputs = parent_def.get("inputs") or []
+                origin_slot = link.get("origin_slot")
+                sg_input = (
+                    sg_inputs[origin_slot]
+                    if isinstance(origin_slot, int) and 0 <= origin_slot < len(sg_inputs)
+                    else None
+                )
+                if isinstance(sg_input, dict) and sg_input.get("name"):
+                    return resolve_write(
+                        workflow, graph, segments[:-1], str(sg_input["name"]), redirected_from=redirected_from or given
+                    )
+            if link is not None:
+                origin = link.get("origin_id")
+                origin_node = next((n for n in parent_def.get("nodes") or [] if str(n.get("id")) == str(origin)), None)
+                raise ValueError(
+                    f"{given} is fed by interior node {'/'.join(segments[:-1])}/{origin} "
+                    f"({origin_node.get('type') if origin_node else '?'}) — that link supplies the value, so a widget "
+                    f"write there would be ignored; edit that node's own widgets instead (see `comfy workflow slots`)"
+                )
+        if target_def is not None:
+            pi = find_promoted(target_def, defs, widget)
+            if pi is not None and pi.is_widget:
+                return WriteTarget(
+                    "host", node=target, widget=widget, segments=segments, redirected_from=redirected_from
+                )
+        return WriteTarget("interior", widget=widget, segments=segments, redirected_from=redirected_from)
+
+    node_str = segments[0]
+    node = _find_top(workflow, node_str)
+    if node is None:
+        raise ValueError(f"node {node_str} not found in workflow")
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
+        return WriteTarget("top", node=node, widget=widget, redirected_from=redirected_from)
+    given = f"{node_str}.{widget}"
+    pi = find_promoted(sg, defs, widget)
+    if pi is not None:
+        if not pi.is_widget:
+            legacy = legacy_proxy_interior(node, widget)
+            if legacy is not None:
+                return WriteTarget(
+                    "interior", widget=widget, segments=[node_str, legacy], redirected_from=redirected_from
+                )
+            raise ValueError(
+                f"promoted input {widget!r} on subgraph node {node_str} is a link input ({pi.type}), not a widget — "
+                f"wire it with `comfy workflow connect <file> <node>.<output> {node_str}.{widget}`"
+            )
+        link_id = external_link(node, widget)
+        if link_id is not None and _link_exists(workflow, link_id):
+            return trace_upstream_write(workflow, graph, link_id, given, redirected_from=redirected_from or given)
+        # No link, or a dangling link id the frontend drops on load: the host
+        # value is what runs.
+        return WriteTarget("host", node=node, widget=widget, segments=[node_str], redirected_from=redirected_from)
+    legacy = legacy_proxy_interior(node, widget)
+    if legacy is not None:
+        return WriteTarget("interior", widget=widget, segments=[node_str, legacy], redirected_from=redirected_from)
+    names = [p.name for p in promoted_inputs(sg, defs) if p.is_widget]
+    raise ValueError(
+        f"promoted input {widget!r} not found on subgraph node {node_str}; "
+        f"promoted widgets: {', '.join(names) if names else '(none)'} "
+        f"(or address an interior widget directly, e.g. {node_str}/<innerId>.<input>)"
+    )
+
+
+def _link_exists(workflow: dict, link_id: Any) -> bool:
+    return any(isinstance(x, (list, tuple)) and x and x[0] == link_id for x in workflow.get("links") or [])
+
+
+def trace_upstream_write(
+    workflow: dict, graph, link_id: Any, given: str, *, redirected_from: str | None
+) -> WriteTarget:
+    """Follow the link feeding a promoted input to the widget that is its source
+    of truth: a primitive's single value widget (``PrimitiveInt.value``, a
+    legacy ``PrimitiveNode``), through any ``Reroute`` chain. Anything else
+    computes the value (``ResolutionSelector``, ``GetImageSize``, another
+    subgraph's output), so a widget write could not take effect — refused
+    with the driver named so the caller edits it or rewires."""
+    from comfy_cli.cql.engine import FRONTEND_MARKER_SLOTS, _widgets_as_positional
+
+    defs = defs_by_id(workflow)
+    links = workflow.get("links") or []
+    for _ in range(_MAX_REROUTE_HOPS):
+        link = next((x for x in links if isinstance(x, (list, tuple)) and len(x) >= 3 and x[0] == link_id), None)
+        if link is None:
+            raise ValueError(f"{given} is fed by link {link_id}, which does not exist in the workflow")
+        src_id, src_slot = link[1], link[2]
+        src = _find_top(workflow, src_id)
+        if src is None:
+            raise ValueError(f"{given} is fed by node {src_id}, which does not exist in the workflow")
+        src_type = str(src.get("type", ""))
+        if src_type == REROUTE_TYPE:
+            inputs = src.get("inputs") or []
+            link_id = inputs[0].get("link") if inputs and isinstance(inputs[0], dict) else None
+            if link_id is None:
+                raise ValueError(f"{given} is fed by Reroute {src_id}, which has no input — connect a primitive to it")
+            continue
+        if src_type == LEGACY_PRIMITIVE_TYPE:
+            outputs = src.get("outputs") or []
+            marker = outputs[0].get("widget") if outputs and isinstance(outputs[0], dict) else None
+            name = marker.get("name") if isinstance(marker, dict) and marker.get("name") else "value"
+            return WriteTarget("legacy_primitive", node=src, widget=str(name), redirected_from=redirected_from)
+        m = graph.node(src_type) if graph is not None and src_type not in defs else None
+        if m is not None:
+            widgets = _widgets_as_positional(src.get("widgets_values"), graph, src_type)
+            order = [n for n in graph.widget_order_for_node(src_type, widgets) if n not in FRONTEND_MARKER_SLOTS]
+            if len(order) == 1:
+                return WriteTarget("top", node=src, widget=order[0], redirected_from=redirected_from)
+        raise ValueError(
+            f"{given} is driven by node {src_id} ({src_type}) output {src_slot} — that link supplies the value, "
+            f"so writing the widget would be ignored. Edit node {src_id}'s own widgets (see `comfy workflow slots`), "
+            f"or connect a primitive (e.g. PrimitiveInt) to {given} and set its value."
+        )
+    raise ValueError(f"{given}: reroute chain too deep")

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -637,16 +637,76 @@ def _set_widget_impl(
     base_version: int = 0,
 ) -> tuple[dict, dict]:
     from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
 
-    # Subgraph-aware: a subgraph instance's *promoted* input (flat ``57.text`` —
-    # exactly what ``comfy workflow slots`` advertises) or an interior node
-    # (nested ``57/27.text``) resolves INTO the subgraph definition. Both forms
-    # reuse the CQL engine's slot resolver so set-widget and slots agree. The op
-    # carries the resolved interior ``path`` + ``inner_widget`` so apply/replay is
-    # deterministic and writes back into the definition (the change persists).
-    sub = _subgraph_write_target(workflow, node_id, widget)
-    if sub is not None:
-        segments, inner_widget = sub
+    # Subgraph-aware. A promoted widget's value lives on the HOST instance
+    # (ADR 0009: the host value wins over the interior default at run time),
+    # and when an outside node feeds the promoted input, on THAT node — never
+    # on the interior node the legacy ``proxyWidgets`` route pointed at. So a
+    # flat ``57.width``, the interior ``57/13.width`` it backs, and a primitive
+    # wired into ``57.width`` all resolve to the one place the frontend runs.
+    # Unpromoted interior widgets (``57/3.cfg``) still write the definition.
+    target = _resolve_widget_write(workflow, graph, node_id, widget)
+    extra: dict[str, Any] = {}
+    if target.redirected_from is not None:
+        extra["redirected_from"] = target.redirected_from
+    if target.kind == "host":
+        instance = target.node
+        defs = _engine._subgraph_defs_by_id(workflow)
+        sg = defs[str(instance.get("type", ""))]
+        pi = _promoted.find_promoted(sg, defs, widget)
+        inner_type, port = _engine.promoted_source_port(sg, pi, defs, graph)
+        value, norm_note = _normalize_combo(graph, inner_type, port.name if port else widget, value)
+        old = _promoted.effective_value(workflow, instance, widget, graph)
+        warnings: list[dict] = []
+        if port is not None:
+            err = port.validate_shape(value)
+            if err:
+                raise ValueError(err)
+            warnings = [dict(w, field=f"{'/'.join(target.segments)}.{widget}") for w in port.validate_catalog(value)]
+            _refuse_fatal(warnings)
+        if norm_note:
+            warnings = [norm_note, *warnings]
+        op = _new_op(
+            "set_widget",
+            actor,
+            base_version,
+            node_id=instance.get("id") if len(target.segments) == 1 else "/".join(target.segments),
+            widget=widget,
+            value=value,
+            old=None if old is _promoted.UNSET else old,
+            promoted={"value_index": pi.value_index, "instance_path": list(target.segments)},
+            **extra,
+        )
+        if warnings:
+            op["warnings"] = warnings
+        workflow = apply_op(workflow, op, graph)
+        # The materialized host array, for an applier that stores the instance
+        # opaquely (no catalog entry for a subgraph type): it can replace the
+        # positional array wholesale instead of decomposing it by name.
+        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(target.node)
+        return workflow, op
+    if target.kind == "legacy_primitive":
+        src = target.node
+        values = src.get("widgets_values")
+        old = values[0] if isinstance(values, list) and values else None
+        op = _new_op(
+            "set_widget",
+            actor,
+            base_version,
+            node_id=src.get("id"),
+            widget=target.widget,
+            value=value,
+            old=old,
+            legacy_primitive=True,
+            **extra,
+        )
+        return apply_op(workflow, op, graph), op
+    if target.kind == "top" and target.redirected_from is not None:
+        node_id = target.node.get("id")
+        widget = target.widget
+    if target.kind == "interior":
+        segments, inner_widget = target.segments, target.widget
         target = _navigate_subgraph_path(workflow, segments)  # read-only: current value + schema
         inner_type = target.get("type", "")
         value, norm_note = _normalize_combo(graph, inner_type, inner_widget, value)
@@ -669,6 +729,7 @@ def _set_widget_impl(
             old=old,
             path=[str(s) for s in segments],
             inner_widget=inner_widget,
+            **extra,
         )
         if warnings:
             op["warnings"] = warnings
@@ -691,10 +752,38 @@ def _set_widget_impl(
         widget=widget,
         value=value,
         old=old,
+        **extra,
     )
     if warnings:
         op["warnings"] = warnings
     return apply_op(workflow, op, graph), op
+
+
+def _refuse_fatal(warnings: list[dict]) -> None:
+    from comfy_cli.cql.engine import FATAL_FINDING_CODES
+
+    for w in warnings:
+        if w.get("code") in FATAL_FINDING_CODES:
+            raise FatalFindingError(w)
+
+
+def _resolve_widget_write(workflow: dict, graph, node_id: Any, widget: str):
+    """Where a set-widget address lands — see ``cql.promoted.resolve_write``.
+    The ``<outer>:<inner>`` alias UI→API lowering mints is accepted like the
+    editable ``<outer>/<inner>`` path."""
+    from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
+
+    node_str = str(node_id)
+    if _engine._SUBGRAPH_PATH_SEP in node_str:
+        segments = node_str.split(_engine._SUBGRAPH_PATH_SEP)
+    elif ":" in node_str and _find_by_str(workflow, node_str) is None:
+        segments = node_str.split(":")
+    else:
+        if _find(workflow, node_id) is None and _find_by_str(workflow, node_str) is None:
+            _require(workflow, node_id)  # canonical not-found error
+        segments = [node_str]
+    return _promoted.resolve_write(workflow, graph, segments, widget)
 
 
 def _subgraph_write_target(workflow: dict, node_id: Any, widget: str) -> tuple[list[str], str] | None:
@@ -854,8 +943,17 @@ def _promoted_widget_error(workflow: dict, node: dict, slot: Any) -> ValueError 
 
     if not isinstance(slot, str):
         return None
-    if _engine._subgraph_defs_by_id(workflow).get(str(node.get("type", ""))) is None:
+    defs = _engine._subgraph_defs_by_id(workflow)
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
         return None
+    from comfy_cli.cql import promoted as _promoted
+
+    pi = _promoted.find_promoted(sg, defs, slot)
+    if pi is not None and (
+        pi.is_widget or pi.source_node is not None or _promoted.legacy_proxy_interior(node, slot) is None
+    ):
+        return None  # a declared input: connect handles it (materialize + wire)
     try:
         target = _subgraph_write_target(workflow, node.get("id"), slot)
     except ValueError:
@@ -910,7 +1008,7 @@ def _connect_impl(
     dst = _require(workflow, to_node)
     out_idx, link_type = _resolve_output_slot(src, graph, from_slot)
     try:
-        in_idx, grow = _resolve_input_target(dst, graph, to_slot, link_type)
+        in_idx, grow = _resolve_input_target(dst, graph, to_slot, link_type, workflow=workflow)
     except ValueError as e:
         promoted = _promoted_widget_error(workflow, dst, to_slot)
         if promoted is not None:
@@ -1705,6 +1803,34 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
     # dropped, so the surviving value is the same in any apply order.
     if not _lww_gate(workflow, op):
         return
+    promoted_write = op.get("promoted")
+    if promoted_write:
+        # Host-owned value of a promoted subgraph input (cql.promoted). The
+        # instance path is one segment for a top-level instance; a nested host
+        # descends (forking shared definitions en route, like interior writes).
+        from comfy_cli.cql import engine as _engine
+        from comfy_cli.cql import promoted as _promoted
+
+        instance_path = [str(s) for s in promoted_write.get("instance_path") or [str(op["node_id"])]]
+        if _find_by_str(workflow, instance_path[0]) is None:
+            return  # instance concurrently deleted => no-op (delete wins)
+        defs_by_id = _engine._subgraph_defs_by_id(workflow)
+        instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
+        _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        _lww_commit(workflow, op)
+        return
+    if op.get("legacy_primitive"):
+        node = _find_by_str(workflow, op["node_id"])
+        if node is None:
+            return
+        values = node.get("widgets_values")
+        values = list(values) if isinstance(values, list) else []
+        if not values:
+            values.append(None)
+        values[0] = op["value"]
+        node["widgets_values"] = values
+        _lww_commit(workflow, op)
+        return
     path = op.get("path")
     if path:
         # Subgraph interior write. A concurrently-deleted instance => no-op
@@ -1797,9 +1923,15 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
         # schema's own element names, when the catalog carries a template).
         ins = dst.setdefault("inputs", [])
         to_idx = next((k for k, i in enumerate(ins) if i.get("grow_id") == op["link_id"]), None)
+        if to_idx is None and grow.get("promoted"):
+            # A promoted subgraph input is ONE register named by the definition:
+            # a concurrent connect that already materialized it shares the entry.
+            to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
         if to_idx is None:
             inputcount = grow.get("inputcount")
-            if inputcount is not None:
+            if grow.get("promoted"):
+                name = grow["name"]
+            elif inputcount is not None:
                 # Bare-key family (see _next_inputcount_name): a collision must
                 # still grow the next free BARE key, never autogrow's dotted
                 # base.elemN fallback — that name is meaningless for this family.
@@ -2392,7 +2524,9 @@ def _inputcount_family_match(graph, node_type: str, slot: str) -> tuple[str, int
     return elem, n
 
 
-def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -> tuple[int | None, dict | None]:
+def _resolve_input_target(
+    node: dict, graph, slot: Any, elem_type: str | None, workflow: dict | None = None
+) -> tuple[int | None, dict | None]:
     """Resolve a connect target. Returns ``(index, None)`` for a concrete input,
     or ``(None, grow)`` where ``grow`` is the input slot to append (autogrow slot,
     or a widget converted to an input).
@@ -2423,6 +2557,15 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
         return idx, None
     except ValueError:
         pass
+    # Promoted subgraph input (``57.width``): the definition declares it, so it
+    # is a link input on the instance even before the instance carries an
+    # ``inputs[]`` entry for it — the frontend rebuilds those from the
+    # definition on load. Materialize it (widget marker when it backs a
+    # widget) and wire it; type-checked against the declared input type.
+    if workflow is not None and isinstance(slot, str):
+        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
+        if promoted_grow is not None:
+            return None, promoted_grow
     # Dotted autogrow key (images.image0) or a base that has no concrete slot yet.
     if isinstance(slot, str):
         base = slot.split(".", 1)[0]
@@ -2511,6 +2654,36 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             )
     names = [i.get("name") for i in ins]
     raise ValueError(f"input {slot!r} not found on node {node.get('id')}; inputs: {names}")
+
+
+def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: str | None) -> dict | None:
+    """The input to materialize on subgraph instance ``node`` for a connect to
+    its declared input ``slot`` (see ``cql.promoted``). ``None`` when ``node``
+    is not an instance or ``slot`` is not one of its definition's inputs."""
+    from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
+
+    defs = _engine._subgraph_defs_by_id(workflow)
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
+        return None
+    pi = _promoted.find_promoted(sg, defs, slot)
+    if pi is None:
+        return None
+    if not pi.is_widget and pi.source_node is None and _promoted.legacy_proxy_interior(node, slot) is not None:
+        # Declared but unbacked, and a legacy proxy routes the name to an
+        # interior widget: still a value, not a link (the frontend repairs it
+        # into a linked input on load). set-widget owns it.
+        return None
+    if elem_type and not _types_compatible(elem_type, pi.type):
+        raise ValueError(
+            f"type mismatch: {elem_type} output cannot connect to {pi.type} input {slot!r} "
+            f"of subgraph node {node.get('id')}"
+        )
+    grow: dict[str, Any] = {"name": slot, "type": pi.type, "promoted": True}
+    if pi.is_widget:
+        grow["widget"] = slot
+    return grow
 
 
 def _resolve_schema_autogrow(

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -683,8 +683,12 @@ def _set_widget_impl(
         workflow = apply_op(workflow, op, graph)
         # The materialized host array, for an applier that stores the instance
         # opaquely (no catalog entry for a subgraph type): it can replace the
-        # positional array wholesale instead of decomposing it by name.
-        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(target.node)
+        # positional array wholesale instead of decomposing it by name. Read
+        # from the instance apply WROTE — a nested host inside a shared
+        # definition was forked on the way down, so the dict captured during
+        # resolution is the pre-fork sibling, not the written one.
+        written = _engine._resolve_node_path(workflow, list(target.segments), _engine._subgraph_defs_by_id(workflow))
+        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(written)
         return workflow, op
     if target.kind == "legacy_primitive":
         src = target.node
@@ -2675,12 +2679,15 @@ def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: s
         # interior widget: still a value, not a link (the frontend repairs it
         # into a linked input on load). set-widget owns it.
         return None
-    if elem_type and not _types_compatible(elem_type, pi.type):
+    # A declared input with no usable type (missing or non-string in the
+    # save) is reachable, not a mismatch: skip the check and stamp the slot
+    # with the source type, as the frontend would infer it.
+    if elem_type and pi.type and not _types_compatible(elem_type, pi.type):
         raise ValueError(
             f"type mismatch: {elem_type} output cannot connect to {pi.type} input {slot!r} "
             f"of subgraph node {node.get('id')}"
         )
-    grow: dict[str, Any] = {"name": slot, "type": pi.type, "promoted": True}
+    grow: dict[str, Any] = {"name": slot, "type": pi.type or elem_type or "*", "promoted": True}
     if pi.is_widget:
         grow["widget"] = slot
     return grow

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -880,11 +880,9 @@ def _render_subgraph_instance_line(
             if link_id is not None:
                 text = _promoted_widget_link_text(pi.name, link_id, nid, ctx, annotations, prim_hits, warnings)
             if text is None:
-                try:
-                    value = _promoted.effective_value(state.workflow, node, pi.name, ctx.graph)
-                except ValueError as e:  # the definition index disagrees with itself: say so, print None
-                    warnings.append(f"node {ctx.qualify(nid)}: promoted widget {pi.name!r} unreadable: {e}")
-                    value = _promoted.UNSET
+                # ``pi`` and the definition index are this loop's own; the
+                # name-lookup entry point would re-derive both per widget.
+                value = _promoted.effective_value_for(state.workflow, node, sg_def, pi, ctx.graph, state.promoted_defs)
                 text = py_literal(None if value is _promoted.UNSET else value)
         elif pi.source_node is None and link_id is None and ctx.graph is not None:
             # Declared but backed by no boundary link: a legacy template still
@@ -1043,7 +1041,7 @@ class _State:
         self.defs_by_id = defs_by_id
         # The whole workflow and cql.promoted's own definition index: a
         # promoted widget's effective value is resolved from the HOST instance
-        # against its definition (``promoted.effective_value``), at any depth.
+        # against its definition (``promoted.effective_value_for``), at any depth.
         self.workflow: dict = workflow if workflow is not None else {}
         self.promoted_defs: dict[str, dict] = _promoted.defs_by_id(self.workflow)
         self.warnings = warnings

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -17,6 +17,18 @@ as an indented block addressed as ``<first instance address>/<inner id>`` —
 fully qualified through every nesting level, matching
 ``workflow_ops._navigate_subgraph_path``.
 
+Two rules keep the printed names the ones the editors take:
+
+* a regular node's widgets print by their value-aware names
+  (``Graph.widget_order_for_node``: ``model``, ``model.resolution``, …); an
+  auto-grow group (``COMFY_AUTOGROW_V3``) owns no widget slot — its grown
+  slots print as links, one open slot stays visible, and the line comment
+  names the group with its element type;
+* a subgraph instance's promoted widgets (``cql.promoted``) print their
+  EFFECTIVE value — the host's, else the interior default — under the
+  instance address (``57.width``); the interior line keeps ``IN.width`` and
+  the definition header says where that value lives.
+
 See the design: decisions D1-D13 (Obsidian, "workflow print (design, 2026-08-25)").
 """
 
@@ -28,7 +40,8 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from comfy_cli.cql.engine import _expand_widget_entries, _widgets_as_positional
+from comfy_cli.cql import promoted as _promoted
+from comfy_cli.cql.engine import _UNRESOLVED, _expand_widget_entries, _resolve_proxy_value, _widgets_as_positional
 from comfy_cli.workflow_to_api import is_subgraph_uuid
 
 if TYPE_CHECKING:
@@ -528,6 +541,57 @@ def _place_arg(name: str, text: str, args: list[str], extra: dict[str, str]) -> 
         extra[name] = text
 
 
+def _autogrow_annotation(group: Any, inputs: list[dict]) -> str:
+    """The line-comment marker for one auto-grow group: its name, the socket
+    type every grown slot carries, and the schema's capacity — so a reader
+    knows the group exists (and what to wire into it) even before anything is
+    connected. The element type comes from the schema template; a catalog
+    that omits it falls back to the type litegraph stamped on a grown slot."""
+    elem = group.autogrow_element_type
+    if not elem:
+        prefix = f"{group.name}."
+        elem = next(
+            (
+                str(inp["type"])
+                for inp in inputs
+                if str(inp.get("name") or "").startswith(prefix) and isinstance(inp.get("type"), str) and inp["type"]
+            ),
+            "any",
+        )
+    _lo, hi = group.autogrow_limits
+    return f" {group.name} grows {elem}" + (f" (max {hi})" if hi is not None else "")
+
+
+def _ensure_open_autogrow_slot(group: Any, inputs: list[dict], extra: dict[str, str]) -> None:
+    """Show ONE open slot for ``group`` when none of its serialized slots is
+    free and the schema allows another — the frontend keeps exactly that free
+    trailing slot on a loaded node, so a UI-built and an agent-built node
+    (whose ``inputs[]`` only carry what ``connect`` grew) print alike, and the
+    printed name is the one ``connect`` accepts next. Inserted right after the
+    group's last existing slot so the group stays contiguous. Never touches the
+    workflow itself."""
+    from comfy_cli.workflow_ops import _autogrow_elem_name, _first_free_autogrow_index
+
+    prefix = f"{group.name}."
+    members = [str(inp.get("name") or "") for inp in inputs if str(inp.get("name") or "").startswith(prefix)]
+    if any(extra.get(name) == "None" for name in members):
+        return
+    _lo, hi = group.autogrow_limits
+    if hi is not None and len(members) >= hi:
+        return
+    template = group.autogrow_template
+    n = _first_free_autogrow_index(set(members), group.name, template)
+    slot = f"{group.name}.{_autogrow_elem_name(group.name, n, template)}"
+    items = list(extra.items())
+    last = max((i for i, (k, _v) in enumerate(items) if k in members), default=None)
+    if last is None:
+        extra[slot] = "None"
+        return
+    items.insert(last + 1, (slot, "None"))
+    extra.clear()
+    extra.update(items)
+
+
 def _build_args(
     node: dict, m: Any, ctx: _RenderCtx, warnings: list[str]
 ) -> tuple[list[str], bool, list[str], list[tuple]]:
@@ -537,7 +601,16 @@ def _build_args(
     ``unknown`` is True when the class isn't in the catalog (or there is no
     catalog), ``annotations`` are suffix strings to append to the line
     comment, and ``prim_hits`` are ``(qualified_primitive_id, qualified_skip_reason)``
-    pairs for PrimitiveNode-into-widget splices found here."""
+    pairs for PrimitiveNode-into-widget splices found here.
+
+    Widgets print by their VALUE-AWARE names (``Graph.widget_order_for_node``):
+    a dynamic combo's selector followed by the selected option's sub-widgets
+    (``model.resolution``…), read at the frontend's positions. A link-only
+    sub-input (a ``COMFY_AUTOGROW_V3`` group) owns no widget slot, so it never
+    prints as a value: its grown slots print as links, one open slot is kept
+    visible (``_ensure_open_autogrow_slot``), and the group itself is named in
+    the line comment with its element type (``_autogrow_annotation``).
+    """
     nid = str(node.get("id"))
     args: list[str] = []
     extra: dict[str, str] = {}
@@ -553,6 +626,20 @@ def _build_args(
             warnings.append(f"node {ctx.qualify(nid)}: ignoring malformed input entry {inp!r}")
             continue
         inputs.append(inp)
+
+    class_type = node.get("type", "")
+    widgets_values = node.get("widgets_values")
+    unknown = m is None
+    if unknown:
+        positional = widgets_values if isinstance(widgets_values, list) else []
+        groups: list = []
+    else:
+        positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
+        # The auto-grow groups this node exposes for its CURRENT selection —
+        # a group nested under a dynamic combo disappears when the selector
+        # moves to an option without it.
+        groups = ctx.graph.autogrow_groups(class_type, positional)
+    group_names = {g.name for g in groups}
 
     # Pre-pass: widget-backed inputs. A LIVE link to a real, printable node is
     # the truth — it's printed as a ref in the link pass below and skipped in
@@ -604,6 +691,11 @@ def _build_args(
                 _place_arg(name, live_link_refs[name], args, extra)
             continue  # otherwise: printed in the widget pass instead
         link_id = inp.get("link")
+        # An auto-grow group's BASE entry (``images`` on an agent-built
+        # BatchImagesNode) is the group itself, not a wireable slot: its slots
+        # are the grown ``images.image0`` entries, handled with the group below.
+        if link_id is None and name in group_names:
+            continue
         if link_id is None:
             _place_arg(name, "None", args, extra)
             continue
@@ -619,16 +711,15 @@ def _build_args(
             annotations.append(ann)
         _place_arg(name, ref if ref is not None else "None", args, extra)
 
-    class_type = node.get("type", "")
-    widgets_values = node.get("widgets_values")
-    unknown = m is None
+    for group in groups:
+        _ensure_open_autogrow_slot(group, inputs, extra)
+        annotations.append(_autogrow_annotation(group, inputs))
+
     if unknown:
-        positional = widgets_values if isinstance(widgets_values, list) else []
         if positional:
             args.append(f"widgets={py_literal(positional)}")
         warnings.append(f"node {ctx.qualify(nid)}: class {class_type!r} not in catalog; widgets printed positionally")
     else:
-        positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
             arg_name = "control_after_generate" if entry.port is None else entry.name
@@ -676,17 +767,75 @@ def _subgraph_instance_name(node: dict, sg_def: dict | None, type_uuid: str) -> 
     return type_uuid
 
 
+def _promoted_widget_link_text(
+    iname: str,
+    link_id: Any,
+    nid: str,
+    ctx: _RenderCtx,
+    annotations: list[str],
+    prim_hits: list[tuple],
+    warnings: list[str],
+) -> str | None:
+    """What an outside link into a promoted WIDGET input prints as — the same
+    rules a regular node's widget-backed input follows (``_build_args``'s
+    pre-pass): a live link to a printable node is the value (its ref), the
+    enclosing definition's input proxy is ``IN.<name>``, a PrimitiveNode keeps
+    the stored value with a ``from primitive`` marker, and a dead-end Reroute
+    keeps it with an ``unlinked`` marker. ``None`` means "print the value"."""
+    link = ctx.link_map.get(str(link_id))
+    if link is None:
+        return None
+    src_id, src_slot, _tgt_id, _tgt_slot = link
+    outcome = _resolve_source(
+        src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
+    )
+    if outcome[0] == "ok":
+        rid_s = str(outcome[1])
+        if rid_s not in ctx.printable_ids:
+            return None
+        src_node = ctx.nodes_by_id.get(rid_s)
+        binding = ctx.binding_by_id.get(rid_s)
+        if src_node is None or binding is None:
+            return None
+        ref, edge_warning = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx)
+        if edge_warning:
+            warnings.append(edge_warning)
+        if src_node.get("mode") == 4:
+            annotations.append(f" {iname} via bypassed {rid_s}")
+        return ref
+    if outcome[0] == "in_proxy":
+        return ctx.in_ref(outcome[1])
+    if outcome[0] == "primitive_no_widget":
+        annotations.append(f" {iname} from primitive {outcome[1]}")
+        prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
+    elif outcome[0] == "dead_reroute":
+        annotations.append(f" {iname} unlinked via reroute {outcome[1]}")
+    return None
+
+
 def _render_subgraph_instance_line(
-    node: dict, type_uuid: str, sg_def: dict, binding: str, ctx: _RenderCtx, warnings: list[str]
+    node: dict, type_uuid: str, sg_def: dict, binding: str, ctx: _RenderCtx, state: _State
 ) -> tuple:
-    """A subgraph instance's own line: exposed link inputs by name (or, when
-    the name isn't a Python identifier, collected into a trailing ``**{}``);
-    widget-backed exposed inputs print positionally from ``widgets_values``
-    (subgraphs are never in the catalog) unless their link resolves to the
-    enclosing definition's own input proxy, in which case that ref is used.
-    Gets the same ``mode=bypass``/``mode=mute`` suffix as a regular node.
-    Any D9 annotation from resolving a link input (e.g. a dead-end Reroute)
-    is appended to the line, same as a regular node. Returns ``(line, prim_hits)``."""
+    """A subgraph instance's own line, argument per declared subgraph input in
+    declaration order (non-identifier names collected into a trailing
+    ``**{}``):
+
+    * a promoted WIDGET input (``cql.promoted``: a declared input a boundary
+      link feeds into an interior widget) prints its EFFECTIVE value — the
+      host instance's own value when materialized, else the interior default
+      — under the name ``set-widget <instance>.<name>`` takes. The host's
+      positional ``widgets_values`` are read the way the frontend reads them
+      (one slot per widget-backed input, in declaration order), never by the
+      instance's serialized ``inputs[]``, which only lists what the UI showed.
+      An outside link into it prints as that link instead (the link is what
+      runs), with the same PrimitiveNode/Reroute markers a regular node gets;
+    * a socket input prints its link (or ``None``).
+
+    A declared input no boundary link backs falls back to the legacy
+    ``proxyWidgets`` route, exactly as ``slots`` does. Any instance
+    ``inputs[]`` entry the definition does not declare prints last, by link.
+    Gets the same ``mode=`` suffix and D9 annotations as a regular node.
+    Returns ``(line, prim_hits)``."""
     nid = str(node.get("id"))
     name_str = _subgraph_instance_name(node, sg_def, type_uuid)
     bracket = json.dumps(name_str, ensure_ascii=False)
@@ -694,54 +843,67 @@ def _render_subgraph_instance_line(
     annotations: list[str] = []
     args: list[str] = []
     extra: dict[str, str] = {}
+    warnings = state.warnings
 
     inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
-    link_inputs = [inp for inp in inputs if "widget" not in inp]
-    widget_inputs = [inp for inp in inputs if "widget" in inp]
+    by_name: dict[str, dict] = {}
+    for inp in inputs:
+        iname = inp.get("name")
+        if isinstance(iname, str) and iname not in by_name:
+            by_name[iname] = inp
+    rendered: set[str] = set()
 
-    for inp in link_inputs:
-        iname = inp.get("name") or ""
-        ref = None
-        link_id = inp.get("link")
-        if link_id is not None:
-            link = ctx.link_map.get(str(link_id))
-            if link is not None:
-                src_id, src_slot, _tgt_id, _tgt_slot = link
-                ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
-                if warn:
-                    warnings.append(warn)
-                if ann:
-                    annotations.append(ann)
-        _place_arg(iname, ref if ref is not None else "None", args, extra)
+    def socket_text(iname: str, link_id: Any) -> str:
+        link = ctx.link_map.get(str(link_id)) if link_id is not None else None
+        if link is None:
+            return "None"
+        src_id, src_slot, _tgt_id, _tgt_slot = link
+        ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+        if warn:
+            warnings.append(warn)
+        if ann:
+            annotations.append(ann)
+        return ref if ref is not None else "None"
 
-    widgets_values = node.get("widgets_values")
-    positional = widgets_values if isinstance(widgets_values, list) else []
-    for k, inp in enumerate(widget_inputs):
+    for pi in _promoted.promoted_inputs(sg_def, state.promoted_defs):
+        rendered.add(pi.name)
+        entry = by_name.get(pi.name)
+        link_id = entry.get("link") if entry is not None else None
+        text = None
+        if pi.is_widget:
+            if link_id is not None:
+                text = _promoted_widget_link_text(pi.name, link_id, nid, ctx, annotations, prim_hits, warnings)
+            if text is None:
+                try:
+                    value = _promoted.effective_value(state.workflow, node, pi.name, ctx.graph)
+                except ValueError as e:  # the definition index disagrees with itself: say so, print None
+                    warnings.append(f"node {ctx.qualify(nid)}: promoted widget {pi.name!r} unreadable: {e}")
+                    value = _promoted.UNSET
+                text = py_literal(None if value is _promoted.UNSET else value)
+        elif pi.source_node is None and link_id is None and ctx.graph is not None:
+            # Declared but backed by no boundary link: a legacy template still
+            # routes it through ``proxyWidgets`` to an interior widget — the
+            # same fallback ``slots`` applies (``_declared_subgraph_slots``).
+            value = _resolve_proxy_value(node, sg_def, pi.name, ctx.graph)
+            if value is not _UNRESOLVED:
+                text = py_literal(value)
+        if text is None:
+            text = socket_text(pi.name, link_id)
+        _place_arg(pi.name, text, args, extra)
+
+    for inp in inputs:
         iname = inp.get("name") or ""
-        override = None
+        if iname in rendered:
+            continue
+        rendered.add(iname)
         link_id = inp.get("link")
-        if link_id is not None:
-            link = ctx.link_map.get(str(link_id))
-            if link is not None:
-                src_id, src_slot, _tgt_id, _tgt_slot = link
-                outcome = _resolve_source(
-                    src_id,
-                    src_slot,
-                    ctx.nodes_by_id,
-                    ctx.reroute_sources,
-                    ctx.set_sources,
-                    ctx.get_vars,
-                    ctx.proxy_in_id,
-                )
-                if outcome[0] == "in_proxy":
-                    override = ctx.in_ref(outcome[1])
-                elif outcome[0] == "primitive_no_widget":
-                    prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
-        if override is not None:
-            text = override
+        text = None
+        if "widget" in inp and link_id is not None:
+            text = _promoted_widget_link_text(iname, link_id, nid, ctx, annotations, prim_hits, warnings)
+            if text is None:
+                text = "None"
         else:
-            value = positional[k] if k < len(positional) else None
-            text = py_literal(value)
+            text = socket_text(iname, link_id)
         _place_arg(iname, text, args, extra)
 
     if extra:
@@ -826,6 +988,24 @@ def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
     )
 
 
+def _promoted_header_line(def_id: str, sg_def: dict, state: _State) -> str | None:
+    """The line under a definition's header that names its promoted WIDGETS —
+    the ``IN.<name>`` references the interior lines below carry. Their values
+    live on the instance (``cql.promoted``), so it spells out the address to
+    edit (``57.<name>``) and the one NOT to (``57/<id>.<name>``, the interior
+    widget the host value overrides). ``None`` when nothing is promoted as a
+    widget (socket-only inputs are links, not values)."""
+    pis = [p for p in _promoted.promoted_inputs(sg_def, state.promoted_defs) if p.is_widget]
+    if not pis:
+        return None
+    first = state.first_instance_by_def.get(def_id, def_id)
+    names = ", ".join(_member_ref("IN", p.name) for p in pis)
+    return (
+        f"#   promoted widgets: {names} — each is the instance's own value: "
+        f"edit {first}.<name>, never {first}/<id>.<name>"
+    )
+
+
 def _def_links(sg_def: dict) -> dict[str, tuple]:
     """Normalise a definition's dict-shaped links into the array-tuple form
     used everywhere else: ``{str(link_id): (origin_id, origin_slot, target_id, target_slot)}``."""
@@ -847,9 +1027,19 @@ class _State:
     that end up on the returned ``PrintResult``."""
 
     def __init__(
-        self, defs_by_id: dict[str, dict], warnings: list[str], skipped: list[dict], bindings: dict[str, str]
+        self,
+        defs_by_id: dict[str, dict],
+        warnings: list[str],
+        skipped: list[dict],
+        bindings: dict[str, str],
+        workflow: dict | None = None,
     ) -> None:
         self.defs_by_id = defs_by_id
+        # The whole workflow and cql.promoted's own definition index: a
+        # promoted widget's effective value is resolved from the HOST instance
+        # against its definition (``promoted.effective_value``), at any depth.
+        self.workflow: dict = workflow if workflow is not None else {}
+        self.promoted_defs: dict[str, dict] = _promoted.defs_by_id(self.workflow)
         self.warnings = warnings
         self.skipped = skipped
         self.bindings = bindings
@@ -943,7 +1133,7 @@ def _render_nodes(
             sg_def = defs_by_id.get(t)
             addr = ctx.qualify(nid)
             if sg_def is not None:
-                line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state.warnings)
+                line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state)
                 for prim_id, reason in prim_hits:
                     state.primitive_reason.setdefault(prim_id, reason)
                 state.register_instance(t, ctx.owner_def, nid, addr, depth)
@@ -1081,9 +1271,12 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     links = workflow.get("links") or []
 
     definitions = workflow.get("definitions")
+    promoted_workflow = workflow
     if definitions is not None and not isinstance(definitions, dict):
         warnings.append("workflow: ignoring non-object definitions block")
         definitions = None
+        # cql.promoted indexes the same block; hand it the sanitized view.
+        promoted_workflow = {**workflow, "definitions": None}
     subgraphs = definitions.get("subgraphs") if definitions else None
     defs_by_id = {sg.get("id"): sg for sg in (subgraphs or []) if isinstance(sg, dict) and sg.get("id")}
 
@@ -1126,7 +1319,7 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     )
 
     skipped: list[dict] = []
-    state = _State(defs_by_id, warnings, skipped, bindings)
+    state = _State(defs_by_id, warnings, skipped, bindings, promoted_workflow)
 
     lines = _render_nodes(order, ctx, graph, defs_by_id, binding_by_id, state, depth=1)
 
@@ -1152,6 +1345,9 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
         node_count += block_count
     for def_id in state.def_order:
         lines.append(_definition_header(def_id, defs_by_id[def_id], state))
+        promoted_line = _promoted_header_line(def_id, defs_by_id[def_id], state)
+        if promoted_line is not None:
+            lines.append(promoted_line)
         lines.extend("    " + bl for bl in block_lines_by_def[def_id])
 
     source = "\n".join(lines) + "\n"

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -722,7 +722,13 @@ def _build_args(
     else:
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
-            arg_name = "control_after_generate" if entry.port is None else entry.name
+            if entry.frontend_injected:
+                # ``upload`` / ``audioUI`` / PREVIEW_3D ``image``: a frontend
+                # button or DOM slot with no schema port and no editable
+                # value (``slots`` omits it, every write surface refuses it).
+                # It owns a positional slot, so it is walked — never printed.
+                continue
+            arg_name = entry.name
             if arg_name in live_link_refs:
                 continue  # already printed in the link pass above
             if arg_name in widget_overrides:

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -223,7 +223,9 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             current = inputs.get(widget)
             if isinstance(current, list) and len(current) == 2:
                 continue  # wired from inside the definition: the link wins
-            inputs[widget] = value
+            # Same wrapping every widget value gets, so a two-item list host
+            # value is never read back as a ``[node, slot]`` link.
+            inputs[widget] = _wrap_widget_value(value)
 
     for node in workflow.get("nodes") or []:
         if not isinstance(node, dict):

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -197,7 +197,12 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
     """
     from comfy_cli.cql import promoted as _promoted
 
-    def visit(instance: dict, sg: dict, prefix: str, depth: int) -> None:
+    def visit(instance: dict, sg: dict, scope: dict, prefix: str, depth: int) -> None:
+        # ``scope`` holds the links that can feed THIS instance's inputs: the
+        # workflow for a top-level instance, the containing definition for a
+        # nested one. A serialized link id that no longer exists there is one
+        # the frontend drops on load — the input is unlinked and the host value
+        # runs, exactly as ``resolve_write`` and ``slots`` treat it.
         if depth > _MAX_SUBGRAPH_ITERATIONS or instance.get("mode") in (_MODE_MUTED, _MODE_BYPASS):
             return
         for inner in sg.get("nodes") or []:
@@ -205,9 +210,9 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
                 continue
             inner_def = subgraph_defs.get(str(inner.get("type", "")))
             if inner_def is not None:
-                visit(inner, inner_def, f"{prefix}:{inner.get('id')}", depth + 1)
+                visit(inner, inner_def, sg, f"{prefix}:{inner.get('id')}", depth + 1)
         for pi in _promoted.promoted_inputs(sg, subgraph_defs):
-            if not pi.is_widget or _promoted.external_link(instance, pi.name) is not None:
+            if not pi.is_widget or _promoted.live_external_link(scope, instance, pi.name) is not None:
                 continue
             value = _promoted.host_value(instance, pi)
             if value is _promoted.UNSET:
@@ -232,7 +237,7 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             continue
         sg = subgraph_defs.get(str(node.get("type", "")))
         if sg is not None:
-            visit(node, sg, str(node.get("id")), 0)
+            visit(node, sg, workflow, str(node.get("id")), 0)
 
 
 def _has_group_nodes(workflow: dict) -> bool:

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -178,7 +178,59 @@ def convert_ui_to_api(workflow: dict, object_info: dict) -> dict:
             logger.exception("Failed to convert node id=%s type=%s; skipping", node_id_str, node_type)
 
     _strip_orphan_link_inputs(api_prompt)
+    _overlay_promoted_host_values(api_prompt, workflow, subgraph_defs)
     return api_prompt
+
+
+def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_defs: dict[str, dict]) -> None:
+    """Apply host-owned promoted widget values onto the expanded interior nodes.
+
+    A promoted widget's value lives on the HOST instance (``widgets_values``
+    positional over the widget-backed subgraph inputs — ADR 0009); the
+    interior widget is only its default. Expansion above copied the interior
+    default, so a post-migration save (host prompt filled in, interior
+    ``caption`` still ``''``) would submit the wrong prompt. Precedence, as the
+    frontend serializes it: a link feeding the instance input wins (already
+    reattached), else the host value when materialized, else the interior.
+    Inner instances are visited first so an outer host wins over an inner one;
+    an inner input promoted further (linked from ``-10``) is left to the outer.
+    """
+    from comfy_cli.cql import promoted as _promoted
+
+    def visit(instance: dict, sg: dict, prefix: str, depth: int) -> None:
+        if depth > _MAX_SUBGRAPH_ITERATIONS or instance.get("mode") in (_MODE_MUTED, _MODE_BYPASS):
+            return
+        for inner in sg.get("nodes") or []:
+            if not isinstance(inner, dict):
+                continue
+            inner_def = subgraph_defs.get(str(inner.get("type", "")))
+            if inner_def is not None:
+                visit(inner, inner_def, f"{prefix}:{inner.get('id')}", depth + 1)
+        for pi in _promoted.promoted_inputs(sg, subgraph_defs):
+            if not pi.is_widget or _promoted.external_link(instance, pi.name) is not None:
+                continue
+            value = _promoted.host_value(instance, pi)
+            if value is _promoted.UNSET:
+                continue
+            target = _promoted.deepest_source(sg, pi, subgraph_defs)
+            if target is None:
+                continue
+            path, widget = target
+            entry = api_prompt.get(":".join([prefix, *path]))
+            if not isinstance(entry, dict):
+                continue
+            inputs = entry.setdefault("inputs", {})
+            current = inputs.get(widget)
+            if isinstance(current, list) and len(current) == 2:
+                continue  # wired from inside the definition: the link wins
+            inputs[widget] = value
+
+    for node in workflow.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        sg = subgraph_defs.get(str(node.get("type", "")))
+        if sg is not None:
+            visit(node, sg, str(node.get("id")), 0)
 
 
 def _has_group_nodes(workflow: dict) -> bool:

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -1,0 +1,307 @@
+"""``set-widget`` / ``connect`` on promoted subgraph widgets (BE-10305 scenarios 1 & 2).
+
+Scenario 1 — *"the agent edited the widget under layer 2, not on the surface;
+the value on the surface overwrites it and the user never sees it."* The
+frontend serializes a promoted widget's value on the HOST instance
+(ADR 0009); ``set-widget 57.width`` used to follow ``proxyWidgets`` into the
+interior node, a value the frontend neither runs nor displays. The write must
+land on the host — and when an outside node feeds the promoted input
+(*"users even have number or text boxes connected to the promoted widget"*),
+on that node's widget, because the link is what the graph runs.
+
+Scenario 2 — *"wire something outside to the promoted widget, e.g. Int node to
+width — the agent cannot do that yet."* A promoted widget IS a subgraph input,
+so ``connect`` materializes it on the instance and wires it.
+
+The rule, in one line: never edit a subgraph's interior for a promoted value —
+edit what it is linked to.
+
+Fixtures: verbatim gallery templates (``fixtures/gallery``) plus source-node
+shapes copied from the wild (``PrimitiveNode`` from
+``templates-multiple_consistent_shots-nb_pro.json``, ``Reroute`` from
+``template_contact_sheet-step_3.app.json``).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_subgraph_promoted.json"
+
+Z_IMAGE_HOST_DEFAULTS = [
+    "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. ",
+    1024,
+    1024,
+    0,
+    8,
+    "z_image_turbo_bf16.safetensors",
+    "qwen_3_4b.safetensors",
+    "ae.safetensors",
+]
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _node(wf: dict, node_id: Any) -> dict:
+    return next(n for n in wf["nodes"] if str(n["id"]) == str(node_id))
+
+
+def _interior(wf: dict, instance_id: Any, inner_id: Any) -> dict:
+    inst = _node(wf, instance_id)
+    sg = next(d for d in wf["definitions"]["subgraphs"] if d["id"] == inst["type"])
+    return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
+
+
+def _input(node: dict, name: str) -> dict:
+    return next(i for i in node.get("inputs") or [] if i["name"] == name)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: the write lands on the host, not the interior
+# --------------------------------------------------------------------------- #
+
+
+def test_promoted_address_writes_the_host_value(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    expected = list(Z_IMAGE_HOST_DEFAULTS)
+    expected[1] = 768
+    assert _node(wf, 57)["widgets_values"] == expected
+    assert _interior(wf, 57, 13)["widgets_values"] == [1024, 1024, 1]
+    assert op["node_id"] == 57
+    assert op["widget"] == "width"
+    assert op["old"] == 1024
+    assert "path" not in op
+    assert op["promoted"]["value_index"] == 1
+    assert op["promoted"]["host_widgets_values"] == expected
+
+
+def test_interior_address_of_a_promoted_widget_is_redirected_to_the_host(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, "57/13", "width", 768)
+    assert _node(wf, 57)["widgets_values"][1] == 768
+    assert _interior(wf, 57, 13)["widgets_values"][0] == 1024
+    assert op["node_id"] == 57
+    assert op["widget"] == "width"
+    assert op["redirected_from"] == "57/13.width"
+
+
+def test_unpromoted_interior_widget_still_writes_the_interior(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, "57/3", "cfg", 2.0)
+    assert op["path"] == ["57", "3"]
+    assert _interior(wf, 57, 3)["widgets_values"][3] == 2.0
+    assert _node(wf, 57)["widgets_values"] == []
+
+
+def test_post_migration_host_write_touches_one_slot(graph):
+    wf = _load("audio_minimax_music_3.json")
+    before = list(_node(wf, 37)["widgets_values"])
+    wf, op = workflow_ops.set_widget(wf, graph, 37, "max_duration", 90)
+    after = _node(wf, 37)["widgets_values"]
+    assert after[2] == 90 and after[:2] == before[:2] and after[3:] == before[3:]
+    assert op["old"] == 60
+    assert _interior(wf, 37, 13)["widgets_values"][2] == 222  # interior default untouched
+
+
+def test_socket_only_promoted_input_is_not_a_widget(graph):
+    wf = _load("api_seedance2_5_video_extend.json")
+    with pytest.raises(ValueError, match="link input"):
+        workflow_ops.set_widget(wf, graph, 39, "clip_to_resize", "x")
+
+
+def test_host_write_replays_idempotently_and_targets_one_register(graph):
+    wf = _load("image_z_image_turbo.json")
+    base = copy.deepcopy(wf)
+    wf, op_host = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    _, op_interior = workflow_ops.set_widget(copy.deepcopy(base), graph, "57/13", "width", 512)
+    assert workflow_ops._write_target(op_host) == workflow_ops._write_target(op_interior)
+    replayed = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), op_host, graph), op_host, graph)
+    assert _node(replayed, 57)["widgets_values"][1] == 768
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: wire an outside node onto the promoted widget
+# --------------------------------------------------------------------------- #
+
+
+def _with_primitive(graph, value: int = 640):
+    wf = _load("image_z_image_turbo.json")
+    wf, prim = workflow_ops.add_node(wf, graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, graph, prim["node_id"], "value", value)
+    return wf, prim["node_id"]
+
+
+def test_connect_materializes_the_promoted_input_and_wires_it(graph):
+    wf, prim = _with_primitive(graph)
+    wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    width = _input(_node(wf, 57), "width")
+    assert width["type"] == "INT"
+    assert width["widget"] == {"name": "width"}
+    assert width["link"] == op["link_id"]
+    assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
+    link = next(link for link in wf["links"] if link[0] == op["link_id"])
+    assert link[1] == prim and link[3] == 57
+
+
+def test_connect_type_mismatch_into_a_promoted_input_is_refused(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, text = workflow_ops.add_node(wf, graph, "PrimitiveStringMultiline")
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, text["node_id"], "STRING", 57, "width")
+
+
+def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
+    wf, prim = _with_primitive(graph)
+    wf, first = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
+    assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1, nuance: follow the link to the source of truth
+# --------------------------------------------------------------------------- #
+
+
+def test_set_widget_follows_the_link_to_the_primitive(graph):
+    wf, prim = _with_primitive(graph)
+    wf, _ = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    # A later write to the same register carries a later base_version (the
+    # CLI's --base-version); equal stamps tie-break by op_id under LWW.
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512, base_version=1)
+    assert op["node_id"] == prim
+    assert op["widget"] == "value"
+    assert op["redirected_from"] == "57.width"
+    assert _node(wf, prim)["widgets_values"][0] == 512
+    assert _node(wf, 57)["widgets_values"] == []  # host untouched: the link is the truth
+
+
+def test_set_widget_follows_a_reroute_chain(graph):
+    wf, prim = _with_primitive(graph)
+    # Reroute as the frontend serializes it (template_contact_sheet-step_3.app.json node 394)
+    wf["last_node_id"] = max(int(n["id"]) for n in wf["nodes"] if isinstance(n["id"], int)) + 1
+    reroute_id = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": reroute_id,
+            "type": "Reroute",
+            "pos": [0, 0],
+            "size": [75, 26],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [{"name": "", "type": "*", "widget": {"name": "value"}, "link": None}],
+            "outputs": [{"name": "", "type": "INT", "links": []}],
+            "properties": {"showOutputText": False, "horizontal": False},
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, prim, "INT", reroute_id, 0)
+    wf, _ = workflow_ops.connect(wf, graph, reroute_id, 0, 57, "width")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512, base_version=1)
+    assert op["node_id"] == prim
+    assert _node(wf, prim)["widgets_values"][0] == 512
+
+
+def test_set_widget_follows_the_link_to_a_legacy_primitive_node(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    # PrimitiveNode as the frontend serializes it (templates-multiple_consistent_shots-nb_pro.json node 7)
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    assert op["node_id"] == legacy
+    assert _node(wf, legacy)["widgets_values"][0] == 512
+
+
+def test_set_widget_refuses_a_driver_it_cannot_edit(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, sel = workflow_ops.add_node(wf, graph, "ResolutionSelector")
+    wf, _ = workflow_ops.connect(wf, graph, sel["node_id"], "width", 57, "width")
+    with pytest.raises(ValueError) as e:
+        workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    msg = str(e.value)
+    assert "ResolutionSelector" in msg and str(sel["node_id"]) in msg
+    assert _node(wf, 57)["widgets_values"] == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(workflow_cmd.app, args, standalone_mode=False)
+    out = capsys.readouterr().out
+    if not out.strip():
+        out = result.stdout or ""
+    for line in reversed([ln for ln in out.strip().splitlines() if ln.strip()]):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={out[:600]})")
+
+
+def test_cli_set_widget_then_slots_show_the_new_host_value(tmp_path, capsys):
+    path = tmp_path / "z.json"
+    path.write_text(json.dumps(_load("image_z_image_turbo.json")))
+    env = _run(["set-widget", str(path), "57.width", "768", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    assert env["data"]["op"]["node_id"] == 57 and "path" not in env["data"]["op"]
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    slots = {s["address"]: s for s in env["data"]["slots"]}
+    assert slots["57.width"]["current_value"] == 768
+    assert slots["57.height"]["current_value"] == 1024
+
+
+def test_cli_connect_int_node_to_promoted_width(tmp_path, capsys):
+    path = tmp_path / "z.json"
+    path.write_text(json.dumps(_load("image_z_image_turbo.json")))
+    env = _run(["add-node", str(path), "PrimitiveInt", "--input", str(OBJECT_INFO)], capsys)
+    prim = env["data"]["op"]["node_id"]
+    env = _run(["connect", str(path), f"{prim}.INT", "57.width", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    saved = json.loads(path.read_text())
+    assert _input(_node(saved, 57), "width")["link"] == env["data"]["op"]["link_id"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -178,6 +178,7 @@ def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
     wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
     assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
     assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
+    assert first["link_id"] not in {link[0] for link in wf["links"]}  # replaced, not duplicated
 
 
 # --------------------------------------------------------------------------- #
@@ -305,3 +306,77 @@ def test_cli_connect_int_node_to_promoted_width(tmp_path, capsys):
     assert env["ok"] is True, env
     saved = json.loads(path.read_text())
     assert _input(_node(saved, 57), "width")["link"] == env["data"]["op"]["link_id"]
+
+
+# --------------------------------------------------------------------------- #
+# Review findings on #815
+# --------------------------------------------------------------------------- #
+
+
+def test_nested_host_payload_reflects_the_forked_instance(graph):
+    """A nested host inside a definition SHARED by two instances is forked on
+    write; the op's ``host_widgets_values`` must be read from the written
+    (forked) instance, not the pre-fork dict captured during resolution."""
+    wf = _load("image_z_image_turbo.json")
+    inner_sg = wf["definitions"]["subgraphs"][0]
+    outer_id = "0e0e0e0e-0000-4000-8000-000000000001"
+    outer = {
+        "id": outer_id,
+        "name": "Outer",
+        "inputs": [],
+        "outputs": [],
+        "widgets": [],
+        "links": [],
+        "nodes": [
+            {
+                "id": 7,
+                "type": inner_sg["id"],
+                "pos": [0, 0],
+                "size": [1, 1],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [],
+                "properties": {},
+                "widgets_values": [],
+            }
+        ],
+    }
+    wf["definitions"]["subgraphs"].append(outer)
+    for nid in (900, 901):  # two instances share the outer definition
+        wf["nodes"].append(
+            {
+                "id": nid,
+                "type": outer_id,
+                "pos": [0, 0],
+                "size": [1, 1],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [],
+                "properties": {},
+                "widgets_values": [],
+            }
+        )
+    wf, op = workflow_ops.set_widget(wf, graph, "900/7", "width", 640)
+    forked = _node(wf, 900)["type"]
+    assert forked != outer_id  # the shared definition was forked for instance 900
+    inner = next(
+        n for n in next(d for d in wf["definitions"]["subgraphs"] if d["id"] == forked)["nodes"] if n["id"] == 7
+    )
+    assert inner["widgets_values"][1] == 640
+    assert op["promoted"]["host_widgets_values"] == inner["widgets_values"]
+    # the sibling's definition is untouched
+    assert next(n for n in outer["nodes"] if n["id"] == 7)["widgets_values"] == []
+
+
+def test_connect_does_not_type_check_against_an_untyped_declared_input(graph):
+    wf, prim = _with_primitive(graph)
+    sg = next(d for d in wf["definitions"]["subgraphs"] if d["id"] == _node(wf, 57)["type"])
+    width = next(i for i in sg["inputs"] if i["name"] == "width")
+    del width["type"]
+    wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    assert _input(_node(wf, 57), "width")["link"] == op["link_id"]
+    assert op["grow"]["type"] == "INT"  # falls back to the source type

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -1,4 +1,4 @@
-"""``set-widget`` / ``connect`` on promoted subgraph widgets (BE-10305 scenarios 1 & 2).
+"""``set-widget`` / ``connect`` on promoted subgraph widgets (the "agent editing subgraph" report, scenarios 1 & 2).
 
 Scenario 1 — *"the agent edited the widget under layer 2, not on the surface;
 the value on the surface overwrites it and the user never sees it."* The

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -692,19 +692,42 @@ class TestSlotsNestedSubgraph:
         env = _run(["slots", str(path)], capsys)
         addrs = {s["address"] for s in env["data"]["slots"]}
         # instance 10 -> inner node 3 (Batch Prompt Iterator subgraph) -> inner
-        # node 7 (PrimitiveStringMultiline) widget "value".
-        assert "10/3/7.value" in addrs, f"missing doubly-nested slot; got {sorted(addrs)[:30]}"
+        # node 8 (RegexReplace): an unpromoted widget two levels down.
+        assert "10/3/8.regex_pattern" in addrs, f"missing doubly-nested slot; got {sorted(addrs)[:30]}"
+        # Inner node 7's ``value`` is promoted twice up (3.value -> 10.value):
+        # the value the frontend runs lives on host 10, so only that address
+        # is advertised — the interior copies are the "layer 2" that edits
+        # used to land on and the surface overrode.
+        assert "10.value" in addrs
+        assert "10/3.value" not in addrs
+        assert "10/3/7.value" not in addrs
 
 
 class TestSetSlotNestedSubgraph:
-    def test_set_slot_writes_into_subgraph_inner_node(self, patched_subgraph_graph, tmp_path, capsys):
+    def test_set_slot_refuses_a_link_driven_interior_widget(self, patched_subgraph_graph, tmp_path, capsys):
+        """GeminiImage2Node 9's ``prompt`` is fed by interior node 3 (the Batch
+        Prompt Iterator): writing the widget could never take effect, so the
+        write is refused and the driver named instead of silently landing on
+        a value the graph ignores."""
         path = _write_workflow(tmp_path, _subgraph_workflow())
         env = _run(["set-slot", str(path), '10/9.prompt="a red fox in snow"'], capsys)
+        assert env["ok"] is False, env
+        assert "10/3" in env["error"]["message"]
+        wf = json.loads(path.read_text())
+        assert _interior_node(wf, D33, 9)["widgets_values"][0] == ""
+
+    def test_set_slot_writes_the_promoted_host_value(self, patched_subgraph_graph, tmp_path, capsys):
+        """The prompt's source of truth is instance 10's promoted ``value``
+        (its outside link id dangles — the frontend drops it on load — so the
+        host value is what runs)."""
+        path = _write_workflow(tmp_path, _subgraph_workflow())
+        env = _run(["set-slot", str(path), '10.value="a red fox in snow"'], capsys)
         assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        gemini = _interior_node(wf, D33, 9)
-        # prompt is widget index 0 for GeminiImage2Node.
-        assert gemini["widgets_values"][0] == "a red fox in snow"
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        assert host["widgets_values"][0] == "a red fox in snow"
+        # nothing inside the definition was rewritten
+        assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_nested_does_not_touch_sibling_instance(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -720,8 +743,11 @@ class TestSetSlotNestedSubgraph:
         env = _run(["set-slot", str(path), '10/3/7.value="iterated prompt"'], capsys)
         assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        prim = _interior_node(wf, BATCH, 7)
-        assert prim["widgets_values"][0] == "iterated prompt"
+        # 7.value is promoted twice up (3.value -> 10.value): the write lands
+        # on host 10, the only place the frontend reads it from.
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        assert host["widgets_values"][0] == "iterated prompt"
+        assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_unknown_nested_inner_node(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -743,7 +769,7 @@ class TestVaryNestedSubgraph:
         path = _write_workflow(tmp_path, _subgraph_workflow())
         out_dir = tmp_path / "out"
         env = _run(
-            ["vary", str(path), "--slot", '10/9.prompt=["cat","dog","fox"]', "--out-dir", str(out_dir)],
+            ["vary", str(path), "--slot", '10.value=["cat","dog","fox"]', "--out-dir", str(out_dir)],
             capsys,
         )
         assert env["ok"] is True
@@ -751,7 +777,7 @@ class TestVaryNestedSubgraph:
         prompts = []
         for f in sorted(out_dir.glob("*.json")):
             wf = json.loads(f.read_text())
-            prompts.append(_interior_node(wf, D33, 9)["widgets_values"][0])
+            prompts.append(next(n for n in wf["nodes"] if n["id"] == 10)["widgets_values"][0])
         assert prompts == ["cat", "dog", "fox"]
 
 

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -212,3 +212,25 @@ def test_slots_do_not_report_a_dangling_link_as_linked_from(graph):
     assert "linked_from" not in slots["37.caption"]
     assert slots["37.caption"]["current_value"].startswith("Global Metadata")
     assert promoted.live_external_link(wf, inst, "caption") is None
+
+
+def test_effective_value_for_skips_the_name_lookup(graph):
+    """``effective_value_for`` is ``effective_value`` for a caller that already
+    holds the ``PromotedInput`` and the definition index: host value when
+    materialized, else the interior source value — and it never re-walks
+    ``promoted_inputs`` (``find_promoted``) to relocate what it was handed."""
+    from unittest import mock
+
+    wf = json.loads((_FIXTURES / "gallery" / "image_z_image_turbo.json").read_text())
+    inst = next(n for n in wf["nodes"] if n["id"] == 57)
+    defs = promoted.defs_by_id(wf)
+    sg = defs[inst["type"]]
+    width = next(p for p in promoted.promoted_inputs(sg, defs) if p.name == "width")
+    with mock.patch.object(promoted, "promoted_inputs", side_effect=AssertionError("re-walked")):
+        assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == 1024  # interior default
+    promoted.set_host_value(wf, inst, "width", 768, graph)
+    with mock.patch.object(promoted, "promoted_inputs", side_effect=AssertionError("re-walked")):
+        assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == 768  # host wins
+    assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == promoted.effective_value(
+        wf, inst, "width", graph
+    )

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -1,4 +1,4 @@
-"""Promoted subgraph widgets: the host-owned value model (BE-10305 scenarios 1/2).
+"""Promoted subgraph widgets: the host-owned value model (the "agent editing subgraph" report, scenarios 1/2).
 
 The frontend (``ComfyUI_frontend`` ADR 0009, ``SubgraphNode.ts``) represents a
 promoted widget as a *linked subgraph input*: the subgraph definition declares

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -1,0 +1,204 @@
+"""Promoted subgraph widgets: the host-owned value model (BE-10305 scenarios 1/2).
+
+The frontend (``ComfyUI_frontend`` ADR 0009, ``SubgraphNode.ts``) represents a
+promoted widget as a *linked subgraph input*: the subgraph definition declares
+an input, a boundary link feeds it into an interior node's widget-backed input,
+and the HOST instance owns the value — ``widgets_values[i]`` on the instance,
+consumed positionally by the i-th subgraph input that resolves to a widget
+(``_applyPromotedWidgetValues`` / ``serializeFromStoreState``). Socket-only
+inputs (``VIDEO``, ``MODEL``) own no slot. The interior widget is only a
+schema/default provider: *"the host/exterior value wins over the
+interior/source value during repair, persistence, and prompt serialization."*
+
+Before this model existed in the CLI, every read and write followed the legacy
+``properties.proxyWidgets`` list to the interior node — so ``set-widget
+57.width 768`` edited a value the frontend never serializes, and ``comfy run``
+submitted the interior prompt on post-migration templates whose real prompt
+lives on the host.
+
+Fixtures are verbatim gallery templates (``tests/comfy_cli/fixtures/gallery``):
+
+* ``image_z_image_turbo.json`` — pre-migration save (frontend 0.3.73): proxies
+  already backed by linked inputs, no host values materialized.
+* ``audio_minimax_music_3.json`` — post-migration save: 8 host values that
+  differ from the interior defaults (interior caption is ``''``).
+* ``api_seedance2_5_video_extend.json`` — mixed: two ``VIDEO`` socket inputs
+  (no slot) and four widget inputs with host values.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_subgraph_promoted.json"
+
+Z_IMAGE_SG = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _instance(wf: dict, node_id: int) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+# --------------------------------------------------------------------------- #
+# the model: which subgraph inputs own a host value slot, and where they land
+# --------------------------------------------------------------------------- #
+
+
+def test_z_image_every_declared_input_is_a_promoted_widget():
+    wf = _load("image_z_image_turbo.json")
+    sg = _def_of(wf, _instance(wf, 57))
+    pis = promoted.promoted_inputs(sg, promoted.defs_by_id(wf))
+    assert [p.name for p in pis] == ["text", "width", "height", "seed", "steps", "unet_name", "clip_name", "vae_name"]
+    assert [p.value_index for p in pis] == list(range(8))
+    width = next(p for p in pis if p.name == "width")
+    assert width.source_node == "13"
+    assert width.source_widget == "width"
+    assert width.type == "INT"
+
+
+def test_socket_inputs_own_no_host_slot():
+    wf = _load("api_seedance2_5_video_extend.json")
+    inst = _instance(wf, 39)
+    pis = promoted.promoted_inputs(_def_of(wf, inst), promoted.defs_by_id(wf))
+    assert [(p.name, p.value_index) for p in pis] == [
+        ("clip_to_resize", None),
+        ("base_video", None),
+        ("pad_second_video", 0),
+        ("interpolation", 1),
+        ("padding_color", 2),
+        ("drop_audio", 3),
+    ]
+    # the captured frontend save has exactly one value per widget-backed input
+    assert len(inst["widgets_values"]) == len([p for p in pis if p.value_index is not None])
+
+
+# --------------------------------------------------------------------------- #
+# reads: host value wins, interior is the fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_effective_value_is_the_host_value_when_materialized(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    caption = promoted.effective_value(wf, inst, "caption", graph)
+    assert caption.startswith("Global Metadata: Lo-fi hip-hop")
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 60
+    # interior default is NOT what the frontend runs
+    interior = next(n for n in _def_of(wf, inst)["nodes"] if n["id"] == 13)
+    assert interior["widgets_values"][0] == ""
+
+
+def test_effective_value_falls_back_to_the_interior_widget(graph):
+    wf = _load("image_z_image_turbo.json")
+    inst = _instance(wf, 57)
+    assert inst["widgets_values"] == []
+    assert promoted.effective_value(wf, inst, "width", graph) == 1024
+    assert promoted.effective_value(wf, inst, "steps", graph) == 8
+    assert promoted.effective_value(wf, inst, "unet_name", graph) == "z_image_turbo_bf16.safetensors"
+
+
+def test_quarantined_host_value_wins_by_name(graph):
+    """ADR 0009: a repaired-but-unresolved legacy entry keeps its host value in
+    ``proxyWidgetErrorQuarantine``; the frontend reads it before ``widgets_values``."""
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["properties"]["proxyWidgetErrorQuarantine"] = [
+        {
+            "originalEntry": ["-1", "max_duration"],
+            "reason": "missingSourceWidget",
+            "hostValue": 12,
+            "attemptedAtVersion": 1,
+        }
+    ]
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 12
+
+
+# --------------------------------------------------------------------------- #
+# writes: materialize the host array in subgraph-input order, never the interior
+# --------------------------------------------------------------------------- #
+
+
+def test_set_host_value_materializes_the_full_array_in_input_order(graph):
+    wf = _load("image_z_image_turbo.json")
+    inst = _instance(wf, 57)
+    before = copy.deepcopy(_def_of(wf, inst))
+    promoted.set_host_value(wf, inst, "width", 768, graph)
+    assert inst["widgets_values"] == [
+        "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. ",
+        768,
+        1024,
+        0,
+        8,
+        "z_image_turbo_bf16.safetensors",
+        "qwen_3_4b.safetensors",
+        "ae.safetensors",
+    ]
+    assert _def_of(wf, inst) == before  # interior untouched
+
+
+def test_set_host_value_updates_one_slot_of_an_existing_array(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    before = list(inst["widgets_values"])
+    promoted.set_host_value(wf, inst, "max_duration", 90, graph)
+    assert inst["widgets_values"][2] == 90
+    assert inst["widgets_values"][:2] == before[:2]
+    assert inst["widgets_values"][3:] == before[3:]
+
+
+def test_set_host_value_rewrites_a_shadowing_quarantine_value(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["properties"]["proxyWidgetErrorQuarantine"] = [
+        {
+            "originalEntry": ["-1", "max_duration"],
+            "reason": "missingSourceWidget",
+            "hostValue": 12,
+            "attemptedAtVersion": 1,
+        }
+    ]
+    promoted.set_host_value(wf, inst, "max_duration", 90, graph)
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 90
+
+
+# --------------------------------------------------------------------------- #
+# slots: the advertised surface reports the value the frontend will run
+# --------------------------------------------------------------------------- #
+
+
+def test_slots_report_host_values_on_a_post_migration_template(graph):
+    wf = _load("audio_minimax_music_3.json")
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["37.caption"]["current_value"].startswith("Global Metadata: Lo-fi hip-hop")
+    assert slots["37.max_duration"]["current_value"] == 60
+    assert slots["37.switch"]["current_value"] is True
+
+
+def test_slots_skip_socket_inputs_and_flag_external_links(graph):
+    wf = _load("api_seedance2_5_video_extend.json")
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert "39.clip_to_resize" not in slots
+    assert slots["39.pad_second_video"]["current_value"] is False
+    assert slots["39.interpolation"]["current_value"] == "lanczos"

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -202,3 +202,13 @@ def test_slots_skip_socket_inputs_and_flag_external_links(graph):
     assert "39.clip_to_resize" not in slots
     assert slots["39.pad_second_video"]["current_value"] is False
     assert slots["39.interpolation"]["current_value"] == "lanczos"
+
+
+def test_slots_do_not_report_a_dangling_link_as_linked_from(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["inputs"].append({"name": "caption", "type": "STRING", "widget": {"name": "caption"}, "link": 999999})
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert "linked_from" not in slots["37.caption"]
+    assert slots["37.caption"]["current_value"].startswith("Global Metadata")
+    assert promoted.live_external_link(wf, inst, "caption") is None

--- a/tests/comfy_cli/fixtures/gallery/README.md
+++ b/tests/comfy_cli/fixtures/gallery/README.md
@@ -11,7 +11,7 @@ Refresh with:
 
 ```bash
 cd tests/comfy_cli/fixtures/gallery
-for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed; do
+for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend; do
   curl -sfL "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/${f}.json" -o "${f}.json"
 done
 ```
@@ -20,3 +20,13 @@ done
 `/object_info` covering only the node types the qwen fixture uses (frontend-only
 `MarkdownNote` excluded, matching a real server response), used to exercise slot
 extraction. If a refresh changes the qwen template's node set, extend it to match.
+
+`image_z_image_turbo.json` (pre-migration save: proxies backed by linked
+inputs, no host values), `audio_minimax_music_3.json` (post-migration save:
+host values differ from the interior defaults) and
+`api_seedance2_5_video_extend.json` (socket + widget inputs mixed) back the
+promoted-widget tests (`tests/comfy_cli/cql/test_promoted_inputs.py`,
+`tests/comfy_cli/command/test_workflow_edit_promoted.py`,
+`tests/comfy_cli/test_workflow_to_api_promoted.py`); their node classes are
+covered by `../object_info_subgraph_promoted.json`, a trimmed copy of the
+cloud catalog entries (tooltips stripped, structure verbatim).

--- a/tests/comfy_cli/fixtures/gallery/api_seedance2_5_video_extend.json
+++ b/tests/comfy_cli/fixtures/gallery/api_seedance2_5_video_extend.json
@@ -1,0 +1,1467 @@
+{
+  "id": "7a06a6de-067d-4d41-b7bf-7d6add20ec8c",
+  "revision": 0,
+  "last_node_id": 43,
+  "last_link_id": 86,
+  "nodes": [
+    {
+      "id": 16,
+      "type": "SaveVideo",
+      "pos": [
+        500,
+        7850
+      ],
+      "size": [
+        700,
+        381.890625
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 31
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "video/Seedance2.5_video_extend",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 35,
+      "type": "LoadVideo",
+      "pos": [
+        -640,
+        7850
+      ],
+      "size": [
+        330,
+        470
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            27,
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": [
+        "sloth_bullfight.mp4",
+        "image"
+      ]
+    },
+    {
+      "id": 36,
+      "type": "Video Slice",
+      "pos": [
+        -260,
+        7850
+      ],
+      "size": [
+        270,
+        150
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 27
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            30
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Video Slice"
+      },
+      "widgets_values": [
+        0,
+        5,
+        false
+      ]
+    },
+    {
+      "id": 38,
+      "type": "ByteDance2ReferenceNodeV2",
+      "pos": [
+        60,
+        7850
+      ],
+      "size": [
+        400,
+        550.484375
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "showAdvanced": false,
+      "inputs": [
+        {
+          "label": "image_1",
+          "name": "model.reference_images.image_1",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "video_1",
+          "name": "model.reference_videos.video_1",
+          "shape": 7,
+          "type": "VIDEO",
+          "link": 30
+        },
+        {
+          "label": "video_2",
+          "name": "model.reference_videos.video_2",
+          "shape": 7,
+          "type": "VIDEO",
+          "link": null
+        },
+        {
+          "label": "audio_1",
+          "name": "model.reference_audios.audio_1",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "label": "asset_1",
+          "name": "model.reference_assets.asset_1",
+          "shape": 7,
+          "type": "STRING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            31,
+            86
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ByteDance2ReferenceNodeV2"
+      },
+      "widgets_values": [
+        "Seedance 2.5",
+        "Continuing from the previous shot, live-action western rodeo, dusty arena, golden hour. The raging bull calms down and stops, the buzzer rings. The sloth in the cowboy hat hops off the bull's back, lands steadily in the dust, slowly dusts off his hat, then strolls away unhurriedly with a deadpan expression. Slow motion, dust floating in warm sunlight, cheering crowd roars and waves hats in the background. Steadicam follow shot. Western arena music swells. No black frames, no text overlays.",
+        "720p",
+        "adaptive",
+        5,
+        true,
+        "extend",
+        "mp4",
+        true,
+        false,
+        1672978219,
+        "fixed",
+        false
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 39,
+      "type": "d9aa59a4-3784-4796-9f1b-5b467fb41fa1",
+      "pos": [
+        1250,
+        7850
+      ],
+      "size": [
+        290,
+        190
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "base_video",
+          "name": "clip_to_resize",
+          "type": "VIDEO",
+          "link": 76
+        },
+        {
+          "label": "second_video",
+          "name": "base_video",
+          "type": "VIDEO",
+          "link": 86
+        },
+        {
+          "label": "pad_second_video",
+          "name": "pad_second_video",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "pad_second_video"
+          },
+          "link": null
+        },
+        {
+          "label": "drop_audio",
+          "name": "drop_audio",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "drop_audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "merged_video",
+          "type": "VIDEO",
+          "links": [
+            78
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.1",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "previewExposures": []
+      },
+      "widgets_values": [
+        false,
+        "lanczos",
+        "white",
+        false
+      ]
+    },
+    {
+      "id": 40,
+      "type": "SaveVideo",
+      "pos": [
+        1590,
+        7850
+      ],
+      "size": [
+        700,
+        381.890625
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 78
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "video/Seedance2.5_video_extend_merged",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 41,
+      "type": "MarkdownNote",
+      "pos": [
+        -1180,
+        7850
+      ],
+      "size": [
+        500,
+        940.6875
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: Video Extend",
+      "properties": {},
+      "widgets_values": [
+        "**Input Assets** \n- [sloth_bullfight.mp4](https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/input/sloth_bullfight.mp4)\n\nThis template extends an existing video forward or backward for a new segment (default 5 seconds). The model keeps the character, scene, aspect ratio, and overall style consistent with your source footage. Only the new segment is generated; the source video is not included in the output.\n\n**How to write the prompt:**\n\n1. **State the extension intent first.** Begin with phrases like \"Continuing from the previous shot\" or \"Extend forward from the source video\" so the model knows this is a continuation, not a new video.\n\n2. **Describe only the new segment.** Don't re-describe the whole scene. Write what happens in the 5 seconds you're adding, e.g., the character lands, reacts, walks away.\n\n3. **Keep the character and environment consistent.** Reference the same character and outfit from the source (\"the same sloth in the cowboy hat\"), and stay in the same location and style.\n\n4. **One camera move, one lighting keyword.** Pick a single camera movement (slow push in, steadicam follow, low angle) and one lighting term (golden hour cinematography). One strong keyword beats a pile of adjectives.\n\n5. **Add audio.** Seedance generates sound natively. Describe the music and sound effects at the end (\"western arena music swells\").\n\n6. **Close with constraints.** End with \"No black frames, no text overlays\" to keep the output clean.\n\n**Example:**\n\n> Continuing from the previous shot, live-action western rodeo, dusty arena, golden hour. The raging bull calms down and stops, the buzzer rings. The sloth in the cowboy hat hops off the bull's back, lands steadily in the dust, slowly dusts off his hat, then strolls away unhurriedly with a deadpan expression. Slow motion, dust floating in warm sunlight, cheering crowd roars and waves hats in the background. Steadicam follow shot. Western arena music swells. No black frames, no text overlays.\n\n## Report Issue\n\nNote: Please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud updates follow stable releases, so some nightly-supported models may not be available yet.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/comfyanonymous/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      27,
+      35,
+      0,
+      36,
+      0,
+      "VIDEO"
+    ],
+    [
+      30,
+      36,
+      0,
+      38,
+      1,
+      "VIDEO"
+    ],
+    [
+      31,
+      38,
+      0,
+      16,
+      0,
+      "VIDEO"
+    ],
+    [
+      76,
+      35,
+      0,
+      39,
+      0,
+      "VIDEO"
+    ],
+    [
+      78,
+      39,
+      0,
+      40,
+      0,
+      "VIDEO"
+    ],
+    [
+      86,
+      38,
+      0,
+      39,
+      1,
+      "VIDEO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "d9aa59a4-3784-4796-9f1b-5b467fb41fa1",
+        "version": 1,
+        "state": {
+          "lastGroupId": 2,
+          "lastNodeId": 43,
+          "lastLinkId": 86,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Merge Videos",
+        "description": "Concatenates two videos end-to-end with optional resize, letterbox padding, and audio merge or drop.",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1990,
+            700,
+            152.5546875,
+            168
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1210,
+            614,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "2fb09e41-c5fa-4654-b9d2-569b59626ec4",
+            "name": "clip_to_resize",
+            "type": "VIDEO",
+            "linkIds": [
+              50
+            ],
+            "localized_name": "clip_to_resize",
+            "label": "base_video",
+            "pos": [
+              -1861.4453125,
+              724
+            ]
+          },
+          {
+            "id": "017f8d09-7900-4dc9-b95c-0cab31bcde7d",
+            "name": "base_video",
+            "type": "VIDEO",
+            "linkIds": [
+              51
+            ],
+            "localized_name": "base_video",
+            "label": "second_video",
+            "pos": [
+              -1861.4453125,
+              744
+            ]
+          },
+          {
+            "id": "a39894ce-1785-4037-b39c-b40d2e470c43",
+            "name": "pad_second_video",
+            "type": "BOOLEAN",
+            "linkIds": [
+              59
+            ],
+            "localized_name": "pad_second_video",
+            "label": "pad_second_video",
+            "pos": [
+              -1861.4453125,
+              764
+            ]
+          },
+          {
+            "id": "b4fb86cb-8d87-4193-8533-88a57df50e18",
+            "name": "interpolation",
+            "type": "COMBO",
+            "linkIds": [
+              60
+            ],
+            "pos": [
+              -1861.4453125,
+              784
+            ]
+          },
+          {
+            "id": "2413a2e2-cfdc-4d1d-9e2e-81e7acdf35e3",
+            "name": "padding_color",
+            "type": "COMBO",
+            "linkIds": [
+              62
+            ],
+            "pos": [
+              -1861.4453125,
+              804
+            ]
+          },
+          {
+            "id": "338b1e09-0efb-424f-949b-e730a0aa8527",
+            "name": "drop_audio",
+            "type": "BOOLEAN",
+            "linkIds": [
+              63
+            ],
+            "localized_name": "drop_audio",
+            "label": "drop_audio",
+            "pos": [
+              -1861.4453125,
+              824
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "be99efc6-7fb3-4059-93d0-136dc8cc8faf",
+            "name": "merged_video",
+            "type": "VIDEO",
+            "linkIds": [
+              16
+            ],
+            "localized_name": "merged_video",
+            "pos": [
+              1234,
+              638
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 11,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              -990,
+              1230
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 63
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 10,
+            "type": "EmptyAudio",
+            "pos": [
+              -990,
+              1060
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  22
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptyAudio",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              60,
+              44100,
+              2
+            ]
+          },
+          {
+            "id": 3,
+            "type": "ComfySwitchNode",
+            "pos": [
+              -370,
+              1010
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "AUDIO",
+                "link": 79
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "AUDIO",
+                "link": 22
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 14
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "AUDIO",
+                "links": [
+                  12
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 6,
+            "type": "ResizeAndPadImage",
+            "pos": [
+              -400,
+              440
+            ],
+            "size": [
+              270,
+              210
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 39
+              },
+              {
+                "localized_name": "target_width",
+                "name": "target_width",
+                "type": "INT",
+                "widget": {
+                  "name": "target_width"
+                },
+                "link": 4
+              },
+              {
+                "localized_name": "target_height",
+                "name": "target_height",
+                "type": "INT",
+                "widget": {
+                  "name": "target_height"
+                },
+                "link": 5
+              },
+              {
+                "localized_name": "padding_color",
+                "name": "padding_color",
+                "type": "COMBO",
+                "widget": {
+                  "name": "padding_color"
+                },
+                "link": 62
+              },
+              {
+                "localized_name": "interpolation",
+                "name": "interpolation",
+                "type": "COMBO",
+                "widget": {
+                  "name": "interpolation"
+                },
+                "link": 60
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  75
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ResizeAndPadImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              512,
+              512,
+              "white",
+              "lanczos"
+            ]
+          },
+          {
+            "id": 8,
+            "type": "CreateVideo",
+            "pos": [
+              880,
+              280
+            ],
+            "size": [
+              270,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 19
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "shape": 7,
+                "type": "AUDIO",
+                "link": 12
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "fps"
+                },
+                "link": 15
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VIDEO",
+                "name": "VIDEO",
+                "type": "VIDEO",
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CreateVideo",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              30,
+              8
+            ]
+          },
+          {
+            "id": 2,
+            "type": "GetVideoComponents",
+            "pos": [
+              -1590,
+              460
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video",
+                "name": "video",
+                "type": "VIDEO",
+                "link": 51
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "links": [
+                  39,
+                  54
+                ]
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "type": "AUDIO",
+                "links": [
+                  83
+                ]
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "links": null
+              },
+              {
+                "localized_name": "bit_depth",
+                "name": "bit_depth",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetVideoComponents",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 27,
+            "type": "ComfySwitchNode",
+            "pos": [
+              60,
+              70
+            ],
+            "size": [
+              280,
+              130
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "IMAGE",
+                "link": 54
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "IMAGE",
+                "link": 75
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 56
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "IMAGE",
+                "links": [
+                  55
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 1,
+            "type": "GetVideoComponents",
+            "pos": [
+              -1600,
+              30
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video",
+                "name": "video",
+                "type": "VIDEO",
+                "link": 50
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "links": [
+                  3,
+                  17
+                ]
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "type": "AUDIO",
+                "links": [
+                  84
+                ]
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "links": [
+                  15
+                ]
+              },
+              {
+                "localized_name": "bit_depth",
+                "name": "bit_depth",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetVideoComponents",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 7,
+            "type": "GetImageSize",
+            "pos": [
+              -1000,
+              480
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 3
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  4
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  5
+                ]
+              },
+              {
+                "localized_name": "batch_size",
+                "name": "batch_size",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetImageSize",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 28,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              -1590,
+              190
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 59
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  56
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 13,
+            "type": "BatchImagesNode",
+            "pos": [
+              530,
+              10
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "image0",
+                "localized_name": "images.image0",
+                "name": "images.image0",
+                "type": "IMAGE",
+                "link": 17
+              },
+              {
+                "label": "image1",
+                "localized_name": "images.image1",
+                "name": "images.image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 55
+              },
+              {
+                "label": "image2",
+                "localized_name": "images.image2",
+                "name": "images.image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  19
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "BatchImagesNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 42,
+            "type": "AudioConcat",
+            "pos": [
+              -990,
+              900
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "audio1",
+                "name": "audio1",
+                "type": "AUDIO",
+                "link": 83
+              },
+              {
+                "localized_name": "audio2",
+                "name": "audio2",
+                "type": "AUDIO",
+                "link": 84
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  79
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "AudioConcat"
+            },
+            "widgets_values": [
+              "after"
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Audio",
+            "bounding": [
+              -1000,
+              820,
+              915,
+              496
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 22,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 14,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 39,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 4,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 5,
+            "origin_id": 7,
+            "origin_slot": 1,
+            "target_id": 6,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 3,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 17,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 19,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 12,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 15,
+            "origin_id": 1,
+            "origin_slot": 2,
+            "target_id": 8,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 16,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 50,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 51,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 54,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 55,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 56,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 59,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 28,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 60,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 6,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 62,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 6,
+            "target_slot": 3,
+            "type": "COMBO"
+          },
+          {
+            "id": 63,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 75,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 79,
+            "origin_id": 42,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 83,
+            "origin_id": 2,
+            "origin_slot": 1,
+            "target_id": 42,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 84,
+            "origin_id": 1,
+            "origin_slot": 1,
+            "target_id": 42,
+            "target_slot": 1,
+            "type": "AUDIO"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.48.7",
+    "ds": {
+      "scale": 0.4153414702717205,
+      "offset": [
+        1504.195224019496,
+        -6911.375448598833
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/audio_minimax_music_3.json
+++ b/tests/comfy_cli/fixtures/gallery/audio_minimax_music_3.json
@@ -1,0 +1,1123 @@
+{
+  "id": "08882d3e-437d-43da-b498-083de04a60a6",
+  "revision": 0,
+  "last_node_id": 43,
+  "last_link_id": 63,
+  "nodes": [
+    {
+      "id": 35,
+      "type": "SaveAudioAdvanced",
+      "pos": [
+        2150,
+        630
+      ],
+      "size": [
+        750,
+        160
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 42
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.31.0"
+      },
+      "widgets_values": [
+        "audio/audio_minimax_music3",
+        "mp3",
+        "V0"
+      ]
+    },
+    {
+      "id": 37,
+      "type": "ac99f841-a3de-4329-9564-953b81cf9e16",
+      "pos": [
+        1620,
+        630
+      ],
+      "size": [
+        490,
+        540
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "tiled_decode",
+          "name": "switch",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "switch"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            42
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.31.0",
+        "previewExposures": []
+      },
+      "widgets_values": [
+        "Global Metadata: Lo-fi hip-hop, chillhop. 78 BPM, D flat major, major scale with jazzy extensions. Laid-back and dreamy throughout, a gentle warm drift with a subtle late-night glow that deepens in the middle and dissolves softly at the end. Studying, raining-outside, headphones-on late-night listening. Bedroom production: muddy warm texture, heavy vinyl crackle, tape hiss and wow-flutter pitch wobble, low-passed dusty mix, soft-clipped drums, everything slightly detuned and cozy.\n\nVocal Details: Soft androgynous vocal, hushed half-sung half-spoken delivery, sitting low in the mix like another instrument, lazy behind-the-beat phrasing, gentle breathy timbre. Sparse murmured double-tracked harmonies, occasional wordless \"mmm\" and \"ooh\" hums drenched in tape delay and warm spring reverb. Long stretches with no vocals at all.\n\nArrangement: Dusty boom-bap drums with a soft thumping kick, cracked snare with lazy swing, brushed hi-hats, low round sub bass. Warm Rhodes piano chords with slow chorus wobble as the harmonic bed, mellow jazzy guitar licks answering the vocal lines, constant vinyl crackle as texture. Intro: rain and vinyl noise, solo Rhodes chords fading in, drums slipping in halfway. Verses: minimal — drums, bass, Rhodes, soft guitar fills between lines. Instrumental sections: guitar and Rhodes trade relaxed jazzy phrases over the beat, occasional muted trumpet ghost notes far in the background. Bridge: drums drop away to rain, crackle, and floating detuned Rhodes, then the beat eases back in. Outro: elements fade one by one until only vinyl crackle and a last unresolved Rhodes chord remain.",
+        "[Intro]\nMmm...\n(rain on the window)\nOoh...\n\n[Verse]\nMidnight and the canvas glows\nDragging little wires where the current flows\nType a quiet dream, let the sampler drift\nNoise into a picture, like the fog just lifts\nTwenty slow steps, I'm in no hurry now\nLatents turning colors and I don't know how\nEvery render's like a polaroid I found\nSoft focus memories, no sound\n\n[Instrumental]\n\n[Verse]\nQueue another frame, let the motion breathe\nPictures start to move like the falling leaves\nVideo drifting by at twenty-four\nLittle animations on my bedroom floor\nSeed after seed like the rain outside\nSome of them are keepers, some I let slide\nSave the ones that feel like a Sunday slow\nNode to node to node... and off we go\n\n[Chorus]\nMmm... let it render on\n(take your time, take your time)\nOoh... by the morning it'll all be done\n(one more queue, one more try)\n\n[Instrumental]\n\n[Bridge]\nRain keeps drawing pictures on the glass...\nMy machine keeps dreaming...\nNeither of us fast...\n\n[Chorus]\nMmm... let it render on\n(take your time, take your time)\nOoh... by the morning it'll all be done\n(one more queue, one more try)\n\n[Instrumental]\n\n[Outro]\nMmm...\n(node to node)\nOoh... goodnight",
+        60,
+        197122968890040,
+        "minimax_music3_dit_fp16.safetensors",
+        "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+        "minimax_music3_dav.safetensors",
+        true
+      ]
+    },
+    {
+      "id": 39,
+      "type": "MarkdownNote",
+      "pos": [
+        1050,
+        630
+      ],
+      "size": [
+        520,
+        660
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: MiniMax Music 3",
+      "properties": {},
+      "widgets_values": [
+        "## MiniMax Music 3\n\nA music generation model by MiniMax that creates complete songs up to 5 minutes long with stable structure and high audio quality. Two inputs drive it: **Caption** (structured music description: style, mood, vocals, arrangement) and **Lyrics** (with `[intro]` `[verse]` `[chorus]` `[bridge]` `[outro]` tags controlling song structure).\n\n### Parameters\n\n| Parameter | Description |\n|---|---|\n| Caption | Music description. Write it in three sections — Global Metadata → Vocal Details → Arrangement. The more specific, the closer the result. |\n| Lyrics | Song lyrics + section tags. Tags are the only executable structural instructions; the lyric text itself only conveys mood. |\n| max_duration | Target song length in seconds (default 120 = 2 minutes; the model supports up to ~300 s / 5 minutes). Longer songs take more time and VRAM. |\n| seed | Random seed for the generation. Keep it fixed to reproduce the same song; change it to get a different take. |\n| Model files | diffusion model / text encoder / VAE.|\n| Tiled decode | Decode the audio VAE in overlapping tiles to drastically cut VRAM usage — helpful for long songs on low-VRAM GPUs. Slightly slower, with a small risk of seams at tile boundaries; turn it off on high-VRAM GPUs for the best quality. |\n\n### Prompt Writing Guide\n\nYou can find an official [Music Caption Rewriter Skill here](https://github.com/MiniMax-AI/MiniMax-Music3)"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 40,
+      "type": "MarkdownNote",
+      "pos": [
+        560,
+        630
+      ],
+      "size": [
+        440,
+        680
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## Model Links\n\n**diffusion_models**\n- [minimax_music3_dit_int8_convrot.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_int8_convrot.safetensors) # For low VRAM\n- [minimax_music3_dit_fp16.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_fp16.safetensors)\n\n**text_encoders**\n\n- [minimax_music3_text_encoder_pruned_int8_convrot.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors)\n\n**vae**\n\n- [minimax_music3_dav.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/vae/minimax_music3_dav.safetensors)\n\n\n## Model Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 diffusion_models/\n│   │   ├── minimax_music3_dit_int8_convrot.safetensors # For low VRAM\n│   │   └── minimax_music3_dit_fp16.safetensors\n│   ├── 📂 text_encoders/\n│   │   └── minimax_music3_text_encoder_pruned_int8_convrot.safetensors\n│   └── 📂 vae/\n│       └── minimax_music3_dav.safetensors\n```\n\n## Report Issue\n\nNote: Please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud updates follow stable releases, so some nightly-supported models may not be available yet.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/comfyanonymous/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      42,
+      37,
+      0,
+      35,
+      0,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "ac99f841-a3de-4329-9564-953b81cf9e16",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 43,
+          "lastLinkId": 63,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Music (MiniMax Music 3)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            320,
+            820,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            3210,
+            380,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "9f92b5c5-dadc-4b0f-84d9-b5ed2b3a0842",
+            "name": "caption",
+            "type": "STRING",
+            "linkIds": [
+              45
+            ],
+            "pos": [
+              424,
+              844
+            ]
+          },
+          {
+            "id": "bb9d2920-ba98-4c51-be7d-4b5736b14407",
+            "name": "lyrics",
+            "type": "STRING",
+            "linkIds": [
+              46
+            ],
+            "pos": [
+              424,
+              864
+            ]
+          },
+          {
+            "id": "be60d2f1-fc99-4ed6-a057-130a7b83945f",
+            "name": "max_duration",
+            "type": "FLOAT",
+            "linkIds": [
+              47
+            ],
+            "pos": [
+              424,
+              884
+            ]
+          },
+          {
+            "id": "a7f66596-0413-4906-a08f-475af0521252",
+            "name": "seed",
+            "type": "INT",
+            "linkIds": [
+              54
+            ],
+            "pos": [
+              424,
+              904
+            ]
+          },
+          {
+            "id": "cbfb7b7b-357f-44ab-80cb-8748020a9880",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              55
+            ],
+            "pos": [
+              424,
+              924
+            ]
+          },
+          {
+            "id": "ec2e20dc-2e7b-4147-922f-5f5f26ac9854",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              56
+            ],
+            "pos": [
+              424,
+              944
+            ]
+          },
+          {
+            "id": "eeefaa94-f342-415e-96e7-eb13dcccbac0",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              57
+            ],
+            "pos": [
+              424,
+              964
+            ]
+          },
+          {
+            "id": "6da74b03-27d0-487e-b8d6-f94018b2ca9a",
+            "name": "switch",
+            "type": "BOOLEAN",
+            "linkIds": [
+              63
+            ],
+            "label": "tiled_decode",
+            "pos": [
+              424,
+              984
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "82bef6fd-2dee-4579-b4ed-7d679d18279f",
+            "name": "AUDIO",
+            "type": "AUDIO",
+            "linkIds": [
+              62
+            ],
+            "localized_name": "AUDIO",
+            "pos": [
+              3234,
+              404
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 6,
+            "type": "UNETLoader",
+            "pos": [
+              700,
+              380
+            ],
+            "size": [
+              480,
+              90
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "showAdvanced": false,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 55
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  6
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "UNETLoader",
+              "models": [
+                {
+                  "name": "minimax_music3_dit_fp16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_fp16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_dit_fp16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 13,
+            "type": "MiniMaxMusic3TextEncode",
+            "pos": [
+              1230,
+              380
+            ],
+            "size": [
+              500,
+              750
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 18
+              },
+              {
+                "localized_name": "caption",
+                "name": "caption",
+                "type": "STRING",
+                "widget": {
+                  "name": "caption"
+                },
+                "link": 45
+              },
+              {
+                "localized_name": "lyrics",
+                "name": "lyrics",
+                "type": "STRING",
+                "widget": {
+                  "name": "lyrics"
+                },
+                "link": 46
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 52
+              },
+              {
+                "localized_name": "max_duration",
+                "name": "max_duration",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "max_duration"
+                },
+                "link": 47
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  15,
+                  16
+                ]
+              },
+              {
+                "localized_name": "seconds",
+                "name": "seconds",
+                "type": "FLOAT",
+                "links": [
+                  20
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "MiniMaxMusic3TextEncode"
+            },
+            "widgets_values": [
+              "",
+              "",
+              222,
+              "fixed",
+              60,
+              1.7,
+              50
+            ]
+          },
+          {
+            "id": 3,
+            "type": "CLIPLoader",
+            "pos": [
+              700,
+              550
+            ],
+            "size": [
+              480,
+              120
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 56
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  18
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "CLIPLoader",
+              "models": [
+                {
+                  "name": "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+                  "directory": "text_encoders"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+              "minimax",
+              "default"
+            ]
+          },
+          {
+            "id": 7,
+            "type": "VAELoader",
+            "pos": [
+              700,
+              750
+            ],
+            "size": [
+              480,
+              70
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 57
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  13,
+                  59
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAELoader",
+              "models": [
+                {
+                  "name": "minimax_music3_dav.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/vae/minimax_music3_dav.safetensors",
+                  "directory": "vae"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_dav.safetensors"
+            ]
+          },
+          {
+            "id": 10,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              1820,
+              540
+            ],
+            "size": [
+              230,
+              40
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 16
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  8
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "ConditioningZeroOut"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 15,
+            "type": "EmptyMiniMaxMusic3LatentAudio",
+            "pos": [
+              1780,
+              380
+            ],
+            "size": [
+              350,
+              90
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "seconds",
+                "name": "seconds",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "seconds"
+                },
+                "link": 20
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  21
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "EmptyMiniMaxMusic3LatentAudio"
+            },
+            "widgets_values": [
+              120,
+              1
+            ]
+          },
+          {
+            "id": 9,
+            "type": "KSampler",
+            "pos": [
+              2170,
+              380
+            ],
+            "size": [
+              370,
+              270
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 6
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 15
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 8
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 21
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 53
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  12,
+                  58
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "KSampler"
+            },
+            "widgets_values": [
+              1111111112,
+              "fixed",
+              30,
+              1.7,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 12,
+            "type": "VAEDecodeAudio",
+            "pos": [
+              2590,
+              380
+            ],
+            "size": [
+              230,
+              60
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 12
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 13
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  60
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAEDecodeAudio"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 38,
+            "type": "SeedNode",
+            "pos": [
+              890,
+              970
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 54
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "links": [
+                  52,
+                  53
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "SeedNode"
+            },
+            "widgets_values": [
+              0,
+              "randomize"
+            ]
+          },
+          {
+            "id": 42,
+            "type": "VAEDecodeAudioTiled",
+            "pos": [
+              2580,
+              500
+            ],
+            "size": [
+              280,
+              110
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 58
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 59
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  61
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAEDecodeAudioTiled"
+            },
+            "widgets_values": [
+              1536,
+              64
+            ]
+          },
+          {
+            "id": 43,
+            "type": "ComfySwitchNode",
+            "pos": [
+              2600,
+              690
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "AUDIO",
+                "link": 60
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "AUDIO",
+                "link": 61
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 63
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "AUDIO",
+                "links": [
+                  62
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "ComfySwitchNode"
+            },
+            "widgets_values": [
+              false
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 18,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 16,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 20,
+            "origin_id": 13,
+            "origin_slot": 1,
+            "target_id": 15,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 6,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 15,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 8,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 21,
+            "origin_id": 15,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 12,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 13,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 12,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 45,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 46,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 13,
+            "target_slot": 2,
+            "type": "STRING"
+          },
+          {
+            "id": 47,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 13,
+            "target_slot": 4,
+            "type": "FLOAT"
+          },
+          {
+            "id": 52,
+            "origin_id": 38,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 3,
+            "type": "INT"
+          },
+          {
+            "id": 53,
+            "origin_id": 38,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 54,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 38,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 55,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 56,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 57,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 58,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 42,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 59,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 42,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 60,
+            "origin_id": 12,
+            "origin_slot": 0,
+            "target_id": 43,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 61,
+            "origin_id": 42,
+            "origin_slot": 0,
+            "target_id": 43,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 62,
+            "origin_id": 43,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 63,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 43,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7901285864132895,
+      "offset": [
+        -390.5963888708135,
+        -245.41184011189858
+      ]
+    },
+    "frontendVersion": "1.48.7",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/image_z_image_turbo.json
+++ b/tests/comfy_cli/fixtures/gallery/image_z_image_turbo.json
@@ -1,0 +1,1064 @@
+{
+  "id": "9ae6082b-c7f4-433c-9971-7a8f65a3ea65",
+  "revision": 0,
+  "last_node_id": 61,
+  "last_link_id": 75,
+  "nodes": [
+    {
+      "id": 35,
+      "type": "MarkdownNote",
+      "pos": [
+        -420.00005528861476,
+        199.99998755061938
+      ],
+      "size": [
+        510,
+        771.953125
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Model link",
+      "properties": {},
+      "widgets_values": [
+        "## Report workflow issue\n\nIf you found any issues when running this workflow, [report template issue here](https://github.com/Comfy-Org/workflow_templates/issues)\n\n\n## Model links\n\n**text_encoders**\n\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors)\n\n**diffusion_models**\n\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n\n**vae**\n\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors)\n\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 text_encoders/\n│   │      └── qwen_3_4b.safetensors\n│   ├── 📂 diffusion_models/\n│   │      └── z_image_turbo_bf16.safetensors\n│   └── 📂 vae/\n│          └── ae.safetensors\n```\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        569.9998957637683,
+        199.99998755061938
+      ],
+      "size": [
+        780,
+        660
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 62
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.64",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "z-image-turbo"
+      ]
+    },
+    {
+      "id": 57,
+      "type": "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1",
+      "pos": [
+        130,
+        200
+      ],
+      "size": [
+        400,
+        470
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            62
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "27",
+            "text"
+          ],
+          [
+            "13",
+            "width"
+          ],
+          [
+            "13",
+            "height"
+          ],
+          [
+            "3",
+            "seed"
+          ],
+          [
+            "3",
+            "steps"
+          ],
+          [
+            "28",
+            "unet_name"
+          ],
+          [
+            "30",
+            "clip_name"
+          ],
+          [
+            "29",
+            "vae_name"
+          ],
+          [
+            "3",
+            "control_after_generate"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.3.73",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      62,
+      57,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1",
+        "version": 1,
+        "state": {
+          "lastGroupId": 4,
+          "lastNodeId": 61,
+          "lastLinkId": 75,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Image (Z-Image-Turbo)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -560,
+            480,
+            120,
+            200
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1670,
+            320,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "fb178669-e742-4a53-8a69-7df59834dfd8",
+            "name": "text",
+            "type": "STRING",
+            "linkIds": [
+              34
+            ],
+            "label": "prompt",
+            "pos": [
+              -460,
+              500
+            ]
+          },
+          {
+            "id": "dd780b3c-23e9-46ff-8469-156008f42e5a",
+            "name": "width",
+            "type": "INT",
+            "linkIds": [
+              35
+            ],
+            "pos": [
+              -460,
+              520
+            ]
+          },
+          {
+            "id": "7b08d546-6bb0-4ef9-82e9-ffae5e1ee6bc",
+            "name": "height",
+            "type": "INT",
+            "linkIds": [
+              36
+            ],
+            "pos": [
+              -460,
+              540
+            ]
+          },
+          {
+            "id": "f77677f7-6bf6-4c19-a71f-c4a553d5981e",
+            "name": "seed",
+            "type": "INT",
+            "linkIds": [
+              71
+            ],
+            "pos": [
+              -460,
+              560
+            ]
+          },
+          {
+            "id": "ef9a9fb1-5983-4bc9-a60b-cf5aec48bff1",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              72
+            ],
+            "pos": [
+              -460,
+              580
+            ]
+          },
+          {
+            "id": "a20a1b30-785f-4a04-bb6d-3d61adab9764",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              73
+            ],
+            "pos": [
+              -460,
+              600
+            ]
+          },
+          {
+            "id": "4af8fc2b-4655-4086-8240-45f8cb38c6f6",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              74
+            ],
+            "pos": [
+              -460,
+              620
+            ]
+          },
+          {
+            "id": "4d518693-2807-439c-9cb6-cffd23ccba2c",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              75
+            ],
+            "pos": [
+              -460,
+              640
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "1fa72a21-ce00-4952-814e-1f2ffbe87d1d",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              16
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1690,
+              340
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 30,
+            "type": "CLIPLoader",
+            "pos": [
+              29.99986879338951,
+              422.66401138970815
+            ],
+            "size": [
+              270,
+              141.328125
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 74
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  28
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "qwen_3_4b.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_3_4b.safetensors",
+              "lumina2",
+              "default"
+            ]
+          },
+          {
+            "id": 29,
+            "type": "VAELoader",
+            "pos": [
+              29.99986879338951,
+              649.9999131978064
+            ],
+            "size": [
+              270,
+              106.65625
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 75
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  27
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "ae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "ae.safetensors"
+            ]
+          },
+          {
+            "id": 33,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              629.9998362150791,
+              959.999861458308
+            ],
+            "size": [
+              225,
+              72
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 32
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  33
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ConditioningZeroOut",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 8,
+            "type": "VAEDecode",
+            "pos": [
+              1319.9997837897204,
+              229.99998088352976
+            ],
+            "size": [
+              225,
+              96
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 14
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 27
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 28,
+            "type": "UNETLoader",
+            "pos": [
+              29.99986879338951,
+              229.99998088352976
+            ],
+            "size": [
+              270,
+              106.65625
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 73
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  26
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "z_image_turbo_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "z_image_turbo_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 27,
+            "type": "CLIPTextEncode",
+            "pos": [
+              399.9978589832622,
+              229.99946973987727
+            ],
+            "size": [
+              450,
+              650
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 28
+              },
+              {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {
+                  "name": "text"
+                },
+                "link": 34
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  30,
+                  32
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. "
+            ]
+          },
+          {
+            "id": 13,
+            "type": "EmptySD3LatentImage",
+            "pos": [
+              39.999933078393155,
+              889.9999101400169
+            ],
+            "size": [
+              260,
+              168
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 35
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 36
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  17
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptySD3LatentImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1024,
+              1024,
+              1
+            ]
+          },
+          {
+            "id": 11,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              949.9997988929108,
+              229.99998088352976
+            ],
+            "size": [
+              310,
+              104
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 26
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  13
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3
+            ]
+          },
+          {
+            "id": 3,
+            "type": "KSampler",
+            "pos": [
+              949.9997988929108,
+              399.9999517059391
+            ],
+            "size": [
+              320,
+              341.328125
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 13
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 30
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 33
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 17
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 71
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 72
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              0,
+              "randomize",
+              8,
+              1,
+              "res_multistep",
+              "simple",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 2,
+            "title": "Step2 - Image size",
+            "bounding": [
+              10,
+              820,
+              320,
+              280
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step3 - Prompt",
+            "bounding": [
+              360,
+              130,
+              530,
+              970
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "Step1 - Load models",
+            "bounding": [
+              0,
+              130,
+              330,
+              660
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 32,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 33,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 26,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 14,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 27,
+            "origin_id": 29,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 13,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 30,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 33,
+            "origin_id": 33,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 17,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 28,
+            "origin_id": 30,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 16,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 34,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 35,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 36,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 71,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 3,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 72,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 3,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 73,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 28,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 74,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 30,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 75,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 29,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6731331717151416,
+      "offset": [
+        841.4738691917171,
+        312.8272327558304
+      ]
+    },
+    "frontendVersion": "1.42.15",
+    "workflowRendererVersion": "LG",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/object_info_subgraph_promoted.json
+++ b/tests/comfy_cli/fixtures/object_info_subgraph_promoted.json
@@ -1,0 +1,3479 @@
+{
+ "AudioConcat": {
+  "input": {
+   "required": {
+    "audio1": [
+     "AUDIO",
+     {}
+    ],
+    "audio2": [
+     "AUDIO",
+     {}
+    ],
+    "direction": [
+     "COMBO",
+     {
+      "default": "after",
+      "multiselect": false,
+      "options": [
+       "after",
+       "before"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "audio1",
+    "audio2",
+    "direction"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "AudioConcat",
+  "display_name": "Concatenate Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "join audio",
+   "combine audio",
+   "append audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "BatchImagesNode": {
+  "input": {
+   "required": {
+    "images": [
+     "COMFY_AUTOGROW_V3",
+     {
+      "template": {
+       "input": {
+        "required": {
+         "image": [
+          "IMAGE",
+          {}
+         ]
+        }
+       },
+       "prefix": "image",
+       "min": 1,
+       "max": 50
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "BatchImagesNode",
+  "display_name": "Batch Images",
+  "python_module": "comfy_extras.nodes_post_processing",
+  "category": "image/batch",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "batch",
+   "image batch",
+   "batch images",
+   "combine images",
+   "merge images",
+   "stack images"
+  ],
+  "essentials_category": "Image Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ByteDance2ReferenceNodeV2": {
+  "input": {
+   "required": {
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Seedance 2.5",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "default": "720p",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "16:9",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 5,
+            "min": 4,
+            "max": 30,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "task_type": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "reference",
+             "edit",
+             "extend"
+            ]
+           }
+          ],
+          "output_format": [
+           "COMBO",
+           {
+            "default": "mp4",
+            "multiselect": false,
+            "options": [
+             "mp4"
+            ]
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14",
+              "image_15",
+              "image_16",
+              "image_17",
+              "image_18",
+              "image_19",
+              "image_20",
+              "image_21",
+              "image_22",
+              "image_23",
+              "image_24",
+              "image_25",
+              "image_26",
+              "image_27",
+              "image_28",
+              "image_29",
+              "image_30"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3",
+              "video_4",
+              "video_5",
+              "video_6",
+              "video_7",
+              "video_8",
+              "video_9",
+              "video_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3",
+              "audio_4",
+              "audio_5",
+              "audio_6",
+              "audio_7",
+              "audio_8",
+              "audio_9",
+              "audio_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9",
+              "asset_10",
+              "asset_11",
+              "asset_12",
+              "asset_13",
+              "asset_14",
+              "asset_15",
+              "asset_16",
+              "asset_17",
+              "asset_18",
+              "asset_19",
+              "asset_20",
+              "asset_21",
+              "asset_22",
+              "asset_23",
+              "asset_24",
+              "asset_25",
+              "asset_26",
+              "asset_27",
+              "asset_28",
+              "asset_29",
+              "asset_30"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p",
+             "4k"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Fast",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Mini",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ],
+    "watermark": [
+     "BOOLEAN",
+     {
+      "advanced": true,
+      "default": false
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "watermark"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ByteDance2ReferenceNodeV2",
+  "display_name": "ByteDance Seedance 2.5 Reference to Video",
+  "python_module": "comfy_api_nodes.nodes_bytedance",
+  "category": "partner/video/ByteDance",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.ratio",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.duration",
+      "type": "INT"
+     },
+     {
+      "name": "model.task_type",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": [
+     "model.reference_videos"
+    ]
+   },
+   "expr": "\n(\n  $m := widgets.model;\n  $res := $lookup(widgets, \"model.resolution\");\n  $ratio := $lookup(widgets, \"model.ratio\");\n  $dur := $lookup(widgets, \"model.duration\");\n  $auto := $lookup(widgets, \"model.task_type\") = \"edit\";\n  $hasVideo := $exists(inputGroups) and $lookup(inputGroups, \"model.reference_videos\") > 0;\n  $ready := $type($m) = \"string\" and $type($res) = \"string\" and ($auto or $type($dur) = \"number\");\n  $ready ? (\n    $contains($m, \"2.5\") ? (\n      $is480 := $res = \"480p\";\n      $is1080 := $res = \"1080p\";\n      $perFrame := $ratio = \"1:1\"  ? ($is480 ? 400      : $is1080 ? 2025      : 900) :\n                   $ratio = \"4:3\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"3:4\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"21:9\" ? ($is480 ? 418.5    : $is1080 ? 2037.9648 : 904.3945) :\n                                     ($is480 ? 400.3125 : $is1080 ? 2025      : 900);\n      $price := $is1080\n        ? ($hasVideo ? 0.01001 : 0.016731)\n        : ($hasVideo ? 0.009152 : 0.015301);\n      $costFor := function($d) { $floor($perFrame * (24 * $d + 1)) / 1000 * $price };\n      $lo := $costFor($auto ? 4 : $dur);\n      $hi := $costFor(($auto ? 30 : $dur) + ($hasVideo ? 30 : 0));\n      $lo = $hi\n        ? {\"type\": \"usd\", \"usd\": $lo, \"format\": {\"approximate\": true}}\n        : {\"type\": \"range_usd\", \"min_usd\": $lo, \"max_usd\": $hi, \"format\": {\"approximate\": true}}\n    ) : (\n      $rate := $res = \"4k\"    ? 195200 :\n               $res = \"1080p\" ? 48800 :\n               $res = \"720p\"  ? 21600 : 10044;\n      $noVideoPrice := $res = \"4k\"    ? 0.00572 :\n                       $res = \"1080p\" ? 0.011011 :\n                       $contains($m, \"mini\") ? 0.005005 :\n                       $contains($m, \"fast\") ? 0.008008 : 0.01001;\n      $videoPrice := $res = \"4k\"    ? 0.003432 :\n                     $res = \"1080p\" ? 0.006721 :\n                     $contains($m, \"mini\") ? 0.003003 :\n                     $contains($m, \"fast\") ? 0.004719 : 0.006149;\n      $hasVideo\n        ? {\"type\": \"range_usd\",\n           \"min_usd\": $ceil($dur * 5 / 3) * $rate * $videoPrice / 1000,\n           \"max_usd\": (15 + $dur) * $rate * $videoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n        : {\"type\": \"usd\", \"usd\": $dur * $rate * $noVideoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n    )\n  ) : undefined\n)\n"
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "CLIPLoader": {
+  "input": {
+   "required": {
+    "clip_name": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "type": [
+     [
+      "stable_diffusion",
+      "stable_cascade",
+      "sd3",
+      "stable_audio",
+      "mochi",
+      "ltxv",
+      "pixart",
+      "cosmos",
+      "lumina2",
+      "wan",
+      "hidream",
+      "chroma",
+      "ace",
+      "omnigen2",
+      "qwen_image",
+      "hunyuan_image",
+      "flux2",
+      "ovis",
+      "longcat_image",
+      "cogvideox",
+      "lens",
+      "pixeldit",
+      "ideogram4",
+      "boogu",
+      "krea2",
+      "joyimage",
+      "mage",
+      "minimax"
+     ]
+    ]
+   },
+   "optional": {
+    "device": [
+     [
+      "default",
+      "cpu"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip_name",
+    "type"
+   ],
+   "optional": [
+    "device"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CLIP"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CLIP"
+  ],
+  "name": "CLIPLoader",
+  "display_name": "Load CLIP",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "CLIPTextEncode": {
+  "input": {
+   "required": {
+    "text": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "clip": [
+     "CLIP",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "text",
+    "clip"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "CLIPTextEncode",
+  "display_name": "CLIP Text Encode (Prompt)",
+  "python_module": "nodes",
+  "category": "model/conditioning",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "A conditioning containing the embedded text used to guide the diffusion model."
+  ],
+  "search_aliases": [
+   "text",
+   "prompt",
+   "text prompt",
+   "positive prompt",
+   "negative prompt",
+   "encode text",
+   "text encoder",
+   "encode prompt"
+  ],
+  "description": ""
+ },
+ "ComfySwitchNode": {
+  "input": {
+   "required": {
+    "switch": [
+     "BOOLEAN",
+     {}
+    ],
+    "on_false": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ],
+    "on_true": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "switch",
+    "on_false",
+    "on_true"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "COMFY_MATCHTYPE_V3"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "output"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": [
+   "switch"
+  ],
+  "name": "ComfySwitchNode",
+  "display_name": "If/Else Switch",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities/logic",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "if",
+   "then",
+   "switch",
+   "conditional",
+   "branch"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ConditioningZeroOut": {
+  "input": {
+   "required": {
+    "conditioning": [
+     "CONDITIONING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "conditioning"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "ConditioningZeroOut",
+  "display_name": "Conditioning Zero Out",
+  "python_module": "nodes",
+  "category": "model/conditioning/transform",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "null conditioning",
+   "clear conditioning"
+  ],
+  "description": ""
+ },
+ "CreateVideo": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "fps": [
+     "FLOAT",
+     {
+      "default": 30.0,
+      "min": 1.0,
+      "max": 120.0,
+      "step": 1.0
+     }
+    ]
+   },
+   "optional": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "bit_depth": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       8,
+       10
+      ]
+     }
+    ],
+    "color_space": [
+     "COMBO",
+     {
+      "default": "sRGB",
+      "multiselect": false,
+      "options": [
+       "sRGB",
+       "HDR",
+       "HDR PQ"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "fps"
+   ],
+   "optional": [
+    "audio",
+    "bit_depth",
+    "color_space"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CreateVideo",
+  "display_name": "Create Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "images to video"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptyAudio": {
+  "input": {
+   "required": {
+    "duration": [
+     "FLOAT",
+     {
+      "default": 60.0,
+      "min": 0.0,
+      "max": 18446744073709551615,
+      "step": 0.01
+     }
+    ],
+    "sample_rate": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 44100,
+      "min": 1,
+      "max": 192000
+     }
+    ],
+    "channels": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 2,
+      "min": 1,
+      "max": 2
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "duration",
+    "sample_rate",
+    "channels"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptyAudio",
+  "display_name": "Empty Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "blank audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptyMiniMaxMusic3LatentAudio": {
+  "input": {
+   "required": {
+    "seconds": [
+     "FLOAT",
+     {
+      "default": 120.0,
+      "min": 0.04,
+      "max": 360.0,
+      "step": 0.04
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "seconds",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptyMiniMaxMusic3LatentAudio",
+  "display_name": "Empty MiniMax Music3 Latent Audio",
+  "python_module": "comfy_extras.nodes_minimax_music",
+  "category": "model/latent/minimax music",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptySD3LatentImage": {
+  "input": {
+   "required": {
+    "width": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "height": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "width",
+    "height",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptySD3LatentImage",
+  "display_name": null,
+  "python_module": "comfy_extras.nodes_sd3",
+  "category": "model/latent/stable diffusion",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GetImageSize": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ]
+   },
+   "hidden": {
+    "unique_id": [
+     "UNIQUE_ID"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ],
+   "hidden": [
+    "unique_id"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height",
+   "batch_size"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetImageSize",
+  "display_name": "Get Image Size",
+  "python_module": "comfy_extras.nodes_images",
+  "category": "image",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "dimensions",
+   "resolution",
+   "image info"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GetVideoComponents": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "AUDIO",
+   "FLOAT",
+   "COMBO",
+   "COMBO"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "images",
+   "audio",
+   "fps",
+   "bit_depth",
+   "color_space"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetVideoComponents",
+  "display_name": "Get Video Components",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract frames",
+   "split video",
+   "video to images",
+   "demux"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "KSampler": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL",
+     {}
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "steps": [
+     "INT",
+     {
+      "default": 20,
+      "min": 1,
+      "max": 10000
+     }
+    ],
+    "cfg": [
+     "FLOAT",
+     {
+      "default": 8.0,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "sampler_name": [
+     [
+      "euler",
+      "euler_cfg_pp",
+      "euler_ancestral",
+      "euler_ancestral_cfg_pp",
+      "heun",
+      "heunpp2",
+      "exp_heun_2_x0",
+      "exp_heun_2_x0_sde",
+      "dpm_2",
+      "dpm_2_ancestral",
+      "lms",
+      "dpm_fast",
+      "dpm_adaptive",
+      "dpmpp_2s_ancestral",
+      "dpmpp_2s_ancestral_cfg_pp",
+      "dpmpp_sde",
+      "dpmpp_sde_gpu",
+      "dpmpp_2m",
+      "dpmpp_2m_cfg_pp",
+      "dpmpp_2m_sde",
+      "dpmpp_2m_sde_gpu",
+      "dpmpp_2m_sde_heun",
+      "dpmpp_2m_sde_heun_gpu",
+      "dpmpp_3m_sde",
+      "dpmpp_3m_sde_gpu",
+      "ddpm",
+      "lcm",
+      "ipndm",
+      "ipndm_v",
+      "deis",
+      "res_multistep",
+      "res_multistep_cfg_pp",
+      "res_multistep_ancestral",
+      "res_multistep_ancestral_cfg_pp",
+      "gradient_estimation",
+      "gradient_estimation_cfg_pp",
+      "er_sde",
+      "seeds_2",
+      "seeds_3",
+      "sa_solver",
+      "sa_solver_pece",
+      "ddim",
+      "uni_pc",
+      "uni_pc_bh2",
+      "legacy_rk",
+      "rk",
+      "rk_beta",
+      "deis_3m_ode",
+      "deis_2m_ode",
+      "deis_3m",
+      "deis_2m",
+      "res_6s_ode",
+      "res_5s_ode",
+      "res_3s_ode",
+      "res_2s_ode",
+      "res_3m_ode",
+      "res_2m_ode",
+      "res_6s",
+      "res_5s",
+      "res_3s",
+      "res_2s",
+      "res_3m",
+      "res_2m"
+     ],
+     {}
+    ],
+    "scheduler": [
+     [
+      "simple",
+      "sgm_uniform",
+      "karras",
+      "exponential",
+      "ddim_uniform",
+      "beta",
+      "normal",
+      "linear_quadratic",
+      "kl_optimal",
+      "bong_tangent",
+      "beta57"
+     ],
+     {}
+    ],
+    "positive": [
+     "CONDITIONING",
+     {}
+    ],
+    "negative": [
+     "CONDITIONING",
+     {}
+    ],
+    "latent_image": [
+     "LATENT",
+     {}
+    ],
+    "denoise": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "steps",
+    "cfg",
+    "sampler_name",
+    "scheduler",
+    "positive",
+    "negative",
+    "latent_image",
+    "denoise"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "name": "KSampler",
+  "display_name": "KSampler",
+  "python_module": "nodes",
+  "category": "model/sampling",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The denoised latent."
+  ],
+  "search_aliases": [
+   "sampler",
+   "sample",
+   "generate",
+   "denoise",
+   "diffuse",
+   "txt2img",
+   "img2img"
+  ],
+  "description": ""
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "MiniMaxMusic3TextEncode": {
+  "input": {
+   "required": {
+    "clip": [
+     "CLIP",
+     {}
+    ],
+    "caption": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "lyrics": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "max_duration": [
+     "FLOAT",
+     {
+      "default": 120.0,
+      "min": 0.04,
+      "max": 360.0,
+      "step": 0.04
+     }
+    ],
+    "cfg_scale": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 1.5,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "top_k": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 50,
+      "min": 1,
+      "max": 16384
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip",
+    "caption",
+    "lyrics",
+    "seed",
+    "max_duration",
+    "cfg_scale",
+    "top_k"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING",
+   "FLOAT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "CONDITIONING",
+   "seconds"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "MiniMaxMusic3TextEncode",
+  "display_name": "MiniMax Music3 Text Encode",
+  "python_module": "comfy_extras.nodes_minimax_music",
+  "category": "model/conditioning/minimax music",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ModelSamplingAuraFlow": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL"
+    ],
+    "shift": [
+     "FLOAT",
+     {
+      "default": 1.73,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "shift"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "ModelSamplingAuraFlow",
+  "display_name": "ModelSamplingAuraFlow",
+  "python_module": "comfy_extras.nodes_model_advanced",
+  "category": "model/patch",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "PrimitiveBoolean": {
+  "input": {
+   "required": {
+    "value": [
+     "BOOLEAN",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "BOOLEAN"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "BOOLEAN"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveBoolean",
+  "display_name": "Boolean",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveFloat": {
+  "input": {
+   "required": {
+    "value": [
+     "FLOAT",
+     {
+      "min": -9223372036854775807,
+      "max": 9223372036854775807,
+      "step": 0.1
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "FLOAT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "FLOAT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveFloat",
+  "display_name": "Float",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveInt": {
+  "input": {
+   "required": {
+    "value": [
+     "INT",
+     {
+      "min": -9223372036854775807,
+      "max": 9223372036854775807,
+      "control_after_generate": "fixed"
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "INT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveInt",
+  "display_name": "Int",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveStringMultiline": {
+  "input": {
+   "required": {
+    "value": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "STRING"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveStringMultiline",
+  "display_name": "Text (Multiline)",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "text",
+   "string",
+   "text multiline",
+   "string multiline",
+   "text box",
+   "prompt"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ResizeAndPadImage": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ],
+    "target_width": [
+     "INT",
+     {
+      "default": 512,
+      "min": 1,
+      "max": 16384,
+      "step": 1
+     }
+    ],
+    "target_height": [
+     "INT",
+     {
+      "default": 512,
+      "min": 1,
+      "max": 16384,
+      "step": 1
+     }
+    ],
+    "padding_color": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "white",
+       "black"
+      ]
+     }
+    ],
+    "interpolation": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "area",
+       "bicubic",
+       "nearest-exact",
+       "bilinear",
+       "lanczos"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "target_width",
+    "target_height",
+    "padding_color",
+    "interpolation"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ResizeAndPadImage",
+  "display_name": "Resize And Pad Image",
+  "python_module": "comfy_extras.nodes_images",
+  "category": "image/transform",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "fit to size"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ResolutionSelector": {
+  "input": {
+   "required": {
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "1:1 (Square)",
+      "multiselect": false,
+      "options": [
+       "1:1 (Square)",
+       "2:3 (Portrait Photo)",
+       "3:2 (Photo)",
+       "3:4 (Portrait Standard)",
+       "4:3 (Standard)",
+       "9:16 (Portrait Widescreen)",
+       "16:9 (Widescreen)",
+       "21:9 (Ultrawide)"
+      ]
+     }
+    ],
+    "megapixels": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.1,
+      "max": 16.0,
+      "step": 0.1
+     }
+    ],
+    "multiple": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 8,
+      "min": 8,
+      "max": 128,
+      "step": 4
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "aspect_ratio",
+    "megapixels",
+    "multiple"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "output_tooltips": [
+   "Calculated width in pixels multiplied by the selected multiple.",
+   "Calculated height in pixels multiplied by the selected multiple."
+  ],
+  "output_matchtypes": null,
+  "name": "ResolutionSelector",
+  "display_name": "Resolution Selector",
+  "python_module": "comfy_extras.nodes_resolution",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SaveAudioAdvanced": {
+  "input": {
+   "required": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "audio/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "flac",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "mp3",
+        "inputs": {
+         "required": {
+          "quality": [
+           "COMBO",
+           {
+            "default": "V0",
+            "multiselect": false,
+            "options": [
+             "V0",
+             "128k",
+             "320k"
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "opus",
+        "inputs": {
+         "required": {
+          "quality": [
+           "COMBO",
+           {
+            "default": "128k",
+            "multiselect": false,
+            "options": [
+             "64k",
+             "96k",
+             "128k",
+             "192k",
+             "320k"
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "audio",
+    "filename_prefix",
+    "format"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "audio"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "SaveAudioAdvanced",
+  "display_name": "Save Audio (Advanced)",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "save audio",
+   "export audio",
+   "output audio",
+   "write audio",
+   "flac",
+   "mp3",
+   "opus"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "save",
+   "save image",
+   "export image",
+   "output image",
+   "write image",
+   "download"
+  ],
+  "essentials_category": "Basics",
+  "description": ""
+ },
+ "SaveVideo": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "video/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mp4",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mkv",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "webm",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "codec": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "hidden": true,
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "h264",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 23.0,
+                  "min": 0.0,
+                  "max": 51.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "av1",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 30.0,
+                  "min": 0.0,
+                  "max": 63.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "filename_prefix",
+    "format"
+   ],
+   "optional": [
+    "codec"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "video"
+  ],
+  "output_tooltips": [
+   "The input video, unchanged."
+  ],
+  "output_matchtypes": null,
+  "name": "SaveVideo",
+  "display_name": "Save Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "export video"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SeedNode": {
+  "input": {
+   "required": {
+    "seed": [
+     "INT",
+     {
+      "min": 0,
+      "max": 9223372036854775807,
+      "control_after_generate": "fixed"
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "seed"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "seed"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "SeedNode",
+  "display_name": "Seed",
+  "python_module": "comfy_extras.nodes_seed",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "seed",
+   "random"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "UNETLoader": {
+  "input": {
+   "required": {
+    "unet_name": [
+     [
+      "put_diffusion_models.safetensors"
+     ]
+    ],
+    "weight_dtype": [
+     [
+      "default",
+      "fp8_e4m3fn",
+      "fp8_e4m3fn_fast",
+      "fp8_e5m2"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "unet_name",
+    "weight_dtype"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "UNETLoader",
+  "display_name": "Load Diffusion Model",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "VAEDecode": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "VAEDecode",
+  "display_name": "VAE Decode",
+  "python_module": "nodes",
+  "category": "model/latent",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The decoded image."
+  ],
+  "search_aliases": [
+   "decode",
+   "decode latent",
+   "latent to image",
+   "render latent"
+  ],
+  "description": ""
+ },
+ "VAEDecodeAudio": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "VAEDecodeAudio",
+  "display_name": "VAE Decode Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "model/latent",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "latent to audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "VAEDecodeAudioTiled": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ],
+    "tile_size": [
+     "INT",
+     {
+      "default": 512,
+      "min": 32,
+      "max": 8192,
+      "step": 8
+     }
+    ],
+    "overlap": [
+     "INT",
+     {
+      "default": 64,
+      "min": 0,
+      "max": 1024,
+      "step": 8
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae",
+    "tile_size",
+    "overlap"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "VAEDecodeAudioTiled",
+  "display_name": "VAE Decode Audio (Tiled)",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "model/latent",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "latent to audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "VAELoader": {
+  "input": {
+   "required": {
+    "vae_name": [
+     [
+      "put_vae.safetensors",
+      "pixel_space"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "vae_name"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VAE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VAE"
+  ],
+  "name": "VAELoader",
+  "display_name": "Load VAE",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "Video Slice": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "start_time": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": -100000.0,
+      "max": 100000.0,
+      "step": 0.001
+     }
+    ],
+    "duration": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": 0.0,
+      "step": 0.001
+     }
+    ],
+    "strict_duration": [
+     "BOOLEAN",
+     {
+      "default": false
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "start_time",
+    "duration",
+    "strict_duration"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "Video Slice",
+  "display_name": "Trim Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "trim video duration",
+   "skip first frames",
+   "frame load cap",
+   "start time"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ }
+}

--- a/tests/comfy_cli/test_subgraph_gallery_templates.py
+++ b/tests/comfy_cli/test_subgraph_gallery_templates.py
@@ -102,13 +102,20 @@ class TestGalleryTemplateSlots:
         interior = [s for s in qwen_schema["slots"] if "/" in s["address"]]
         assert interior, f"no subgraph-interior slots surfaced; got {[s['address'] for s in qwen_schema['slots']]}"
 
-    def test_interior_prompt_and_seed_are_addressable(self, qwen_schema):
-        """The slots an agent actually edits: the prompt + seed inside the
-        opaque 'Qwen Image Edit 2509' subgraph instance (node 141)."""
+    def test_promoted_prompt_and_seed_are_addressed_at_the_host(self, qwen_schema):
+        """The slots an agent actually edits: the prompt + seed of the opaque
+        'Qwen Image Edit 2509' subgraph instance (node 141). Both are promoted
+        widgets, so they live at the instance address with the HOST value —
+        the interior KSampler still carries a stale seed (1118877715456453)
+        the frontend never runs (ADR 0009)."""
         by_addr = {s["address"]: s for s in qwen_schema["slots"]}
-        assert "141/132.prompt" in by_addr, f"missing interior prompt slot; got {sorted(by_addr)}"
-        assert by_addr["141/132.prompt"]["current_value"].startswith("Change the style")
-        assert by_addr["141/137.seed"]["current_value"] == 1118877715456453
+        assert "141.prompt" in by_addr, f"missing promoted prompt slot; got {sorted(by_addr)}"
+        assert by_addr["141.prompt"]["current_value"].startswith("Change the style")
+        assert by_addr["141.seed"]["current_value"] == 392667428726572
+        assert "141/132.prompt" not in by_addr
+        assert "141/137.seed" not in by_addr
+        # unpromoted interior widgets stay reachable
+        assert by_addr["141/137.steps"]["current_value"] == 4
 
     def test_top_level_slots_still_present(self, qwen_schema):
         by_addr = {s["address"]: s for s in qwen_schema["slots"]}

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -635,7 +635,7 @@ SEEDREAM_GOLDEN_LINE = (
     'creating depth. The overall mood is high-tech, dystopian, and avant-garde.", model="seedream 5.0 pro", '
     'seed=0, control_after_generate="randomize", watermark=False, thinking=True, '
     '**{"model.images.image_1": None, "model.size_preset": "(1K) 1024x1024 (1:1)", "model.width": 2048, '
-    '"model.height": 2048})  # 1'
+    '"model.height": 2048})  # 1 model.images grows IMAGE'
 )
 
 
@@ -650,7 +650,9 @@ def test_seedream_dynamic_combo_golden():
     res = render_py(wf, graph)
     ast.parse(res.source)  # the whole render is syntactically valid Python
 
-    line = next(ln for ln in res.source.splitlines() if ln.endswith("  # 1"))
+    line = next(ln for ln in res.source.splitlines() if "  # 1 " in ln)
+    # The auto-grow group `model.images` owns no widget slot; it is named in
+    # the comment (with its element type) so the reader knows it exists.
     assert line == SEEDREAM_GOLDEN_LINE
     kwargs = line.split("**{", 1)[1]
     for frag in (

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -65,9 +65,10 @@ def _add(wf: dict, graph: Graph, class_type: str) -> tuple[dict, int]:
 
 
 def _line(source: str, node_id: Any) -> str:
-    """The printed line whose trailing comment names ``node_id``."""
-    marker = f"  # {node_id}"
-    return next(ln for ln in source.splitlines() if marker in ln)
+    """The printed line whose trailing comment names ``node_id`` — the whole
+    id, so ``# 4`` never matches a minted id that merely starts with 4."""
+    pattern = re.compile(rf"  # {re.escape(str(node_id))}(?!\d)")
+    return next(ln for ln in source.splitlines() if pattern.search(ln))
 
 
 def _kwargs(line: str) -> str:
@@ -518,3 +519,18 @@ def test_existing_workflow_is_not_mutated_by_printing(promoted_graph, autogrow_g
     before2 = copy.deepcopy(wf2)
     render_py(wf2, autogrow_graph)
     assert wf2 == before2
+
+
+def test_frontend_injected_slots_are_not_printed_as_control_after_generate(autogrow_graph):
+    """An older frontend serialized LoadImage as ``["a.png", "image"]`` — the
+    second value is the injected ``upload`` button slot (``serialize:false``
+    now). It owns no schema port, but it is NOT ``control_after_generate``,
+    and it is not an editable value either: it must not print at all."""
+    wf, nid = _add(_empty(), autogrow_graph, "LoadImage")
+    node = next(n for n in wf["nodes"] if n["id"] == nid)
+    node["widgets_values"] = ["a.png", "image"]
+    source = render_py(wf, autogrow_graph).source
+    line = _line(source, nid)
+    assert 'image="a.png"' in line
+    assert "control_after_generate" not in line
+    assert "upload" not in line

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -534,3 +534,44 @@ def test_frontend_injected_slots_are_not_printed_as_control_after_generate(autog
     assert 'image="a.png"' in line
     assert "control_after_generate" not in line
     assert "upload" not in line
+
+
+def test_promoted_values_resolve_once_per_instance_not_per_widget(promoted_graph, monkeypatch):
+    """Review (PR #816): the instance line used to call the public
+    ``promoted.effective_value`` per promoted widget, which re-derived the
+    definition index and re-located the ``PromotedInput`` the loop already
+    held — 451 ``promoted_inputs`` calls for 51 needed on 50 instances. The
+    loop's own ``pi`` and ``_State.promoted_defs`` are the whole answer."""
+    from comfy_cli.cql import promoted as promoted_mod
+
+    base = _gallery("image_z_image_turbo.json")
+    template = next(n for n in base["nodes"] if n["id"] == 57)
+    n_instances = 40
+    wf = {**base, "nodes": [n for n in base["nodes"] if n["id"] != 57], "links": []}
+    for k in range(n_instances):
+        inst = copy.deepcopy(template)
+        inst["id"] = 1000 + k
+        inst["outputs"] = [{**o, "links": []} for o in inst.get("outputs") or []]
+        wf["nodes"].append(inst)
+    wf["nodes"] = [n for n in wf["nodes"] if n["id"] != 9]  # drop the SaveImage that consumed 57
+
+    calls = {"promoted_inputs": 0, "defs_by_id": 0}
+    real_pi, real_defs = promoted_mod.promoted_inputs, promoted_mod.defs_by_id
+
+    def counting_pi(*a, **k):
+        calls["promoted_inputs"] += 1
+        return real_pi(*a, **k)
+
+    def counting_defs(*a, **k):
+        calls["defs_by_id"] += 1
+        return real_defs(*a, **k)
+
+    monkeypatch.setattr(promoted_mod, "promoted_inputs", counting_pi)
+    monkeypatch.setattr(promoted_mod, "defs_by_id", counting_defs)
+    res = render_py(wf, promoted_graph)
+    assert res.warnings == []
+    assert sum("width=1024" in ln for ln in res.source.splitlines()) == n_instances
+    # one walk per instance line, one for the definition's promoted header —
+    # never one per promoted widget (8 per instance here)
+    assert calls["promoted_inputs"] <= n_instances + 2, calls
+    assert calls["defs_by_id"] <= 2, calls

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -1,0 +1,520 @@
+"""``comfy workflow print`` on dynamic-combo / auto-grow nodes and on subgraph
+instances with promoted widgets.
+
+Two things the printer has to get right, both of which the slot surface
+(``comfy workflow slots``) and the editors (``set-widget`` / ``connect``)
+already model:
+
+* **Dynamic combos and auto-grow groups.** Widgets print by their value-aware
+  names (``model``, ``model.aspect_ratio``, …) at the frontend's positions —
+  never shifted, never a phantom widget slot for a link-only sub-input such as
+  a ``COMFY_AUTOGROW_V3`` group. The group itself is a *link* surface: its
+  grown slots print as links, and when nothing is wired the group is still
+  visible with its element type so a reader knows the address exists.
+
+* **Subgraph instances with promoted widgets.** A promoted widget's value
+  lives on the HOST instance (``cql.promoted``) — the instance line prints
+  the EFFECTIVE value (host value, else interior default) under the name the
+  agent edits (``57.width``), an outside link into it prints as a link, and
+  the interior line keeps ``IN.<name>`` so nobody edits ``57/13.width``.
+
+Fixtures: ``object_info_nested_autogrow.json`` (dynamic combos + auto-grow)
+and the verbatim gallery templates under ``fixtures/gallery`` with
+``object_info_subgraph_promoted.json``.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+from comfy_cli.workflow_print import render_py
+
+FIXTURES = Path(__file__).parent / "fixtures"
+GALLERY = FIXTURES / "gallery"
+
+
+@pytest.fixture(scope="module")
+def autogrow_graph() -> Graph:
+    return Graph.from_object_info(json.loads((FIXTURES / "object_info_nested_autogrow.json").read_text()))
+
+
+@pytest.fixture(scope="module")
+def promoted_graph() -> Graph:
+    return Graph.from_object_info(json.loads((FIXTURES / "object_info_subgraph_promoted.json").read_text()))
+
+
+def _empty() -> dict[str, Any]:
+    return {"last_node_id": 0, "last_link_id": 0, "nodes": [], "links": [], "groups": [], "version": 0.4}
+
+
+def _add(wf: dict, graph: Graph, class_type: str) -> tuple[dict, int]:
+    wf, op = workflow_ops.add_node(wf, graph, class_type)
+    return wf, op["node_id"]
+
+
+def _line(source: str, node_id: Any) -> str:
+    """The printed line whose trailing comment names ``node_id``."""
+    marker = f"  # {node_id}"
+    return next(ln for ln in source.splitlines() if marker in ln)
+
+
+def _kwargs(line: str) -> str:
+    """The trailing ``**{...}`` dict of a printed line (dotted names live there)."""
+    return line.split("**{", 1)[1] if "**{" in line else ""
+
+
+def _gallery(name: str) -> dict:
+    return json.loads((GALLERY / name).read_text())
+
+
+def _parses(source: str) -> None:
+    """Every printed statement is valid Python on its own. (A definition
+    block is indented under its ``# subgraph`` header, so the source as a
+    whole is deliberately not one parseable module — the lines are.)"""
+    for ln in source.splitlines():
+        stripped = ln.strip()
+        if stripped and not stripped.startswith("#"):
+            ast.parse(stripped)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Dynamic combos + auto-grow groups
+# --------------------------------------------------------------------------- #
+
+
+def test_dynamic_combo_widgets_print_by_value_aware_names(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    assert 'model="Nano Banana 2 (Gemini 3.1 Flash Image)"' in line
+    assert "seed=42" in line and 'control_after_generate="fixed"' in line
+    assert "temperature=1.0" in line and "top_p=0.95" in line
+    kwargs = _kwargs(line)
+    for frag in ('"model.aspect_ratio": "auto"', '"model.resolution": "1K"', '"model.thinking_level": "MINIMAL"'):
+        assert frag in kwargs
+    # the link-only sub-input owns no widget slot: never printed as a value
+    assert '"model.images":' not in line
+    assert res.warnings == []
+
+
+def test_switching_the_selector_reexpands_the_sub_widgets_without_shifting(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.set_widget(wf, autogrow_graph, b, "model", "Nano Banana 2 Lite")
+    wf, _ = workflow_ops.set_widget(wf, autogrow_graph, b, "seed", 7)
+    line = _line(render_py(wf, autogrow_graph).source, b)
+    assert 'model="Nano Banana 2 Lite"' in line
+    assert "seed=7" in line
+    assert '"model.resolution": "1K"' in _kwargs(line)
+
+
+def test_unwired_autogrow_group_is_visible_with_its_element_type(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    # the group's first slot is shown open, under the name `connect` accepts
+    assert '"model.images.image_1": None' in _kwargs(line)
+    # ...and the comment names the group, its element type and its capacity
+    assert "model.images grows IMAGE (max 14)" in line.split("  # ", 1)[1]
+
+
+def test_wired_autogrow_slots_print_as_links_then_the_next_free_slot(autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, c = _add(wf, autogrow_graph, "LoadImage")
+    wf, b = _add(wf, autogrow_graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", b, "model.images.image_1")
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, c, "IMAGE", b, "model.images")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    kwargs = _kwargs(line)
+    # each grown slot references the loader wired into it (binding names are
+    # assigned in print order, so resolve them through `bindings`)
+    refs = dict(re.findall(r'"(model\.images\.image_\d+)": (\w+)\.IMAGE', kwargs))
+    assert res.bindings[refs["model.images.image_1"]] == str(a)
+    assert res.bindings[refs["model.images.image_2"]] == str(c)
+    assert '"model.images.image_3": None' in kwargs
+    assert '"model.images.image_4"' not in kwargs
+    # the wired group shifted nothing: the widgets still read at their names
+    assert "seed=42" in line and '"model.resolution": "1K"' in kwargs
+    assert "model.images grows IMAGE (max 14)" in line
+    assert res.warnings == []
+
+
+def test_top_level_autogrow_base_entry_is_the_group_not_a_phantom_link_input(autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, d = _add(wf, autogrow_graph, "BatchImagesNode")
+    line = _line(render_py(wf, autogrow_graph).source, d)
+    assert "images=None" not in line
+    assert '"images.image0": None' in _kwargs(line)
+    assert "images grows IMAGE (max 50)" in line
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", d, "images")
+    line = _line(render_py(wf, autogrow_graph).source, d)
+    assert "images=None" not in line
+    assert '"images.image0": load_image' in _kwargs(line)
+    assert '"images.image1": None' in _kwargs(line)
+
+
+def _minimax_ui_workflow() -> dict[str, Any]:
+    """A UI-built ``MinimaxHailuo03ReferenceNode``: ``image_1`` wired, one free
+    trailing slot per group (the frontend's shape), 8 widget values."""
+    return {
+        "last_node_id": 4,
+        "last_link_id": 4,
+        "version": 0.4,
+        "groups": [],
+        "nodes": [
+            {
+                "id": 2,
+                "type": "LoadImage",
+                "pos": [0, 0],
+                "size": [300, 300],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [
+                    {"name": "IMAGE", "type": "IMAGE", "links": [4]},
+                    {"name": "MASK", "type": "MASK", "links": []},
+                ],
+                "properties": {},
+                "widgets_values": ["storyboard.png", "image"],
+            },
+            {
+                "id": 4,
+                "type": "MinimaxHailuo03ReferenceNode",
+                "pos": [400, 0],
+                "size": [400, 300],
+                "flags": {},
+                "order": 1,
+                "mode": 0,
+                "inputs": [
+                    {
+                        "label": "image_1",
+                        "name": "model.reference_images.image_1",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": 4,
+                    },
+                    {
+                        "label": "image_2",
+                        "name": "model.reference_images.image_2",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": None,
+                    },
+                    {
+                        "label": "video_1",
+                        "name": "model.reference_videos.video_1",
+                        "shape": 7,
+                        "type": "VIDEO",
+                        "link": None,
+                    },
+                    {
+                        "label": "audio_1",
+                        "name": "model.reference_audios.audio_1",
+                        "shape": 7,
+                        "type": "AUDIO",
+                        "link": None,
+                    },
+                ],
+                "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": []}],
+                "properties": {},
+                "widgets_values": ["MiniMax H3", "storyboard prompt", "768P", "adaptive", 5, 42, "randomize", False],
+            },
+        ],
+        "links": [[4, 2, 0, 4, 0, "IMAGE"]],
+    }
+
+
+def test_ui_built_free_slots_are_reused_not_duplicated(autogrow_graph):
+    res = render_py(_minimax_ui_workflow(), autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, 4)
+    kwargs = _kwargs(line)
+    assert '"model.reference_images.image_1": load_image.IMAGE' in kwargs
+    assert '"model.reference_images.image_2": None' in kwargs
+    assert '"model.reference_images.image_3"' not in kwargs  # a free slot already exists
+    assert '"model.reference_videos.video_1": None' in kwargs
+    assert '"model.reference_audios.audio_1": None' in kwargs
+    comment = line.split("  # ", 1)[1]
+    assert "model.reference_images grows IMAGE (max 9)" in comment
+    assert "model.reference_videos grows VIDEO (max 3)" in comment
+    assert "model.reference_audios grows AUDIO (max 3)" in comment
+    # widgets at their frontend positions, unshifted by the groups
+    assert 'model="MiniMax H3"' in line and "seed=42" in line and "watermark=False" in line
+    assert '"model.prompt": "storyboard prompt"' in kwargs and '"model.resolution": "768P"' in kwargs
+
+
+def test_full_group_prints_no_free_slot(autogrow_graph):
+    wf = _minimax_ui_workflow()
+    wf, v = _add(wf, autogrow_graph, "LoadVideo")
+    for _ in range(3):
+        wf, _ = workflow_ops.connect(wf, autogrow_graph, v, "VIDEO", 4, "model.reference_videos")
+    line = _line(render_py(wf, autogrow_graph).source, 4)
+    kwargs = _kwargs(line)
+    assert '"model.reference_videos.video_3": load_video' in kwargs
+    assert '"model.reference_videos.video_4"' not in kwargs
+    assert "model.reference_videos grows VIDEO (max 3)" in line
+
+
+def test_autogrow_group_follows_the_current_selection(autogrow_graph):
+    """A node switched to an option without the group stops advertising it."""
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    node = next(n for n in wf["nodes"] if n["id"] == b)
+    node["widgets_values"][1] = "not an option"  # no option → no sub-inputs, no group
+    line = _line(render_py(wf, autogrow_graph).source, b)
+    assert "model.images" not in line
+
+
+# --------------------------------------------------------------------------- #
+# 2. Subgraph instances with promoted widgets
+# --------------------------------------------------------------------------- #
+
+
+def test_pre_migration_instance_prints_interior_defaults_at_the_host_address(promoted_graph):
+    """``image_z_image_turbo``: the host has no values yet, so the instance
+    line shows the interior defaults — under the names ``set-widget 57.<name>``
+    takes, not buried in the interior block."""
+    wf = _gallery("image_z_image_turbo.json")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "57 subgraph")
+    assert line.startswith('text_to_image_z_image_turbo = Subgraph["Text to Image (Z-Image-Turbo)"](')
+    assert 'text="Latina female with thick wavy hair' in line
+    for frag in (
+        "width=1024",
+        "height=1024",
+        "seed=0",
+        "steps=8",
+        'unet_name="z_image_turbo_bf16.safetensors"',
+        'clip_name="qwen_3_4b.safetensors"',
+        'vae_name="ae.safetensors"',
+    ):
+        assert frag in line
+    assert "text=None" not in line
+    assert res.bindings["text_to_image_z_image_turbo"] == "57"
+    assert res.warnings == []
+
+
+def test_post_migration_host_values_win_over_the_interior(promoted_graph):
+    """``audio_minimax_music_3``: the host materialized every promoted value;
+    the interior caption is ``''`` but the host's is the real prompt. The
+    values must land under the RIGHT names — not the instance's serialized
+    ``inputs[]`` order, which only lists the one input the UI showed."""
+    wf = _gallery("audio_minimax_music_3.json")
+    line = _line(render_py(wf, promoted_graph).source, "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    assert 'lyrics="[Intro]' in line
+    assert "max_duration=60" in line
+    assert "seed=197122968890040" in line
+    assert 'unet_name="minimax_music3_dit_fp16.safetensors"' in line
+    assert "switch=True" in line
+    assert 'switch="Global Metadata' not in line
+    assert 'caption=""' not in line
+
+
+def test_promoted_values_are_never_positionally_shifted(promoted_graph):
+    """``api_seedance2_5_video_extend``: two VIDEO sockets precede the widget
+    inputs, and the host's ``widgets_values`` cover ONLY the widget-backed ones
+    (in declaration order). The old positional read printed
+    ``drop_audio="lanczos"``."""
+    wf = _gallery("api_seedance2_5_video_extend.json")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "39 subgraph")
+    assert "clip_to_resize=load_video" in line
+    assert "base_video=byte_dance2_reference_node_v2" in line
+    for frag in ("pad_second_video=False", 'interpolation="lanczos"', 'padding_color="white"', "drop_audio=False"):
+        assert frag in line
+    assert 'drop_audio="lanczos"' not in line
+
+
+def test_interior_promoted_widgets_point_at_the_host_not_at_a_value(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    src = render_py(wf, promoted_graph).source
+    interior = _line(src, "13")
+    assert interior.strip().startswith("empty_sd3_latent_image = EmptySD3LatentImage(")
+    # the promoted widget is a reference to the instance's value, not a literal
+    assert "width=IN.width" in interior and "height=IN.height" in interior
+    assert "width=1024" not in interior
+    # the unpromoted widget still prints as a plain, editable value
+    assert "batch_size=1" in interior
+    # the definition block says where those IN.* values live and how to edit them
+    header_idx = next(i for i, ln in enumerate(src.splitlines()) if ln.startswith("# subgraph f2fdebf6"))
+    promoted_line = src.splitlines()[header_idx + 1]
+    assert promoted_line.startswith("#")
+    assert "promoted" in promoted_line
+    for name in ("text", "width", "height", "seed", "steps", "unet_name", "clip_name", "vae_name"):
+        assert f"IN.{name}" in promoted_line
+    assert "57.<name>" in promoted_line
+    assert "57/<id>.<name>" in promoted_line
+
+
+def test_socket_only_subgraph_inputs_are_not_listed_as_promoted_widgets(promoted_graph):
+    wf = _gallery("api_seedance2_5_video_extend.json")
+    src = render_py(wf, promoted_graph).source
+    header_idx = next(i for i, ln in enumerate(src.splitlines()) if ln.startswith("# subgraph d9aa59a4"))
+    promoted_line = src.splitlines()[header_idx + 1]
+    assert "IN.interpolation" in promoted_line and "IN.drop_audio" in promoted_line
+    assert "IN.clip_to_resize" not in promoted_line and "IN.base_video" not in promoted_line
+
+
+def test_outside_link_into_a_promoted_input_prints_as_a_link(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    wf, prim = _add(wf, promoted_graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, promoted_graph, prim, "value", 640)
+    wf, _ = workflow_ops.connect(wf, promoted_graph, prim, "INT", 57, "width")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "57 subgraph")
+    assert "width=primitive_int" in line
+    assert "width=1024" not in line
+    assert "height=1024" in line  # the sibling is still the host/interior value
+    # the primitive prints before the instance that consumes it
+    assert res.source.index("primitive_int = PrimitiveInt(") < res.source.index("text_to_image_z_image_turbo = ")
+
+
+def test_host_value_edited_by_set_widget_is_what_prints(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, promoted_graph, 57, "width", 768)
+    line = _line(render_py(wf, promoted_graph).source, "57 subgraph")
+    assert "width=768" in line
+    assert "height=1024" in line
+
+
+def test_nested_promotion_prints_the_effective_value_and_legacy_proxies(promoted_graph):
+    """``subgraph_template_ui``: instance 10's ``value`` is promoted THROUGH a
+    nested instance (10/3) — it shows on the instance line with the value the
+    frontend runs; the nested instance's line inside the definition keeps
+    referencing the outer proxy. Its legacy ``proxyWidgets`` route for
+    ``seed`` (interior node 9, never declared as an input) is not a surface
+    slot — ``slots`` does not advertise it, so neither does ``print``."""
+    wf = json.loads((FIXTURES / "subgraph_template_ui.json").read_text())
+    graph = Graph.from_object_info(json.loads((FIXTURES / "subgraph_object_info.json").read_text()))
+    res = render_py(wf, graph)
+    _parses(res.source)
+    inst = _line(res.source, "10 subgraph")
+    assert 'value=""' in inst
+    assert 'aspect_ratio="16:9"' in inst
+    assert "seed=" not in inst
+    assert '**{"images.image0": None}' in inst
+    nested = _line(res.source, "3 subgraph da09b826")
+    assert "value=IN.value" in nested
+
+
+def test_self_referential_definition_is_bounded(promoted_graph):
+    """A definition that instantiates itself and promotes through itself must
+    print (with the nested value unresolved), not recurse forever."""
+    uuid = "aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa"
+    sg = {
+        "id": uuid,
+        "name": "Ouroboros",
+        "inputs": [{"name": "value", "type": "INT", "linkIds": [1]}],
+        "outputs": [],
+        "nodes": [
+            {
+                "id": 2,
+                "type": uuid,
+                "inputs": [{"name": "value", "type": "INT", "link": 1, "widget": {"name": "value"}}],
+                "outputs": [],
+                "widgets_values": [],
+            }
+        ],
+        "links": [{"id": 1, "origin_id": -10, "origin_slot": 0, "target_id": 2, "target_slot": 0}],
+    }
+    wf = {
+        "nodes": [
+            {
+                "id": 1,
+                "type": uuid,
+                "inputs": [{"name": "value", "type": "INT", "link": None, "widget": {"name": "value"}}],
+                "outputs": [],
+                "widgets_values": [3],
+            }
+        ],
+        "links": [],
+        "definitions": {"subgraphs": [sg]},
+        "version": 0.4,
+    }
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    assert res.source.count("# subgraph aaaaaaaa-0000") == 1
+    assert "value=IN.value" in _line(res.source, "2 subgraph")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Through the CLI: the printed addresses are the ones the editors take
+# --------------------------------------------------------------------------- #
+
+
+def _run_print(path: Path, object_info: Path) -> dict:
+    set_renderer(Renderer(OutputMode.JSON))
+    try:
+        result = CliRunner().invoke(workflow_cmd.app, ["print", str(path), "--input", str(object_info)])
+    finally:
+        set_renderer(Renderer(OutputMode.PRETTY))
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)["data"]
+
+
+def test_cli_print_addresses_match_the_editors(tmp_path, promoted_graph):
+    wf = _gallery("audio_minimax_music_3.json")
+    path = tmp_path / "wf.json"
+    path.write_text(json.dumps(wf))
+    data = _run_print(path, FIXTURES / "object_info_subgraph_promoted.json")
+    line = _line(data["source"], "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    # the binding resolves to the address `set-widget` takes: 37.caption
+    assert data["bindings"]["text_to_music_mini_max_music_3"] == "37"
+    wf2, op = workflow_ops.set_widget(wf, promoted_graph, 37, "caption", "new caption")
+    assert op["node_id"] == 37 and op["widget"] == "caption"
+    assert 'caption="new caption"' in _line(render_py(wf2, promoted_graph).source, "37 subgraph")
+
+
+def test_cli_print_autogrow_addresses_match_connect(tmp_path, autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, b = _add(wf, autogrow_graph, "GeminiNanoBanana2V2")
+    path = tmp_path / "wf.json"
+    path.write_text(json.dumps(wf))
+    data = _run_print(path, FIXTURES / "object_info_nested_autogrow.json")
+    line = _line(data["source"], b)
+    assert '"model.images.image_1": None' in line
+    # that printed slot name is exactly what connect grows
+    wf2, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", b, "model.images.image_1")
+    node = next(n for n in wf2["nodes"] if n["id"] == b)
+    assert [i["name"] for i in node["inputs"]] == ["model.images.image_1"]
+
+
+def test_no_catalog_still_prints_the_instance_values(promoted_graph):
+    """Without object_info nothing is value-aware — but promoted values that
+    the host materialized are still the host's, by name."""
+    wf = _gallery("audio_minimax_music_3.json")
+    res = render_py(wf, None)
+    line = _line(res.source, "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    assert "switch=True" in line
+
+
+def test_existing_workflow_is_not_mutated_by_printing(promoted_graph, autogrow_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    before = copy.deepcopy(wf)
+    render_py(wf, promoted_graph)
+    assert wf == before
+    wf2, _ = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    before2 = copy.deepcopy(wf2)
+    render_py(wf2, autogrow_graph)
+    assert wf2 == before2

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -1,0 +1,97 @@
+"""UI→API conversion honors host-owned promoted widget values (BE-10305).
+
+``convert_ui_to_api`` expanded subgraph instances by reattaching *external*
+links to interior inputs and otherwise reading the interior node's own
+``widgets_values``. That is the pre-ADR-0009 world. A post-migration save
+keeps the promoted value on the HOST instance (``widgets_values`` positional
+over the widget-backed subgraph inputs), so the interior widget can be stale
+or empty — ``audio_minimax_music_3`` ships an interior ``caption`` of ``''``
+while the host carries the whole prompt — and the prompt the CLI submitted
+(``comfy run`` / ``validate``) was not the prompt the frontend runs.
+
+Precedence, exactly as the frontend serializes it: an external link into the
+instance input wins over everything; else the host value when materialized;
+else the interior widget.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli import workflow_ops
+from comfy_cli.cql.engine import Graph
+from comfy_cli.workflow_to_api import convert_ui_to_api
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+
+
+@pytest.fixture(scope="module")
+def object_info() -> dict:
+    return json.loads((_FIXTURES / "object_info_subgraph_promoted.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def graph(object_info) -> Graph:
+    return Graph.from_object_info(object_info)
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _api_node(api: dict, class_type: str, api_id: str | None = None) -> dict:
+    if api_id is not None:
+        return api[api_id]
+    return next(v for v in api.values() if v["class_type"] == class_type)
+
+
+def test_post_migration_host_values_reach_the_prompt(object_info):
+    api = convert_ui_to_api(_load("audio_minimax_music_3.json"), object_info)
+    enc = _api_node(api, "MiniMaxMusic3TextEncode", "37:13")["inputs"]
+    assert enc["caption"].startswith("Global Metadata: Lo-fi hip-hop")
+    assert enc["lyrics"].startswith("[Intro]")
+    assert enc["max_duration"] == 60
+    assert _api_node(api, "UNETLoader", "37:6")["inputs"]["unet_name"] == "minimax_music3_dit_fp16.safetensors"
+    assert _api_node(api, "ComfySwitchNode", "37:43")["inputs"]["switch"] is True
+
+
+def test_host_value_written_by_set_widget_reaches_the_prompt(object_info, graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    api = convert_ui_to_api(wf, object_info)
+    latent = _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]
+    assert latent["width"] == 768
+    assert latent["height"] == 1024
+
+
+def test_interior_value_still_used_when_no_host_value_exists(object_info):
+    api = convert_ui_to_api(_load("image_z_image_turbo.json"), object_info)
+    assert _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]["width"] == 1024
+    assert _api_node(api, "KSampler", "57:3")["inputs"]["steps"] == 8
+
+
+def test_external_link_into_a_promoted_input_wins_over_the_host_value(object_info, graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    wf, prim = workflow_ops.add_node(wf, graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, graph, prim["node_id"], "value", 640)
+    wf, _ = workflow_ops.connect(wf, graph, prim["node_id"], "INT", 57, "width")
+    api = convert_ui_to_api(wf, object_info)
+    assert _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]["width"] == [str(prim["node_id"]), 0]
+    assert api[str(prim["node_id"])]["inputs"]["value"] == 640
+
+
+def test_socket_links_and_host_values_coexist(object_info):
+    api = convert_ui_to_api(_load("api_seedance2_5_video_extend.json"), object_info)
+    pad = _api_node(api, "PrimitiveBoolean", "39:28")["inputs"]
+    assert pad["value"] is False
+    resize = _api_node(api, "ResizeAndPadImage", "39:6")["inputs"]
+    assert resize["interpolation"] == "lanczos"
+    assert resize["padding_color"] == "white"
+    # the two VIDEO socket inputs are external links, reattached as before
+    comps = _api_node(api, "GetVideoComponents", "39:1")["inputs"]
+    assert isinstance(comps["video"], list) and len(comps["video"]) == 2

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -112,3 +112,16 @@ def test_list_valued_host_values_are_wrapped_not_read_as_links(object_info, grap
     assert isinstance(plain, str)
     assert text != ["a", "b"] or not (isinstance(text, list) and len(text) == 2 and isinstance(text[0], str))
     assert text == workflow_to_api._wrap_widget_value(["a", "b"])
+
+
+def test_dangling_link_on_a_promoted_input_does_not_drop_the_host_value(object_info):
+    """A promoted input whose serialized ``link`` id no longer exists in
+    ``links`` is unlinked as far as the frontend is concerned (it drops the
+    link on load): the host value must reach the prompt, exactly as
+    ``resolve_write`` already treats that shape."""
+    wf = _load("audio_minimax_music_3.json")
+    inst = next(n for n in wf["nodes"] if n["id"] == 37)
+    inst["inputs"].append({"name": "caption", "type": "STRING", "widget": {"name": "caption"}, "link": 999999})
+    assert all(link[0] != 999999 for link in wf["links"])
+    api = convert_ui_to_api(wf, object_info)
+    assert _api_node(api, "MiniMaxMusic3TextEncode", "37:13")["inputs"]["caption"].startswith("Global Metadata")

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from comfy_cli import workflow_ops
+from comfy_cli import workflow_ops, workflow_to_api
 from comfy_cli.cql.engine import Graph
 from comfy_cli.workflow_to_api import convert_ui_to_api
 
@@ -95,3 +95,20 @@ def test_socket_links_and_host_values_coexist(object_info):
     # the two VIDEO socket inputs are external links, reattached as before
     comps = _api_node(api, "GetVideoComponents", "39:1")["inputs"]
     assert isinstance(comps["video"], list) and len(comps["video"]) == 2
+
+
+def test_list_valued_host_values_are_wrapped_not_read_as_links(object_info, graph):
+    """A two-item list host value must not be mistaken for a ``[node, slot]``
+    link when overlaid onto the interior node."""
+    wf = _load("image_z_image_turbo.json")
+    from comfy_cli.cql import promoted
+
+    promoted.set_host_value(wf, next(n for n in wf["nodes"] if n["id"] == 57), "text", ["a", "b"], graph)
+    api = convert_ui_to_api(wf, object_info)
+    text = _api_node(api, "CLIPTextEncode", "57:27")["inputs"]["text"]
+    plain = _api_node(convert_ui_to_api(_load("image_z_image_turbo.json"), object_info), "CLIPTextEncode", "57:27")[
+        "inputs"
+    ]["text"]
+    assert isinstance(plain, str)
+    assert text != ["a", "b"] or not (isinstance(text, list) and len(text) == 2 and isinstance(text[0], str))
+    assert text == workflow_to_api._wrap_widget_value(["a", "b"])

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -1,8 +1,8 @@
-"""UI→API conversion honors host-owned promoted widget values (BE-10305).
+"""UI→API conversion honors host-owned promoted widget values.
 
 ``convert_ui_to_api`` expanded subgraph instances by reattaching *external*
 links to interior inputs and otherwise reading the interior node's own
-``widgets_values``. That is the pre-ADR-0009 world. A post-migration save
+``widgets_values``. That is the pre-ADR 0009 world. A post-migration save
 keeps the promoted value on the HOST instance (``widgets_values`` positional
 over the widget-backed subgraph inputs), so the interior widget can be stale
 or empty — ``audio_minimax_music_3`` ships an interior ``caption`` of ``''``


### PR DESCRIPTION
> **Stacked on #815** (`kishore/be-10305-…`) → #812 → #809. Retarget as they land.

## Why

`comfy workflow print` is how the agent reads a canvas before editing it. It was wrong for the two node shapes the last two PRs fixed:

- **Subgraph instances**: promoted values were read positionally from the instance's serialized `inputs[]` (only what the UI happened to show) instead of per widget-backed declared input the way the frontend does. Captured on real gallery templates: `audio_minimax_music_3` printed the caption under `switch=` and hid caption/lyrics/seed/models; `api_seedance2_5_video_extend` printed `drop_audio="lanczos"` (shifted) and dropped `interpolation`/`padding_color`; `image_z_image_turbo` printed `text=None` with all eight promoted widgets invisible and interior lines with no editable address.
- **Auto-grow groups**: an agent-built `GeminiNanoBanana2V2`'s `model.images` group was invisible; an agent-built `BatchImagesNode` printed a phantom `images=None`.

## Change (`comfy_cli/workflow_print.py`)

- Instance line: one argument per declared subgraph input in declaration order; promoted widgets print `promoted.effective_value` (host value, else interior default) under the address `set-widget` takes (`57.width`); an outside link into a promoted input prints as the link; sockets print their link; declared-but-unbacked inputs fall back to `proxyWidgets` exactly as `slots` does.
- Definition block: interior lines keep `IN.width`; the header gains `promoted widgets: IN.text, IN.width, … — each is the instance's own value: edit 57.<name>, never 57/<id>.<name>`.
- Auto-grow: groups from `Graph.autogrow_groups` for the node's current selection; grown slots print as links; when no free slot exists and the schema allows one, the next schema name prints as an open slot (the free trailing slot the frontend itself keeps — and exactly what `connect` grows next); the line comment names the group and element type (`model.images grows IMAGE (max 14)`). Widgets are never shifted.

## Red → green

`tests/comfy_cli/test_workflow_print_promoted_autogrow.py`: 21 cases written first, 17 failed on the base (4 pin already-correct value-aware naming/selector behaviour). One golden line in `test_workflow_print.py` updated for the group annotation.

## Verification

Full suite **6259 passed, 38 skipped**; ruff 0.15.15 check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
