### PR TITLE
fix(ops): gate promoted connect grows as one register; positional payload for PrimitiveNode writes (amendment v1.5)

### DIFF
--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1944,8 +1944,14 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
     if grow is not None:
         # Autogrow is NOT a shared register: every grow mints its own slot keyed
         # by ``grow_id``, so two concurrent grows onto one base both survive and
-        # there is nothing to gate (§1.2 / amendment v1.2's carve-out).
-        if _find_by_str(workflow, op["from_node"]) is None:
+        # there is nothing to gate (§1.2 / amendment v1.2's carve-out) — a
+        # deleted source simply means nothing to wire. A PROMOTED grow IS a
+        # register (§14.2), so it must reach the gate below even when its
+        # source is gone: bailing here would make the incumbent depend on
+        # whether the concurrent delete of this op's source had arrived yet.
+        # Delete wins over the LINK, not over the claim — the entry is left
+        # empty at the ``src is None`` check further down.
+        if not grow.get("promoted") and _find_by_str(workflow, op["from_node"]) is None:
             return
         # Autogrow: grow a concrete slot and wire it. Keyed by ``grow_id`` (the
         # link id) so replay is idempotent AND non-clobbering — a concurrent
@@ -2600,7 +2606,7 @@ def _resolve_input_target(
     # (a concrete ``to_slot`` op would find no slot, be dropped, and never
     # replay). Apply reuses the entry by name; type-checked against the
     # declared input type.
-    if workflow is not None and isinstance(slot, str):
+    if workflow is not None and isinstance(slot, (str, int)) and not isinstance(slot, bool):
         promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
         if promoted_grow is not None:
             return None, promoted_grow
@@ -2710,10 +2716,14 @@ def _resolve_input_target(
     raise ValueError(f"input {slot!r} not found on node {node.get('id')}; inputs: {names}")
 
 
-def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: str | None) -> dict | None:
+def _resolve_promoted_target(workflow: dict, node: dict, slot: Any, elem_type: str | None) -> dict | None:
     """The input to materialize on subgraph instance ``node`` for a connect to
     its declared input ``slot`` (see ``cql.promoted``). ``None`` when ``node``
-    is not an instance or ``slot`` is not one of its definition's inputs."""
+    is not an instance or ``slot`` is not one of its definition's inputs.
+
+    An INDEX (``57.1``) that lands on an already-materialized entry for a
+    declared input is the same input as its name (``57.width``): it maps onto
+    the name so both addresses share one register (§14.2)."""
     from comfy_cli.cql import engine as _engine
     from comfy_cli.cql import promoted as _promoted
 
@@ -2721,6 +2731,13 @@ def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: s
     sg = defs.get(str(node.get("type", "")))
     if sg is None:
         return None
+    if isinstance(slot, int) or (isinstance(slot, str) and slot.lstrip("-").isdigit()):
+        ins = node.get("inputs") or []
+        idx = int(slot)
+        entry = ins[idx] if 0 <= idx < len(ins) and isinstance(ins[idx], dict) else None
+        if entry is None or not entry.get("name"):
+            return None
+        slot = str(entry["name"])
     pi = _promoted.find_promoted(sg, defs, slot)
     if pi is None:
         return None

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1883,11 +1883,13 @@ def _apply_positional_write(node: dict, positional: dict, value: Any) -> None:
     values = node.get("widgets_values")
     values = list(values) if isinstance(values, list) else []
     seed = positional.get("host_widgets_values")
-    if len(values) <= idx:
-        if isinstance(seed, list) and len(seed) > len(values):
-            values.extend(seed[len(values) :])
-        while len(values) <= idx:
-            values.append(None)
+    # A receiver holding a truncated array takes the payload's tail whether or
+    # not the written index is inside it — otherwise replicas keep different
+    # opaque state for the same node.
+    if isinstance(seed, list) and len(seed) > len(values):
+        values.extend(seed[len(values) :])
+    while len(values) <= idx:
+        values.append(None)
     values[idx] = value
     node["widgets_values"] = values
 
@@ -2589,6 +2591,19 @@ def _resolve_input_target(
       the API converter reads the link and skips the widget by name.
     """
     ins = node.get("inputs") or []
+    # Promoted subgraph input (``57.width``): the definition declares it, so it
+    # is a link input on the instance even before the instance carries an
+    # ``inputs[]`` entry for it — the frontend rebuilds those from the
+    # definition on load. ALWAYS addressed as a promoted grow, even once the
+    # entry exists: the register is the declared name, so a replica that
+    # receives a later connect before the materializing one still lands it
+    # (a concrete ``to_slot`` op would find no slot, be dropped, and never
+    # replay). Apply reuses the entry by name; type-checked against the
+    # declared input type.
+    if workflow is not None and isinstance(slot, str):
+        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
+        if promoted_grow is not None:
+            return None, promoted_grow
     # Concrete slot (index or exact name) that is NOT an autogrow base.
     try:
         idx = _resolve_input_slot(node, None, slot)
@@ -2605,15 +2620,6 @@ def _resolve_input_target(
         return idx, None
     except ValueError:
         pass
-    # Promoted subgraph input (``57.width``): the definition declares it, so it
-    # is a link input on the instance even before the instance carries an
-    # ``inputs[]`` entry for it — the frontend rebuilds those from the
-    # definition on load. Materialize it (widget marker when it backs a
-    # widget) and wire it; type-checked against the declared input type.
-    if workflow is not None and isinstance(slot, str):
-        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
-        if promoted_grow is not None:
-            return None, promoted_grow
     # Dotted autogrow key (images.image0) or a base that has no concrete slot yet.
     if isinstance(slot, str):
         base = slot.split(".", 1)[0]

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -691,6 +691,9 @@ def _set_widget_impl(
         op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(written)
         return workflow, op
     if target.kind == "legacy_primitive":
+        # A frontend-only PrimitiveNode has no catalog entry, so every
+        # replica stores it opaquely (positional): carry the same positional
+        # payload a host write carries, and apply it the same way.
         src = target.node
         values = src.get("widgets_values")
         old = values[0] if isinstance(values, list) and values else None
@@ -703,9 +706,12 @@ def _set_widget_impl(
             value=value,
             old=old,
             legacy_primitive=True,
+            promoted={"value_index": 0, "instance_path": [str(src.get("id"))]},
             **extra,
         )
-        return apply_op(workflow, op, graph), op
+        workflow = apply_op(workflow, op, graph)
+        op["promoted"]["host_widgets_values"] = list(src.get("widgets_values") or [])
+        return workflow, op
     if target.kind == "top" and target.redirected_from is not None:
         node_id = target.node.get("id")
         widget = target.widget
@@ -1820,19 +1826,20 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
             return  # instance concurrently deleted => no-op (delete wins)
         defs_by_id = _engine._subgraph_defs_by_id(workflow)
         instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
-        _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        if defs_by_id.get(str(instance.get("type", ""))) is not None:
+            _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        else:
+            # Not a subgraph instance (a frontend-only PrimitiveNode): a plain
+            # positional write, aligned from the op's materialized array.
+            _apply_positional_write(instance, promoted_write, op["value"])
         _lww_commit(workflow, op)
         return
     if op.get("legacy_primitive"):
+        # Pre-payload shape (no ``promoted`` block): widgets_values[0].
         node = _find_by_str(workflow, op["node_id"])
         if node is None:
             return
-        values = node.get("widgets_values")
-        values = list(values) if isinstance(values, list) else []
-        if not values:
-            values.append(None)
-        values[0] = op["value"]
-        node["widgets_values"] = values
+        _apply_positional_write(node, {"value_index": 0}, op["value"])
         _lww_commit(workflow, op)
         return
     path = op.get("path")
@@ -1863,6 +1870,26 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
         widgets.extend([None] * (idx + 1 - len(widgets)))
     widgets[idx] = op["value"]
     _lww_commit(workflow, op)
+
+
+def _apply_positional_write(node: dict, positional: dict, value: Any) -> None:
+    """Write ``value`` at ``positional["value_index"]`` of an opaquely stored
+    node's ``widgets_values``, extending a shorter array from the op's own
+    ``host_widgets_values`` so alignment is preserved (the same rule the
+    doc-host applier follows for a node without a catalog entry)."""
+    idx = positional.get("value_index")
+    if not isinstance(idx, int) or isinstance(idx, bool) or idx < 0:
+        return
+    values = node.get("widgets_values")
+    values = list(values) if isinstance(values, list) else []
+    seed = positional.get("host_widgets_values")
+    if len(values) <= idx:
+        if isinstance(seed, list) and len(seed) > len(values):
+            values.extend(seed[len(values) :])
+        while len(values) <= idx:
+            values.append(None)
+    values[idx] = value
+    node["widgets_values"] = values
 
 
 def _apply_inputcount_bump(workflow: dict, dst: dict, op: dict, graph, widget: str, value: Any) -> None:
@@ -1927,10 +1954,23 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
         # schema's own element names, when the catalog carries a template).
         ins = dst.setdefault("inputs", [])
         to_idx = next((k for k, i in enumerate(ins) if i.get("grow_id") == op["link_id"]), None)
-        if to_idx is None and grow.get("promoted"):
-            # A promoted subgraph input is ONE register named by the definition:
-            # a concurrent connect that already materialized it shares the entry.
-            to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
+        if grow.get("promoted"):
+            # A promoted subgraph input is ONE register named by the definition
+            # (``("input", to_node, "grow", name)``), not a fresh slot per
+            # connect: gate it exactly like a concrete input so the occupant is
+            # decided by stamp, not arrival order, and the doc-host applier
+            # (comfy-multi-player) converges with this replica. The claim is
+            # unconditional once the gate passes (see the concrete branch).
+            if to_idx is None and not _lww_gate(workflow, op):
+                return
+            _lww_commit(workflow, op)
+            if to_idx is None:
+                to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
+            if to_idx is not None:
+                prev = ins[to_idx].get("link")
+                if prev is not None and prev != op["link_id"]:
+                    _remove_link(workflow, prev)
+                ins[to_idx]["grow_id"] = op["link_id"]  # the register follows the winner
         if to_idx is None:
             inputcount = grow.get("inputcount")
             if grow.get("promoted"):
@@ -2156,6 +2196,10 @@ def _write_target(op: dict) -> tuple:
             # Two autogrow connects onto the same base share a target (their
             # relative order in the batch is the sequence decision the merge
             # consumer must make); distinct bases don't collide.
+            if grow.get("promoted"):
+                # A promoted subgraph input is one register per declared NAME
+                # (names may contain dots: ``images.image0``), never per base.
+                return ("input", str(op["to_node"]), "grow", str(grow["name"]))
             # The group is everything before the LAST dot: a group nested
             # under a dynamic combo (``model.reference_images.image_1``) must
             # not share a target with its sibling (``model.reference_videos``).

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -742,7 +742,7 @@ A write to a promoted input is a top-level `set_widget` on the INSTANCE
 (`node_id`, `widget` = the declared input name; no `path`/`inner_widget`)
 carrying
 
-```
+```json
 "promoted": {"value_index": <int>, "instance_path": [<id>, …],
              "host_widgets_values": [<full materialized array>]}
 ```
@@ -767,7 +767,7 @@ time); a merge consumer treats them as distinct targets.
 A `connect` whose target is a declared subgraph input the instance does not
 yet carry an `inputs[]` entry for carries
 
-```
+```json
 "grow": {"name": <declared input name>, "type": <declared type>,
          "promoted": true, "widget": <name, only when the input backs a widget>}
 ```
@@ -780,9 +780,11 @@ stamp owns the entry in either apply order, `grow_id` follows the winner, the
 loser's link is retired, and the claim is unconditional once the gate passes.
 Apply reuses an existing entry by name (a concurrent materialization shares
 it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
-verbatim — no numbering. Once materialized, a later connect to the same name
-resolves it as a concrete slot (`to_slot`) on the concrete register; both
-sides agree, and this is not drift.
+verbatim — no numbering. Every connect to a declared promoted input is this
+promoted grow, even once the entry exists: the register is the declared name
+for the life of the input, so a replica that receives a later connect before
+the materializing one still lands it (a concrete `to_slot` op would find no
+slot, be dropped with its `op_id` consumed, and never replay).
 
 ### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
 

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -723,3 +723,71 @@ rebuilds the executable graph — the API prompt — not the canvas decoration.
 
 **No change to §§2-8.** No op kind was added, removed, or re-scoped;
 `FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS` are untouched.
+
+## 14. Amendment v1.5 — 2026-08-28 (promoted subgraph inputs: host writes, one register per declared input, opaque positional writes)
+
+The frontend (ComfyUI_frontend ADR 0009) keeps a promoted subgraph widget's
+value on the HOST instance — `widgets_values[i]` on the instance, positional
+over the definition's inputs that resolve to an interior widget — and runs
+that value over the interior default. Interior `path` writes (§8.7) therefore
+never reached the canvas for a promoted widget. Both sides (this repo,
+comfy-multi-player Amendment A15) now speak the shapes below; a subgraph
+instance's `type` is a definition UUID with no catalog entry, so every replica
+stores its widgets opaquely (positional) and these ops carry what an opaque
+store needs.
+
+### 14.1 `set_widget` host write: the `promoted` payload
+
+A write to a promoted input is a top-level `set_widget` on the INSTANCE
+(`node_id`, `widget` = the declared input name; no `path`/`inner_widget`)
+carrying
+
+```
+"promoted": {"value_index": <int>, "instance_path": [<id>, …],
+             "host_widgets_values": [<full materialized array>]}
+```
+
+`value_index` is the input's position among the definition's widget-backed
+inputs (socket-only inputs own no slot); `instance_path` is one segment for a
+top-level instance and the interior node path for a nested host, resolved and
+forked exactly like an interior `path`; `host_widgets_values` is the array
+after the write, seeded from each input's current effective value so the
+positional array stays aligned with the definition. Apply writes ONE slot,
+extending a shorter stored array from the payload. The register is the
+ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
+address and the interior address that backs it (`57/13.width`, which the
+minting side redirects to the host — `redirected_from` records the given
+address, informational) share one register. The host-write register and an
+interior `path` register for the interior widget behind the same promotion
+are deliberately NOT unified (that would need the promotion table at apply
+time); a merge consumer treats them as distinct targets.
+
+### 14.2 `connect` onto a promoted input: one register per declared name
+
+A `connect` whose target is a declared subgraph input the instance does not
+yet carry an `inputs[]` entry for carries
+
+```
+"grow": {"name": <declared input name>, "type": <declared type>,
+         "promoted": true, "widget": <name, only when the input backs a widget>}
+```
+
+Unlike autogrow (§1.2 carve-out), a promoted input is ONE register named by the
+definition — `("input", to_node, "grow", <full name>)`, never split on a dot
+(declared names such as `images.image0` contain one) — and is gated by
+`_lww_gate`/`_lww_commit` exactly like a concrete input (§11.1): the higher
+stamp owns the entry in either apply order, `grow_id` follows the winner, the
+loser's link is retired, and the claim is unconditional once the gate passes.
+Apply reuses an existing entry by name (a concurrent materialization shares
+it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
+verbatim — no numbering. Once materialized, a later connect to the same name
+resolves it as a concrete slot (`to_slot`) on the concrete register; both
+sides agree, and this is not drift.
+
+### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
+
+A write that resolves to a frontend-only `PrimitiveNode` (no catalog entry;
+`widgets_values[0]` holds the value) carries `legacy_primitive: true` AND the
+§14.1 `promoted` payload with `value_index: 0` and `instance_path` = the node
+id, so an opaque store applies it as a plain positional write. Apply treats a
+`promoted` payload on a non-instance node as that positional write.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -752,9 +752,12 @@ inputs (socket-only inputs own no slot); `instance_path` is one segment for a
 top-level instance and the interior node path for a nested host, resolved and
 forked exactly like an interior `path`; `host_widgets_values` is the array
 after the write, seeded from each input's current effective value so the
-positional array stays aligned with the definition. Apply writes ONE slot,
-extending a shorter stored array from the payload. The register is the
-ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
+positional array stays aligned with the definition. Apply writes ONE slot;
+a shorter stored array is extended from the payload as **best-effort
+repair** — only the written index is under the register, so two concurrent
+writes carrying different tails settle the tail by apply order (an accepted
+limitation: a truncated replica is no longer left truncated). The register is
+the ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
 address and the interior address that backs it (`57/13.width`, which the
 minting side redirects to the host — `redirected_from` records the given
 address, informational) share one register. The host-write register and an
@@ -781,10 +784,18 @@ loser's link is retired, and the claim is unconditional once the gate passes.
 Apply reuses an existing entry by name (a concurrent materialization shares
 it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
 verbatim — no numbering. Every connect to a declared promoted input is this
-promoted grow, even once the entry exists: the register is the declared name
-for the life of the input, so a replica that receives a later connect before
-the materializing one still lands it (a concrete `to_slot` op would find no
-slot, be dropped with its `op_id` consumed, and never replay).
+promoted grow, even once the entry exists and even when addressed by INDEX
+(`57.1` landing on the materialized `width` entry maps onto the name at mint
+time): the register is the declared name for the life of the input, so a
+replica that receives a later connect before the materializing one still
+lands it (a concrete `to_slot` op would find no slot, be dropped with its
+`op_id` consumed, and never replay). The claim is unconditional once the
+gate passes: a promoted grow whose source was concurrently deleted still
+claims the register and leaves the entry empty (delete wins over the link,
+not over the claim — §11.1), so every interleaving converges. Scope: an op
+minted by a pre-v1.5 replica as a concrete `to_slot` onto such an input does
+not gate against the promoted register; both replicas must run v1.5 for the
+register to be shared.
 
 ### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
 

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -175,7 +175,9 @@ def test_connect_type_mismatch_into_a_promoted_input_is_refused(graph):
 def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
     wf, prim = _with_primitive(graph)
     wf, first = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
-    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    # every connect to a promoted input shares one LWW register, so a later
+    # connect carries a later base_version (the CLI's --base-version)
+    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width", base_version=1)
     assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
     assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
     assert first["link_id"] not in {link[0] for link in wf["links"]}  # replaced, not duplicated
@@ -439,4 +441,57 @@ def test_legacy_primitive_write_carries_a_positional_payload(graph):
     assert op["legacy_primitive"] is True
     assert op["promoted"] == {"value_index": 0, "instance_path": [str(legacy)], "host_widgets_values": [512, "fixed"]}
     replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+    assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]
+
+
+def test_later_connect_to_a_materialized_promoted_input_stays_on_the_declared_register(graph):
+    """Once ``57.width`` is materialized, a later connect to it must still be
+    a promoted grow on ``("input", 57, "grow", "width")`` — not a concrete
+    ``to_slot`` op. Otherwise a replica that receives the later op FIRST finds
+    no such slot, drops it (consuming its op_id), then installs the older
+    link from the materializing op: the newer link can never replay."""
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    wf, first = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=0)
+    wf, second = workflow_ops.connect(wf, graph, b, "INT", 57, "width", actor="a", base_version=1)
+    assert second.get("grow", {}).get("promoted") is True
+    assert second["to_slot"] is None
+    assert workflow_ops._write_target(second) == workflow_ops._write_target(first)
+    for order in ((first, second), (second, first)):
+        replica = copy.deepcopy(base)
+        for op in order:
+            replica = workflow_ops.apply_op(replica, op, graph)
+        entries = [i for i in _node(replica, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1 and entries[0]["link"] == second["link_id"]
+        assert {link[0] for link in replica["links"]} & {first["link_id"], second["link_id"]} == {second["link_id"]}
+
+
+def test_positional_replay_extends_a_partially_present_array_from_the_payload(graph):
+    """A receiver holding a truncated opaque array (``[1024]``) must end up
+    with the payload's tail too, or replicas diverge on the node's state."""
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    receiver = copy.deepcopy(wf)
+    _node(receiver, legacy)["widgets_values"] = [1024]
+    _, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    replayed = workflow_ops.apply_op(receiver, op, graph)
     assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -495,3 +495,57 @@ def test_positional_replay_extends_a_partially_present_array_from_the_payload(gr
     _, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
     replayed = workflow_ops.apply_op(receiver, op, graph)
     assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]
+
+
+# --------------------------------------------------------------------------- #
+# Review (annehe9) on #818
+# --------------------------------------------------------------------------- #
+
+
+def _apply_all(base: dict, ops: list[dict], graph) -> dict:
+    wf = copy.deepcopy(base)
+    for op in ops:
+        wf = workflow_ops.apply_op(wf, op, graph)
+    return wf
+
+
+def test_promoted_connect_claims_its_register_even_when_its_source_was_deleted(graph):
+    """Two promoted connects into ``57.width`` (stamps lo < hi) plus a delete
+    of the hi op's source, in all six orders: the hi op must claim the
+    register whether or not the delete arrived first (delete wins over the
+    LINK, not over the claim), so every order converges on one state —
+    one ``width`` entry, ``link=None``, ``grow_id=<hi>``."""
+    import itertools
+
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    _, op_lo = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=0)
+    _, op_hi = workflow_ops.connect(copy.deepcopy(base), graph, b, "INT", 57, "width", actor="b", base_version=1)
+    _, op_del = workflow_ops.delete_node(copy.deepcopy(base), graph, b, actor="c", base_version=2)
+    states = set()
+    for order in itertools.permutations((op_lo, op_hi, op_del)):
+        wf = _apply_all(base, list(order), graph)
+        states.add(json.dumps(workflow_ops.canonical(wf), sort_keys=True, default=str))
+        entries = [i for i in _node(wf, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1
+        assert entries[0]["link"] is None
+        assert entries[0]["grow_id"] == op_hi["link_id"]
+    assert len(states) == 1
+
+
+def test_index_address_of_a_materialized_promoted_input_shares_the_name_register(graph):
+    """``57.width`` and ``57.<index>`` name the same materialized input, so
+    they must gate against each other: the higher stamp wins in either order."""
+    base, prim = _with_primitive(graph)
+    base, _ = workflow_ops.connect(base, graph, prim, "INT", 57, "width")
+    base, other = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    other = other["node_id"]
+    idx = next(k for k, i in enumerate(_node(base, 57)["inputs"]) if i["name"] == "width")
+    _, by_name = workflow_ops.connect(copy.deepcopy(base), graph, other, "INT", 57, "width", actor="a", base_version=1)
+    _, by_index = workflow_ops.connect(copy.deepcopy(base), graph, prim, "INT", 57, idx, actor="b", base_version=2)
+    assert workflow_ops._write_target(by_index) == workflow_ops._write_target(by_name)
+    for order in ((by_name, by_index), (by_index, by_name)):
+        wf = _apply_all(base, list(order), graph)
+        assert _input(_node(wf, 57), "width")["link"] == by_index["link_id"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -380,3 +380,63 @@ def test_connect_does_not_type_check_against_an_untyped_declared_input(graph):
     wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
     assert _input(_node(wf, 57), "width")["link"] == op["link_id"]
     assert op["grow"]["type"] == "INT"  # falls back to the source type
+
+
+# Op shapes the doc-host applier (comfy-multi-player) needs to converge
+# --------------------------------------------------------------------------- #
+
+
+def test_concurrent_promoted_connects_converge_by_stamp(graph):
+    """Two replicas wire different primitives into ``57.width`` concurrently.
+    The promoted input is ONE register (``("input", 57, "grow", "width")``):
+    the higher stamp owns the entry in either apply order, ``grow_id`` follows
+    the winner, and the loser's link is not left dangling."""
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    _, op_hi = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=1)
+    _, op_lo = workflow_ops.connect(copy.deepcopy(base), graph, b, "INT", 57, "width", actor="b", base_version=0)
+    assert workflow_ops._write_target(op_hi) == workflow_ops._write_target(op_lo) == ("input", "57", "grow", "width")
+    for order in ((op_hi, op_lo), (op_lo, op_hi)):
+        wf = copy.deepcopy(base)
+        for op in order:
+            wf = workflow_ops.apply_op(wf, op, graph)
+        entries = [i for i in _node(wf, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1
+        assert entries[0]["link"] == op_hi["link_id"]
+        assert entries[0]["grow_id"] == op_hi["link_id"]
+        link_ids = {link[0] for link in wf["links"]}
+        assert op_hi["link_id"] in link_ids and op_lo["link_id"] not in link_ids
+
+
+def test_legacy_primitive_write_carries_a_positional_payload(graph):
+    """A frontend-only ``PrimitiveNode`` has no catalog entry, so the doc host
+    stores it opaquely: the op must carry the positional payload
+    (``promoted.value_index`` + ``host_widgets_values``) the applier writes,
+    exactly like a host write — and replay on a fresh copy must apply it."""
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    base = copy.deepcopy(wf)
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    assert op["legacy_primitive"] is True
+    assert op["promoted"] == {"value_index": 0, "instance_path": [str(legacy)], "host_widgets_values": [512, "fixed"]}
+    replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+    assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]


### PR DESCRIPTION
> **Stacked on #816** → #815 → #812 → #809. Pairs with comfy-multi-player **#104** (applier side).

## Why

comfy-multi-player #104 implemented the host-write and promoted-connect op shapes #815 introduced (so the in-app doc host can apply them), and its convergence review sent two asks back to this repo:

1. **Promoted `connect` grows were not gated.** A promoted subgraph input is ONE register named by the definition, but `_apply_connect` kept the autogrow "every grow mints its own slot" carve-out: two concurrent connects onto `57.width` left the entry with whichever link arrived first, and `grow_id` stayed on the first arrival — two replicas could disagree. Now gated by `_lww_gate`/`_lww_commit` on `("input", to_node, "grow", <full name>)` exactly like a concrete input (§11.1): higher stamp wins in either order, `grow_id` follows the winner, the loser's link is retired. The register uses the **full** declared name — sg inputs such as `images.image0` contain a dot, and the old base-split would alias two inputs onto one register.
2. **`PrimitiveNode` writes had no positional payload.** A frontend-only `PrimitiveNode` has no catalog entry, so an opaque store rejected the `legacy_primitive` op. It now carries the same `promoted` payload a host write carries (`value_index: 0`, `instance_path`, `host_widgets_values`); apply treats a `promoted` payload on a non-instance node as a plain positional write.

## Red → green

`test_concurrent_promoted_connects_converge_by_stamp` (both apply orders → one `width` entry, winner's link + `grow_id`, loser's link gone; failed red with the arrival-order winner) and `test_legacy_primitive_write_carries_a_positional_payload` (exact payload; replay on a fresh copy applies it; failed red with `KeyError: 'promoted'`).

## Contract

`docs/op-vocabulary-v1.md` **Amendment v1.5** — records the `promoted` host-write payload, `redirected_from`, `grow.promoted` (introduced by #815 without an amendment), the promoted-grow register and gating, and the opaque positional write. Host-write vs interior-`path` registers stay deliberately un-unified (needs the promotion table at apply time), matching multi-player A15.

## Verification

Full suite **6261 passed, 38 skipped**; ruff 0.15.15 check + format clean; `test_op_vocabulary_contract.py` (doc == constants == dispatch) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
