### PR TITLE
feat(knowledge): carry the model row's best_for on each pick

### DIFF
--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -206,11 +206,12 @@ def pick_cmd(
     if renderer.is_pretty():
         from rich.table import Table
 
-        columns = ("rank", "model", "route", "template", "status", "caveat")
+        columns = ("rank", "model", "route", "template", "status", "caveat", "best_for")
         tbl = Table(show_header=True, header_style="bold")
         for col in columns:
             tbl.add_column(col)
         for p in picks:
-            tbl.add_row(*(sanitize_markup("" if p[c] is None else p[c]) for c in columns))
+            cells = {**p, "best_for": ", ".join(p.get("best_for") or [])}
+            tbl.add_row(*(sanitize_markup("" if cells[c] is None else cells[c]) for c in columns))
         renderer.console().print(tbl)
     renderer.emit(payload, command="knowledge pick")

--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -190,18 +190,7 @@ def pick_cmd(
     knowledge.log_query("knowledge pick", logged, hit_ids=[f"cap:{capability_id}"], zero_hit=False, bundle=bundle)
     picks = []
     for p in cap["picks"]:
-        model_id = p.get("model")
-        model_id = model_id if isinstance(model_id, str) else None
-        row = bundle.models.get(model_id) or {}
-        entry = {
-            "rank": knowledge.pick_rank(p),
-            "model": model_id,
-            "route": _text(p.get("route")),
-            "template": _text(p.get("template")),
-            "caveat": _text(p.get("caveat")),
-            "status": _text(row.get("status")),
-            "superseded_by": _text(row.get("superseded_by")),
-        }
+        entry = knowledge.pick_entry(bundle, p)
         if "fits" in p:
             entry["fits"] = p["fits"]
         picks.append(entry)

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -47,6 +47,10 @@ MAX_MODELS = 3
 MAX_MODELS_BRIEF = 20
 MAX_PICKS = 8
 MAX_LIST_ITEMS = 8
+# best_for items per pick. 1 keeps every capability's `knowledge pick` envelope
+# under the 4096 bytes the cloud agent admits verbatim; 2, or not_for alongside,
+# sends image-edit over.
+MAX_PICK_BEST_FOR = 1
 MAX_BLOCK_BYTES = 8192
 MAX_QUERY_CHARS = 200  # CLI text is unbounded; the clip bounds the lookup key and the nudge echo
 MAX_VERSION_CHARS = 64
@@ -686,26 +690,39 @@ def _model_entry(bundle: Bundle, model_id: str, row: dict, *, matched_on: str, b
     return entry
 
 
+def pick_entry(bundle: Bundle, p: dict) -> dict:
+    """One pick as emitted, plus the status and routing opinion of its model row.
+
+    ``best_for`` is the head of the row's list, omitted when the row has none.
+    The pick's ``caveat`` is written for one capability; the row's ``best_for``
+    says what the model is for across all of them, which is what a routing
+    decision reads.
+    """
+    model_id = _text(p.get("model"))
+    row = bundle.models.get(model_id, {}) if model_id is not None else {}
+    dep = bundle.deprecations.get(model_id, {}) if model_id is not None else {}
+    entry = {
+        "rank": pick_rank(p),
+        "model": model_id,
+        "route": _text(p.get("route")),
+        "template": _text(p.get("template")),
+        "caveat": _text(p.get("caveat")),
+        "status": _text(row.get("status")),
+        "superseded_by": _text(dep.get("superseded_by") or row.get("superseded_by")),
+    }
+    if best_for := _str_list(row.get("best_for"))[:MAX_PICK_BEST_FOR]:
+        entry["best_for"] = best_for
+    return entry
+
+
 def _pick_entries(bundle: Bundle, capability_id: str, *, catalog_templates: Collection[str] | None) -> list[dict]:
     cap = pick(bundle, capability_id)
     if cap is None:
         return []
     out: list[dict] = []
     for p in cap["picks"]:
-        template = p.get("template") if isinstance(p.get("template"), str) else None
-        model_id = p.get("model")
-        row = bundle.models.get(model_id, {}) if isinstance(model_id, str) else {}
-        dep = bundle.deprecations.get(model_id, {}) if isinstance(model_id, str) else {}
-        entry = {
-            "capability": capability_id,
-            "rank": pick_rank(p),
-            "model": _text(model_id),
-            "route": _text(p.get("route")),
-            "template": template,
-            "caveat": _text(p.get("caveat")),
-            "status": _text(row.get("status")),
-            "superseded_by": _text(dep.get("superseded_by") or row.get("superseded_by")),
-        }
+        entry = {"capability": capability_id, **pick_entry(bundle, p)}
+        template = entry["template"]
         if catalog_templates is not None and template is not None and template not in catalog_templates:
             entry["available_locally"] = False
             entry["unavailable_reason"] = UNAVAILABLE_LOCALLY

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -47,9 +47,11 @@ MAX_MODELS = 3
 MAX_MODELS_BRIEF = 20
 MAX_PICKS = 8
 MAX_LIST_ITEMS = 8
-# best_for items per pick. 1 keeps every capability's `knowledge pick` envelope
-# under the 4096 bytes the cloud agent admits verbatim; 2, or not_for alongside,
-# sends image-edit over.
+# best_for items per pick. Bounds item count, not bytes: with today's bundle, 1
+# keeps every capability's `knowledge pick` envelope under the 4096 bytes the
+# cloud agent admits verbatim (2, or not_for alongside, sends image-edit over),
+# but a bundle recompile with longer best_for text isn't guaranteed to stay
+# under that.
 MAX_PICK_BEST_FOR = 1
 MAX_BLOCK_BYTES = 8192
 MAX_QUERY_CHARS = 200  # CLI text is unbounded; the clip bounds the lookup key and the nudge echo
@@ -699,8 +701,8 @@ def pick_entry(bundle: Bundle, p: dict) -> dict:
     decision reads.
     """
     model_id = _text(p.get("model"))
-    row = bundle.models.get(model_id, {}) if model_id is not None else {}
-    dep = bundle.deprecations.get(model_id, {}) if model_id is not None else {}
+    row = (bundle.models.get(model_id) or {}) if model_id is not None else {}
+    dep = (bundle.deprecations.get(model_id) or {}) if model_id is not None else {}
     entry = {
         "rank": pick_rank(p),
         "model": model_id,
@@ -708,9 +710,9 @@ def pick_entry(bundle: Bundle, p: dict) -> dict:
         "template": _text(p.get("template")),
         "caveat": _text(p.get("caveat")),
         "status": _text(row.get("status")),
-        "superseded_by": _text(dep.get("superseded_by") or row.get("superseded_by")),
+        "superseded_by": _text(dep.get("superseded_by")) or _text(row.get("superseded_by")),
     }
-    if best_for := _str_list(row.get("best_for"))[:MAX_PICK_BEST_FOR]:
+    if best_for := [x for x in _str_list(row.get("best_for")) if x][:MAX_PICK_BEST_FOR]:
         entry["best_for"] = best_for
     return entry
 

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -53,7 +53,8 @@
           "template": { "type": ["string", "null"] },
           "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
-          "superseded_by": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
+          "superseded_by": { "type": ["string", "null"], "description": "From the deprecations list or the pick's model row." },
+          "best_for": { "type": "array", "items": { "type": "string" }, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
           "fits": { "type": "object", "description": "The model row's fits block (vram_gb per variant, a credit rate, max_refs, source), present only when the row carries one." }
         }
       }

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -54,7 +54,7 @@
           "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
           "superseded_by": { "type": ["string", "null"], "description": "From the deprecations list or the pick's model row." },
-          "best_for": { "type": "array", "items": { "type": "string" }, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
+          "best_for": { "type": "array", "items": { "type": "string" }, "maxItems": 1, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
           "fits": { "type": "object", "description": "The model row's fits block (vram_gb per variant, a credit rate, max_refs, source), present only when the row carries one." }
         }
       }

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -57,7 +57,7 @@
           "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
           "superseded_by": { "type": ["string", "null"], "description": "From the deprecations list or the pick's model row." },
-          "best_for": { "type": "array", "items": { "type": "string" }, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
+          "best_for": { "type": "array", "items": { "type": "string" }, "maxItems": 1, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
           "available_locally": { "type": "boolean", "description": "Present and false when the pick's template is absent from the catalog the command loaded. Ranked picks keep rank order, so a lower-ranked pick without this field is the runnable-now alternative." },
           "unavailable_reason": { "type": "string", "description": "Why available_locally is false." }
         }

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -57,6 +57,7 @@
           "caveat": { "type": ["string", "null"] },
           "status": { "type": ["string", "null"], "description": "Copied from the pick's model row when that row exists." },
           "superseded_by": { "type": ["string", "null"], "description": "From the deprecations list or the pick's model row." },
+          "best_for": { "type": "array", "items": { "type": "string" }, "description": "Head of the model row's best_for list, present only when the row has one. The caveat is per capability; this is the row's own routing opinion." },
           "available_locally": { "type": "boolean", "description": "Present and false when the pick's template is absent from the catalog the command loaded. Ranked picks keep rank order, so a lower-ranked pick without this field is the runnable-now alternative." },
           "unavailable_reason": { "type": "string", "description": "Why available_locally is false." }
         }

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -854,6 +854,39 @@ class TestCli:
         assert rc == 1
         assert env["error"]["code"] == "knowledge_unavailable"
 
+    def test_pick_carries_the_row_best_for_capped(self, tmp_path, monkeypatch, capsys):
+        # A routing opinion written only in the model row must reach the caller
+        # of `knowledge pick`, since the pick's caveat is per capability.
+        picks = [{"model": "x", "rank": 1}, {"model": "y", "rank": 2}, {"model": "z", "rank": 3}]
+        models = {
+            "x": {"id": "x", "best_for": ["multi-ref identity", "product shots", 7, "brand consistency"]},
+            "y": {"id": "y", "status": "available"},
+            "z": {"id": "z", "best_for": "not a list"},
+        }
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps({"models": models, "capabilities": {"c": {"id": "c", "picks": picks}}}))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        rc, env = _run(["pick", "c"], capsys)
+        assert rc == 0
+        by_model = {q["model"]: q for q in env["data"]["picks"]}
+        assert by_model["x"]["best_for"] == ["multi-ref identity"]
+        assert "best_for" not in by_model["y"]
+        assert "best_for" not in by_model["z"]
+        _validate(env["data"])
+
+    def test_pick_superseded_by_reads_the_deprecations_list(self, tmp_path, monkeypatch, capsys):
+        data = {
+            "models": {},
+            "deprecations": [{"id": "x", "superseded_by": "y"}],
+            "capabilities": {"c": {"id": "c", "picks": [{"model": "x", "rank": 1}]}},
+        }
+        p = tmp_path / "k.json"
+        p.write_text(json.dumps(data))
+        monkeypatch.setenv(knowledge.ENV_FILE, str(p))
+        _rc, env = _run(["pick", "c"], capsys)
+        assert env["data"]["picks"][0]["superseded_by"] == "y"
+        _validate(env["data"])
+
     def test_pick_payload_normalizes_rank_and_model(self, tmp_path, monkeypatch, capsys):
         picks = [
             {"model": "x", "rank": "1"},

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -176,11 +176,16 @@ class TestLookup:
             "caveat",
             "status",
             "superseded_by",
+            "best_for",
         }
         assert by_model["testvid"]["status"] == "available"
         assert by_model["testvid"]["template"] is None
-        # A pick naming a model the trimmed fixture lacks still ships, with nulls.
+        # The row's routing opinion rides along, capped; lipco-3's row lists two.
+        assert by_model["lipco-3"]["best_for"] == ["paid talking image: a portrait plus a voiceover"]
+        # A pick naming a model the trimmed fixture lacks still ships, with nulls
+        # and no best_for key at all.
         assert by_model["testlx"]["status"] is None
+        assert "best_for" not in by_model["testlx"]
 
     def test_reverse_index_templates_and_nodes(self):
         p = _attach(templates=["video_acme_h3_i2v"])


### PR DESCRIPTION
## Overview

`comfy knowledge pick <capability>` now carries each pick's model-row `best_for` (head of the list, one item). The per-pick dict is built by one shared helper, `knowledge.pick_entry`, used by both the CLI command and the envelope-enrichment block, so the two paths emit the same shape.

## Motivation

`knowledge pick` is what the hosted cloud agent's `list_model_picks` tool runs. Per pick it emitted only rank, model, route, template, caveat, status, superseded_by and `fits`. A routing opinion written only in the model row was invisible at recommendation time.

Three eval cases failed on this in run `run_2a4c15d4` (2026-08-28). The flux-2 row says `local multi-reference identity, product or brand consistency (up to 8 refs)` in `best_for[0]`, but its image-edit pick caveat says `fast/cheap everyday edits`, so the agent recommended Seedream for a multi-ref ask. With this change the image-edit table shows:

```
2 flux-2   | FLUX.2 Klein - community No.2 OSS edit model, fast/cheap eve… | best_for: ['local multi-reference identity, product or brand consistency (up to 8 refs, autogrow)']
6 seedream | Multi-reference, brand/character consistency, product edit a… | best_for: ['an unspecified closed-source still - the API photoreal default']
```

## Research findings

**Where the output is built.** The task pointed at `_pick_entries` in `comfy_cli/knowledge.py`, but the CLI command does not call it. `pick_cmd` in `comfy_cli/command/knowledge.py` built its own per-pick dict inline (rank/model/route/template/caveat/status/superseded_by, plus `fits`). `_pick_entries` is the envelope-enrichment path (`knowledge.attach`, the passenger `knowledge` block on `nodes search` etc.), and it adds a `capability` key and skips `fits`. The two also disagreed on `superseded_by`: `_pick_entries` read `bundle.deprecations` first, `pick_cmd` read only the row. Both now go through `pick_entry`.

**Consumers of the pick shape.** `tests/comfy_cli/test_knowledge_attach.py::test_pick_entry_shape` asserts the exact key set on an enrichment pick (updated). `comfy_cli/schemas/knowledge.json` documents the `pick` payload without `additionalProperties: false` (field added). In the cloud repo, `services/agent/internal/loop/cli_fields.json` contracts `data.picks[].{rank,model,route,template,caveat,status,superseded_by}` by presence only, so an added key needs no change there. No docs under `docs/` describe the pick fields.

**Sizing.** Whole `--json` envelope bytes per capability, real bundle (`COMFY_KNOWLEDGE_FILE=cloud/services/agent/knowledge/knowledge.json`), 14 capabilities, 70 picks. Baseline and final rows are `comfy --json knowledge pick -- <cap> | wc -c`; the candidate rows were measured in-process through the same command with the cap patched.

| shape | avg bytes | max bytes | capabilities over 4096 |
|---|---|---|---|
| today | 1849 | 2847 (image-edit) | 0 |
| best_for[:1] **(chosen)** | 2385 | 3657 (image-edit) | 0 |
| best_for[:1] + not_for[:1] | 2764 | 4239 (image-edit) | 1 |
| best_for[:2] | 2820 | 4120 (image-edit) | 1 |
| best_for[:3] | 2964 | 4478 (image-edit) | 2 |
| best_for[:2] + not_for[:2] | 3385 | 5167 (text-to-video) | 5 |
| full best_for + not_for (cap 8) | 3681 | 5695 (text-to-video) | 5 |

Bundle stats: every pick's row has `best_for` (median 2.5 items, max 4); `not_for` median 2, absent on 10 of 70.

**Decision.** `MAX_PICK_BEST_FOR = 1`, key name `best_for`, list of one, same key as `knowledge resolve`. `not_for` is left out: even one item sends image-edit over the cap.

## Changes

- `comfy_cli/knowledge.py`: new `pick_entry(bundle, p)` builds the per-pick dict and adds `best_for` via the same `_str_list` slice `_model_entry` uses. `_pick_entries` prepends `capability` and keeps its `available_locally` annotation. New constant `MAX_PICK_BEST_FOR = 1`.
- `comfy_cli/command/knowledge.py`: `pick_cmd` calls `pick_entry` and adds `fits` as before. Side effect: its `superseded_by` now also reads the bundle's `deprecations` list, matching the enrichment block.
- `comfy_cli/schemas/knowledge.json` and `comfy_cli/schemas/knowledge_block.json`: `picks[].best_for` documented; `knowledge.json`'s `superseded_by` description now matches the block schema (deprecations list or row).
- `tests/comfy_cli/test_knowledge.py`: `test_pick_carries_the_row_best_for_capped` (a 4-item row emits 1, a row without the key emits no key, a non-list value emits no key) and `test_pick_superseded_by_reads_the_deprecations_list`.
- `tests/comfy_cli/test_knowledge_attach.py::test_pick_entry_shape`: key set includes `best_for`, lipco-3 is capped to 1, a pick with no model row has no key.

## Notes

- The cloud agent inlines `list_model_picks` results verbatim (exempt from the spill seam), but the harness admission cap is 4096 bytes and an exempt result over the cap emits an `agent.spill outcome=exempt` span on every call. The cap of 1 is the largest that keeps all 14 capabilities under 4096 with today's bundle (max 3657, 439 bytes of headroom on image-edit). A bundle edit that grows image-edit's caveats or descriptions by that much would need this revisited.
- The enrichment block's own ceiling is `MAX_BLOCK_BYTES = 8192` with `_fit` shedding whole entries, so the larger pick rows there are bounded the same way as before.
- The cloud agent must bump its pinned comfy-cli SHA in `services/agent/Dockerfile` (currently `50d095d`) to pick this up. `cli_fields.json` needs no change; adding `data.picks[].best_for` there is optional.

## Test plan

- [x] `uvx ruff@0.15.15 check .` (CI's pinned version): All checks passed
- [x] `uvx ruff@0.15.15 format --diff .`: 355 files already formatted
- [x] `NO_COLOR=1 uv run pytest tests/comfy_cli/test_knowledge.py tests/comfy_cli/test_knowledge_attach.py tests/comfy_cli/command/test_knowledge_enrichment.py -q`: 263 passed
- [x] `uv run --extra dev pytest .` (before the schema/test follow-ups): 6146 passed, 2 failed, 39 skipped. The 2 failures (`test_build.py::test_from_workflow_refuses_a_workflow_nested_past_the_parser_limit`, `test_pretty_print_sanitize.py::test_status_glyph_keeps_its_own_tags_live`) fail identically on a clean `origin/main` checkout in this environment (signed-in state and terminal styling), unrelated to this diff.
- [x] After the follow-ups: knowledge, enrichment and schema-consuming test files (`test_knowledge*.py`, `test_knowledge_enrichment.py`, `command/generate`, `test_nodes_introspect.py`, `test_templates_get.py`): 652 passed
- [x] Real-command sizing above: 14/14 capabilities under 4096 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153s9cR6S73y6m2XYxkv9Vb
