### PR TITLE
fix(subgraph): repair legacy proxyWidgets promotions before writing them, the way the frontend does on load (BE-10305)

### DIFF
--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2721,6 +2721,8 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             if fully_curated and not promoted:
                 continue
             hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
+            # …and the interior widgets a pending legacy repair will own.
+            hidden |= _promoted.planned_hidden_sources(workflow, node, graph, defs_by_id)
             walk(sg.get("nodes") or [], node_path, depth + 1, hidden, sg)
 
     walk(workflow.get("nodes") or [], "", 0, set(), workflow)
@@ -2808,6 +2810,32 @@ def _declared_subgraph_slots(
         if linked_from is not None:
             slot["linked_from"] = linked_from
         declared.append(slot)
+    if workflow is not None:
+        # Legacy ``proxyWidgets`` promotions the definition does not back
+        # yet: the frontend repairs them into linked inputs on load, so they
+        # are advertised where they will live — ``<instance>.<name>`` with the
+        # value the frontend shows (legacy host value, else the interior
+        # source). Reads never mutate; the first write performs the repair.
+        advertised = {s["name"] for s in declared}
+        for entry in _promoted.plan_proxy_migration(workflow, instance, graph, defs):
+            if not entry.repairable or entry.name in advertised:
+                continue
+            advertised.add(entry.name)
+            any_declared = True
+            current = _promoted.entry_effective_value(workflow, sg, entry, graph, defs)
+            if current is _promoted.UNSET:
+                all_resolved = False
+                continue
+            declared.append(
+                {
+                    "address": f"{instance_id}.{entry.name}",
+                    "name": entry.name,
+                    "type": str(entry.type),
+                    "current_value": current,
+                    "instance_id": instance_id,
+                    "node_type": instance.get("type", ""),
+                }
+            )
     return declared, (any_declared and all_resolved)
 
 
@@ -3214,7 +3242,10 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
         # non-terminal hop and is not forked — its values are its own).
         instance = _resolve_node_path(workflow, target.segments, defs_by_id)
         sg = _subgraph_defs_by_id(workflow).get(str(instance.get("type", "")))
-        pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
+        if target.repair is not None:
+            pi = target.repair.as_promoted_input(sg)
+        else:
+            pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
         _class, port = promoted_source_port(sg, pi, _subgraph_defs_by_id(workflow), graph)
         warnings: list[dict] = []
         if port is not None:
@@ -3222,6 +3253,12 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
             if err:
                 raise ValueError(err)
             warnings = [dict(w, field=addr) for w in port.validate_catalog(value)]
+        if target.repair is not None:
+            # A legacy ``proxyWidgets`` promotion: run the frontend's forward
+            # migration on this instance first (forking a shared definition,
+            # since the repair mutates it), exactly as the op path does.
+            _isolate_shared_subgraph(workflow, instance, _subgraph_defs_by_id(workflow))
+            _promoted.flush_proxy_migration(workflow, instance, graph, instance_path=list(target.segments))
         _promoted.set_host_value(workflow, instance, target.widget, value, graph)
         return warnings
     if target.kind == "interior":

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -1352,15 +1352,27 @@ def flush_proxy_migration(
         source = _inner_node(sg, e.source_node)
         slot_index = e.slot_index
         if slot_index is None:
-            source.setdefault("inputs", []).append(
-                {
+            if e.source_input is not None:
+                # A nested instance backs the widget with its OWN host input
+                # for the projecting subgraph input (``getSlotFromWidget``
+                # over ``promotedInputWidget``): the slot carries that input's
+                # name, or the outer definition could never resolve the
+                # promotion through the inner one.
+                entry = {
+                    "name": e.source_input,
+                    "type": e.type,
+                    "widget": {"name": e.source_input},
+                    "link": None,
+                }
+            else:
+                entry = {
                     "localized_name": e.widget,
                     "name": e.widget,
                     "type": e.type,
                     "widget": {"name": e.widget},
                     "link": None,
                 }
-            )
+            source.setdefault("inputs", []).append(entry)
             slot_index = len(source["inputs"]) - 1
         new_input = _add_subgraph_input(sg, ids[e.key]["input"], str(e.name), str(e.type), e.label)
         _add_boundary_link(sg, new_input, ids[e.key]["links"][0], source, slot_index, str(e.type))
@@ -1382,9 +1394,12 @@ def flush_proxy_migration(
             quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
             continue
         targets = _primitive_targets(sg, primitive)
-        for link in [x for x in sg.get("links") or [] if str(x.get("origin_id")) == primitive_id]:
-            if link.get("origin_slot") == 0:
-                _remove_link(sg, link.get("id"))
+        for link in [
+            x
+            for x in sg.get("links") or []
+            if isinstance(x, dict) and str(x.get("origin_id")) == primitive_id and x.get("origin_slot") == 0
+        ]:
+            _remove_link(sg, link.get("id"))
         link_ids = ids[first.key]["links"]
         if len(link_ids) < len(targets):
             link_ids = repair_ids(instance_path, first.source_node, first.widget, len(targets))["links"]

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -17,17 +17,24 @@ linked inputs"*, ``SubgraphNode.ts``) represents a promoted widget as a
 The interior widget is only a schema/default provider — *"the host/exterior
 value wins over the interior/source value during repair, persistence, and
 prompt serialization"*. ``properties.proxyWidgets`` is legacy load-time input
-the frontend consumes on migration; it is honored here only as a fallback for
-a name the definition does not declare as an input.
+the frontend consumes on migration. A legacy entry the definition does not
+back with a linked input is repaired the way the frontend repairs it on load
+(:func:`flush_proxy_migration`, the "forward migration" section below) before
+a write lands on it; an entry the migration cannot repair is quarantined and
+its interior widget stays the live one.
 
-Everything in this module is a pure function over workflow JSON. It never
-mutates a subgraph definition: a promoted value is edited on the instance,
-so sibling instances of a shared definition stay independent by construction.
+Everything in this module is a pure function over workflow JSON. A promoted
+value is edited on the instance — the definition is touched only by the
+forward migration, which the op layer runs on an isolated (forked) copy when
+the definition is shared, so sibling instances stay independent.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib as _hashlib
+import re as _re
+import uuid as _uuid
+from dataclasses import dataclass, field
 from typing import Any
 
 #: LiteGraph's id for the virtual subgraph *input* node inside a definition.
@@ -290,6 +297,11 @@ def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
     when nothing outside feeds it: the host value if materialized, else the
     interior source value (:data:`UNSET` if even that cannot be read).
 
+    A legacy ``proxyWidgets`` promotion the definition does not back yet
+    reads as the frontend will show it after its own migration: the legacy
+    positional host value, else the interior source (the address is the
+    input name the repair mints — see :func:`plan_proxy_migration`).
+
     Raises ``ValueError`` for a name the definition does not declare, or one
     that is a socket-only input.
     """
@@ -297,6 +309,13 @@ def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
     sg = defs.get(str(instance.get("type", "")))
     if sg is None:
         raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    pi = find_promoted(sg, defs, name)
+    if pi is None or not pi.is_widget:
+        pending = next(
+            (e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable and e.name == name), None
+        )
+        if pending is not None:
+            return entry_effective_value(workflow, sg, pending, graph, defs)
     return _effective(workflow, instance, sg, name, graph, defs)
 
 
@@ -396,6 +415,11 @@ class WriteTarget:
     widget: str | None = None
     segments: list[str] | None = None
     redirected_from: str | None = None
+    #: A ``host`` target whose promotion is still a legacy ``proxyWidgets``
+    #: entry: the write must first run :func:`flush_proxy_migration` on the
+    #: instance. This is the entry it repairs; ``widget`` is the input name
+    #: the repair mints.
+    repair: Any = None
 
 
 def _find_top(workflow: dict, node_id: Any) -> dict | None:
@@ -442,8 +466,14 @@ def resolve_write(
       there (``redirected_from`` records the given address). An interior
       widget fed by another interior node is refused the same way.
     * any other interior widget — written in the definition, as before.
-    * a promoted name the definition does not declare as an input but the
-      legacy ``proxyWidgets`` still route — the interior, as before.
+    * a name only the legacy ``proxyWidgets`` route — a promotion the
+      frontend's load-time migration turns into a linked input. The host,
+      after the same repair (``repair`` names the entry; see
+      :func:`flush_proxy_migration`). An interior address the repair would
+      own (the entry's source widget, a primitive's fan-out target) redirects
+      there too. An entry the migration cannot repair (quarantined — e.g.
+      ``control_after_generate``, which has no backing input slot) keeps the
+      interior widget as the live one, so the write lands there as before.
     """
     defs = defs_by_id(workflow)
     if len(segments) > 1:
@@ -452,6 +482,17 @@ def resolve_write(
         parent_def = defs.get(str(parent.get("type", "")))
         target_def = defs.get(str(target.get("type", "")))
         given = f"{'/'.join(segments)}.{widget}"
+        if parent_def is not None:
+            pending = planned_repair_for_interior(workflow, parent, graph, str(target.get("id")), widget, defs)
+            if pending is not None:
+                return WriteTarget(
+                    "host",
+                    node=parent,
+                    widget=str(pending.name),
+                    segments=segments[:-1],
+                    redirected_from=redirected_from or given,
+                    repair=pending,
+                )
         entry = next(
             (
                 i
@@ -506,6 +547,17 @@ def resolve_write(
         return WriteTarget("top", node=node, widget=widget, redirected_from=redirected_from)
     given = f"{node_str}.{widget}"
     pi = find_promoted(sg, defs, widget)
+    if pi is None or not pi.is_widget:
+        pending = planned_repair(workflow, node, graph, widget, defs)
+        if pending is not None:
+            return WriteTarget(
+                "host",
+                node=node,
+                widget=str(pending.name),
+                segments=[node_str],
+                redirected_from=redirected_from or (given if pending.name != widget else None),
+                repair=pending,
+            )
     if pi is not None:
         if not pi.is_widget:
             legacy = legacy_proxy_interior(node, widget)
@@ -579,3 +631,863 @@ def trace_upstream_write(
             f"or connect a primitive (e.g. PrimitiveInt) to {given} and set its value."
         )
     raise ValueError(f"{given}: reroute chain too deep")
+
+
+# --------------------------------------------------------------------------- #
+# Legacy ``properties.proxyWidgets`` → linked inputs: the forward migration
+# --------------------------------------------------------------------------- #
+#
+# A port of the frontend's ``flushProxyWidgetMigration``
+# (``src/core/graph/subgraph/migration/proxyWidgetMigration.ts``; ADR 0009
+# "Forward migration", "Primitive-node repair", "Proxy widget error
+# quarantine", "Serialization"). The frontend runs it on every subgraph host
+# when a workflow loads; the CLI runs it on the one instance whose legacy
+# promotion a write is about to edit, so that write can land on the HOST
+# value like every other promoted widget instead of on the interior node.
+#
+# Per entry ``[sourceNodeId, sourceWidgetName(, disambiguator)]``:
+#
+# * already represented by a linked subgraph input → consumed (``alreadyLinked``);
+# * a ``$$``-prefixed name or a preview pseudo-widget → a display-only preview
+#   exposure: no input, no value. The frontend moves it into its
+#   preview-exposure store; the CLI leaves the entry in ``proxyWidgets`` so the
+#   frontend's own load-time migration (which also auto-exposes preview nodes
+#   when ``previewExposures`` is unset) produces exactly the state it would
+#   have produced from the untouched file;
+# * a ``PrimitiveNode`` source → ONE subgraph input for its whole fan-out, every
+#   former target reconnected to it, the primitive left in place but inert
+#   (``primitiveBypass``; all-or-quarantine);
+# * any other value widget → a subgraph input named after the widget
+#   (``nextUniqueName`` on collision), a boundary link from the subgraph input
+#   node (``-10``) into the widget's backing input slot, and the host value
+#   (``createSubgraphInput``);
+# * anything unrepairable → ``properties.proxyWidgetErrorQuarantine`` with
+#   ``{originalEntry, reason, hostValue?, attemptedAtVersion: 1}``.
+#
+# Host values come from the instance's pre-migration ``widgets_values``
+# POSITIONALLY BY ``proxyWidgets`` ORDER (``pickHostValue``) — a hole (no
+# such index) means "keep the interior default". Consumed and quarantined
+# entries are removed from ``proxyWidgets``; canonical saves never re-emit
+# them.
+#
+# Determinism: every id the repair mints (the subgraph input's uuid, each
+# boundary link id) is DERIVED from ``(instance path, source node, widget)``
+# — never random, never a counter — so two replicas replaying the same op, or
+# two replicas independently repairing the same entry, produce byte-identical
+# documents (the convergence requirement of :mod:`comfy_cli.workflow_ops`).
+
+QUARANTINE_PROPERTY = "proxyWidgetErrorQuarantine"
+PROXY_BYPASS_MARKER_PROPERTY = "proxyBypassedToSubgraphInput"
+QUARANTINE_VERSION = 1
+CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview"
+
+#: ``isPreviewPseudoWidget``: a ``$$`` name, or a ``serialize:false`` widget of
+#: type ``preview``/``video``/``audioUI``. The catalog carries no frontend-only
+#: widgets, so the CLI projects the type rule onto the one such widget the
+#: engine already models by name (``FRONTEND_MARKER_SLOTS``): ``audioUI``.
+_PREVIEW_PSEUDO_WIDGET_NAMES = frozenset({"audioUI"})
+
+#: The legacy ``PrimitiveNode`` has no server schema: its value widget is named
+#: ``value`` and, when the target widget carries one, a linked
+#: ``control_after_generate`` follows it in ``widgets_values``.
+_PRIMITIVE_WIDGET_ORDER = ("value", "control_after_generate")
+
+#: ``LEGACY_PROXY_WIDGET_PREFIX_PATTERN``: an older save could prefix a nested
+#: widget name with its node id (``"12:seed"``).
+_LEGACY_PREFIX_RE = _re.compile(r"^\s*(\d+)\s*:\s*(.+)$")
+
+#: Minted link ids share the op model's leaderless range (see
+#: ``workflow_ops.mint_id``): always above any frontend counter id, always
+#: inside JS ``Number.MAX_SAFE_INTEGER``.
+_LINK_ID_FLOOR = 1 << 40
+_LINK_ID_BITS = 52
+
+PLAN_ALREADY_LINKED = "alreadyLinked"
+PLAN_CREATE = "createSubgraphInput"
+PLAN_PRIMITIVE = "primitiveBypass"
+PLAN_PREVIEW = "previewExposure"
+PLAN_QUARANTINE = "quarantine"
+
+
+def next_unique_name(name: str, existing: Any = ()) -> str:
+    """``nextUniqueName``: ``seed`` → ``seed_1`` → ``seed_2`` … while taken."""
+    existing = list(existing)
+    base, i = name, 1
+    while name in existing:
+        name = f"{base}_{i}"
+        i += 1
+    return name
+
+
+@dataclass
+class LegacyEntry:
+    """One ``proxyWidgets`` tuple with the migration's decision for it.
+
+    ``name`` is the subgraph input the entry resolves to: the linked input for
+    ``alreadyLinked``, the (collision-free) input the flush will mint for
+    ``createSubgraphInput``/``primitiveBypass``. ``host_value`` is the legacy
+    positional host value (:data:`UNSET` for a hole). ``targets`` are a
+    primitive's ``(target node id, slot)`` fan-out in reconnect order.
+    """
+
+    original: list
+    index: int
+    source_node: str
+    widget: str
+    disambiguator: str | None
+    plan: str
+    name: str | None = None
+    reason: str | None = None
+    host_value: Any = UNSET
+    type: str | None = None
+    targets: list[tuple[str, int]] = field(default_factory=list)
+    source_input: str | None = None  # a nested instance source: the input it projects
+    slot_index: int | None = None  # createSubgraphInput: the backing input slot (None → synthesize)
+    label: str | None = None
+
+    @property
+    def repairable(self) -> bool:
+        return self.plan in (PLAN_CREATE, PLAN_PRIMITIVE)
+
+    @property
+    def key(self) -> str:
+        return f"{self.source_node}.{self.widget}"
+
+    def as_promoted_input(self, sg: dict) -> PromotedInput:
+        """A schema-only view of the input the repair mints, so the same
+        validation/source-port lookup a linked promotion gets applies."""
+        if self.plan == PLAN_PRIMITIVE:
+            tid, slot = self.targets[0]
+            target = next((n for n in sg.get("nodes") or [] if str(n.get("id")) == tid), None)
+            entry = (target.get("inputs") or [])[slot] if target is not None else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            widget = marker.get("name") if isinstance(marker, dict) and marker.get("name") else entry.get("name")
+            return PromotedInput(
+                name=str(self.name),
+                type=str(self.type),
+                index=-1,
+                value_index=-1,
+                source_node=tid,
+                source_input=str(entry.get("name")) if isinstance(entry, dict) else None,
+                source_widget=str(widget),
+            )
+        nested = self.source_input is not None
+        return PromotedInput(
+            name=str(self.name),
+            type=str(self.type),
+            index=-1,
+            value_index=-1,
+            source_node=self.source_node,
+            source_input=self.source_input if nested else self.widget,
+            source_widget=None if nested else self.widget,
+            nested=nested,
+        )
+
+
+@dataclass
+class FlushReport:
+    consumed: list[list] = field(default_factory=list)
+    created: list[str] = field(default_factory=list)
+    quarantined: list[dict] = field(default_factory=list)
+    remaining: list[list] = field(default_factory=list)
+
+
+def _proxy_tuples(instance: dict) -> list[list]:
+    """``parseProxyWidgets``: the whole property must parse (an array of
+    2/3-string tuples) or none of it migrates."""
+    raw = (instance.get("properties") or {}).get("proxyWidgets")
+    if not isinstance(raw, list):
+        return []
+    out: list[list] = []
+    for entry in raw:
+        if not isinstance(entry, list) or len(entry) not in (2, 3) or not all(isinstance(x, str) for x in entry):
+            return []
+        out.append(list(entry))
+    return out
+
+
+def _inner_node(sg: dict, node_id: Any) -> dict | None:
+    return next((n for n in sg.get("nodes") or [] if isinstance(n, dict) and str(n.get("id")) == str(node_id)), None)
+
+
+def _node_widget_names(node: dict, graph) -> list[str]:
+    """The widgets the frontend would find on ``node`` (``node.widgets``)."""
+    if str(node.get("type", "")) == LEGACY_PRIMITIVE_TYPE:
+        return list(_PRIMITIVE_WIDGET_ORDER)
+    if graph is None:
+        return []
+    from comfy_cli.cql.engine import _widgets_as_positional
+
+    node_type = str(node.get("type", ""))
+    values = _widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    return list(graph.widget_order_for_node(node_type, values))
+
+
+def _node_widget_value(node: dict, widget: str, graph) -> Any:
+    order = _node_widget_names(node, graph)
+    if widget not in order:
+        return UNSET
+    values = node.get("widgets_values")
+    if str(node.get("type", "")) != LEGACY_PRIMITIVE_TYPE and graph is not None:
+        from comfy_cli.cql.engine import _widgets_as_positional
+
+        values = _widgets_as_positional(values, graph, str(node.get("type", "")))
+    if not isinstance(values, list):
+        return UNSET
+    idx = order.index(widget)
+    return values[idx] if idx < len(values) else UNSET
+
+
+def _is_preview_pseudo_widget(widget: str) -> bool:
+    return widget.startswith("$$") or widget in _PREVIEW_PSEUDO_WIDGET_NAMES
+
+
+def _promotion_source(sg: dict, inp: dict, defs: dict[str, dict]) -> tuple[str, str] | None:
+    """``resolvePromotionSource``: the ``(interior node, widget)`` a subgraph
+    input projects — the first of its links that lands on a nested instance's
+    input or on a widget-backed input slot."""
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    for link_id in inp.get("linkIds") or []:
+        link = links.get(link_id) if isinstance(link_id, (int, str)) else None
+        if link is None:
+            continue
+        target = _inner_node(sg, link.get("target_id"))
+        if target is None:
+            continue
+        entries = target.get("inputs") or []
+        slot = link.get("target_slot")
+        entry = entries[slot] if isinstance(slot, int) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            continue
+        if str(target.get("type", "")) in defs:
+            return str(target.get("id")), str(entry.get("name"))
+        marker = entry.get("widget")
+        if isinstance(marker, dict) and marker.get("name"):
+            return str(target.get("id")), str(marker["name"])
+    return None
+
+
+def _find_host_input_for_promotion(sg: dict, defs: dict[str, dict], node_id: str, widget: str) -> str | None:
+    for inp in sg.get("inputs") or []:
+        if isinstance(inp, dict) and _promotion_source(sg, inp, defs) == (node_id, widget):
+            return str(inp.get("name"))
+    return None
+
+
+def _subgraph_input_target(inner_def: dict, defs: dict[str, dict], input_name: str) -> tuple[str, str] | None:
+    """``resolveSubgraphInputTarget``: what a nested instance's input projects."""
+    inp = next((i for i in inner_def.get("inputs") or [] if isinstance(i, dict) and i.get("name") == input_name), None)
+    return _promotion_source(inner_def, inp, defs) if inp is not None else None
+
+
+def _can_resolve_legacy_proxy(sg: dict, defs: dict[str, dict], node_id: str, widget: str, graph) -> bool:
+    """``resolveConcretePromotedWidget(...).status === 'resolved'``: walk
+    through nested instances to a concrete interior widget."""
+    current_sg, current_id, current_widget = sg, node_id, widget
+    for _ in range(_MAX_NESTED_PROMOTION_DEPTH):
+        node = _inner_node(current_sg, current_id)
+        if node is None:
+            return False
+        inner_def = defs.get(str(node.get("type", "")))
+        if inner_def is not None:
+            target = _subgraph_input_target(inner_def, defs, current_widget)
+            if target is None:
+                return False
+            current_sg, (current_id, current_widget) = inner_def, target
+            continue
+        return current_widget in _node_widget_names(node, graph)
+    return False
+
+
+def _normalize_entry(
+    sg: dict, defs: dict[str, dict], node_id: str, widget: str, disambiguator: str | None, graph
+) -> tuple[str, str, str | None]:
+    """``normalizeLegacyProxyWidgetEntry``: strip ``<id>:`` prefixes off a
+    widget name that does not resolve as written, surfacing the deepest
+    prefix as the disambiguator."""
+    if _can_resolve_legacy_proxy(sg, defs, node_id, widget, graph):
+        return node_id, widget, disambiguator
+    remaining, deepest = widget, None
+    while True:
+        m = _LEGACY_PREFIX_RE.match(remaining)
+        if m is None:
+            break
+        deepest, remaining = m.group(1), m.group(2)
+    return node_id, remaining, deepest or disambiguator
+
+
+def _resolve_source_widget(
+    sg: dict, source: dict, widget: str, disambiguator: str | None, defs: dict[str, dict], graph
+) -> tuple[str, str | None] | None:
+    """``resolveSourceWidget``: ``(widget name, projecting input name)``.
+
+    On a nested instance the widget is one of its widget-backed promoted
+    inputs (matched by what the input projects, or by the input's own name);
+    on an ordinary node it is one of the node's widgets — plus the virtual
+    canvas preview every image node can expose (``getPromotableWidgets``).
+    """
+    inner_def = defs.get(str(source.get("type", "")))
+    if inner_def is not None:
+        by_name = {p.name: p for p in promoted_inputs(inner_def, defs)}
+        for inp in inner_def.get("inputs") or []:
+            if not isinstance(inp, dict):
+                continue
+            target = _subgraph_input_target(inner_def, defs, str(inp.get("name")))
+            if disambiguator is not None:
+                hit = target is not None and target[1] == widget and target[0] == disambiguator
+            else:
+                hit = inp.get("name") == widget or (target is not None and target[1] == widget)
+            if not hit:
+                continue
+            pi = by_name.get(str(inp.get("name")))
+            return (widget, str(inp.get("name"))) if pi is not None and pi.is_widget else None
+        return None
+    if widget in _node_widget_names(source, graph) or widget == CANVAS_IMAGE_PREVIEW_WIDGET:
+        return widget, None
+    return None
+
+
+def _slot_for_widget(source: dict, widget: str, projecting_input: str | None, defs: dict[str, dict], graph):
+    """``getSlotFromWidget``: ``(index, entry, type)`` of the input slot backing
+    ``widget``. The serialized ``inputs[]`` may omit an unlinked widget slot
+    the runtime node still has (older saves); then ``index`` is ``None`` and
+    the flush appends one with ``type``. ``None`` when no slot backs it — a
+    frontend-only widget such as ``control_after_generate``."""
+    entries = source.get("inputs") or []
+    inner_def = defs.get(str(source.get("type", "")))
+    if inner_def is not None:
+        name = projecting_input or widget
+        for idx, entry in enumerate(entries):
+            if isinstance(entry, dict) and entry.get("name") == name:
+                return idx, entry, str(entry.get("type") or "*")
+        pi = find_promoted(inner_def, defs, name)
+        return (None, None, pi.type) if pi is not None else None
+    for idx, entry in enumerate(entries):
+        marker = entry.get("widget") if isinstance(entry, dict) else None
+        if isinstance(marker, dict) and marker.get("name") == widget:
+            return idx, entry, str(entry.get("type") or "*")
+    m = graph.node(str(source.get("type", ""))) if graph is not None else None
+    port = next((p for p in m.inputs if p.name == widget), None) if m is not None else None
+    if port is None or port.is_link:
+        return None
+    return None, None, str(port.type)
+
+
+def _primitive_targets(sg: dict, primitive: dict) -> list[tuple[str, int]]:
+    """Every existing link out of the primitive's output 0, in link order."""
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    outputs = primitive.get("outputs") or []
+    listed = outputs[0].get("links") if outputs and isinstance(outputs[0], dict) else None
+    ordered = [links[i] for i in listed if i in links] if isinstance(listed, list) else []
+    if not ordered:
+        ordered = [
+            x
+            for x in links.values()
+            if str(x.get("origin_id")) == str(primitive.get("id")) and x.get("origin_slot") == 0
+        ]
+    return [(str(x.get("target_id")), x.get("target_slot")) for x in ordered if isinstance(x.get("target_slot"), int)]
+
+
+def _types_compatible(a: str, b: str) -> bool:
+    return a == b or a == "*" or b == "*"
+
+
+def plan_proxy_migration(workflow: dict, instance: dict, graph, defs: dict[str, dict] | None = None) -> list:
+    """The migration's decision for every ``proxyWidgets`` entry of
+    ``instance`` — a dry run of :func:`flush_proxy_migration`, in entry order,
+    with the input names the flush will mint (creates first, then primitive
+    cohorts, each ``nextUniqueName``-collision-free against what precedes it).
+    Empty when the instance has no (valid) legacy entries."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    tuples = _proxy_tuples(instance)
+    if sg is None or not tuples:
+        return []
+    host_values = instance.get("widgets_values")
+    host_values = host_values if isinstance(host_values, list) else None
+
+    normalized = [_normalize_entry(sg, defs, t[0], t[1], t[2] if len(t) > 2 else None, graph) for t in tuples]
+    cohort = [(n[0], n[1]) for n in normalized]
+    entries: list[LegacyEntry] = []
+    for index, (original, (node_id, widget, disambiguator)) in enumerate(zip(tuples, normalized)):
+        host_value = host_values[index] if host_values is not None and index < len(host_values) else UNSET
+        e = LegacyEntry(original, index, node_id, widget, disambiguator, PLAN_QUARANTINE, host_value=host_value)
+        entries.append(e)
+        linked = _find_host_input_for_promotion(sg, defs, node_id, widget)
+        if linked is not None:
+            matches = [p for p in promoted_inputs(sg, defs) if p.name == linked]
+            if len(matches) > 1:
+                e.reason = "ambiguousSubgraphInput"
+            elif not matches or not matches[0].is_widget:
+                e.reason = "missingSubgraphInput"
+            else:
+                e.plan, e.name, e.type = PLAN_ALREADY_LINKED, linked, matches[0].type
+            continue
+        source = _inner_node(sg, node_id)
+        if source is None:
+            e.reason = "missingSourceNode"
+            continue
+        if str(source.get("type", "")) == LEGACY_PRIMITIVE_TYPE:
+            bypassed = (source.get("properties") or {}).get(PROXY_BYPASS_MARKER_PROPERTY)
+            if isinstance(bypassed, str):
+                existing = next((p for p in promoted_inputs(sg, defs) if p.name == bypassed), None)
+                if existing is not None:
+                    if existing.is_widget:
+                        e.plan, e.name, e.type = PLAN_ALREADY_LINKED, bypassed, existing.type
+                    else:
+                        e.reason = "missingSubgraphInput"
+                    continue
+            targets = _primitive_targets(sg, source)
+            # ``cohortDuplicatesPrimitive``: two entries naming this primitive
+            # (whatever their widget) still form a cohort to validate.
+            if targets or sum(1 for n in cohort if n[0] == node_id) >= 2:
+                e.plan, e.targets = PLAN_PRIMITIVE, targets
+            else:
+                e.reason = "unlinkedSourceWidget"
+            continue
+        resolved = _resolve_source_widget(sg, source, widget, disambiguator, defs, graph)
+        if resolved is None:
+            e.reason = "missingSourceWidget"
+            continue
+        widget_name, projecting = resolved
+        if widget.startswith("$$") or _is_preview_pseudo_widget(widget_name):
+            e.plan = PLAN_PREVIEW
+            continue
+        slot = _slot_for_widget(source, widget_name, projecting, defs, graph)
+        if slot is None:
+            e.reason = "missingSubgraphInput"  # the widget has no backing input slot
+            continue
+        idx, entry, slot_type = slot
+        e.plan, e.type, e.slot_index, e.source_input = PLAN_CREATE, slot_type, idx, projecting
+        if isinstance(entry, dict) and entry.get("label") is not None:
+            e.label = str(entry["label"])
+
+    # Names, in flush order: creates as they come, then one input per primitive
+    # cohort (validated all-or-quarantine, exactly like ``repairPrimitive``).
+    existing = [str(i.get("name")) for i in sg.get("inputs") or [] if isinstance(i, dict)]
+    for e in entries:
+        if e.plan == PLAN_CREATE:
+            e.name = next_unique_name(e.widget, existing)
+            existing.append(e.name)
+    cohorts: dict[str, list[LegacyEntry]] = {}
+    for e in entries:
+        if e.plan == PLAN_PRIMITIVE:
+            cohorts.setdefault(e.source_node, []).append(e)
+    for primitive_id, members in cohorts.items():
+        primitive = _inner_node(sg, primitive_id)
+        failure = _validate_primitive_cohort(sg, primitive, members)
+        if failure is not None:
+            for e in members:
+                e.plan, e.reason, e.targets = PLAN_QUARANTINE, "primitiveBypassFailed", []
+            continue
+        outputs = primitive.get("outputs") or []
+        output_type = str(outputs[0].get("type") or "*")
+        title = primitive.get("title")
+        base = title if isinstance(title, str) and title and title != LEGACY_PRIMITIVE_TYPE else members[0].widget
+        name = next_unique_name(base, existing)
+        existing.append(name)
+        for e in members:
+            e.name, e.type = name, output_type
+    return entries
+
+
+def _validate_primitive_cohort(sg: dict, primitive: dict | None, members: list) -> str | None:
+    """``validateCohort`` + the pre-mutation checks of ``repairPrimitive``:
+    one primitive, one widget name, every target present and type-compatible."""
+    first = members[0]
+    if any(m.widget != first.widget for m in members):
+        return "cohort validation failed"
+    if primitive is None or str(primitive.get("type", "")) != LEGACY_PRIMITIVE_TYPE:
+        return "node is not a PrimitiveNode"
+    targets = _primitive_targets(sg, primitive)
+    if not targets:
+        return "no targets to reconnect"
+    outputs = primitive.get("outputs") or []
+    if not outputs or not isinstance(outputs[0], dict):
+        return "primitive has no output"
+    output_type = str(outputs[0].get("type") or "*")
+    for tid, slot in targets:
+        target = _inner_node(sg, tid)
+        entries = target.get("inputs") if target is not None else None
+        entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            return "target slot missing"
+        if not _types_compatible(str(entry.get("type") or "*"), output_type):
+            return "target slot type incompatible"
+    return None
+
+
+def planned_repair(workflow: dict, instance: dict, graph, widget: str, defs: dict[str, dict] | None = None):
+    """The repairable legacy entry a host address ``<instance>.<widget>`` names:
+    by the input name the repair will mint, else by the legacy tuple's own
+    widget name (an alias the caller reports as a redirect)."""
+    plan = [e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable]
+    by_name = next((e for e in plan if e.name == widget), None)
+    return by_name if by_name is not None else next((e for e in plan if e.widget == widget), None)
+
+
+def planned_repair_for_interior(
+    workflow: dict, instance: dict, graph, inner_id: str, widget: str, defs: dict[str, dict] | None = None
+):
+    """The repairable legacy entry whose value the interior address
+    ``<instance>/<inner>.<widget>`` would edit: the entry's own source widget,
+    or one of a primitive's fan-out targets."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        return None
+    for e in plan_proxy_migration(workflow, instance, graph, defs):
+        if not e.repairable:
+            continue
+        if e.source_node == inner_id and e.widget == widget:
+            return e
+        for tid, slot in e.targets:
+            target = _inner_node(sg, tid)
+            entries = target.get("inputs") if target is not None else None
+            entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            if tid == inner_id and isinstance(marker, dict) and marker.get("name") == widget:
+                return e
+    return None
+
+
+def planned_hidden_sources(workflow: dict, instance: dict, graph, defs: dict[str, dict] | None = None) -> set:
+    """``(interior node, widget)`` pairs a pending repair will own — the
+    interior addresses whose edits the host surface overrides."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    hidden: set[tuple[str, str]] = set()
+    if sg is None:
+        return hidden
+    for e in plan_proxy_migration(workflow, instance, graph, defs):
+        if not e.repairable:
+            continue
+        hidden.add((e.source_node, e.widget))
+        for tid, slot in e.targets:
+            target = _inner_node(sg, tid)
+            entries = target.get("inputs") if target is not None else None
+            entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            if isinstance(marker, dict) and marker.get("name"):
+                hidden.add((tid, str(marker["name"])))
+    return hidden
+
+
+def entry_effective_value(workflow: dict, sg: dict, entry: LegacyEntry, graph, defs: dict[str, dict]) -> Any:
+    """What the frontend shows for the entry after its own migration: the
+    legacy positional host value when present, else the source widget's
+    current value (a primitive's own value for a bypass)."""
+    if entry.host_value is not UNSET:
+        return entry.host_value
+    if entry.plan == PLAN_PRIMITIVE:
+        primitive = _inner_node(sg, entry.source_node)
+        return _node_widget_value(primitive, entry.widget, graph) if primitive is not None else UNSET
+    return source_value(workflow, sg, entry.as_promoted_input(sg), graph, defs)
+
+
+def repair_ids(instance_path: list, source_node: str, widget: str, n_links: int) -> dict:
+    """The ids a repair of ``(source_node, widget)`` on the instance at
+    ``instance_path`` mints: the subgraph input's uuid and one link id per
+    boundary link. Derived with SHA-256 from the identifiers alone (like
+    ``engine._deterministic_fork_id``), so they are stable across processes
+    and replicas."""
+    seed = "\x00".join(["proxy-repair", *[str(s) for s in instance_path], str(source_node), str(widget)])
+    input_id = str(_uuid.UUID(bytes=_hashlib.sha256(seed.encode()).digest()[:16], version=4))
+    links = []
+    for k in range(n_links):
+        digest = _hashlib.sha256(f"{seed}\x00link{k}".encode()).digest()
+        links.append(_LINK_ID_FLOOR | (int.from_bytes(digest[:8], "big") & ((1 << _LINK_ID_BITS) - 1)))
+    return {"input": input_id, "links": links}
+
+
+def plan_repair_ids(instance_path: list, plan: list) -> dict[str, dict]:
+    """Every repairable entry's ids, keyed ``<source node>.<widget>``."""
+    out: dict[str, dict] = {}
+    for e in plan:
+        if e.repairable and e.key not in out:
+            out[e.key] = repair_ids(instance_path, e.source_node, e.widget, max(1, len(e.targets)))
+    return out
+
+
+def _remove_link(sg: dict, link_id: Any) -> None:
+    link = next((x for x in sg.get("links") or [] if isinstance(x, dict) and x.get("id") == link_id), None)
+    if link is None:
+        return
+    sg["links"] = [x for x in sg.get("links") or [] if x is not link]
+    origin = link.get("origin_id")
+    if origin == SUBGRAPH_INPUT_NODE_ID:
+        for inp in sg.get("inputs") or []:
+            if isinstance(inp, dict) and isinstance(inp.get("linkIds"), list) and link_id in inp["linkIds"]:
+                inp["linkIds"] = [x for x in inp["linkIds"] if x != link_id]
+    else:
+        origin_node = _inner_node(sg, origin)
+        outputs = origin_node.get("outputs") if origin_node is not None else None
+        slot = link.get("origin_slot")
+        if isinstance(outputs, list) and isinstance(slot, int) and 0 <= slot < len(outputs):
+            links = outputs[slot].get("links")
+            if isinstance(links, list):
+                outputs[slot]["links"] = [x for x in links if x != link_id]
+    target = _inner_node(sg, link.get("target_id"))
+    entries = target.get("inputs") if target is not None else None
+    slot = link.get("target_slot")
+    if isinstance(entries, list) and isinstance(slot, int) and 0 <= slot < len(entries):
+        if isinstance(entries[slot], dict) and entries[slot].get("link") == link_id:
+            entries[slot]["link"] = None
+
+
+def _add_boundary_link(sg: dict, new_input: dict, link_id: Any, target: dict, slot: int, slot_type: str) -> None:
+    """``SubgraphInput.connect``: replace whatever fed the slot with a link
+    from the subgraph input node, as the frontend serializes one."""
+    entries = target["inputs"]
+    existing = entries[slot].get("link")
+    if existing is not None:
+        _remove_link(sg, existing)
+    origin_slot = next(i for i, inp in enumerate(sg["inputs"]) if inp is new_input)
+    sg.setdefault("links", []).append(
+        {
+            "id": link_id,
+            "origin_id": SUBGRAPH_INPUT_NODE_ID,
+            "origin_slot": origin_slot,
+            "target_id": target.get("id"),
+            "target_slot": slot,
+            "type": slot_type,
+        }
+    )
+    entries[slot]["link"] = link_id
+    new_input.setdefault("linkIds", []).append(link_id)
+    state = sg.get("state")
+    if isinstance(state, dict):
+        last = state.get("lastLinkId")
+        state["lastLinkId"] = max(last if isinstance(last, int) else 0, link_id)
+
+
+def _add_subgraph_input(sg: dict, input_id: str, name: str, slot_type: str, label: str | None) -> dict:
+    """``Subgraph.addInput`` as the frontend serializes a ``SubgraphInput``
+    (``id``, ``name``, ``type``, ``linkIds``; ``label`` when the source slot
+    carried one). ``pos`` is layout the input node assigns on load."""
+    new_input: dict = {"id": input_id, "name": name, "type": slot_type, "linkIds": []}
+    if label is not None:
+        new_input["label"] = label
+    sg.setdefault("inputs", []).append(new_input)
+    return new_input
+
+
+def _add_host_input(instance: dict, name: str, slot_type: str, label: str | None) -> None:
+    """The host's own ``inputs[]`` entry for a new promoted widget input —
+    the shape a post-migration save carries (``audio_minimax_music_3.json``
+    node 37). Left alone when the instance already serializes one."""
+    if instance_input(instance, name) is not None:
+        return
+    entry: dict = {"name": name, "type": slot_type, "widget": {"name": name}, "link": None}
+    if label is not None:
+        entry = {"label": label, **entry}
+    instance.setdefault("inputs", []).append(entry)
+
+
+def _quarantine_entry(entry: LegacyEntry, reason: str) -> dict:
+    out = {"originalEntry": list(entry.original), "reason": reason, "attemptedAtVersion": QUARANTINE_VERSION}
+    if entry.host_value is not UNSET:
+        out["hostValue"] = entry.host_value
+    return out
+
+
+def flush_proxy_migration(
+    workflow: dict, instance: dict, graph, ids: dict[str, dict] | None = None, instance_path: list | None = None
+) -> FlushReport:
+    """Run the forward migration on ``instance`` IN PLACE (its definition, its
+    interior nodes, its own ``inputs``/``widgets_values``/``properties``).
+
+    ``ids`` are the minted ids per repairable entry (:func:`plan_repair_ids`);
+    derived from ``instance_path`` when not given. Idempotent: an instance
+    without legacy value entries is left untouched. The definition is
+    mutated — callers isolate a shared definition first (the op layer does,
+    via ``engine._isolate_shared_subgraph``).
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    report = FlushReport()
+    if sg is None or not _proxy_tuples(instance):
+        return report
+    if graph is None:
+        # Without the catalog no interior widget can be resolved, and the
+        # honest answer to that is not "quarantine everything".
+        raise ValueError(
+            f"repairing the legacy proxyWidgets of subgraph node {instance.get('id')} needs the node catalog"
+        )
+    plan = plan_proxy_migration(workflow, instance, graph, defs)
+    if not plan:
+        return report
+    instance_path = instance_path if instance_path is not None else [str(instance.get("id"))]
+    ids = dict(ids or {})
+    for e in plan:
+        if e.repairable and e.key not in ids:
+            ids[e.key] = repair_ids(instance_path, e.source_node, e.widget, max(1, len(e.targets)))
+
+    # Values the host already carries, read the way ``configure`` applies them
+    # (positionally over the linked inputs) — before the structure changes.
+    pre = {p.name: host_value(instance, p) for p in promoted_inputs(sg, defs) if p.is_widget}
+    applied: dict[str, Any] = {}
+    quarantine: list[dict] = []
+    remaining: list[list] = []
+    cohorts: dict[str, list[LegacyEntry]] = {}
+    for e in plan:
+        if e.plan == PLAN_PREVIEW:
+            remaining.append(list(e.original))
+            continue
+        if e.plan == PLAN_QUARANTINE:
+            if e.reason != "primitiveBypassFailed":
+                quarantine.append(_quarantine_entry(e, str(e.reason)))
+            else:
+                cohorts.setdefault(e.source_node, []).append(e)
+            continue
+        report.consumed.append(list(e.original))
+        if e.plan == PLAN_ALREADY_LINKED:
+            if e.host_value is not UNSET:
+                applied[str(e.name)] = e.host_value
+            continue
+        if e.plan == PLAN_PRIMITIVE:
+            cohorts.setdefault(e.source_node, []).append(e)
+            continue
+        # createSubgraphInput
+        source = _inner_node(sg, e.source_node)
+        slot_index = e.slot_index
+        if slot_index is None:
+            source.setdefault("inputs", []).append(
+                {
+                    "localized_name": e.widget,
+                    "name": e.widget,
+                    "type": e.type,
+                    "widget": {"name": e.widget},
+                    "link": None,
+                }
+            )
+            slot_index = len(source["inputs"]) - 1
+        new_input = _add_subgraph_input(sg, ids[e.key]["input"], str(e.name), str(e.type), e.label)
+        _add_boundary_link(sg, new_input, ids[e.key]["links"][0], source, slot_index, str(e.type))
+        _add_host_input(instance, str(e.name), str(e.type), e.label)
+        report.created.append(str(e.name))
+        if e.host_value is not UNSET:
+            applied[str(e.name)] = e.host_value
+
+    for primitive_id, members in cohorts.items():
+        if members[0].plan == PLAN_QUARANTINE:
+            quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
+            continue
+        first = members[0]
+        primitive = _inner_node(sg, primitive_id)
+        # ``repairPrimitive`` re-validates against the graph as it is NOW: a
+        # ``createSubgraphInput`` above may have taken over one of the
+        # primitive's targets, so the fan-out is collected again.
+        if _validate_primitive_cohort(sg, primitive, members) is not None:
+            quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
+            continue
+        targets = _primitive_targets(sg, primitive)
+        for link in [x for x in sg.get("links") or [] if str(x.get("origin_id")) == primitive_id]:
+            if link.get("origin_slot") == 0:
+                _remove_link(sg, link.get("id"))
+        link_ids = ids[first.key]["links"]
+        if len(link_ids) < len(targets):
+            link_ids = repair_ids(instance_path, first.source_node, first.widget, len(targets))["links"]
+        new_input = _add_subgraph_input(sg, ids[first.key]["input"], str(first.name), str(first.type), None)
+        for k, (tid, slot) in enumerate(targets):
+            target = _inner_node(sg, tid)
+            _add_boundary_link(sg, new_input, link_ids[k], target, slot, str(target["inputs"][slot].get("type") or "*"))
+        _add_host_input(instance, str(first.name), str(first.type), None)
+        primitive.setdefault("properties", {})[PROXY_BYPASS_MARKER_PROPERTY] = str(first.name)
+        report.created.append(str(first.name))
+        unique: list[LegacyEntry] = []
+        for m in members:
+            if not any(
+                (u.source_node, u.widget, u.disambiguator) == (m.source_node, m.widget, m.disambiguator) for u in unique
+            ):
+                unique.append(m)
+        valued = next((u for u in unique if u.host_value is not UNSET), None)
+        if valued is not None:
+            applied[str(first.name)] = valued.host_value
+        else:
+            seed = _node_widget_value(primitive, first.widget, graph)
+            if seed is not UNSET:
+                applied[str(first.name)] = seed
+
+    if not report.consumed and not quarantine:
+        return report  # previews only: nothing to consume, nothing to write
+
+    # ``appendQuarantine``: a ``-1`` entry's host value lands on the input of
+    # that name; entries are deduplicated by their original tuple.
+    props = instance.setdefault("properties", {})
+    existing_q = [q for q in props.get(QUARANTINE_PROPERTY) or [] if isinstance(q, dict)]
+    for q in quarantine:
+        if q["originalEntry"][0] == "-1" and "hostValue" in q:
+            applied[str(q["originalEntry"][1])] = q["hostValue"]
+        if not any(x.get("originalEntry") == q["originalEntry"] for x in existing_q):
+            existing_q.append(q)
+            report.quarantined.append(q)
+    if existing_q:
+        props[QUARANTINE_PROPERTY] = existing_q
+    if remaining:
+        props["proxyWidgets"] = remaining
+    else:
+        props.pop("proxyWidgets", None)
+    report.remaining = remaining
+
+    # The host array, positional over the (now repaired) widget-backed inputs:
+    # migrated values first, then what the host already carried, then the
+    # interior default — the serialization the frontend writes after its flush.
+    values: list[Any] = []
+    for p in promoted_inputs(sg, defs):
+        if not p.is_widget:
+            continue
+        value = applied.get(p.name, pre.get(p.name, UNSET))
+        if value is UNSET:
+            value = source_value(workflow, sg, p, graph, defs)
+        values.append(None if value is UNSET else value)
+    instance["widgets_values"] = values
+    return report
+
+
+def boundary_widget_targets(sg: dict, pi: PromotedInput, defs: dict[str, dict]) -> list[tuple[list[str], str]]:
+    """Every concrete ``(interior node path, widget)`` a promoted input feeds —
+    all of its boundary links, through nested instances. A repaired primitive
+    fan-out has several; :func:`deepest_source` reports only the first."""
+    inputs = sg.get("inputs") or []
+    inp = inputs[pi.index] if 0 <= pi.index < len(inputs) and isinstance(inputs[pi.index], dict) else None
+    if inp is None:
+        single = deepest_source(sg, pi, defs)
+        return [single] if single is not None else []
+    return _boundary_targets(sg, inp, defs, 0)
+
+
+def _boundary_targets(sg: dict, inp: dict, defs: dict[str, dict], depth: int) -> list[tuple[list[str], str]]:
+    if depth > _MAX_NESTED_PROMOTION_DEPTH:
+        return []
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    out: list[tuple[list[str], str]] = []
+    for link_id in inp.get("linkIds") or []:
+        link = links.get(link_id) if isinstance(link_id, (int, str)) else None
+        target = _inner_node(sg, link.get("target_id")) if link is not None else None
+        if target is None:
+            continue
+        entries = target.get("inputs") or []
+        slot = link.get("target_slot")
+        entry = entries[slot] if isinstance(slot, int) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            continue
+        tid = str(target.get("id"))
+        inner_def = defs.get(str(target.get("type", "")))
+        if inner_def is not None:
+            inner_inp = next(
+                (
+                    i
+                    for i in inner_def.get("inputs") or []
+                    if isinstance(i, dict) and i.get("name") == entry.get("name")
+                ),
+                None,
+            )
+            if inner_inp is not None:
+                out.extend(([tid, *path], w) for path, w in _boundary_targets(inner_def, inner_inp, defs, depth + 1))
+            continue
+        marker = entry.get("widget")
+        if marker:
+            widget = marker.get("name") if isinstance(marker, dict) else None
+            out.append(([tid], str(widget or entry.get("name"))))
+    return out

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -483,6 +483,12 @@ def resolve_write(
         target_def = defs.get(str(target.get("type", "")))
         given = f"{'/'.join(segments)}.{widget}"
         if parent_def is not None:
+            # Checked BEFORE the interior-feeder refusal below on purpose: a
+            # widget a legacy entry owns is repaired by the frontend on load,
+            # and that repair replaces any interior link feeding its slot
+            # (see ``plan_proxy_migration``), so the host value — not the
+            # feeder — is what will run. The same slot with no legacy entry
+            # keeps its feeder and is refused.
             pending = planned_repair_for_interior(workflow, parent, graph, str(target.get("id")), widget, defs)
             if pending is not None:
                 return WriteTarget(
@@ -966,6 +972,12 @@ def _slot_for_widget(source: dict, widget: str, projecting_input: str | None, de
         marker = entry.get("widget") if isinstance(entry, dict) else None
         if isinstance(marker, dict) and marker.get("name") == widget:
             return idx, entry, str(entry.get("type") or "*")
+    # An older save can serialize the widget's slot by ``name`` alone (no
+    # marker): that IS the backing slot — the flush restores its marker —
+    # never a reason to append a duplicate beside it.
+    for idx, entry in enumerate(entries):
+        if isinstance(entry, dict) and entry.get("widget") is None and entry.get("name") == widget:
+            return idx, entry, str(entry.get("type") or "*")
     m = graph.node(str(source.get("type", ""))) if graph is not None else None
     port = next((p for p in m.inputs if p.name == widget), None) if m is not None else None
     if port is None or port.is_link:
@@ -1055,9 +1067,18 @@ def plan_proxy_migration(workflow: dict, instance: dict, graph, defs: dict[str, 
             continue
         slot = _slot_for_widget(source, widget_name, projecting, defs, graph)
         if slot is None:
-            e.reason = "missingSubgraphInput"  # the widget has no backing input slot
+            # The widget has no backing input slot (``control_after_generate``).
+            # ``missingSubgraphInput`` is the frontend's own reason code for
+            # this case — ``repairCreateSubgraphInput``: "source widget has no
+            # backing input slot; quarantining" → ``reason: 'missingSubgraphInput'``.
+            e.reason = "missingSubgraphInput"
             continue
         idx, entry, slot_type = slot
+        # A slot already fed by an interior link is repaired all the same: the
+        # frontend calls ``SubgraphInput.connect(slot, node)`` unconditionally
+        # and ``connect`` replaces the incumbent link (``replaceLinkTopology``
+        # + ``_disconnectNodeInput``), so the boundary link takes the slot over
+        # and the interior feeder is dropped — see ``_add_boundary_link``.
         e.plan, e.type, e.slot_index, e.source_input = PLAN_CREATE, slot_type, idx, projecting
         if isinstance(entry, dict) and entry.get("label") is not None:
             e.label = str(entry["label"])
@@ -1123,7 +1144,22 @@ def planned_repair(workflow: dict, instance: dict, graph, widget: str, defs: dic
     widget name (an alias the caller reports as a redirect)."""
     plan = [e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable]
     by_name = next((e for e in plan if e.name == widget), None)
-    return by_name if by_name is not None else next((e for e in plan if e.widget == widget), None)
+    if by_name is not None:
+        return by_name
+    aliased: list[LegacyEntry] = []
+    for e in plan:
+        if e.widget == widget and all(a.name != e.name for a in aliased):
+            aliased.append(e)
+    if len(aliased) > 1:
+        # Two entries share the legacy widget name (two primitives both named
+        # ``value``): never pick one silently — name the minted inputs.
+        node_id = instance.get("id")
+        raise ValueError(
+            f"{node_id}.{widget} is ambiguous: {len(aliased)} legacy promotions on subgraph node {node_id} share "
+            f"the widget name {widget!r}; address one by its input name — "
+            f"{', '.join(f'{node_id}.{a.name}' for a in aliased)}"
+        )
+    return aliased[0] if aliased else None
 
 
 def planned_repair_for_interior(
@@ -1351,6 +1387,14 @@ def flush_proxy_migration(
         # createSubgraphInput
         source = _inner_node(sg, e.source_node)
         slot_index = e.slot_index
+        if slot_index is not None and not isinstance(source["inputs"][slot_index].get("widget"), dict):
+            # A slot serialized by name alone: give it back the marker a
+            # converted widget carries, in the frontend's key order.
+            found = source["inputs"][slot_index]
+            marked = {k: v for k, v in found.items() if k != "link"}
+            marked["widget"] = {"name": e.source_input or e.widget}
+            marked["link"] = found.get("link")
+            source["inputs"][slot_index] = marked
         if slot_index is None:
             if e.source_input is not None:
                 # A nested instance backs the widget with its OWN host input

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -652,12 +652,31 @@ def _set_widget_impl(
         extra["redirected_from"] = target.redirected_from
     if target.kind == "host":
         instance = target.node
+        widget = str(target.widget)
         defs = _engine._subgraph_defs_by_id(workflow)
         sg = defs[str(instance.get("type", ""))]
-        pi = _promoted.find_promoted(sg, defs, widget)
+        promoted_meta: dict[str, Any] = {"instance_path": list(target.segments)}
+        if target.repair is not None:
+            # A legacy ``proxyWidgets`` promotion (see ``cql.promoted``
+            # "forward migration"): apply repairs the instance's definition
+            # first — with ids DERIVED from the instance path and the entry,
+            # carried here so any replica mints the same input and links —
+            # and only then writes the host value. The schema/old value come
+            # from the interior widget the repair will link.
+            entry = target.repair
+            plan = _promoted.plan_proxy_migration(workflow, instance, graph, defs)
+            promoted_meta["repair"] = {
+                "entry": list(entry.original),
+                "ids": _promoted.plan_repair_ids(list(target.segments), plan),
+            }
+            pi = entry.as_promoted_input(sg)
+            old = _promoted.entry_effective_value(workflow, sg, entry, graph, defs)
+        else:
+            pi = _promoted.find_promoted(sg, defs, widget)
+            promoted_meta["value_index"] = pi.value_index
+            old = _promoted.effective_value(workflow, instance, widget, graph)
         inner_type, port = _engine.promoted_source_port(sg, pi, defs, graph)
         value, norm_note = _normalize_combo(graph, inner_type, port.name if port else widget, value)
-        old = _promoted.effective_value(workflow, instance, widget, graph)
         warnings: list[dict] = []
         if port is not None:
             err = port.validate_shape(value)
@@ -675,12 +694,18 @@ def _set_widget_impl(
             widget=widget,
             value=value,
             old=None if old is _promoted.UNSET else old,
-            promoted={"value_index": pi.value_index, "instance_path": list(target.segments)},
+            promoted=promoted_meta,
             **extra,
         )
         if warnings:
             op["warnings"] = warnings
         workflow = apply_op(workflow, op, graph)
+        if target.repair is not None:
+            # The slot only exists after the repair (and the instance may sit
+            # on a freshly forked definition): read it back from the document.
+            repaired = _engine._subgraph_defs_by_id(workflow)
+            sg = repaired[str(instance.get("type", ""))]
+            op["promoted"]["value_index"] = _promoted.find_promoted(sg, repaired, widget).value_index
         # The materialized host array, for an applier that stores the instance
         # opaquely (no catalog entry for a subgraph type): it can replace the
         # positional array wholesale instead of decomposing it by name. Read
@@ -1826,7 +1851,20 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
             return  # instance concurrently deleted => no-op (delete wins)
         defs_by_id = _engine._subgraph_defs_by_id(workflow)
         instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
-        if defs_by_id.get(str(instance.get("type", ""))) is not None:
+        repair = promoted_write.get("repair")
+        if repair:
+            # Legacy ``proxyWidgets`` promotion: repair the instance's
+            # definition (the frontend's forward migration) before the host
+            # write. The definition is MUTATED, so a shared one is forked
+            # first (deterministic fork id), and the input/link ids come from
+            # the op — replay anywhere yields the same document. Re-resolved
+            # against the current graph: an entry another replica already
+            # repaired is consumed as already linked.
+            _engine._isolate_shared_subgraph(workflow, instance, _engine._subgraph_defs_by_id(workflow))
+            _promoted.flush_proxy_migration(
+                workflow, instance, graph, ids=repair.get("ids") or None, instance_path=instance_path
+            )
+        if _engine._subgraph_defs_by_id(workflow).get(str(instance.get("type", ""))) is not None:
             _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
         else:
             # Not a subgraph instance (a frontend-only PrimitiveNode): a plain

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -217,20 +217,19 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             value = _promoted.host_value(instance, pi)
             if value is _promoted.UNSET:
                 continue
-            target = _promoted.deepest_source(sg, pi, subgraph_defs)
-            if target is None:
-                continue
-            path, widget = target
-            entry = api_prompt.get(":".join([prefix, *path]))
-            if not isinstance(entry, dict):
-                continue
-            inputs = entry.setdefault("inputs", {})
-            current = inputs.get(widget)
-            if isinstance(current, list) and len(current) == 2:
-                continue  # wired from inside the definition: the link wins
-            # Same wrapping every widget value gets, so a two-item list host
-            # value is never read back as a ``[node, slot]`` link.
-            inputs[widget] = _wrap_widget_value(value)
+            # Every interior widget the input feeds — a repaired primitive
+            # fan-out links one host value into several targets.
+            for path, widget in _promoted.boundary_widget_targets(sg, pi, subgraph_defs):
+                entry = api_prompt.get(":".join([prefix, *path]))
+                if not isinstance(entry, dict):
+                    continue
+                inputs = entry.setdefault("inputs", {})
+                current = inputs.get(widget)
+                if isinstance(current, list) and len(current) == 2:
+                    continue  # wired from inside the definition: the link wins
+                # Same wrapping every widget value gets, so a two-item list
+                # host value is never read back as a ``[node, slot]`` link.
+                inputs[widget] = _wrap_widget_value(value)
 
     for node in workflow.get("nodes") or []:
         if not isinstance(node, dict):

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -414,7 +414,7 @@ Current contract, pinned:
   never random — and the instance's `type` is repointed, so two replicas
   replaying the same op produce byte-identical graphs and sibling instances
   are never aliased.
-* **Promoted widgets are HOST writes** (BE-10305; `cql.promoted`). A
+* **Promoted widgets are HOST writes** (`cql.promoted`). A
   `set_widget` on a promoted input carries `promoted: {instance_path,
   value_index}` instead of `path`, and its LWW target is the host register
   `("widget", "57", "text")` — the flat form, the nested interior form of the

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -414,6 +414,20 @@ Current contract, pinned:
   never random — and the instance's `type` is repointed, so two replicas
   replaying the same op produce byte-identical graphs and sibling instances
   are never aliased.
+* **Promoted widgets are HOST writes** (BE-10305; `cql.promoted`). A
+  `set_widget` on a promoted input carries `promoted: {instance_path,
+  value_index}` instead of `path`, and its LWW target is the host register
+  `("widget", "57", "text")` — the flat form, the nested interior form of the
+  widget the input links, and the flattened alias all converge there. A
+  legacy `properties.proxyWidgets` entry the definition does not back with a
+  linked input is first repaired the way the frontend's forward migration
+  repairs it on load (`promoted.flush_proxy_migration`): the op additionally
+  carries `promoted.repair = {entry, ids}` where `ids` maps every repairable
+  entry of that instance to the subgraph-input uuid and boundary-link ids the
+  repair mints, derived with SHA-256 from `(instance path, source node,
+  widget)` — deterministic, never random — so replay on any replica produces
+  a byte-identical document. The repair mutates the definition, so a shared
+  one is forked first exactly like an interior write.
 * OPEN: the shared-definition forking semantics above are apply-time behavior
   that rewrites `instance.type` without an explicit op saying so. A full
   specification (fork visibility, interaction with concurrent interior writes
@@ -804,3 +818,13 @@ A write that resolves to a frontend-only `PrimitiveNode` (no catalog entry;
 §14.1 `promoted` payload with `value_index: 0` and `instance_path` = the node
 id, so an opaque store applies it as a plain positional write. Apply treats a
 `promoted` payload on a non-instance node as that positional write.
+
+### 14.4 Legacy `proxyWidgets` entries are repaired before the host write
+
+A `properties.proxyWidgets` entry the definition does not back with a linked
+input is repaired first — the frontend's own forward migration
+(`proxyWidgetMigration.ts`), ported as `promoted.flush_proxy_migration` — and
+the op additionally carries `promoted.repair = {entry, ids}` with the
+subgraph-input and boundary-link ids the repair mints, derived by SHA-256 from
+`(instance path, source node, widget)` so replay anywhere is byte-identical.
+The pinned contract text in §8.7 states the full rule.

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -677,11 +677,23 @@ _SG_UUID = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
 
 
 def _subgraph_workflow() -> dict:
-    """A minimal curated subgraph template (derived from a fetched gallery
-    template): a top-level subgraph instance `57` whose promoted `text`/`seed`/
-    `steps` route through `proxyWidgets` to interior CLIPTextEncode `27` and
-    KSampler `3`, plus a plain top-level node `9` so we can prove top-level edits
-    still work alongside subgraph edits."""
+    """A minimal LEGACY subgraph template, shaped like the pre-ADR-0009 saves
+    in the gallery (e.g. ``flux_dev_checkpoint_example.json`` node 56 → 52):
+    a top-level subgraph instance `57` whose promoted `text`/`seed`/`steps`
+    exist ONLY as `properties.proxyWidgets` entries routing to interior
+    CLIPTextEncode `27` and KSampler `3` — the definition declares no input
+    for them — plus a plain top-level node `9` so we can prove top-level edits
+    still work alongside subgraph edits.
+
+    History: an earlier version of this fixture also DECLARED `text`/`seed`/
+    `steps` as (unlinked) subgraph inputs. The frontend never writes that
+    shape for a promotion — a declared input nobody links is a dangling
+    socket — and under the frontend's forward migration (which the CLI now
+    runs before writing a legacy promotion) such a declaration collides with
+    the input the repair mints, so `text` would become `text_1`
+    (``nextUniqueName``). See ``test_declared_unlinked_socket_collides_with_the_repair``
+    for that pin; the realistic shape is what the rest of the class uses.
+    """
     return {
         "last_node_id": 60,
         "last_link_id": 0,
@@ -709,15 +721,12 @@ def _subgraph_workflow() -> dict:
                 {
                     "id": _SG_UUID,
                     "name": "Text to Image",
-                    "inputs": [
-                        {"name": "text", "type": "STRING"},
-                        {"name": "seed", "type": "INT"},
-                        {"name": "steps", "type": "INT"},
-                    ],
+                    "inputs": [],
                     "nodes": [
                         {"id": 27, "type": "CLIPTextEncode", "widgets_values": ["old prompt"]},
                         {"id": 3, "type": "KSampler", "widgets_values": [42, "fixed", 20, 8.0, "euler", "normal", 1.0]},
                     ],
+                    "links": [],
                 }
             ]
         },
@@ -729,48 +738,95 @@ def _interior(wf: dict, inner_id) -> dict:
     return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
 
 
+def _instance(wf: dict, node_id=57) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
 class TestSetWidgetSubgraph:
-    def test_flat_promoted_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
-        """`57.text` — the exact address `slots` advertises — writes CLIPTextEncode 27."""
+    """Legacy ``proxyWidgets`` promotions under the migration semantics.
+
+    These pins changed with the legacy-proxy repair. Before, ``57.text``
+    followed ``proxyWidgets`` into CLIPTextEncode 27 and wrote its
+    ``widgets_values`` — the "layer 2" edit BE-10305 is about: the frontend's
+    load-time migration re-seeds the host from that interior value, so it
+    *looked* right, but the value lived where no other promoted write puts
+    it and ``comfy run`` had no host value to submit. Now the write mirrors
+    the frontend exactly: the definition gains a linked input per legacy
+    entry (``text``/``seed``/``steps``, boundary-linked from the subgraph
+    input node), the instance carries the value, and the interior widget is
+    only the default. The op is a HOST write (no ``path``), carrying the
+    repair it performed so a replica replays to the same document.
+    """
+
+    def test_flat_promoted_address_repairs_and_writes_the_host(self, patched_graph, tmp_path, capsys):
+        """`57.text` — the exact address `slots` advertises — writes the HOST value
+        of the input the repair mints for CLIPTextEncode 27's `text`."""
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.text", "a cat on a bicycle"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
         assert op["op"] == "set_widget"
         assert op["node_id"] == 57
+        assert op["widget"] == "text"
         assert op["value"] == "a cat on a bicycle"
         assert op["old"] == "old prompt"
-        # op is self-describing + replayable: resolved interior path + widget.
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        # op is self-describing + replayable: a host write plus the repair it ran.
+        assert "path" not in op
+        assert op["promoted"]["instance_path"] == ["57"]
+        assert op["promoted"]["value_index"] == 0
+        assert op["promoted"]["repair"]["entry"] == ["27", "text"]
+        assert set(op["promoted"]["repair"]["ids"]) == {"27.text", "3.seed", "3.steps"}
         # CRDT stamping preserved.
         assert isinstance(op["op_id"], str) and op["op_id"]
         assert op["stamp"] == [0, "cli"]
-        # value landed on the interior node, in the definition (persists on disk).
+        # on disk: the definition is repaired, the host owns the value, the
+        # interior widget keeps its default, the legacy route is consumed.
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a cat on a bicycle"
+        sg = wf["definitions"]["subgraphs"][0]
+        assert [i["name"] for i in sg["inputs"]] == ["text", "seed", "steps"]
+        assert [(ln["origin_id"], ln["origin_slot"], ln["target_id"]) for ln in sg["links"]] == [
+            (-10, 0, 27),
+            (-10, 1, 3),
+            (-10, 2, 3),
+        ]
+        assert _interior(wf, 27)["inputs"] == [
+            {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {"name": "text"},
+                "link": sg["links"][0]["id"],
+            }
+        ]
+        assert _instance(wf)["widgets_values"] == ["a cat on a bicycle", 42, 20]
+        assert _interior(wf, 27)["widgets_values"][0] == "old prompt"
+        assert "proxyWidgets" not in _instance(wf)["properties"]
 
-    def test_flat_promoted_int_input_writes_ksampler(self, patched_graph, tmp_path, capsys):
+    def test_flat_promoted_int_input_writes_the_host_slot(self, patched_graph, tmp_path, capsys):
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.seed", "12345"], capsys)
         assert env["ok"] is True, env
-        assert env["data"]["op"]["path"] == ["57", "3"]
+        assert env["data"]["op"]["promoted"]["value_index"] == 1
         wf = json.loads(path.read_text())
-        assert _interior(wf, 3)["widgets_values"][0] == 12345  # seed is index 0
+        assert _instance(wf)["widgets_values"] == ["old prompt", 12345, 20]
+        assert _interior(wf, 3)["widgets_values"][0] == 42  # interior default untouched
 
-    def test_nested_interior_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
-        """`57/27.text` (the nested form the skill documents) hits the same widget."""
+    def test_nested_interior_address_is_redirected_to_the_host(self, patched_graph, tmp_path, capsys):
+        """`57/27.text` (the nested form the skill documents) is the widget a
+        legacy promotion owns: the write is redirected to the host, like the
+        interior address of any linked promotion."""
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57/27.text", "a nested cat"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
-        assert op["node_id"] == "57/27"
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        assert op["node_id"] == 57 and op["widget"] == "text"
+        assert op["redirected_from"] == "57/27.text"
+        assert "path" not in op
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a nested cat"
+        assert _instance(wf)["widgets_values"][0] == "a nested cat"
+        assert _interior(wf, 27)["widgets_values"][0] == "old prompt"
 
-    def test_flattened_colon_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
+    def test_flattened_colon_address_is_redirected_to_the_host(self, patched_graph, tmp_path, capsys):
         """`57:27.text` — the FLATTENED id namespace `validate` and server
         node_errors report after UI→API lowering (workflow_to_api composes inner
         ids as `<outer>:<inner>`) — is accepted as an alias for `57/27.text`.
@@ -780,10 +836,10 @@ class TestSetWidgetSubgraph:
         env = _run(["set-widget", str(path), "57:27.text", "a flattened cat"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        assert op["node_id"] == 57 and op["widget"] == "text"
+        assert op["redirected_from"] == "57/27.text"
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a flattened cat"
+        assert _instance(wf)["widgets_values"][0] == "a flattened cat"
 
     def test_flattened_colon_converges_with_nested_form(self):
         """`57:27.text` and `57/27.text` resolve to the SAME CRDT write target."""
@@ -800,29 +856,68 @@ class TestSetWidgetSubgraph:
         assert "interior node 99 not found" in env["error"]["message"]
 
     def test_flat_and_nested_share_a_conflict_target(self):
-        """Flat `57.text` and nested `57/27.text` land on the same interior
-        widget, so their ops must resolve to the SAME CRDT write target (they
+        """Flat `57.text` and nested `57/27.text` land on the same host value,
+        so their ops must resolve to the SAME CRDT write target (they
         converge — one does not silently clobber the other undetected)."""
         wf = _subgraph_workflow()
         _, flat = workflow_ops.set_widget(copy.deepcopy(wf), _graph(), 57, "text", "A")
         _, nested = workflow_ops.set_widget(copy.deepcopy(wf), _graph(), "57/27", "text", "B")
-        assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested)
+        assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested) == ("widget", "57", "text")
         assert workflow_ops.detect_conflict(flat, nested) is True  # different values, same target
+
+    def test_repair_replays_identically_on_a_fresh_copy(self):
+        base = _subgraph_workflow()
+        applied, op = workflow_ops.set_widget(copy.deepcopy(base), _graph(), 57, "seed", 7)
+        replayed = workflow_ops.apply_op(copy.deepcopy(base), op, _graph())
+        for w in (applied, replayed):
+            w.pop("_applied_ops", None)
+            w.pop("_widget_stamps", None)
+        assert json.dumps(replayed, sort_keys=True) == json.dumps(applied, sort_keys=True)
 
     def test_slots_and_set_widget_agree(self, patched_graph, monkeypatch, tmp_path, capsys):
         """The self-consistency the bug broke: every flat address `slots` emits
-        for the subgraph instance is accepted by set-widget."""
+        for the subgraph instance is accepted by set-widget — before the repair
+        (the legacy entries are advertised where the frontend will show them)
+        and after it (they are ordinary promoted widgets)."""
         # slots resolves its graph via workflow.py's _get_graph; set-widget via
         # workflow_edit.py's. patched_graph covers the latter; patch the former too.
         monkeypatch.setattr(workflow_cmd, "_get_graph", lambda *a, **kw: _graph())
         path = _write(tmp_path, _subgraph_workflow())
         slots_env = _run(["slots", str(path)], capsys)
-        addrs = [s["address"] for s in slots_env["data"]["slots"] if str(s["address"]).startswith("57.")]
+        by_addr = {s["address"]: s for s in slots_env["data"]["slots"]}
+        addrs = [a for a in by_addr if a.startswith("57.")]
         assert addrs, slots_env  # the instance's promoted inputs are advertised flat
+        assert by_addr["57.text"]["current_value"] == "old prompt"
+        assert "57/27.text" not in by_addr  # the interior behind a promotion is not advertised
         for addr in ("57.text", "57.seed", "57.steps"):
             assert addr in addrs
             env = _run(["set-widget", str(path), addr, "3" if addr != "57.text" else "x"], capsys)
             assert env["ok"] is True, (addr, env)
+        slots_env = _run(["slots", str(path)], capsys)
+        after = {s["address"]: s for s in slots_env["data"]["slots"]}
+        assert after["57.text"]["current_value"] == "x" and after["57.seed"]["current_value"] == 3
+
+    def test_declared_unlinked_socket_collides_with_the_repair(self, patched_graph, tmp_path, capsys):
+        """The shape this fixture USED to have: `text` declared as a subgraph
+        input nobody links, plus the legacy `['27','text']` entry. The frontend's
+        migration keeps the dangling socket and mints `text_1` for the widget
+        (``nextUniqueName``); addressing `57.text` still reaches the widget —
+        by its legacy source-widget name — and reports the redirect."""
+        wf = _subgraph_workflow()
+        wf["definitions"]["subgraphs"][0]["inputs"] = [{"name": "text", "type": "STRING"}]
+        path = _write(tmp_path, wf)
+        env = _run(["set-widget", str(path), "57.text", "a cat"], capsys)
+        assert env["ok"] is True, env
+        op = env["data"]["op"]
+        assert op["widget"] == "text_1" and op["redirected_from"] == "57.text"
+        saved = json.loads(path.read_text())
+        assert [i["name"] for i in saved["definitions"]["subgraphs"][0]["inputs"]] == [
+            "text",
+            "text_1",
+            "seed",
+            "steps",
+        ]
+        assert _instance(saved)["widgets_values"] == ["a cat", 42, 20]
 
     def test_unknown_promoted_input_errors_cleanly(self, patched_graph, tmp_path, capsys):
         path = _write(tmp_path, _subgraph_workflow())
@@ -835,9 +930,9 @@ class TestSetWidgetSubgraph:
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.seed", '"notanumber"'], capsys)
         assert env["ok"] is False
-        # unchanged on disk (edit rejected before write).
+        # unchanged on disk (edit rejected before write — and before any repair).
         wf = json.loads(path.read_text())
-        assert _interior(wf, 3)["widgets_values"][0] == 42
+        assert wf == _subgraph_workflow()
 
     def test_top_level_edit_still_works_with_subgraphs_present(self, patched_graph, tmp_path, capsys):
         """A plain top-level node in a workflow that also contains subgraphs is

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -677,7 +677,7 @@ _SG_UUID = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
 
 
 def _subgraph_workflow() -> dict:
-    """A minimal LEGACY subgraph template, shaped like the pre-ADR-0009 saves
+    """A minimal LEGACY subgraph template, shaped like the pre-ADR 0009 saves
     in the gallery (e.g. ``flux_dev_checkpoint_example.json`` node 56 → 52):
     a top-level subgraph instance `57` whose promoted `text`/`seed`/`steps`
     exist ONLY as `properties.proxyWidgets` entries routing to interior
@@ -747,7 +747,7 @@ class TestSetWidgetSubgraph:
 
     These pins changed with the legacy-proxy repair. Before, ``57.text``
     followed ``proxyWidgets`` into CLIPTextEncode 27 and wrote its
-    ``widgets_values`` — the "layer 2" edit BE-10305 is about: the frontend's
+    ``widgets_values`` — the "layer 2" edit the subgraph-editing report is about: the frontend's
     load-time migration re-seeds the host from that interior value, so it
     *looked* right, but the value lived where no other promoted write puts
     it and ``comfy run`` had no host value to submit. Now the write mirrors

--- a/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
+++ b/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
@@ -160,13 +160,46 @@ def test_primitive_fanout_write_lands_on_the_host_and_previews_stay(graph):
     assert [e[1] for e in inst["properties"]["proxyWidgets"]] == ["$$canvas-image-preview"] * 3
 
 
-def test_legacy_source_widget_name_addresses_a_primitive_repair_too(graph):
-    """``143.value`` — the legacy tuple's own widget name — is accepted as an
-    alias for the input the repair mints (``resolution`` here is the primitive
-    the FIRST ``value`` entry names), reported as a redirect."""
+def test_ambiguous_legacy_alias_is_refused_with_the_minted_names(graph):
+    """``143.value`` — the legacy tuple's own widget name — is an alias for
+    the input the repair mints. Two primitives share it here, so guessing it
+    is refused with both real addresses instead of silently picking one;
+    with one entry left the alias redirects."""
     wf = _load(RECOMPOSER)
+    before = _stripped(wf)
+    with pytest.raises(ValueError) as e:
+        workflow_ops.set_widget(wf, graph, 143, "value", "1K")
+    assert "143.resolution" in str(e.value) and "143.aspect_ratio" in str(e.value)
+    assert _stripped(wf) == before
+    inst = _node(wf, 143)
+    inst["properties"]["proxyWidgets"] = [x for x in inst["properties"]["proxyWidgets"] if x != ["142", "value"]]
     wf, op = workflow_ops.set_widget(wf, graph, 143, "value", "1K")
     assert op["widget"] == "resolution" and op["redirected_from"] == "143.value"
+
+
+def test_interior_address_owned_by_a_legacy_entry_is_redirected_even_when_link_fed(graph):
+    """``143/135.choice`` fed by interior node 2: with no legacy entry naming
+    it the widget write is refused (the link supplies the value). With the
+    legacy entry, the frontend's own migration replaces that link with the
+    boundary link on load, so the host value is what will run — the write is
+    redirected there and the feeder link is dropped, as the frontend drops it."""
+    wf = _load(RECOMPOSER)
+    sg = _def_of(wf, _node(wf, 143))
+    sg["links"].append(
+        {"id": 999001, "origin_id": 2, "origin_slot": 0, "target_id": 135, "target_slot": 0, "type": "STRING"}
+    )
+    _interior(wf, 143, 135)["inputs"][0]["link"] = 999001
+    _interior(wf, 143, 2)["outputs"][0]["links"].append(999001)
+    unowned = copy.deepcopy(wf)
+    _node(unowned, 143)["properties"]["proxyWidgets"] = [["156", "value"], ["142", "value"]]
+    with pytest.raises(ValueError, match="fed by interior node 143/2"):
+        promoted.resolve_write(unowned, graph, ["143", "135"], "choice")
+    target = promoted.resolve_write(wf, graph, ["143", "135"], "choice")
+    assert target.kind == "host" and target.widget == "choice" and target.redirected_from == "143/135.choice"
+    assert target.repair is not None and target.repair.original == ["135", "choice"]
+    # (``choice`` is a COMBO the catalog lists no options for, so the write
+    # itself is refused by validation; the flush that drops the feeder link is
+    # pinned in tests/comfy_cli/cql/test_proxy_migration.py.)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
+++ b/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
@@ -1,0 +1,318 @@
+"""``set-widget`` / ``set-slot`` on a legacy ``proxyWidgets`` promotion the
+subgraph definition does NOT back with a linked input.
+
+Before: the write followed ``proxyWidgets`` into the interior node — an edit
+under layer 2 that the frontend's load-time migration then re-seeds the host
+from (so it *appeared* to work) but that diverged from every other promoted
+write and left no host value for ``comfy run`` to submit.
+
+After: the write first performs the frontend's forward migration on that
+instance (``cql.promoted.flush_proxy_migration`` — a port of
+``flushProxyWidgetMigration``), turning the legacy entry into a linked
+subgraph input, and then writes the HOST value like any other promoted widget.
+The op carries the deterministic ids the repair minted, so replaying it on
+another replica produces a byte-identical document.
+
+Fixtures are verbatim gallery templates — see ``tests/comfy_cli/cql/test_proxy_migration.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph, _deterministic_fork_id
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+from comfy_cli.workflow_to_api import convert_ui_to_api
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_legacy_proxy.json"
+
+RECOMPOSER = "templates_graphic_design_recomposer.json"
+EXTENSION = "template_horizontal_vertical_extension.json"
+FLUX = "flux_dev_checkpoint_example.json"
+FLUX_SEED = 53943644181156
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _node(wf: dict, node_id: Any) -> dict:
+    return next(n for n in wf["nodes"] if str(n["id"]) == str(node_id))
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+def _interior(wf: dict, instance_id: Any, inner_id: Any) -> dict:
+    sg = _def_of(wf, _node(wf, instance_id))
+    return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
+
+
+def _stripped(wf: dict) -> str:
+    w = copy.deepcopy(wf)
+    w.pop("_applied_ops", None)
+    w.pop("_widget_stamps", None)
+    return json.dumps(w, sort_keys=True)
+
+
+# --------------------------------------------------------------------------- #
+# the write lands on the host, after repairing the definition
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_write_repairs_the_definition_and_writes_the_host(graph):
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    inst = _node(wf, 56)
+    sg = _def_of(wf, inst)
+    assert [i["name"] for i in sg["inputs"]][-1] == "seed"
+    assert inst["widgets_values"][-1] == 5
+    assert _interior(wf, 56, 52)["widgets_values"][0] == FLUX_SEED  # interior is only the default
+    assert "proxyWidgets" not in inst["properties"]
+    assert "path" not in op
+    assert op["node_id"] == 56 and op["widget"] == "seed"
+    assert op["old"] == FLUX_SEED
+    assert op["promoted"]["value_index"] == 7
+    assert op["promoted"]["host_widgets_values"][-1] == 5
+    repair = op["promoted"]["repair"]
+    assert repair["entry"] == ["52", "seed"]
+    assert repair["ids"] == {"52.seed": promoted.repair_ids(["56"], "52", "seed", 1)}
+    assert repair["ids"]["52.seed"]["links"][0] == sg["inputs"][-1]["linkIds"][0]
+
+
+def test_interior_address_of_a_legacy_promotion_is_redirected_to_the_host(graph):
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, "56/52", "seed", 5)
+    assert op["node_id"] == 56 and op["widget"] == "seed"
+    assert op["redirected_from"] == "56/52.seed"
+    assert _node(wf, 56)["widgets_values"][-1] == 5
+    assert _interior(wf, 56, 52)["widgets_values"][0] == FLUX_SEED
+
+
+def test_flat_and_interior_forms_share_one_write_target(graph):
+    wf = _load(FLUX)
+    _, flat = workflow_ops.set_widget(copy.deepcopy(wf), graph, 56, "seed", 1)
+    _, nested = workflow_ops.set_widget(copy.deepcopy(wf), graph, "56/52", "seed", 2)
+    assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested) == ("widget", "56", "seed")
+    assert workflow_ops.detect_conflict(flat, nested) is True
+
+
+def test_unrepairable_legacy_entry_still_writes_the_interior_and_leaves_the_document_alone(graph):
+    """``control_after_generate`` has no backing input slot: the frontend
+    quarantines it and the interior widget stays the live one, so the write
+    lands there and no repair is triggered."""
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "control_after_generate", "fixed")
+    assert op["path"] == ["56", "52"] and op["inner_widget"] == "control_after_generate"
+    assert _interior(wf, 56, 52)["widgets_values"][1] == "fixed"
+    inst = _node(wf, 56)
+    assert len(inst["properties"]["proxyWidgets"]) == 9
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+
+
+def test_repair_quarantines_the_unrepairable_sibling_entries(graph):
+    wf = _load(FLUX)
+    wf, _ = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _node(wf, 56)["properties"]["proxyWidgetErrorQuarantine"] == [
+        {"originalEntry": ["52", "control_after_generate"], "reason": "missingSubgraphInput", "attemptedAtVersion": 1}
+    ]
+
+
+def test_type_mismatch_is_refused_before_any_repair(graph):
+    wf = _load(FLUX)
+    before = _stripped(wf)
+    with pytest.raises(ValueError):
+        workflow_ops.set_widget(wf, graph, 56, "seed", "notanumber")
+    assert _stripped(wf) == before
+
+
+def test_primitive_fanout_write_lands_on_the_host_and_previews_stay(graph):
+    wf = _load(RECOMPOSER)
+    wf, op = workflow_ops.set_widget(wf, graph, 143, "resolution", "1K")
+    inst = _node(wf, 143)
+    assert op["widget"] == "resolution" and op["old"] == "2K"
+    assert op["promoted"]["repair"]["entry"] == ["156", "value"]
+    assert inst["widgets_values"] == ["Nano Banana 2", "1K", "16:9"]
+    assert _interior(wf, 143, 156)["widgets_values"][0] == "2K"  # the primitive is inert, untouched
+
+    wf = _load(EXTENSION)
+    wf, op = workflow_ops.set_widget(wf, graph, 252, "aspect_ratio", "1:1 (Square)")
+    inst = _node(wf, 252)
+    assert inst["widgets_values"] == ["1:1 (Square)"]
+    assert [e[1] for e in inst["properties"]["proxyWidgets"]] == ["$$canvas-image-preview"] * 3
+
+
+def test_legacy_source_widget_name_addresses_a_primitive_repair_too(graph):
+    """``143.value`` — the legacy tuple's own widget name — is accepted as an
+    alias for the input the repair mints (``resolution`` here is the primitive
+    the FIRST ``value`` entry names), reported as a redirect."""
+    wf = _load(RECOMPOSER)
+    wf, op = workflow_ops.set_widget(wf, graph, 143, "value", "1K")
+    assert op["widget"] == "resolution" and op["redirected_from"] == "143.value"
+
+
+# --------------------------------------------------------------------------- #
+# replay: deterministic on another replica; shared definitions are forked
+# --------------------------------------------------------------------------- #
+
+
+def test_repair_op_replays_to_a_byte_identical_document(graph):
+    for name, node_id, widget, value in ((FLUX, 56, "seed", 5), (RECOMPOSER, 143, "aspect_ratio", "1:1")):
+        base = _load(name)
+        applied, op = workflow_ops.set_widget(copy.deepcopy(base), graph, node_id, widget, value)
+        replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+        assert _stripped(replayed) == _stripped(applied)
+        # idempotent: a second delivery is a no-op
+        assert _stripped(workflow_ops.apply_op(replayed, op, graph)) == _stripped(applied)
+
+
+def test_concurrent_repairs_of_one_instance_converge(graph):
+    base = _load(RECOMPOSER)
+    _, a = workflow_ops.set_widget(copy.deepcopy(base), graph, 143, "resolution", "1K", actor="a")
+    _, b = workflow_ops.set_widget(copy.deepcopy(base), graph, 143, "aspect_ratio", "1:1", actor="b")
+    ab = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), a, graph), b, graph)
+    ba = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), b, graph), a, graph)
+    assert _stripped(ab) == _stripped(ba)
+    assert _node(ab, 143)["widgets_values"] == ["Nano Banana 2", "1K", "1:1"]
+
+
+def test_shared_definition_is_forked_not_mutated(graph):
+    wf = _load(FLUX)
+    sibling = copy.deepcopy(_node(wf, 56))
+    sibling["id"] = 156
+    wf["nodes"].append(sibling)
+    original_def_id = sibling["type"]
+    original_def = copy.deepcopy(_def_of(wf, sibling))
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _node(wf, 56)["type"] == _deterministic_fork_id(original_def_id, 56)
+    assert _node(wf, 156)["type"] == original_def_id
+    assert _def_of(wf, _node(wf, 156)) == original_def
+    assert _node(wf, 156)["properties"]["proxyWidgets"] == sibling["properties"]["proxyWidgets"]
+    assert [i["name"] for i in _def_of(wf, _node(wf, 56))["inputs"]][-1] == "seed"
+    # the sibling repairs independently: it now owns the original definition
+    # alone, so that one is repaired in place and the fork stays as it was
+    forked = copy.deepcopy(_def_of(wf, _node(wf, 56)))
+    wf, _ = workflow_ops.set_widget(wf, graph, 156, "seed", 6)
+    assert _node(wf, 156)["type"] == original_def_id
+    assert [i["name"] for i in _def_of(wf, _node(wf, 156))["inputs"]][-1] == "seed"
+    assert _def_of(wf, _node(wf, 56)) == forked
+    assert _node(wf, 56)["widgets_values"][-1] == 5 and _node(wf, 156)["widgets_values"][-1] == 6
+
+
+# --------------------------------------------------------------------------- #
+# the converter runs the host value
+# --------------------------------------------------------------------------- #
+
+
+def _api(wf: dict) -> dict:
+    return convert_ui_to_api(wf, json.loads(OBJECT_INFO.read_text()))
+
+
+def test_converter_emits_the_host_value_after_repair(graph):
+    wf = _load(FLUX)
+    assert _api(wf)["56:52"]["inputs"]["seed"] == FLUX_SEED
+    wf, _ = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _api(wf)["56:52"]["inputs"]["seed"] == 5
+
+
+def test_converter_applies_a_fanned_out_host_value_to_every_target(graph):
+    wf = _load(RECOMPOSER)
+    wf, _ = workflow_ops.set_widget(wf, graph, 143, "aspect_ratio", "1:1")
+    api = _api(wf)
+    assert api["143:130"]["inputs"]["aspect_ratio"] == "1:1"
+    assert api["143:157"]["inputs"]["model.aspect_ratio"] == "1:1"
+
+
+# --------------------------------------------------------------------------- #
+# reads: slots advertise the promotion at the host, before any repair
+# --------------------------------------------------------------------------- #
+
+
+def test_slots_advertise_a_legacy_promotion_at_the_host_address(graph):
+    wf = _load(FLUX)
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["56.seed"]["current_value"] == FLUX_SEED
+    assert slots["56.seed"]["type"] == "INT"
+    assert "56/52.seed" not in slots  # layer 2: the surface value wins
+    assert "56/52.cfg" in slots  # unpromoted interior widgets stay reachable
+    assert "56.control_after_generate" not in slots  # quarantined: never a host widget
+
+
+def test_slots_advertise_primitive_fanouts_under_their_planned_name(graph):
+    wf = _load(RECOMPOSER)
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["143.resolution"]["current_value"] == "2K"
+    assert slots["143.aspect_ratio"]["current_value"] == "16:9"
+    assert slots["143.choice"]["current_value"] == "Nano Banana 2"
+    assert "143/130.resolution" not in slots and "143/157.model.resolution" not in slots
+
+
+def test_set_slot_path_repairs_like_set_widget(graph):
+    via_op, _ = workflow_ops.set_widget(_load(FLUX), graph, 56, "seed", 5)
+    via_slot, warnings = graph.apply_slots(_load(FLUX), {"56.seed": 5})
+    assert warnings == []
+    assert _stripped(via_slot) == _stripped(via_op)
+
+
+def test_effective_value_reads_an_unrepaired_legacy_promotion(graph):
+    wf = _load(FLUX)
+    assert promoted.effective_value(wf, _node(wf, 56), "seed", graph) == FLUX_SEED
+    with pytest.raises(ValueError):
+        promoted.effective_value(wf, _node(wf, 56), "control_after_generate", graph)
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(workflow_cmd.app, args, standalone_mode=False)
+    out = capsys.readouterr().out
+    if not out.strip():
+        out = result.stdout or ""
+    for line in reversed([ln for ln in out.strip().splitlines() if ln.strip()]):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={out[:600]})")
+
+
+def test_cli_set_widget_repairs_then_slots_show_the_host_value(tmp_path, capsys):
+    path = tmp_path / "flux.json"
+    path.write_text(json.dumps(_load(FLUX)))
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    before = {s["address"]: s for s in env["data"]["slots"]}
+    assert before["56.seed"]["current_value"] == FLUX_SEED
+    env = _run(["set-widget", str(path), "56.seed", "5", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    assert env["data"]["op"]["promoted"]["repair"]["entry"] == ["52", "seed"]
+    saved = json.loads(path.read_text())
+    assert "proxyWidgets" not in _node(saved, 56)["properties"]
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    after = {s["address"]: s for s in env["data"]["slots"]}
+    assert after["56.seed"]["current_value"] == 5

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -673,10 +673,17 @@ class TestSlotsNestedSubgraph:
         env = _run(["slots", str(path)], capsys)
         assert env["ok"] is True
         by_addr = {s["address"]: s for s in env["data"]["slots"]}
-        # The editable inner prompt + seed of the Gemini node inside instance 10.
+        # The editable inner prompt of the Gemini node inside instance 10.
         assert "10/9.prompt" in by_addr, f"missing nested prompt slot; got {sorted(by_addr)[:20]}"
-        assert "10/9.seed" in by_addr
-        assert by_addr["10/9.seed"]["current_value"] == 1
+        # Its ``seed`` is promoted by a legacy ``proxyWidgets`` entry
+        # (``['9','seed']``) the definition does not back with a linked input
+        # yet. The frontend repairs that into a host widget on load, so the
+        # slot is advertised where the frontend shows it — ``10.seed``, with
+        # the interior value as its current one — and the interior address is
+        # the "layer 2" the host overrides (see cql.promoted, forward migration).
+        assert "10.seed" in by_addr
+        assert by_addr["10.seed"]["current_value"] == 1
+        assert "10/9.seed" not in by_addr
 
     def test_nested_addresses_are_instance_scoped(self, patched_subgraph_graph, tmp_path, capsys):
         """Two instances of same-named ('New Subgraph') but DIFFERENT defs must
@@ -684,8 +691,8 @@ class TestSlotsNestedSubgraph:
         path = _write_workflow(tmp_path, _subgraph_workflow())
         env = _run(["slots", str(path)], capsys)
         by_addr = {s["address"]: s for s in env["data"]["slots"]}
-        assert by_addr["10/9.seed"]["current_value"] == 1
-        assert by_addr["19/9.seed"]["current_value"] == 2
+        assert by_addr["10.seed"]["current_value"] == 1
+        assert by_addr["19.seed"]["current_value"] == 2
 
     def test_slots_recurses_into_doubly_nested_subgraph(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -730,13 +737,28 @@ class TestSetSlotNestedSubgraph:
         assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_nested_does_not_touch_sibling_instance(self, patched_subgraph_graph, tmp_path, capsys):
+        """``10/9.seed`` is the interior widget a legacy ``proxyWidgets`` entry
+        promotes: the write repairs instance 10's definition the way the
+        frontend's load-time migration does (a linked ``seed`` input) and
+        lands on the HOST, leaving the interior widget as the default.
+        Before the repair semantics this wrote the interior widget — a value
+        the frontend's own migration would then re-seed the host from."""
         path = _write_workflow(tmp_path, _subgraph_workflow())
-        _run(["set-slot", str(path), "10/9.seed=777"], capsys)
+        env = _run(["set-slot", str(path), "10/9.seed=777"], capsys)
+        assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        # seed is widget index 2 (index 3 is control_after_generate).
-        assert _interior_node(wf, D33, 9)["widgets_values"][2] == 777
-        # The other instance's def must be untouched.
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        d33 = next(s for s in wf["definitions"]["subgraphs"] if s["id"] == D33)
+        assert [i["name"] for i in d33["inputs"]] == ["value", "images.image0", "aspect_ratio", "seed"]
+        assert host["widgets_values"][-1] == 777
+        assert _interior_node(wf, D33, 9)["widgets_values"][2] == 1  # interior default untouched
+        # the legacy route is consumed; its unrepairable ``-1`` entries are quarantined
+        assert "proxyWidgets" not in host["properties"]
+        assert [q["reason"] for q in host["properties"]["proxyWidgetErrorQuarantine"]] == ["missingSourceNode"] * 2
+        # The other instance (a different def) must be untouched.
         assert _interior_node(wf, F22, 9)["widgets_values"][2] == 2
+        sibling = next(n for n in wf["nodes"] if n["id"] == 19)
+        assert sibling["properties"]["proxyWidgets"] == [["-1", "value"], ["-1", "aspect_ratio"], ["9", "seed"]]
 
     def test_set_slot_doubly_nested(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -410,6 +410,77 @@ def test_flush_ignores_a_malformed_link_entry(graph):
     assert json.dumps(wf, sort_keys=True) == json.dumps(clean, sort_keys=True)
 
 
+def _wire_interior_feeder_into_choice(sg: dict, link_id: int = 999001) -> None:
+    """Feed CustomCombo 135's ``choice`` slot from interior node 2
+    (PrimitiveStringMultiline) — the shape ``resolve_write`` refuses to
+    widget-write when no legacy entry names the slot."""
+    sg["links"].append(
+        {"id": link_id, "origin_id": 2, "origin_slot": 0, "target_id": 135, "target_slot": 0, "type": "STRING"}
+    )
+    _inner(sg, 135)["inputs"][0]["link"] = link_id
+    _inner(sg, 2)["outputs"][0]["links"].append(link_id)
+
+
+def test_flush_replaces_an_interior_link_feeding_the_source_slot(graph):
+    """A legacy entry whose backing slot is already fed by an interior link is
+    still repaired, and the boundary link REPLACES that link — exactly what
+    the frontend does: ``repairCreateSubgraphInput`` calls
+    ``SubgraphInput.connect(slot, node)`` unconditionally, and ``connect``
+    resolves ``inputLink(...)`` for the slot, ``replaceLinkTopology``s it and
+    ``_disconnectNodeInput``s the incumbent (``SubgraphInput.ts``). After the
+    frontend loads such a file the interior feeder is gone and the host value
+    runs, so this is the state a write has to target."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    _wire_interior_feeder_into_choice(sg)
+    assert _plans(wf, 143, graph)[("135", "choice")].plan == "createSubgraphInput"
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    boundary = ids["135.choice"]["links"][0]
+    assert _link(sg, 999001) is None
+    assert _inner(sg, 2)["outputs"][0]["links"] == [211, 247]
+    assert _inner(sg, 135)["inputs"][0]["link"] == boundary
+    assert _link(sg, boundary)["origin_id"] == -10
+    assert inst["widgets_values"][0] == "Nano Banana 2"
+
+
+def test_flush_reuses_a_slot_serialized_by_name_only(graph):
+    """An older save can serialize a widget's input slot with ``name`` but no
+    ``widget`` marker: that slot is the backing slot (matched by name), gets
+    its marker back, and is never duplicated."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    del _inner(sg, 135)["inputs"][0]["widget"]
+    entry = _plans(wf, 143, graph)[("135", "choice")]
+    assert entry.plan == "createSubgraphInput" and entry.slot_index == 0 and entry.label == "model"
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    assert _inner(sg, 135)["inputs"] == [
+        {
+            "label": "model",
+            "localized_name": "choice",
+            "name": "choice",
+            "type": "COMBO",
+            "widget": {"name": "choice"},
+            "link": ids["135.choice"]["links"][0],
+        }
+    ]
+    assert next(i for i in sg["inputs"] if i["name"] == "choice")["label"] == "model"
+
+
+def test_planned_repair_refuses_an_ambiguous_legacy_alias(graph):
+    """Two entries share the legacy widget name ``value`` (both primitives):
+    the alias is refused with the minted names, never resolved to one of them."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    with pytest.raises(ValueError, match=r"143\.resolution.*143\.aspect_ratio"):
+        promoted.planned_repair(wf, inst, graph, "value")
+    inst["properties"]["proxyWidgets"] = [e for e in inst["properties"]["proxyWidgets"] if e != ["142", "value"]]
+    assert promoted.planned_repair(wf, inst, graph, "value").name == "resolution"
+
+
 def test_flush_leaves_preview_exposures_in_place(graph):
     """``$$`` entries are display-only: no input, no value, and the entry stays
     in ``proxyWidgets`` for the frontend's own preview-exposure migration

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -1,0 +1,407 @@
+"""Legacy ``properties.proxyWidgets`` → linked-input repair: a port of the
+frontend's forward migration (``proxyWidgetMigration.ts``, ADR 0009).
+
+The frontend runs ``flushProxyWidgetMigration`` on every subgraph host at load
+time. The CLI runs the same flush on the instance whose legacy promotion a
+write is about to edit, so the write can land on the HOST value the way it
+does for every other promoted widget. These tests pin the port against real
+gallery templates (``tests/comfy_cli/fixtures/gallery``):
+
+* ``templates_graphic_design_recomposer.json`` — instance 143: a value widget
+  with a labelled backing slot (``['135','choice']``) plus two ``PrimitiveNode``
+  fan-outs (``['156','value']`` → two targets, ``['142','value']`` → two
+  targets), both primitives renamed by the user.
+* ``template_horizontal_vertical_extension.json`` — instance 252: three
+  ``$$canvas-image-preview`` exposures plus a value widget whose interior node
+  serializes no ``inputs[]`` at all (``['285','aspect_ratio']``).
+* ``flux_dev_checkpoint_example.json`` — instance 56: seven entries already
+  backed by linked inputs, ``['52','seed']`` repairable, and
+  ``['52','control_after_generate']`` — a frontend-only widget with no backing
+  input slot, which the frontend quarantines.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_legacy_proxy.json"
+
+RECOMPOSER = "templates_graphic_design_recomposer.json"
+EXTENSION = "template_horizontal_vertical_extension.json"
+FLUX = "flux_dev_checkpoint_example.json"
+
+FLUX_SEED = 53943644181156
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _instance(wf: dict, node_id: int) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+def _inner(sg: dict, node_id: int) -> dict:
+    return next(n for n in sg["nodes"] if n["id"] == node_id)
+
+
+def _link(sg: dict, link_id) -> dict | None:
+    return next((x for x in sg["links"] if x["id"] == link_id), None)
+
+
+def _plans(wf: dict, instance_id: int, graph) -> dict[tuple, promoted.LegacyEntry]:
+    return {tuple(e.original): e for e in promoted.plan_proxy_migration(wf, _instance(wf, instance_id), graph)}
+
+
+# --------------------------------------------------------------------------- #
+# nextUniqueName — the frontend's collision rule, ported verbatim
+# --------------------------------------------------------------------------- #
+
+
+def test_next_unique_name_appends_underscore_counter():
+    assert promoted.next_unique_name("seed", []) == "seed"
+    assert promoted.next_unique_name("seed", ["seed"]) == "seed_1"
+    assert promoted.next_unique_name("seed", ["seed", "seed_1"]) == "seed_2"
+    # the counter restarts from the BASE name, never from an existing suffix
+    assert promoted.next_unique_name("seed", ["seed", "seed_2"]) == "seed_1"
+
+
+# --------------------------------------------------------------------------- #
+# classification (``classify`` in the frontend)
+# --------------------------------------------------------------------------- #
+
+
+def test_flux_plan_classifies_linked_repairable_and_unrepairable(graph):
+    wf = _load(FLUX)
+    plans = _plans(wf, 56, graph)
+    linked = [e for e in plans.values() if e.plan == "alreadyLinked"]
+    assert [e.name for e in linked] == ["text", "width", "height", "unet_name", "clip_name1", "clip_name2", "vae_name"]
+    seed = plans[("52", "seed")]
+    assert seed.plan == "createSubgraphInput"
+    assert seed.name == "seed"
+    assert seed.type == "INT"
+    assert seed.host_value is promoted.UNSET  # widgets_values is [] — a hole
+    cag = plans[("52", "control_after_generate")]
+    assert cag.plan == "quarantine"
+    assert cag.reason == "missingSubgraphInput"  # a widget with no backing input slot
+
+
+def test_recomposer_plan_repairs_primitive_fanouts_under_the_user_title(graph):
+    wf = _load(RECOMPOSER)
+    plans = _plans(wf, 143, graph)
+    choice = plans[("135", "choice")]
+    assert choice.plan == "createSubgraphInput" and choice.name == "choice" and choice.type == "COMBO"
+    resolution = plans[("156", "value")]
+    assert resolution.plan == "primitiveBypass"
+    assert resolution.name == "resolution"  # the primitive's user title, not its widget name
+    assert resolution.type == "COMBO"
+    assert resolution.targets == [("130", 4), ("157", 2)]
+    aspect = plans[("142", "value")]
+    assert aspect.plan == "primitiveBypass" and aspect.name == "aspect_ratio"
+    assert aspect.targets == [("130", 3), ("157", 1)]
+
+
+def test_extension_plan_keeps_previews_out_of_the_value_path(graph):
+    wf = _load(EXTENSION)
+    plans = _plans(wf, 252, graph)
+    previews = [e for e in plans.values() if e.plan == "previewExposure"]
+    assert [tuple(e.original) for e in previews] == [
+        ("233", "$$canvas-image-preview"),
+        ("232", "$$canvas-image-preview"),
+        ("234", "$$canvas-image-preview"),
+    ]
+    aspect = plans[("285", "aspect_ratio")]
+    assert aspect.plan == "createSubgraphInput" and aspect.type == "COMBO"
+
+
+def test_plan_quarantines_missing_node_missing_widget_and_host_self_reference(graph):
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["properties"]["proxyWidgets"] = [["999", "seed"], ["52", "nope"], ["-1", "width"]]
+    inst["widgets_values"] = [1, 2, 640]
+    plans = _plans(wf, 56, graph)
+    assert plans[("999", "seed")].plan == "quarantine" and plans[("999", "seed")].reason == "missingSourceNode"
+    assert plans[("52", "nope")].reason == "missingSourceWidget"
+    # ``-1`` names the host itself: no interior node has that id, so the
+    # frontend quarantines it too — but its host value is preserved.
+    minus_one = plans[("-1", "width")]
+    assert minus_one.reason == "missingSourceNode"
+    assert minus_one.host_value == 640
+
+
+def test_plan_quarantines_a_primitive_cohort_with_mixed_widget_names(graph):
+    """``['156','value']`` + ``['156','control_after_generate']`` name ONE
+    primitive with two widgets: the frontend's cohort validation fails and
+    every entry of the cohort is quarantined (all-or-quarantine)."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    inst["properties"]["proxyWidgets"].append(["156", "control_after_generate"])
+    plans = _plans(wf, 143, graph)
+    assert plans[("156", "value")].plan == "quarantine"
+    assert plans[("156", "value")].reason == "primitiveBypassFailed"
+    assert plans[("156", "control_after_generate")].reason == "primitiveBypassFailed"
+    # the other primitive is unaffected
+    assert plans[("142", "value")].plan == "primitiveBypass"
+
+
+def test_plan_quarantines_a_primitive_with_no_fanout(graph):
+    wf = _load(RECOMPOSER)
+    sg = _def_of(wf, _instance(wf, 143))
+    sg["links"] = [x for x in sg["links"] if x["origin_id"] != 156]
+    _inner(sg, 156)["outputs"][0]["links"] = []
+    assert _plans(wf, 143, graph)[("156", "value")].reason == "unlinkedSourceWidget"
+
+
+def test_plan_uses_a_unique_name_when_the_widget_name_is_taken(graph):
+    wf = _load(FLUX)
+    sg = _def_of(wf, _instance(wf, 56))
+    sg["inputs"].append({"id": "x", "name": "seed", "type": "INT", "linkIds": []})
+    assert _plans(wf, 56, graph)[("52", "seed")].name == "seed_1"
+
+
+# --------------------------------------------------------------------------- #
+# flush: the structural repair
+# --------------------------------------------------------------------------- #
+
+
+def test_flush_creates_the_input_the_boundary_link_and_the_host_value(graph):
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    sg = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["56"], promoted.plan_proxy_migration(wf, inst, graph))
+    report = promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+
+    assert report.created == ["seed"]
+    new_input = sg["inputs"][-1]
+    link_id = ids["52.seed"]["links"][0]
+    assert new_input == {"id": ids["52.seed"]["input"], "name": "seed", "type": "INT", "linkIds": [link_id]}
+    assert _link(sg, link_id) == {
+        "id": link_id,
+        "origin_id": -10,
+        "origin_slot": 7,
+        "target_id": 52,
+        "target_slot": 4,
+        "type": "INT",
+    }
+    # the interior input entry is created the way the frontend serializes a
+    # converted widget (flux_dev_checkpoint_example.json node 50 ``width``)
+    ksampler = _inner(sg, 52)
+    assert ksampler["inputs"][4] == {
+        "localized_name": "seed",
+        "name": "seed",
+        "type": "INT",
+        "widget": {"name": "seed"},
+        "link": link_id,
+    }
+    assert ksampler["widgets_values"][0] == FLUX_SEED  # interior untouched
+    assert sg["state"]["lastLinkId"] >= link_id
+    # host: the instance carries the value, materialized in subgraph-input order
+    pis = promoted.promoted_inputs(sg, promoted.defs_by_id(wf))
+    assert [p.name for p in pis if p.is_widget][-1] == "seed"
+    assert inst["widgets_values"][-1] == FLUX_SEED
+    assert inst["inputs"][-1] == {"name": "seed", "type": "INT", "widget": {"name": "seed"}, "link": None}
+    # consumed: canonical saves do not re-emit repaired entries
+    assert "proxyWidgets" not in inst["properties"]
+    assert inst["properties"]["proxyWidgetErrorQuarantine"] == [
+        {"originalEntry": ["52", "control_after_generate"], "reason": "missingSubgraphInput", "attemptedAtVersion": 1}
+    ]
+
+
+def test_flush_reads_legacy_host_values_by_proxy_position(graph):
+    """A pre-migration save stores host values positionally by ``proxyWidgets``
+    order (``pickHostValue``): those win over the interior defaults, for
+    already-linked and freshly created inputs alike."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    # proxy order: text, width, height, unet_name, clip_name1, clip_name2, vae_name, seed, c_a_g
+    inst["widgets_values"] = [None, 640]
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    by_name = {p.name: p for p in promoted.promoted_inputs(sg, promoted.defs_by_id(wf))}
+    assert promoted.host_value(inst, by_name["width"]) == 640
+    assert promoted.host_value(inst, by_name["text"]) is None  # an explicit null is a value, not a hole
+    assert promoted.host_value(inst, by_name["height"]) == 1024  # hole → interior default
+    assert promoted.host_value(inst, by_name["seed"]) == FLUX_SEED  # hole → seeded from the source widget
+
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["widgets_values"] = [None] * 7 + [777]
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    by_name = {p.name: p for p in promoted.promoted_inputs(sg, promoted.defs_by_id(wf))}
+    assert promoted.host_value(inst, by_name["seed"]) == 777  # a legacy host value beats the interior
+
+
+def test_flush_preserves_the_source_slot_label(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    choice = next(i for i in sg["inputs"] if i["name"] == "choice")
+    assert choice["label"] == "model"
+    assert promoted.instance_input(inst, "choice")["label"] == "model"
+
+
+def test_flush_synthesizes_the_interior_input_entry_when_none_is_serialized(graph):
+    wf = _load(EXTENSION)
+    inst = _instance(wf, 252)
+    sg = _def_of(wf, inst)
+    assert _inner(sg, 285).get("inputs") == []
+    ids = promoted.plan_repair_ids(["252"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    link_id = ids["285.aspect_ratio"]["links"][0]
+    assert _inner(sg, 285)["inputs"] == [
+        {
+            "localized_name": "aspect_ratio",
+            "name": "aspect_ratio",
+            "type": "COMBO",
+            "widget": {"name": "aspect_ratio"},
+            "link": link_id,
+        }
+    ]
+    assert _link(sg, link_id)["target_slot"] == 0
+    assert inst["widgets_values"] == ["9:16 (Portrait Widescreen)"]
+
+
+def test_flush_leaves_preview_exposures_in_place(graph):
+    """``$$`` entries are display-only: no input, no value, and the entry stays
+    in ``proxyWidgets`` for the frontend's own preview-exposure migration
+    (which also auto-exposes preview nodes when ``previewExposures`` is unset)."""
+    wf = _load(EXTENSION)
+    inst = _instance(wf, 252)
+    before = copy.deepcopy(inst["properties"]["proxyWidgets"])
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.remaining == before[:3]
+    assert inst["properties"]["proxyWidgets"] == before[:3]
+    assert "previewExposures" not in inst["properties"]
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+    assert [i["name"] for i in _def_of(wf, inst)["inputs"]] == ["image", "aspect_ratio"]
+
+
+def test_flush_bypasses_a_primitive_fanout_through_one_input(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    report = promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+
+    assert report.created == ["choice", "resolution", "aspect_ratio"]  # creates first, then primitive cohorts
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "resolution", "aspect_ratio"]
+    resolution = sg["inputs"][2]
+    links = ids["156.value"]["links"]
+    assert resolution == {"id": ids["156.value"]["input"], "name": "resolution", "type": "COMBO", "linkIds": links}
+    # former primitive links are gone; every target is reconnected in target order
+    assert _link(sg, 243) is None and _link(sg, 246) is None
+    assert _link(sg, links[0]) == {
+        "id": links[0],
+        "origin_id": -10,
+        "origin_slot": 2,
+        "target_id": 130,
+        "target_slot": 4,
+        "type": "COMBO",
+    }
+    assert _link(sg, links[1])["target_id"] == 157 and _link(sg, links[1])["target_slot"] == 2
+    assert _inner(sg, 130)["inputs"][4]["link"] == links[0]
+    assert _inner(sg, 157)["inputs"][2]["link"] == links[1]
+    # the primitive stays, disconnected and inert, marked with its bypass
+    primitive = _inner(sg, 156)
+    assert primitive["outputs"][0]["links"] == []
+    assert primitive["properties"]["proxyBypassedToSubgraphInput"] == "resolution"
+    assert primitive["widgets_values"] == ["2K", "fixed", ""]
+    # host values: seeded from the source widgets (the primitive's own value)
+    assert inst["widgets_values"] == ["Nano Banana 2", "2K", "16:9"]
+    assert "proxyWidgets" not in inst["properties"]
+
+
+def test_flush_repairs_creates_before_primitive_cohorts(graph):
+    """Entry order is the frontend's: value widgets first, primitive cohorts
+    after — so a value entry naming a primitive's own target takes that
+    target over (its link is replaced), the cohort is re-collected against
+    the mutated graph, and the primitive's input is named around the
+    collision (``resolution`` → ``resolution_1``)."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    inst["properties"]["proxyWidgets"].insert(1, ["130", "resolution"])
+    promoted.flush_proxy_migration(wf, inst, graph)
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "resolution", "resolution_1", "aspect_ratio"]
+    by_name = {i["name"]: i for i in sg["inputs"]}
+    assert _inner(sg, 130)["inputs"][4]["link"] == by_name["resolution"]["linkIds"][0]
+    assert [_link(sg, x)["target_id"] for x in by_name["resolution_1"]["linkIds"]] == [157]
+    assert _link(sg, 243) is None and _link(sg, 246) is None
+    assert inst["widgets_values"] == ["Nano Banana 2", "2K", "2K", "16:9"]
+
+
+def test_flush_coalesces_duplicate_primitive_entries(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    inst["properties"]["proxyWidgets"].append(["156", "value"])
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    assert [i["name"] for i in sg["inputs"]].count("resolution") == 1
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+
+
+def test_flush_quarantines_a_type_incompatible_primitive_target(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    _inner(sg, 157)["inputs"][2]["type"] = "STRING"
+    promoted.flush_proxy_migration(wf, inst, graph)
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "aspect_ratio"]
+    assert _link(sg, 243) is not None and _link(sg, 246) is not None  # untouched: all-or-quarantine
+    assert {tuple(q["originalEntry"]): q["reason"] for q in inst["properties"]["proxyWidgetErrorQuarantine"]} == {
+        ("156", "value"): "primitiveBypassFailed"
+    }
+
+
+def test_flush_is_idempotent_and_deterministic(graph):
+    wf = _load(RECOMPOSER)
+    a, b = copy.deepcopy(wf), copy.deepcopy(wf)
+    promoted.flush_proxy_migration(a, _instance(a, 143), graph)
+    promoted.flush_proxy_migration(b, _instance(b, 143), graph)
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+    once = json.dumps(a, sort_keys=True)
+    report = promoted.flush_proxy_migration(a, _instance(a, 143), graph)
+    assert report.created == [] and report.quarantined == []
+    assert json.dumps(a, sort_keys=True) == once
+
+
+def test_flush_consumes_an_entry_a_previous_repair_already_linked(graph):
+    """Replaying a repair against a document another replica already repaired
+    finds the entry ``alreadyLinked`` and changes nothing structural."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    promoted.flush_proxy_migration(wf, inst, graph)
+    inst["properties"]["proxyWidgets"] = [["52", "seed"]]
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.created == []
+    assert report.consumed == [["52", "seed"]]
+    assert [i["name"] for i in _def_of(wf, inst)["inputs"]].count("seed") == 1
+
+
+def test_repair_ids_are_stable_across_processes():
+    ids = promoted.repair_ids(["56"], "52", "seed", 1)
+    again = promoted.repair_ids(["56"], "52", "seed", 1)
+    assert ids == again
+    assert ids["links"][0] >= 1 << 40  # the op model's leaderless id range
+    assert promoted.repair_ids(["156"], "52", "seed", 1) != ids  # another instance, other ids
+    assert promoted.repair_ids(["56"], "52", "seed", 2)["links"][0] == ids["links"][0]

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -71,6 +71,67 @@ def _plans(wf: dict, instance_id: int, graph) -> dict[tuple, promoted.LegacyEntr
     return {tuple(e.original): e for e in promoted.plan_proxy_migration(wf, _instance(wf, instance_id), graph)}
 
 
+OUTER = "0f6b0a4e-outer-0000-0000-000000000001"
+INNER = "0f6b0a4e-inner-0000-0000-000000000002"
+
+
+def _nested_legacy_workflow(entries: list[list[str]]) -> dict:
+    """Synthetic: a legacy promotion whose SOURCE is a nested subgraph instance
+    (top 10 → OUTER's node 5, an INNER instance) and whose projecting input
+    (``prompt_text``) is named differently from the widget it projects
+    (CLIPTextEncode 27's ``text``). Node 5 serializes no ``inputs[]`` — the
+    older-save shape — so the repair must synthesize the slot. Node/link
+    shapes are copied from ``flux_dev_checkpoint_example.json``."""
+    return {
+        "last_node_id": 10,
+        "last_link_id": 0,
+        "nodes": [{"id": 10, "type": OUTER, "inputs": [], "outputs": [], "properties": {"proxyWidgets": entries}}],
+        "links": [],
+        "definitions": {
+            "subgraphs": [
+                {
+                    "id": OUTER,
+                    "name": "Outer",
+                    "state": {"lastGroupId": 0, "lastNodeId": 5, "lastLinkId": 0, "lastRerouteId": 0},
+                    "inputs": [],
+                    "outputs": [],
+                    "nodes": [{"id": 5, "type": INNER, "inputs": [], "outputs": [], "widgets_values": []}],
+                    "links": [],
+                },
+                {
+                    "id": INNER,
+                    "name": "Inner",
+                    "state": {"lastGroupId": 0, "lastNodeId": 27, "lastLinkId": 1, "lastRerouteId": 0},
+                    "inputs": [{"id": "i1", "name": "prompt_text", "type": "STRING", "linkIds": [1]}],
+                    "outputs": [],
+                    "nodes": [
+                        {
+                            "id": 27,
+                            "type": "CLIPTextEncode",
+                            "inputs": [
+                                {"name": "clip", "type": "CLIP", "link": None},
+                                {"name": "text", "type": "STRING", "widget": {"name": "text"}, "link": 1},
+                            ],
+                            "outputs": [{"name": "CONDITIONING", "type": "CONDITIONING", "links": []}],
+                            "widgets_values": ["hi"],
+                        }
+                    ],
+                    "links": [
+                        {
+                            "id": 1,
+                            "origin_id": -10,
+                            "origin_slot": 0,
+                            "target_id": 27,
+                            "target_slot": 1,
+                            "type": "STRING",
+                        }
+                    ],
+                },
+            ]
+        },
+    }
+
+
 # --------------------------------------------------------------------------- #
 # nextUniqueName — the frontend's collision rule, ported verbatim
 # --------------------------------------------------------------------------- #
@@ -177,6 +238,32 @@ def test_plan_uses_a_unique_name_when_the_widget_name_is_taken(graph):
     assert _plans(wf, 56, graph)[("52", "seed")].name == "seed_1"
 
 
+def test_plan_normalizes_a_node_prefixed_widget_name(graph):
+    """An older save could prefix the widget name with its node id
+    (``normalizeLegacyProxyWidgetEntry``): the prefix is stripped and kept as
+    the disambiguator; the repair claims the bare widget."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["properties"]["proxyWidgets"] = [["52", "52:seed"]]
+    entry = _plans(wf, 56, graph)[("52", "52:seed")]
+    assert entry.plan == "createSubgraphInput"
+    assert entry.widget == "seed"
+    assert entry.disambiguator == "52"
+    assert entry.name == "seed"
+    assert entry.key == "52.seed"
+
+
+def test_plan_resolves_a_nested_instance_source_by_disambiguator(graph):
+    """Through a nested instance the disambiguator must name the interior
+    node the projecting input lands on (``resolveSourceWidget``)."""
+    wf = _nested_legacy_workflow([["5", "27:text"], ["5", "99:text"]])
+    plans = _plans(wf, 10, graph)
+    hit = plans[("5", "27:text")]
+    assert hit.plan == "createSubgraphInput"
+    assert (hit.widget, hit.disambiguator, hit.source_input, hit.type) == ("text", "27", "prompt_text", "STRING")
+    assert plans[("5", "99:text")].reason == "missingSourceWidget"
+
+
 # --------------------------------------------------------------------------- #
 # flush: the structural repair
 # --------------------------------------------------------------------------- #
@@ -279,6 +366,48 @@ def test_flush_synthesizes_the_interior_input_entry_when_none_is_serialized(grap
     ]
     assert _link(sg, link_id)["target_slot"] == 0
     assert inst["widgets_values"] == ["9:16 (Portrait Widescreen)"]
+
+
+def test_flush_synthesizes_a_nested_instance_slot_under_its_projecting_input(graph):
+    """The slot a nested instance backs a promoted widget with is its own
+    host input — named after the PROJECTING INPUT, not the interior widget
+    (``getSlotFromWidget(promotedInputWidget(input))``). Only that name lets
+    the outer definition resolve the promotion through the inner one."""
+    wf = _nested_legacy_workflow([["5", "text"]])
+    inst = _instance(wf, 10)
+    outer = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["10"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    link_id = ids["5.text"]["links"][0]
+    assert _inner(outer, 5)["inputs"] == [
+        {"name": "prompt_text", "type": "STRING", "widget": {"name": "prompt_text"}, "link": link_id}
+    ]
+    assert _link(outer, link_id)["target_slot"] == 0
+    pis = promoted.promoted_inputs(outer, promoted.defs_by_id(wf))
+    assert [(p.name, p.value_index, p.nested, p.source_node, p.source_input) for p in pis] == [
+        ("text", 0, True, "5", "prompt_text")
+    ]
+    assert inst["widgets_values"] == ["hi"]
+    promoted.set_host_value(wf, inst, "text", "yo", graph)
+    assert promoted.effective_value(wf, inst, "text", graph) == "yo"
+    # the outer promotion resolves through the inner one to the concrete widget
+    assert promoted.deepest_source(outer, pis[0], promoted.defs_by_id(wf)) == (["5", "27"], "text")
+
+
+def test_flush_ignores_a_malformed_link_entry(graph):
+    """A stray non-dict among ``links`` is skipped like everywhere else in the
+    module, not stack-traced — the primitive repair scans links too."""
+    clean = _load(RECOMPOSER)
+    promoted.flush_proxy_migration(clean, _instance(clean, 143), graph)
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    sg["links"].insert(0, ["not", "a", "link"])
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.created == ["choice", "resolution", "aspect_ratio"]
+    assert sg["links"][0] == ["not", "a", "link"]
+    sg["links"].pop(0)
+    assert json.dumps(wf, sort_keys=True) == json.dumps(clean, sort_keys=True)
 
 
 def test_flush_leaves_preview_exposures_in_place(graph):

--- a/tests/comfy_cli/fixtures/gallery/README.md
+++ b/tests/comfy_cli/fixtures/gallery/README.md
@@ -11,7 +11,7 @@ Refresh with:
 
 ```bash
 cd tests/comfy_cli/fixtures/gallery
-for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend; do
+for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend templates_graphic_design_recomposer template_horizontal_vertical_extension flux_dev_checkpoint_example; do
   curl -sfL "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/${f}.json" -o "${f}.json"
 done
 ```
@@ -30,3 +30,18 @@ promoted-widget tests (`tests/comfy_cli/cql/test_promoted_inputs.py`,
 `tests/comfy_cli/test_workflow_to_api_promoted.py`); their node classes are
 covered by `../object_info_subgraph_promoted.json`, a trimmed copy of the
 cloud catalog entries (tooltips stripped, structure verbatim).
+
+`templates_graphic_design_recomposer.json` (two `PrimitiveNode` fan-outs and a
+labelled value widget promoted only through legacy `proxyWidgets`),
+`template_horizontal_vertical_extension.json` (three `$$canvas-image-preview`
+exposures plus a value widget whose interior node serializes no `inputs[]`)
+and `flux_dev_checkpoint_example.json` (seven linked promotions, one
+repairable `seed`, one unrepairable `control_after_generate`) back the
+legacy-proxy repair tests (`tests/comfy_cli/cql/test_proxy_migration.py`,
+`tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py`) — the port of the
+frontend's `proxyWidgetMigration.ts`. Their node classes are covered by
+`../object_info_legacy_proxy.json`, built the same way as
+`object_info_subgraph_promoted.json`: for every class the three templates use,
+the cloud catalog entry (`services/ingest/data/object_info.json`) verbatim with
+every `tooltip` key stripped; frontend-only classes (`MarkdownNote`, `Note`,
+`PrimitiveNode`) have no catalog entry and are omitted.

--- a/tests/comfy_cli/fixtures/gallery/flux_dev_checkpoint_example.json
+++ b/tests/comfy_cli/fixtures/gallery/flux_dev_checkpoint_example.json
@@ -1,0 +1,969 @@
+{
+  "id": "9879cb25-f885-4a02-ba58-5a5b8eda769a",
+  "revision": 0,
+  "last_node_id": 56,
+  "last_link_id": 76,
+  "nodes": [
+    {
+      "id": 40,
+      "type": "MarkdownNote",
+      "pos": [
+        -730,
+        630
+      ],
+      "size": [
+        540,
+        887.15625
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "For Local User",
+      "properties": {},
+      "widgets_values": [
+        "Guide: [Subgraph](https://docs.comfy.org/interface/features/subgraph)\n\n## Model links\n\n**text_encoders**\n\n- [clip_l.safetensors](https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors)\n- [t5xxl_fp16.safetensors](https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors)\n\n**diffusion_models**\n\n- [flux1-dev.safetensors](https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev.safetensors)\n\n**vae**\n\n- [ae.safetensors](https://huggingface.co/Comfy-Org/Lumina_Image_2.0_Repackaged/resolve/main/split_files/vae/ae.safetensors)\n\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 text_encoders/\n│   │      ├── clip_l.safetensors\n│   │      └── t5xxl_fp16.safetensors\n│   ├── 📂 diffusion_models/\n│   │      └── flux1-dev.safetensors\n│   └── 📂 vae/\n│          └── ae.safetensors\n```\n\n## Report issue\n\nNote: please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud will be updated after the stable release; nightly-supported models may not be included yet, please wait for the next stable release.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/Comfy-Org/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        460.000012246621,
+        629.9999713116897
+      ],
+      "size": [
+        630,
+        680
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 72
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.4.0",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "Flux.1_Dev"
+      ]
+    },
+    {
+      "id": 56,
+      "type": "e2a55522-bf16-4d9f-a222-5b8788ef2982",
+      "pos": [
+        -110.00000931000295,
+        630.0000115388268
+      ],
+      "size": [
+        510,
+        640
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            72
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "51",
+            "text"
+          ],
+          [
+            "50",
+            "width"
+          ],
+          [
+            "50",
+            "height"
+          ],
+          [
+            "48",
+            "unet_name"
+          ],
+          [
+            "49",
+            "clip_name1"
+          ],
+          [
+            "49",
+            "clip_name2"
+          ],
+          [
+            "47",
+            "vae_name"
+          ],
+          [
+            "52",
+            "seed"
+          ],
+          [
+            "52",
+            "control_after_generate"
+          ]
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      72,
+      56,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "e2a55522-bf16-4d9f-a222-5b8788ef2982",
+        "version": 1,
+        "state": {
+          "lastGroupId": 3,
+          "lastNodeId": 56,
+          "lastLinkId": 76,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Image (Flux.1 Dev)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1130,
+            410,
+            120,
+            180
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            760,
+            680,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "669e384e-5e26-4291-9bac-e1d1f04b4a16",
+            "name": "text",
+            "type": "STRING",
+            "linkIds": [
+              68
+            ],
+            "label": "prompt",
+            "pos": [
+              -1030,
+              430
+            ]
+          },
+          {
+            "id": "5a5c0b01-5836-4ca6-a24f-68c0a4fb9802",
+            "name": "width",
+            "type": "INT",
+            "linkIds": [
+              69
+            ],
+            "pos": [
+              -1030,
+              450
+            ]
+          },
+          {
+            "id": "5e01104a-ed7f-457b-aaee-934e8ecc088d",
+            "name": "height",
+            "type": "INT",
+            "linkIds": [
+              70
+            ],
+            "pos": [
+              -1030,
+              470
+            ]
+          },
+          {
+            "id": "61106c75-ce1d-46dc-94a8-7b6de0e930d2",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              73
+            ],
+            "pos": [
+              -1030,
+              490
+            ]
+          },
+          {
+            "id": "88aaaea3-31c1-47cd-ad83-2a9414a3122d",
+            "name": "clip_name1",
+            "type": "COMBO",
+            "linkIds": [
+              74
+            ],
+            "pos": [
+              -1030,
+              510
+            ]
+          },
+          {
+            "id": "323e0873-f219-4307-a95d-2c1b92e5b60c",
+            "name": "clip_name2",
+            "type": "COMBO",
+            "linkIds": [
+              75
+            ],
+            "pos": [
+              -1030,
+              530
+            ]
+          },
+          {
+            "id": "fbc1372b-943f-43a9-a772-020630f409ab",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              76
+            ],
+            "pos": [
+              -1030,
+              550
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "2185cb4d-8689-4cf8-b345-75319fb46a8e",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              9
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              780,
+              700
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 47,
+            "type": "VAELoader",
+            "pos": [
+              -780,
+              620
+            ],
+            "size": [
+              270,
+              108
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 76
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  58
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "ae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Lumina_Image_2.0_Repackaged/resolve/main/split_files/vae/ae.safetensors",
+                  "directory": "vae"
+                }
+              ]
+            },
+            "widgets_values": [
+              "ae.safetensors"
+            ]
+          },
+          {
+            "id": 48,
+            "type": "UNETLoader",
+            "pos": [
+              -780,
+              150
+            ],
+            "size": [
+              270,
+              108
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 73
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  61
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "flux1-dev.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ]
+            },
+            "widgets_values": [
+              "flux1-dev.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 49,
+            "type": "DualCLIPLoader",
+            "pos": [
+              -780,
+              350
+            ],
+            "size": [
+              270,
+              175.984375
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name1",
+                "name": "clip_name1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name1"
+                },
+                "link": 74
+              },
+              {
+                "localized_name": "clip_name2",
+                "name": "clip_name2",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name2"
+                },
+                "link": 75
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  64
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "DualCLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "clip_l.safetensors",
+                  "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors",
+                  "directory": "text_encoders"
+                },
+                {
+                  "name": "t5xxl_fp16.safetensors",
+                  "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors",
+                  "directory": "text_encoders"
+                }
+              ]
+            },
+            "widgets_values": [
+              "clip_l.safetensors",
+              "t5xxl_fp16.safetensors",
+              "flux",
+              "default"
+            ]
+          },
+          {
+            "id": 50,
+            "type": "EmptySD3LatentImage",
+            "pos": [
+              -800,
+              870
+            ],
+            "size": [
+              270,
+              168
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 69
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 70
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  51
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptySD3LatentImage",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [
+              1024,
+              1024,
+              1
+            ]
+          },
+          {
+            "id": 51,
+            "type": "CLIPTextEncode",
+            "pos": [
+              -439.999938141949,
+              160.00001459060425
+            ],
+            "size": [
+              450,
+              500
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 64
+              },
+              {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {
+                  "name": "text"
+                },
+                "link": 68
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  65,
+                  66
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1"
+            },
+            "widgets_values": [
+              "Beautiful photography of a gorgeous-haired female artist, natural and authentic, her hair styled in a messy casual bun, smiling joyfully and looking directly at the camera, cinematic lighting, soft natural daylight, shallow depth of field, warm gentle tones, film grain, high detail, 8K, realistic portrait\n"
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 52,
+            "type": "KSampler",
+            "pos": [
+              70.00043027350216,
+              110.00000338120918
+            ],
+            "size": [
+              360,
+              630
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 61
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 65
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 63
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 51
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  52
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [
+              53943644181156,
+              "randomize",
+              20,
+              1,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 53,
+            "type": "VAEDecode",
+            "pos": [
+              80,
+              810
+            ],
+            "size": [
+              340,
+              96
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 52
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 58
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  9
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 54,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              -220,
+              720
+            ],
+            "size": [
+              225,
+              72
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 66
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  63
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ConditioningZeroOut",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [],
+            "color": "#223",
+            "bgcolor": "#335"
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Step 1 - Load Models Here",
+            "bounding": [
+              -820,
+              70,
+              350,
+              680
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Step 2 - Image Size",
+            "bounding": [
+              -820,
+              770,
+              350,
+              310
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step 3 - Prompt",
+            "bounding": [
+              -450,
+              70,
+              480,
+              680
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 52,
+            "origin_id": 52,
+            "origin_slot": 0,
+            "target_id": 53,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 58,
+            "origin_id": 47,
+            "origin_slot": 0,
+            "target_id": 53,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 61,
+            "origin_id": 48,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 63,
+            "origin_id": 54,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 51,
+            "origin_id": 50,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 9,
+            "origin_id": 53,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 64,
+            "origin_id": 49,
+            "origin_slot": 0,
+            "target_id": 51,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 65,
+            "origin_id": 51,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 66,
+            "origin_id": 51,
+            "origin_slot": 0,
+            "target_id": 54,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 68,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 51,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 69,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 50,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 70,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 50,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 73,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 48,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 74,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 49,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 75,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 49,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 76,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 47,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ds": {
+            "scale": 0.7513148009015777,
+            "offset": [
+              1726.1426909346173,
+              146.66925047394233
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6352941176470595,
+      "offset": [
+        879.7861322211784,
+        -201.76040190950405
+      ]
+    },
+    "frontendVersion": "1.41.13",
+    "workflowRendererVersion": "LG",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/template_horizontal_vertical_extension.json
+++ b/tests/comfy_cli/fixtures/gallery/template_horizontal_vertical_extension.json
@@ -1,0 +1,1484 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "revision": 0,
+  "last_node_id": 304,
+  "last_link_id": 641,
+  "nodes": [
+    {
+      "id": 248,
+      "type": "GetVideoComponents",
+      "pos": [
+        1829.9999084472656,
+        509.99999618530273
+      ],
+      "size": [
+        230,
+        120
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 493
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            634
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            611
+          ]
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "links": [
+            612
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetVideoComponents",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 247,
+      "type": "LoadVideo",
+      "pos": [
+        850.0000133514404,
+        499.9999828338623
+      ],
+      "size": [
+        640,
+        490
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            501
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "animated_man_framing.mp4",
+        "image"
+      ]
+    },
+    {
+      "id": 254,
+      "type": "Video Slice",
+      "pos": [
+        1539.9998931884766,
+        509.99999618530273
+      ],
+      "size": [
+        270,
+        170
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 501
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            493
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Video Slice",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        0,
+        0,
+        false
+      ]
+    },
+    {
+      "id": 252,
+      "type": "7594b5c0-2b90-4aeb-846b-e3eb8fa89f33",
+      "pos": [
+        2490.000045776367,
+        640.000020980835
+      ],
+      "size": [
+        400,
+        150
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 639
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            494
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "233",
+            "$$canvas-image-preview"
+          ],
+          [
+            "232",
+            "$$canvas-image-preview"
+          ],
+          [
+            "234",
+            "$$canvas-image-preview"
+          ],
+          [
+            "285",
+            "aspect_ratio"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 249,
+      "type": "CreateVideo",
+      "pos": [
+        2920.000099182129,
+        509.99999618530273
+      ],
+      "size": [
+        230,
+        130
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 494
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": 611
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": 612
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            491
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CreateVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        30
+      ]
+    },
+    {
+      "id": 245,
+      "type": "KlingOmniProEditVideoNode",
+      "pos": [
+        3250.0001678466797,
+        499.9999828338623
+      ],
+      "size": [
+        430,
+        360
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 491
+        },
+        {
+          "name": "reference_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            640
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KlingOmniProEditVideoNode",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "kling-v3-omni",
+        "remove and outpaint the white borders of the video",
+        true,
+        "1080p",
+        1652002455,
+        "randomize"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 270,
+      "type": "SaveVideo",
+      "pos": [
+        3750.0000915527344,
+        439.9999771118164
+      ],
+      "size": [
+        590,
+        1230
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 640
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "video/9x16",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 295,
+      "type": "Note",
+      "pos": [
+        2119.9999237060547,
+        1029.9999465942383
+      ],
+      "size": [
+        580,
+        230
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "Adjust the offsets to reframe the video vertically or horizontally before extension\n\nThis workflow is only designed for horizontal to vertical and vice versa. If you want to adjust the aspect ratio only slightly or to 1x1 square format, Kling Video Edit node is not recommended."
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 302,
+      "type": "JWImageResizeByShorterSide",
+      "pos": [
+        2140.000099182129,
+        640.000020980835
+      ],
+      "size": [
+        300,
+        140
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 634
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            639
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "JWImageResizeByShorterSide"
+      },
+      "widgets_values": [
+        1080,
+        "bicubic"
+      ]
+    }
+  ],
+  "links": [
+    [
+      491,
+      249,
+      0,
+      245,
+      0,
+      "VIDEO"
+    ],
+    [
+      493,
+      254,
+      0,
+      248,
+      0,
+      "VIDEO"
+    ],
+    [
+      494,
+      252,
+      0,
+      249,
+      0,
+      "IMAGE"
+    ],
+    [
+      501,
+      247,
+      0,
+      254,
+      0,
+      "VIDEO"
+    ],
+    [
+      611,
+      248,
+      1,
+      249,
+      1,
+      "AUDIO"
+    ],
+    [
+      612,
+      248,
+      2,
+      249,
+      2,
+      "FLOAT"
+    ],
+    [
+      634,
+      248,
+      0,
+      302,
+      0,
+      "IMAGE"
+    ],
+    [
+      639,
+      302,
+      0,
+      252,
+      0,
+      "IMAGE"
+    ],
+    [
+      640,
+      245,
+      0,
+      270,
+      0,
+      "VIDEO"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 5,
+      "title": "Video Resize and Extend",
+      "bounding": [
+        2120,
+        410,
+        1060,
+        560
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "Input Video",
+      "bounding": [
+        830,
+        420,
+        690,
+        620
+      ],
+      "color": "#8A8",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "Video Outpaint",
+      "bounding": [
+        3210,
+        410,
+        500,
+        560
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "7594b5c0-2b90-4aeb-846b-e3eb8fa89f33",
+        "version": 1,
+        "state": {
+          "lastGroupId": 8,
+          "lastNodeId": 304,
+          "lastLinkId": 641,
+          "lastRerouteId": 2
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Video Extend",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -2390,
+            610,
+            120,
+            60
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            110.99131176844274,
+            366.6738400794415,
+            120,
+            80
+          ]
+        },
+        "inputs": [
+          {
+            "id": "190e929c-5f4a-4ae7-8294-b948fcc0806d",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              429,
+              430
+            ],
+            "localized_name": "image",
+            "pos": [
+              -2290,
+              630
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "df58d266-37ca-4c0a-a9bb-db0887941c34",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              275,
+              275
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              130.99131176844276,
+              386.6738400794415
+            ]
+          },
+          {
+            "id": "844db080-9f93-4ca2-ab10-bb75acec9f2c",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [
+              533
+            ],
+            "pos": [
+              130.99131176844276,
+              406.6738400794415
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 229,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1260,
+              20
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 460
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 461
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  447,
+                  448
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#ffffff"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 230,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1260,
+              270
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 607
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 609
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  451
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#000000"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 233,
+            "type": "PreviewImage",
+            "pos": [
+              240,
+              0
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 462
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 232,
+            "type": "PreviewImage",
+            "pos": [
+              250,
+              520
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 459
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 163,
+            "type": "Get Image Size",
+            "pos": [
+              -1590,
+              70
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 429
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "slot_index": 0,
+                "links": [
+                  460
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "slot_index": 1,
+                "links": [
+                  461
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Get Image Size",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 234,
+            "type": "PreviewImage",
+            "pos": [
+              -810,
+              780
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 466
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 162,
+            "type": "ImageRemoveAlpha+",
+            "pos": [
+              -350,
+              530
+            ],
+            "size": [
+              300,
+              80
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 263
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  275,
+                  459
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ImageRemoveAlpha+",
+              "cnr_id": "comfyui_essentials",
+              "ver": "1.1.0",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 153,
+            "type": "ImageToMask",
+            "pos": [
+              -810,
+              280
+            ],
+            "size": [
+              350,
+              110
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 249
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MASK",
+                "name": "MASK",
+                "type": "MASK",
+                "slot_index": 0,
+                "links": [
+                  533
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ImageToMask",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.39",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "red"
+            ]
+          },
+          {
+            "id": 152,
+            "type": "Paste By Mask",
+            "pos": [
+              -820,
+              10
+            ],
+            "size": [
+              350,
+              180
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image_base",
+                "name": "image_base",
+                "type": "IMAGE",
+                "link": 451
+              },
+              {
+                "localized_name": "image_to_paste",
+                "name": "image_to_paste",
+                "type": "IMAGE",
+                "link": 447
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "IMAGE",
+                "link": 448
+              },
+              {
+                "localized_name": "mask_mapping_optional",
+                "name": "mask_mapping_optional",
+                "shape": 7,
+                "type": "MASK_MAPPING",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  249,
+                  267,
+                  462
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Paste By Mask",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "keep_ratio_fit"
+            ]
+          },
+          {
+            "id": 165,
+            "type": "Paste By Mask",
+            "pos": [
+              -810,
+              530
+            ],
+            "size": [
+              350,
+              180
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image_base",
+                "name": "image_base",
+                "type": "IMAGE",
+                "link": 454
+              },
+              {
+                "localized_name": "image_to_paste",
+                "name": "image_to_paste",
+                "type": "IMAGE",
+                "link": 430
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "IMAGE",
+                "link": 267
+              },
+              {
+                "localized_name": "mask_mapping_optional",
+                "name": "mask_mapping_optional",
+                "shape": 7,
+                "type": "MASK_MAPPING",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  263
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Paste By Mask",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "keep_ratio_fit"
+            ]
+          },
+          {
+            "id": 231,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1250,
+              530
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 608
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 610
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  454,
+                  466
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#ffffff"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 228,
+            "type": "MarkdownNote",
+            "pos": [
+              -1580,
+              530
+            ],
+            "size": [
+              260,
+              200
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "Change Fill Color",
+            "properties": {
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "## Tips\n\n- If your image doesn't have enough contrast to the empty area, change the background color here 👉"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 285,
+            "type": "ResolutionSelector",
+            "pos": [
+              -1590,
+              250
+            ],
+            "size": [
+              270,
+              170
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  607,
+                  608
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  609,
+                  610
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ResolutionSelector",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "9:16 (Portrait Widescreen)",
+              2
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 4,
+            "title": "autoExtend",
+            "bounding": [
+              -1620,
+              -60,
+              1670,
+              1310
+            ],
+            "color": "#3f789e",
+            "font_size": 22,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 249,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 153,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 267,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 263,
+            "origin_id": 165,
+            "origin_slot": 0,
+            "target_id": 162,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 429,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 163,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 430,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 275,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 447,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 448,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 451,
+            "origin_id": 230,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 454,
+            "origin_id": 231,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 459,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": 232,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 460,
+            "origin_id": 163,
+            "origin_slot": 0,
+            "target_id": 229,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 461,
+            "origin_id": 163,
+            "origin_slot": 1,
+            "target_id": 229,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 462,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 233,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 466,
+            "origin_id": 231,
+            "origin_slot": 0,
+            "target_id": 234,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 533,
+            "origin_id": 153,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          },
+          {
+            "id": 607,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 230,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 608,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 231,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 609,
+            "origin_id": 285,
+            "origin_slot": 1,
+            "target_id": 230,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 610,
+            "origin_id": 285,
+            "origin_slot": 1,
+            "target_id": 231,
+            "target_slot": 2,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.41.13",
+    "linearData": {
+      "inputs": [
+        [
+          "247",
+          "file"
+        ],
+        [
+          254,
+          "start_time"
+        ],
+        [
+          254,
+          "duration"
+        ],
+        [
+          "285",
+          "aspect_ratio"
+        ],
+        [
+          245,
+          "resolution"
+        ]
+      ],
+      "outputs": [
+        "270"
+      ]
+    },
+    "VHS_KeepIntermediate": true,
+    "VHS_MetadataImage": true,
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "linearMode": false,
+    "links_added_by_ue": [],
+    "ue_links": [],
+    "ds": {
+      "scale": 0.20512820512820512,
+      "offset": [
+        1163.83447265625,
+        879.85498046875
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/templates_graphic_design_recomposer.json
+++ b/tests/comfy_cli/fixtures/gallery/templates_graphic_design_recomposer.json
@@ -1,0 +1,821 @@
+{
+  "id": "73b6b198-be12-4114-9363-c1dcd74bf81c",
+  "revision": 0,
+  "last_node_id": 157,
+  "last_link_id": 248,
+  "nodes": [
+    {
+      "id": 125,
+      "type": "LoadImage",
+      "pos": [
+        2860,
+        4920
+      ],
+      "size": [
+        380,
+        480
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            233
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "latent_space_clud.png",
+        "image"
+      ]
+    },
+    {
+      "id": 131,
+      "type": "SaveImage",
+      "pos": [
+        3670,
+        4920
+      ],
+      "size": [
+        580,
+        480
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 234
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "graphic_design_recompose"
+      ]
+    },
+    {
+      "id": 143,
+      "type": "172f1008-9337-4d2f-9212-ee081cb4faf5",
+      "pos": [
+        3280,
+        4920
+      ],
+      "size": [
+        340,
+        180
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 233
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "IMAGE",
+          "links": [
+            234
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "135",
+            "choice"
+          ],
+          [
+            "156",
+            "value"
+          ],
+          [
+            "142",
+            "value"
+          ]
+        ]
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      233,
+      125,
+      0,
+      143,
+      0,
+      "IMAGE"
+    ],
+    [
+      234,
+      143,
+      0,
+      131,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "172f1008-9337-4d2f-9212-ee081cb4faf5",
+        "version": 1,
+        "state": {
+          "lastGroupId": 15,
+          "lastNodeId": 157,
+          "lastLinkId": 248,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Recompose Image",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            4690,
+            7430,
+            128,
+            68
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            7680,
+            7470,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "7cbedb18-b324-4f1b-96d7-4517996bc432",
+            "name": "images",
+            "type": "IMAGE",
+            "linkIds": [
+              212,
+              244
+            ],
+            "localized_name": "images",
+            "shape": 7,
+            "pos": [
+              4794,
+              7454
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "cde817df-cc4a-4726-9aca-fb1e9200a1e6",
+            "name": "output",
+            "type": "IMAGE",
+            "linkIds": [
+              230
+            ],
+            "localized_name": "output",
+            "pos": [
+              7704,
+              7494
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2,
+            "type": "PrimitiveStringMultiline",
+            "pos": [
+              5190,
+              7570
+            ],
+            "size": [
+              560,
+              580
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  211,
+                  247
+                ]
+              }
+            ],
+            "title": "Prompt",
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": [
+              "Role: Act as an expert art director and compositing specialist. Your objective is to adapt the provided image to a new aspect ratio by expanding the background and rearranging its core elements. Never stretch, squish, or letterbox the image.\n\n1. Canvas Expansion & Outpainting\n\nSeamless Extension: Expand the canvas to the target dimensions using generative outpainting. Seamlessly continue the existing environment (sky, textures, walls, floors) while perfectly matching the original lighting, grain, and perspective.\n\nStrict Limitations: Do not shrink the original image onto a blurred or colored background. Do not introduce new focal objects, characters, or decorative borders. Only continue existing environmental elements.\n\n2. Element Redistribution\n\nTreat as Layers: Separate the main components (typography, logos, hero imagery, credits) into distinct, movable elements.\n\nSmart Rearrangement: Reposition these elements to suit the new aspect ratio using professional layout principles (e.g., shifting a vertical stack into a horizontal, side-by-side composition). Use the newly generated space intentionally to avoid awkward negative space.\n\nPreserve Proportions: Maintain the exact original aspect ratio of every individual element. Keep all font styles, weights, and text styling identical. Scale elements uniformly only if required for layout balance.\n\n3. Visual Integrity & Polish\n\nMaintain Hierarchy: Preserve the original visual dominance of the headline, hero image, and logo placement.\n\nNative Feel: The final composition must look cohesive, breathable, and deliberately designed from scratch for this specific format."
+            ]
+          },
+          {
+            "id": 130,
+            "type": "GeminiImage2Node",
+            "pos": [
+              6020,
+              6910
+            ],
+            "size": [
+              470,
+              350
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 212
+              },
+              {
+                "localized_name": "files",
+                "name": "files",
+                "shape": 7,
+                "type": "GEMINI_INPUT_FILES",
+                "link": null
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 211
+              },
+              {
+                "localized_name": "aspect_ratio",
+                "name": "aspect_ratio",
+                "type": "COMBO",
+                "widget": {
+                  "name": "aspect_ratio"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "resolution",
+                "name": "resolution",
+                "type": "COMBO",
+                "widget": {
+                  "name": "resolution"
+                },
+                "link": 243
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  232
+                ]
+              },
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GeminiImage2Node"
+            },
+            "widgets_values": [
+              "",
+              "gemini-3-pro-image-preview",
+              314507571392615,
+              "randomize",
+              "16:9",
+              "2K",
+              "IMAGE+TEXT",
+              "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input—regardless of format, intent, or abstraction—as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 134,
+            "type": "ComfySwitchNode",
+            "pos": [
+              7280,
+              7470
+            ],
+            "size": [
+              280,
+              130
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "IMAGE",
+                "link": 232
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "IMAGE",
+                "link": 248
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 222
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "IMAGE",
+                "links": [
+                  230
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode"
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 135,
+            "type": "CustomCombo",
+            "pos": [
+              6030,
+              8030
+            ],
+            "size": [
+              280,
+              250
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "model",
+                "localized_name": "choice",
+                "name": "choice",
+                "type": "COMBO",
+                "widget": {
+                  "name": "choice"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  217
+                ]
+              },
+              {
+                "localized_name": "INDEX",
+                "name": "INDEX",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CustomCombo"
+            },
+            "widgets_values": [
+              "Nano Banana 2",
+              0,
+              "Nano Banana 2",
+              "Nano Banana Pro",
+              ""
+            ]
+          },
+          {
+            "id": 157,
+            "type": "GeminiNanoBanana2V2",
+            "pos": [
+              6020,
+              7540
+            ],
+            "size": [
+              400,
+              350
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 247
+              },
+              {
+                "localized_name": "model.aspect_ratio",
+                "name": "model.aspect_ratio",
+                "type": "COMBO",
+                "widget": {
+                  "name": "model.aspect_ratio"
+                },
+                "link": 245
+              },
+              {
+                "localized_name": "model.resolution",
+                "name": "model.resolution",
+                "type": "COMBO",
+                "widget": {
+                  "name": "model.resolution"
+                },
+                "link": 246
+              },
+              {
+                "label": "image_1",
+                "localized_name": "model.images.image_1",
+                "name": "model.images.image_1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 244
+              },
+              {
+                "label": "image_2",
+                "localized_name": "model.images.image_2",
+                "name": "model.images.image_2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "files",
+                "localized_name": "model.files",
+                "name": "model.files",
+                "shape": 7,
+                "type": "GEMINI_INPUT_FILES",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  248
+                ]
+              },
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": null
+              },
+              {
+                "localized_name": "thought_image",
+                "name": "thought_image",
+                "type": "IMAGE",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GeminiNanoBanana2V2"
+            },
+            "widgets_values": [
+              "",
+              "Nano Banana 2 (Gemini 3.1 Flash Image)",
+              "16:9",
+              "2K",
+              "MINIMAL",
+              42,
+              "randomize",
+              "IMAGE",
+              "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input—regardless of format, intent, or abstraction—as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 156,
+            "type": "PrimitiveNode",
+            "pos": [
+              5280,
+              7090
+            ],
+            "size": [
+              450,
+              150
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "COMBO",
+                "type": "COMBO",
+                "widget": {
+                  "name": "resolution"
+                },
+                "links": [
+                  243,
+                  246
+                ]
+              }
+            ],
+            "title": "resolution",
+            "properties": {
+              "Run widget replace on values": false
+            },
+            "widgets_values": [
+              "2K",
+              "fixed",
+              ""
+            ]
+          },
+          {
+            "id": 142,
+            "type": "PrimitiveNode",
+            "pos": [
+              5280,
+              7310
+            ],
+            "size": [
+              450,
+              150
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "COMBO",
+                "type": "COMBO",
+                "widget": {
+                  "name": "aspect_ratio"
+                },
+                "links": [
+                  229,
+                  245
+                ]
+              }
+            ],
+            "title": "aspect_ratio",
+            "properties": {
+              "Run widget replace on values": false
+            },
+            "widgets_values": [
+              "16:9",
+              "fixed",
+              ""
+            ]
+          },
+          {
+            "id": 136,
+            "type": "StringCompare",
+            "pos": [
+              6430,
+              8020
+            ],
+            "size": [
+              300,
+              280
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  222
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringCompare"
+            },
+            "widgets_values": [
+              "Nano Banana 2",
+              "nano banana 2",
+              "Starts With",
+              false
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 211,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 2,
+            "type": "STRING"
+          },
+          {
+            "id": 229,
+            "origin_id": 142,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 3,
+            "type": "COMBO"
+          },
+          {
+            "id": 232,
+            "origin_id": 130,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": 136,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 217,
+            "origin_id": 135,
+            "origin_slot": 0,
+            "target_id": 136,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 212,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 230,
+            "origin_id": 134,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 243,
+            "origin_id": 156,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 244,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 245,
+            "origin_id": 142,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 246,
+            "origin_id": 156,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 2,
+            "type": "COMBO"
+          },
+          {
+            "id": 247,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 248,
+            "origin_id": 157,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 1,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.44.15",
+    "workflowRendererVersion": "Vue-corrected",
+    "linearMode": false,
+    "linearData": {
+      "inputs": [
+        [
+          "125",
+          "image"
+        ],
+        [
+          "135",
+          "choice"
+        ],
+        [
+          "156",
+          "value"
+        ],
+        [
+          "142",
+          "value"
+        ]
+      ],
+      "outputs": [
+        "131"
+      ]
+    },
+    "VHS_KeepIntermediate": true,
+    "VHS_MetadataImage": true,
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "ds": {
+      "scale": 0.4022323830016147,
+      "offset": [
+        -4682.813818294955,
+        -5898.263907601024
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/object_info_legacy_proxy.json
+++ b/tests/comfy_cli/fixtures/object_info_legacy_proxy.json
@@ -1,0 +1,2790 @@
+{
+ "CLIPTextEncode": {
+  "input": {
+   "required": {
+    "text": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "clip": [
+     "CLIP",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "text",
+    "clip"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "CLIPTextEncode",
+  "display_name": "CLIP Text Encode (Prompt)",
+  "description": "Encodes a text prompt using a CLIP model into an embedding that can be used to guide the diffusion model towards generating specific images.",
+  "python_module": "nodes",
+  "category": "model/conditioning",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "A conditioning containing the embedded text used to guide the diffusion model."
+  ],
+  "search_aliases": [
+   "text",
+   "prompt",
+   "text prompt",
+   "positive prompt",
+   "negative prompt",
+   "encode text",
+   "text encoder",
+   "encode prompt"
+  ]
+ },
+ "ComfySwitchNode": {
+  "input": {
+   "required": {
+    "switch": [
+     "BOOLEAN",
+     {}
+    ],
+    "on_false": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ],
+    "on_true": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "switch",
+    "on_false",
+    "on_true"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "COMFY_MATCHTYPE_V3"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "output"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": [
+   "switch"
+  ],
+  "name": "ComfySwitchNode",
+  "display_name": "If/Else Switch",
+  "description": "",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities/logic",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "if",
+   "then",
+   "switch",
+   "conditional",
+   "branch"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "ConditioningZeroOut": {
+  "input": {
+   "required": {
+    "conditioning": [
+     "CONDITIONING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "conditioning"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "ConditioningZeroOut",
+  "display_name": "Conditioning Zero Out",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/conditioning/transform",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "null conditioning",
+   "clear conditioning"
+  ]
+ },
+ "CreateVideo": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "fps": [
+     "FLOAT",
+     {
+      "default": 30.0,
+      "min": 1.0,
+      "max": 120.0,
+      "step": 1.0
+     }
+    ]
+   },
+   "optional": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "bit_depth": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       8,
+       10
+      ]
+     }
+    ],
+    "color_space": [
+     "COMBO",
+     {
+      "default": "sRGB",
+      "multiselect": false,
+      "options": [
+       "sRGB",
+       "HDR",
+       "HDR PQ"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "fps"
+   ],
+   "optional": [
+    "audio",
+    "bit_depth",
+    "color_space"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CreateVideo",
+  "display_name": "Create Video",
+  "description": "Create a video from images.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "images to video"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false
+ },
+ "CustomCombo": {
+  "input": {
+   "required": {
+    "choice": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": []
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "choice"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "STRING",
+   "INDEX"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CustomCombo",
+  "display_name": "Custom Combo",
+  "description": "",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "DualCLIPLoader": {
+  "input": {
+   "required": {
+    "clip_name1": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "clip_name2": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "type": [
+     [
+      "sdxl",
+      "sd3",
+      "flux",
+      "hunyuan_video",
+      "hidream",
+      "hunyuan_image",
+      "hunyuan_video_15",
+      "kandinsky5",
+      "kandinsky5_image",
+      "ltxv",
+      "newbie",
+      "ace"
+     ]
+    ]
+   },
+   "optional": {
+    "device": [
+     [
+      "default",
+      "cpu"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip_name1",
+    "clip_name2",
+    "type"
+   ],
+   "optional": [
+    "device"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CLIP"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CLIP"
+  ],
+  "name": "DualCLIPLoader",
+  "display_name": "Load CLIP (Dual)",
+  "description": "Recipes:\nsdxl: clip-l, clip-g\nsd3: clip-l, clip-g / clip-l, t5 / clip-g, t5\nflux: clip-l, t5\nhidream: at least one of t5 or llama, recommended t5 and llama\nhunyuan_image: qwen2.5vl 7b and byt5 small\nnewbie: gemma-3-4b-it, jina clip v2",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "EmptySD3LatentImage": {
+  "input": {
+   "required": {
+    "width": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "height": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "width",
+    "height",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptySD3LatentImage",
+  "display_name": null,
+  "description": "",
+  "python_module": "comfy_extras.nodes_sd3",
+  "category": "model/latent/stable diffusion",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "GeminiImage2Node": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "gemini-3-pro-image-preview",
+       "Nano Banana 2 (Gemini 3.1 Flash Image)"
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       "1:1",
+       "2:3",
+       "3:2",
+       "3:4",
+       "4:3",
+       "4:5",
+       "5:4",
+       "9:16",
+       "16:9",
+       "21:9"
+      ]
+     }
+    ],
+    "resolution": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "1K",
+       "2K",
+       "4K"
+      ]
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE+TEXT",
+       "IMAGE"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "files": [
+     "GEMINI_INPUT_FILES",
+     {}
+    ],
+    "system_prompt": [
+     "STRING",
+     {
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "aspect_ratio",
+    "resolution",
+    "response_modalities"
+   ],
+   "optional": [
+    "images",
+    "files",
+    "system_prompt"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiImage2Node",
+  "display_name": "Nano Banana Pro (Google Gemini Image)",
+  "description": "Generate or edit images synchronously via Google Vertex API.",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMBO"
+     },
+     {
+      "name": "resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n    (\n      $m := widgets.model;\n      $r := widgets.resolution;\n      $isFlash := $contains($m, \"nano banana 2\");\n      $flashPrices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n      $proPrices := {\"1k\": 0.1608, \"2k\": 0.1608, \"4k\": 0.288};\n      $prices := $isFlash ? $flashPrices : $proPrices;\n      {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n    )\n    "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "GeminiNanoBanana2V2": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K",
+             "2K",
+             "4K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       },
+       {
+        "key": "Nano Banana 2 Lite",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE",
+       "IMAGE+TEXT"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "system_prompt": [
+     "STRING",
+     {
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ],
+    "temperature": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 1.0,
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.01
+     }
+    ],
+    "top_p": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 0.95,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "response_modalities"
+   ],
+   "optional": [
+    "system_prompt",
+    "temperature",
+    "top_p"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING",
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING",
+   "thought_image"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   "First image from the model's thinking process. Only available with thinking_level HIGH and IMAGE+TEXT modality."
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiNanoBanana2V2",
+  "display_name": "Nano Banana 2",
+  "description": "Generate or edit images synchronously via Google Vertex API.",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $contains(widgets.model, \"lite\")\n                    ? {\"type\":\"usd\",\"usd\": 0.0408, \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                    : (\n                        $r := $lookup(widgets, \"model.resolution\");\n                        $prices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n                        {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                      )\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "Get Image Size": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "name": "Get Image Size",
+  "display_name": "Get Image Size",
+  "description": "",
+  "python_module": "custom_nodes.masquerade-nodes-comfyui",
+  "category": "Masquerade Nodes",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "GetVideoComponents": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "AUDIO",
+   "FLOAT",
+   "COMBO",
+   "COMBO"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "images",
+   "audio",
+   "fps",
+   "bit_depth",
+   "color_space"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetVideoComponents",
+  "display_name": "Get Video Components",
+  "description": "Extracts video frames, audio, frame rate, bit depth, and color space.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract frames",
+   "split video",
+   "video to images",
+   "demux"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "ImageRemoveAlpha+": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "ImageRemoveAlpha+",
+  "display_name": "\ud83d\udd27 Image Remove Alpha",
+  "description": "",
+  "python_module": "custom_nodes.comfyui_essentials",
+  "category": "essentials/image utils",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "ImageToMask": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ],
+    "channel": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "red",
+       "green",
+       "blue",
+       "alpha"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "channel"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MASK"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MASK"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ImageToMask",
+  "display_name": "Convert Image to Mask",
+  "description": "",
+  "python_module": "comfy_extras.nodes_mask",
+  "category": "image/mask",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract channel",
+   "channel to mask"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "JWImageResizeByShorterSide": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ],
+    "size": [
+     "INT",
+     {
+      "default": 512,
+      "min": 0,
+      "step": 1,
+      "max": 99999
+     }
+    ],
+    "interpolation_mode": [
+     [
+      "bicubic",
+      "bilinear",
+      "nearest",
+      "nearest exact"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "size",
+    "interpolation_mode"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "JWImageResizeByShorterSide",
+  "display_name": "Image Resize by Shorter Side",
+  "description": "",
+  "python_module": "custom_nodes.comfyui-various",
+  "category": "jamesWalker55",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "KSampler": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL",
+     {}
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "steps": [
+     "INT",
+     {
+      "default": 20,
+      "min": 1,
+      "max": 10000
+     }
+    ],
+    "cfg": [
+     "FLOAT",
+     {
+      "default": 8.0,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "sampler_name": [
+     [
+      "euler",
+      "euler_cfg_pp",
+      "euler_ancestral",
+      "euler_ancestral_cfg_pp",
+      "heun",
+      "heunpp2",
+      "exp_heun_2_x0",
+      "exp_heun_2_x0_sde",
+      "dpm_2",
+      "dpm_2_ancestral",
+      "lms",
+      "dpm_fast",
+      "dpm_adaptive",
+      "dpmpp_2s_ancestral",
+      "dpmpp_2s_ancestral_cfg_pp",
+      "dpmpp_sde",
+      "dpmpp_sde_gpu",
+      "dpmpp_2m",
+      "dpmpp_2m_cfg_pp",
+      "dpmpp_2m_sde",
+      "dpmpp_2m_sde_gpu",
+      "dpmpp_2m_sde_heun",
+      "dpmpp_2m_sde_heun_gpu",
+      "dpmpp_3m_sde",
+      "dpmpp_3m_sde_gpu",
+      "ddpm",
+      "lcm",
+      "ipndm",
+      "ipndm_v",
+      "deis",
+      "res_multistep",
+      "res_multistep_cfg_pp",
+      "res_multistep_ancestral",
+      "res_multistep_ancestral_cfg_pp",
+      "gradient_estimation",
+      "gradient_estimation_cfg_pp",
+      "er_sde",
+      "seeds_2",
+      "seeds_3",
+      "sa_solver",
+      "sa_solver_pece",
+      "ddim",
+      "uni_pc",
+      "uni_pc_bh2",
+      "legacy_rk",
+      "rk",
+      "rk_beta",
+      "deis_3m_ode",
+      "deis_2m_ode",
+      "deis_3m",
+      "deis_2m",
+      "res_6s_ode",
+      "res_5s_ode",
+      "res_3s_ode",
+      "res_2s_ode",
+      "res_3m_ode",
+      "res_2m_ode",
+      "res_6s",
+      "res_5s",
+      "res_3s",
+      "res_2s",
+      "res_3m",
+      "res_2m"
+     ],
+     {}
+    ],
+    "scheduler": [
+     [
+      "simple",
+      "sgm_uniform",
+      "karras",
+      "exponential",
+      "ddim_uniform",
+      "beta",
+      "normal",
+      "linear_quadratic",
+      "kl_optimal",
+      "bong_tangent",
+      "beta57"
+     ],
+     {}
+    ],
+    "positive": [
+     "CONDITIONING",
+     {}
+    ],
+    "negative": [
+     "CONDITIONING",
+     {}
+    ],
+    "latent_image": [
+     "LATENT",
+     {}
+    ],
+    "denoise": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "steps",
+    "cfg",
+    "sampler_name",
+    "scheduler",
+    "positive",
+    "negative",
+    "latent_image",
+    "denoise"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "name": "KSampler",
+  "display_name": "KSampler",
+  "description": "Uses the provided model, positive and negative conditioning to denoise the latent image.",
+  "python_module": "nodes",
+  "category": "model/sampling",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The denoised latent."
+  ],
+  "search_aliases": [
+   "sampler",
+   "sample",
+   "generate",
+   "denoise",
+   "diffuse",
+   "txt2img",
+   "img2img"
+  ]
+ },
+ "KlingOmniProEditVideoNode": {
+  "input": {
+   "required": {
+    "model_name": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "kling-v3-omni",
+       "kling-video-o1"
+      ]
+     }
+    ],
+    "prompt": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "keep_original_sound": [
+     "BOOLEAN",
+     {
+      "default": true
+     }
+    ]
+   },
+   "optional": {
+    "reference_images": [
+     "IMAGE",
+     {}
+    ],
+    "resolution": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "1080p",
+       "720p"
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model_name",
+    "prompt",
+    "video",
+    "keep_original_sound"
+   ],
+   "optional": [
+    "reference_images",
+    "resolution",
+    "seed"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "KlingOmniProEditVideoNode",
+  "display_name": "Kling 3.0 Omni Edit Video",
+  "description": "Edit an existing video with the latest model from Kling.",
+  "python_module": "comfy_api_nodes.nodes_kling",
+  "category": "partner/video/Kling",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $mode := (widgets.resolution = \"720p\") ? \"std\" : \"pro\";\n                  $rates := {\"std\": 0.126, \"pro\": 0.168};\n                  {\"type\":\"usd\",\"usd\": $lookup($rates, $mode), \"format\":{\"suffix\":\"/second\"}}\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": "Video Generation",
+  "has_intermediate_output": false
+ },
+ "LayerUtility: ColorImage V2": {
+  "input": {
+   "required": {
+    "size": [
+     [
+      "custom",
+      "1024 x 1024",
+      "768 x 512",
+      "512 x 768",
+      "1280 x 720",
+      "720 x 1280",
+      "1344 x 768",
+      "768 x 1344",
+      "1536 x 640",
+      "640 x 1536"
+     ]
+    ],
+    "custom_width": [
+     "INT",
+     {
+      "default": 512,
+      "min": 4,
+      "max": 99999,
+      "step": 1
+     }
+    ],
+    "custom_height": [
+     "INT",
+     {
+      "default": 512,
+      "min": 4,
+      "max": 99999,
+      "step": 1
+     }
+    ],
+    "color": [
+     "STRING",
+     {
+      "default": "#000000"
+     }
+    ]
+   },
+   "optional": {
+    "size_as": [
+     "*",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "size",
+    "custom_width",
+    "custom_height",
+    "color"
+   ],
+   "optional": [
+    "size_as"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "image"
+  ],
+  "name": "LayerUtility: ColorImage V2",
+  "display_name": "LayerUtility: ColorImage V2",
+  "description": "",
+  "python_module": "custom_nodes.comfyui_layerstyle",
+  "category": "\ud83d\ude3adzNodes/LayerUtility",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "LoadImage": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "MASK"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "MASK"
+  ],
+  "name": "LoadImage",
+  "display_name": "Load Image",
+  "description": "",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "load image",
+   "open image",
+   "import image",
+   "image input",
+   "upload image",
+   "read image",
+   "image loader"
+  ],
+  "essentials_category": "Basics"
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "description": "",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "Paste By Mask": {
+  "input": {
+   "required": {
+    "image_base": [
+     "IMAGE"
+    ],
+    "image_to_paste": [
+     "IMAGE"
+    ],
+    "mask": [
+     "IMAGE"
+    ],
+    "resize_behavior": [
+     [
+      "resize",
+      "keep_ratio_fill",
+      "keep_ratio_fit",
+      "source_size",
+      "source_size_unmasked"
+     ]
+    ]
+   },
+   "optional": {
+    "mask_mapping_optional": [
+     "MASK_MAPPING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image_base",
+    "image_to_paste",
+    "mask",
+    "resize_behavior"
+   ],
+   "optional": [
+    "mask_mapping_optional"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "Paste By Mask",
+  "display_name": "Paste By Mask",
+  "description": "",
+  "python_module": "custom_nodes.masquerade-nodes-comfyui",
+  "category": "Masquerade Nodes",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "PreviewImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE"
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "PreviewImage",
+  "display_name": "Preview Image",
+  "description": "Preview the images without saving them to the ComfyUI output directory.",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "preview",
+   "preview image",
+   "show image",
+   "view image",
+   "display image",
+   "image viewer"
+  ],
+  "essentials_category": "Basics"
+ },
+ "PrimitiveStringMultiline": {
+  "input": {
+   "required": {
+    "value": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "STRING"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveStringMultiline",
+  "display_name": "Text (Multiline)",
+  "description": "",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "text",
+   "string",
+   "text multiline",
+   "string multiline",
+   "text box",
+   "prompt"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "ResolutionSelector": {
+  "input": {
+   "required": {
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "1:1 (Square)",
+      "multiselect": false,
+      "options": [
+       "1:1 (Square)",
+       "2:3 (Portrait Photo)",
+       "3:2 (Photo)",
+       "3:4 (Portrait Standard)",
+       "4:3 (Standard)",
+       "9:16 (Portrait Widescreen)",
+       "16:9 (Widescreen)",
+       "21:9 (Ultrawide)"
+      ]
+     }
+    ],
+    "megapixels": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.1,
+      "max": 16.0,
+      "step": 0.1
+     }
+    ],
+    "multiple": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 8,
+      "min": 8,
+      "max": 128,
+      "step": 4
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "aspect_ratio",
+    "megapixels",
+    "multiple"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "output_tooltips": [
+   "Calculated width in pixels multiplied by the selected multiple.",
+   "Calculated height in pixels multiplied by the selected multiple."
+  ],
+  "output_matchtypes": null,
+  "name": "ResolutionSelector",
+  "display_name": "Resolution Selector",
+  "description": "Calculate width and height from aspect ratio and megapixel target. Useful for setting up Empty Latent Image dimensions.",
+  "python_module": "comfy_extras.nodes_resolution",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "description": "Saves the input images to your ComfyUI output directory.",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "save",
+   "save image",
+   "export image",
+   "output image",
+   "write image",
+   "download"
+  ],
+  "essentials_category": "Basics"
+ },
+ "SaveVideo": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "video/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mp4",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mkv",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "webm",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "codec": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "hidden": true,
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "h264",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 23.0,
+                  "min": 0.0,
+                  "max": 51.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "av1",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 30.0,
+                  "min": 0.0,
+                  "max": 63.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "filename_prefix",
+    "format"
+   ],
+   "optional": [
+    "codec"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "video"
+  ],
+  "output_tooltips": [
+   "The input video, unchanged."
+  ],
+  "output_matchtypes": null,
+  "name": "SaveVideo",
+  "display_name": "Save Video",
+  "description": "Saves the input videos to your ComfyUI output directory.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "export video"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "StringCompare": {
+  "input": {
+   "required": {
+    "string_a": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "string_b": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "mode": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "Starts With",
+       "Ends With",
+       "Equal"
+      ]
+     }
+    ],
+    "case_sensitive": [
+     "BOOLEAN",
+     {
+      "advanced": true,
+      "default": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "string_a",
+    "string_b",
+    "mode",
+    "case_sensitive"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "BOOLEAN"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "BOOLEAN"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "StringCompare",
+  "display_name": "Compare Text",
+  "description": "",
+  "python_module": "comfy_extras.nodes_string",
+  "category": "text",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "compare",
+   "text match",
+   "string equals",
+   "starts with",
+   "ends with"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "UNETLoader": {
+  "input": {
+   "required": {
+    "unet_name": [
+     [
+      "put_diffusion_models.safetensors"
+     ]
+    ],
+    "weight_dtype": [
+     [
+      "default",
+      "fp8_e4m3fn",
+      "fp8_e4m3fn_fast",
+      "fp8_e5m2"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "unet_name",
+    "weight_dtype"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "UNETLoader",
+  "display_name": "Load Diffusion Model",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "VAEDecode": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "VAEDecode",
+  "display_name": "VAE Decode",
+  "description": "Decodes latent images back into pixel space images.",
+  "python_module": "nodes",
+  "category": "model/latent",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The decoded image."
+  ],
+  "search_aliases": [
+   "decode",
+   "decode latent",
+   "latent to image",
+   "render latent"
+  ]
+ },
+ "VAELoader": {
+  "input": {
+   "required": {
+    "vae_name": [
+     [
+      "put_vae.safetensors",
+      "pixel_space"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "vae_name"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VAE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VAE"
+  ],
+  "name": "VAELoader",
+  "display_name": "Load VAE",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "Video Slice": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "start_time": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": -100000.0,
+      "max": 100000.0,
+      "step": 0.001
+     }
+    ],
+    "duration": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": 0.0,
+      "step": 0.001
+     }
+    ],
+    "strict_duration": [
+     "BOOLEAN",
+     {
+      "default": false
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "start_time",
+    "duration",
+    "strict_duration"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "Video Slice",
+  "display_name": "Trim Video",
+  "description": "",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "trim video duration",
+   "skip first frames",
+   "frame load cap",
+   "start time"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false
+ }
+}


### PR DESCRIPTION
> **Stacked on #818** → #816 → #815 → #812 → #809. Closes the "legacy proxies not backed by a linked input still route to the interior" gap left open in #815.

## Why

364 of the 1,922 `proxyWidgets` entries in the gallery corpus (old templates) are not backed by a linked subgraph input. For those, #815 kept the legacy behaviour — a write into the interior node, an edit under "layer 2" that the frontend's load-time migration happens to re-seed the host from, but that no other promoted write shares and that `comfy run` never submitted as a host value.

## What

A faithful port of the frontend's forward migration (`proxyWidgetMigration.ts`, ADR 0009) into `cql.promoted`, run on write:

`cql.promoted` now carries a port of the frontend's forward migration
(`proxyWidgetMigration.ts`, ADR 0009): `plan_proxy_migration` classifies
every entry of an instance exactly as `classify` does (already linked;
`createSubgraphInput`; `PrimitiveNode` fan-out bypass, all-or-quarantine;
`$$`/preview pseudo-widget exposure; quarantine with the frontend's reason
codes), and `flush_proxy_migration` performs it: a subgraph input named with
`nextUniqueName`, a boundary link from the subgraph input node into the
widget's backing input slot (synthesized in the shape the frontend
serializes when an older save omits it), the host value read positionally
by legacy proxy order, quarantine rows `{originalEntry, reason, hostValue?,
attemptedAtVersion: 1}`, repaired entries consumed. Preview entries are left
in `proxyWidgets` so the frontend's own preview-exposure migration (and its
auto-exposure of preview nodes) produces the state it would have produced
from the untouched file.

`resolve_write` turns such an entry — addressed flat, by its legacy widget
name, or through the interior widget/primitive target it owns — into a HOST
target carrying the repair; the op records `promoted.repair = {entry, ids}`
with input/link ids derived by SHA-256 from (instance path, source node,
widget), never random, so replay on another replica is byte-identical and
concurrent repairs of one instance converge. A shared definition is forked
first, like an interior write. Entries the migration quarantines
(`control_after_generate` has no backing slot) keep the interior widget as
the live one, so those writes land there as before.

Reads present a pending repair where the frontend will show it:
`slots`/`effective_value` advertise `<instance>.<name>` with the legacy host
value or the interior source, and hide the interior address; reads never
mutate. The converter now overlays a host value onto EVERY boundary-link
target, which a repaired primitive fan-out needs.

Fixtures: three verbatim gallery templates (primitive fan-outs under user
titles, `$$canvas-image-preview` exposures next to a value widget with no
serialized input slot, and the common `seed` + `control_after_generate`
pair) with a trimmed cloud catalog. `TestSetWidgetSubgraph` is rewritten for
the migration semantics on a realistic legacy fixture, with the old
declared-but-unlinked shape pinned separately (`nextUniqueName` mints
`text_1` beside the dangling socket).



## Verification

Targeted subgraph/edit/converter suites on the rebased head: 635 passed; full suite on the stack head (#820) is reported there. ruff 0.15.15 check + format clean. Contract: §8.7 pinned text + Amendment v1.5 §14.4.

## Known follow-ups (pre-existing, not introduced here)

- A host write on an instance whose `proxyWidgets` entries are ALL already linked does not flush the legacy list, so a linked-order `widgets_values` sits beside a proxy-order-indexed legacy list. Harmless when the orders coincide — they do in every gallery template — but a hazard in principle; flushing on any host write would close it.
- Replaying a repair op requires the catalog (`graph=None` raises clearly rather than quarantining everything).

Verification on this head (`27214b8a`): full suite 6301 passed, 38 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
