### PR TITLE
fix: five CLI-fixable tool-error clusters from the Aug 25–28 Langfuse sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ history.
 
 ### Fixed
 
+- Promoted subgraph widgets are edited where the frontend reads them. The
+  frontend (ADR 0009) keeps a promoted widget's value on the HOST instance
+  (`widgets_values` positional over the widget-backed subgraph inputs) and
+  runs that value over the interior default; `set-widget 57.width` used to
+  follow the legacy `proxyWidgets` route into the interior node, so the edit
+  neither ran nor showed on the canvas. `set-widget`, `set-slot` and `vary`
+  now write the host value for `<instance>.<input>`, redirect an interior
+  address that backs a promotion (`57/13.width`) to the same host value
+  (`redirected_from` on the op), follow an outside link feeding the promoted
+  input to its primitive (`PrimitiveInt`/`PrimitiveString*`/legacy
+  `PrimitiveNode`, through `Reroute`s) and refuse — naming the driver — when
+  a non-primitive node computes the value. Unpromoted interior widgets still
+  write the definition. The op carries `promoted.value_index` and the
+  materialized `host_widgets_values`.
+- `comfy workflow connect` wires an outside node to a promoted widget
+  (`PrimitiveInt.INT → 57.width`): the definition declares the input, so it
+  is materialized on the instance (with the frontend's `widget` marker) and
+  linked, type-checked against the declared input type.
+- `comfy workflow slots` advertises promoted widgets at the instance address
+  with the value the frontend runs (host value, else interior default), flags
+  widgets fed by a link (`linked_from`), keeps unpromoted interior widgets
+  reachable at `<instance>/<inner>.<widget>` (nested instances included), and
+  no longer advertises the interior address behind a promotion.
+- `convert_ui_to_api` (`comfy run`, `validate`) applies host-owned promoted
+  values onto the expanded interior nodes — a post-migration template whose
+  host prompt differs from the interior default (`audio_minimax_music_3`:
+  interior caption `''`) was submitted with the interior value. Precedence
+  matches the frontend: outside link, then host value, then interior.
 - `comfy workflow connect` can wire a Load Image / Load Video / Load Audio
   into an auto-grow group nested under a dynamic combo (`GeminiNanoBanana2V2`
   `model.images`, `MinimaxHailuo03ReferenceNode` / `ByteDance2ReferenceNodeV2`

--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -102,7 +102,26 @@ def ensure_cmd(
     try:
         status, body = http_request(url, target, method="POST", body={"hash": hash, "tags": tag_list})
     except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
-        raise handle_cloud_http_error(renderer, e, operation="ensure") from e
+        # The parameterized helper, not `cloud_http`'s: that one hardcodes the
+        # saved-workflow vocabulary, so a 404 here read "workflow not found
+        # (ensure)" with a hint to list workflows — for a request that never
+        # named a workflow. Seen in prod when an agent passed a file name where
+        # the content hash belongs.
+        from comfy_cli.command._cloud_errors import handle_cloud_http_error as _handle_cloud_http_error
+
+        raise _handle_cloud_http_error(
+            renderer,
+            e,
+            operation="ensure",
+            not_found_code="asset_not_found",
+            not_found_message=f"no asset with content hash {hash!r} in your Comfy Cloud library",
+            not_found_hint=(
+                "pass the `hash` from `comfy --json assets library ls --name <file>` "
+                "(a file name is not a hash), or upload the file first with `comfy upload <file> --where cloud`"
+            ),
+            id_label="hash",
+            resource_id=hash,
+        ) from e
 
     b = body or {}
     payload = {

--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -572,6 +572,21 @@ def _generate(model: str, extra_args: list[str]) -> None:
             renderer = get_renderer()
             try:
                 workflow = emit.write_workflow(name, values, Path(emit_path).expanduser(), output_prefix=prefix)
+            except emit.UnsupportedModelError as e:
+                # Its own code: the remedy is "pick another model", which is
+                # not what the umbrella `emit_workflow_failed` hint says, and
+                # the supported set travels as data rather than prose.
+                _track_error("emit", e)
+                renderer.error(
+                    code="emit_workflow_unsupported_model",
+                    message=str(e),
+                    hint=(
+                        "choose a model whose `emit_supported` is true in `comfy --json generate list` "
+                        "(see `details.supported`), or call the model through the proxy without --emit-workflow"
+                    ),
+                    details={"model": e.model, "supported": e.supported},
+                )
+                raise typer.Exit(code=1) from e
             except (emit.EmitError, OSError) as e:
                 _track_error("emit", e)
                 hint = (
@@ -821,6 +836,10 @@ def _model_record(e: spec.Endpoint) -> dict[str, object]:
         "category": e.category,
         "mode": "async" if e.polling else "sync",
         "summary": e.summary,
+        # Whether `--emit-workflow` has a partner-node mapping for this model.
+        # Most of the catalog is proxy-only; an agent that could not see this
+        # asked for a workflow it could never get (`emit_workflow_failed`).
+        "emit_supported": emit.is_supported(e.id),
     }
 
 

--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -25,7 +25,26 @@ from comfy_cli.command.generate import spec
 
 
 class EmitError(RuntimeError):
-    """``--emit-workflow`` cannot map this model to a partner node."""
+    """``--emit-workflow`` cannot build a workflow for this request."""
+
+
+class UnsupportedModelError(EmitError):
+    """``--emit-workflow`` has no partner-node mapping for ``model``.
+
+    Distinct from the other :class:`EmitError` causes (bad parameters) because
+    the remedy is different — pick a model from ``supported`` — and an agent
+    needs to branch on that without parsing prose. ``generate list`` exposes
+    the same answer up front as ``emit_supported`` per row.
+    """
+
+    def __init__(self, model: str, supported: list[str]):
+        self.model = model
+        self.supported = supported
+        super().__init__(
+            f"--emit-workflow does not support model {model!r}.\n"
+            f"Supported models: {', '.join(supported)}.\n"
+            "These map to ComfyUI API nodes; other proxy models have no node mapping yet."
+        )
 
 
 @dataclass(frozen=True)
@@ -216,20 +235,29 @@ def supported_models() -> list[str]:
     return sorted(MODEL_NODE_MAP)
 
 
-def _resolve_model(model: str) -> tuple[str, NodeSpec]:
-    """Map a user-typed model to a (alias, NodeSpec). Accepts an alias or the
-    canonical endpoint id that an alias resolves to."""
+def _lookup_model(model: str) -> tuple[str, NodeSpec] | None:
+    """(alias, NodeSpec) for a user-typed model — an alias or the canonical
+    endpoint id an alias resolves to — or None when nothing maps to a node."""
     if model in MODEL_NODE_MAP:
         return model, MODEL_NODE_MAP[model]
     canonical = spec.resolve_alias(model)
     pref = spec.preferred_alias(canonical)
     if pref and pref in MODEL_NODE_MAP:
         return pref, MODEL_NODE_MAP[pref]
-    raise EmitError(
-        f"--emit-workflow does not support model {model!r}.\n"
-        f"Supported models: {', '.join(supported_models())}.\n"
-        "These map to ComfyUI API nodes; other proxy models have no node mapping yet."
-    )
+    return None
+
+
+def is_supported(model: str) -> bool:
+    """Whether ``--emit-workflow`` can render ``model`` (alias or canonical id)
+    as a partner node. The per-row ``emit_supported`` flag of ``generate list``."""
+    return _lookup_model(model) is not None
+
+
+def _resolve_model(model: str) -> tuple[str, NodeSpec]:
+    found = _lookup_model(model)
+    if found is None:
+        raise UnsupportedModelError(model, supported_models())
+    return found
 
 
 def build_workflow(model: str, values: dict[str, Any], *, output_prefix: str = "generate") -> dict[str, Any]:

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -14,6 +14,7 @@ collide; widgets are addressed by name, not array index. See ``workflow_ops``.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Annotated, Any
 
 import typer
@@ -427,9 +428,57 @@ def delete_nodes_cmd(
 # ---------------------------------------------------------------------------
 
 
+def _load_clearable_workflow_or_fail(renderer, path: str) -> tuple[Path, dict[str, Any]]:
+    """Load a workflow file for an operation that DISCARDS its content.
+
+    Every edit command reads through ``_load_workflow_or_fail`` and refuses an
+    API-format document (``workflow_not_frontend_format``), because slot
+    addressing needs ``nodes[]``/``links[]``. ``clear`` and ``reset-doc`` do
+    not: the result is the empty frontend document either way. Gating them on
+    the format of what is being thrown away locked a tab in prod — a
+    ``generate --emit-workflow`` API-format draft could then be neither edited
+    NOR cleared, and the agent abandoned the tab.
+
+    An API-format file is replaced by the empty frontend baseline (the same
+    shape ``foreach`` mints a fresh document from) so the op applies to a
+    frontend document and the file is editable afterwards. A JSON value that is
+    a workflow in neither format still fails as before.
+    """
+    from comfy_cli.command.workflow import _is_frontend_format
+    from comfy_cli.workflow_to_api import is_api_format
+
+    p = Path(path).expanduser()
+    if not p.is_file():
+        renderer.error(code="workflow_not_found", message=f"Workflow file not found: {path}", hint="check the path")
+        raise typer.Exit(code=1)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except OSError as e:
+        renderer.error(code="workflow_not_found", message=f"Unable to read workflow file: {e}")
+        raise typer.Exit(code=1) from e
+    except json.JSONDecodeError as e:
+        renderer.error(
+            code="workflow_invalid_json",
+            message=f"Workflow file is not valid JSON: {e}",
+            hint="check the file or re-export from ComfyUI",
+        )
+        raise typer.Exit(code=1) from e
+    if _is_frontend_format(data):
+        return p, data
+    if is_api_format(data):
+        return p, {"nodes": [], "links": [], "groups": [], "last_node_id": 0, "last_link_id": 0}
+    renderer.error(
+        code="workflow_not_frontend_format",
+        message="`comfy workflow` requires a workflow document (frontend `nodes[]`/`links[]`, or API format).",
+        hint="in ComfyUI, use `File > Save (As)` to export the editing format",
+        details={"path": str(p)},
+    )
+    raise typer.Exit(code=1)
+
+
 @tracking.track_command("workflow")
 def clear_cmd(
-    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
+    file: Annotated[str, typer.Argument(help="Workflow JSON (frontend or API format — the content is discarded).")],
     actor: ActorOpt = "cli",
     base_version: BaseVersionOpt = 0,
     stdout: StdoutOpt = False,
@@ -437,7 +486,7 @@ def clear_cmd(
 ):
     renderer = get_renderer()
     renderer.command = "workflow clear"
-    p, workflow = _load_workflow_or_fail(renderer, file)
+    p, workflow = _load_clearable_workflow_or_fail(renderer, file)
     workflow, op = workflow_ops.clear(workflow, actor=actor, base_version=base_version)
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow clear")
 
@@ -449,7 +498,7 @@ def clear_cmd(
 
 @tracking.track_command("workflow")
 def reset_doc_cmd(
-    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
+    file: Annotated[str, typer.Argument(help="Workflow JSON (frontend or API format — the content is discarded).")],
     confirm: Annotated[
         bool,
         typer.Option(
@@ -485,7 +534,7 @@ def reset_doc_cmd(
             ),
         )
         raise typer.Exit(code=1)
-    p, workflow = _load_workflow_or_fail(renderer, file)
+    p, workflow = _load_clearable_workflow_or_fail(renderer, file)
     workflow, op = workflow_ops.reset_doc(workflow, actor=actor, base_version=base_version)
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow reset-doc")
 

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2638,6 +2638,23 @@ def _node_widget_slots(node: dict, prefix: str, graph: Graph) -> list[dict]:
         }
         if entry.port.enum_values:
             slot["enum"] = list(entry.port.enum_values)
+        # A widget converted to an input and wired: the link supplies the value
+        # at run time and the stored widget value is inert — say so, so a
+        # caller edits the source instead (the same rule promoted widgets
+        # follow across a subgraph boundary).
+        linked = next(
+            (
+                i.get("link")
+                for i in node.get("inputs") or []
+                if isinstance(i, dict)
+                and isinstance(i.get("widget"), dict)
+                and i["widget"].get("name") == entry.name
+                and i.get("link") is not None
+            ),
+            None,
+        )
+        if linked is not None:
+            slot["linked_from"] = linked
         slots.append(slot)
     return slots
 
@@ -2669,7 +2686,9 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
         seen_addrs.add(addr)
         slots.append(slot)
 
-    def walk(nodes: list, prefix: str, depth: int) -> None:
+    from comfy_cli.cql import promoted as _promoted
+
+    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]]) -> None:
         if depth > _MAX_SUBGRAPH_DEPTH:
             return
         for node in nodes:
@@ -2681,23 +2700,30 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             sg = defs_by_id.get(node_type)
             if sg is None:
                 for slot in _node_widget_slots(node, node_path, graph):
-                    add(slot)
+                    if (node_id, slot["name"]) not in exclude:
+                        add(slot)
                 continue
 
-            # Subgraph instance. A *curated* template (every declared proxy input
-            # resolves to a live interior widget) keeps its clean, hand-picked
-            # parameter view — we surface only its declared inputs and do NOT
-            # recurse, so the agent sees the intended surface. When the proxies
-            # are missing or dangling (the norm for fetched gallery templates,
-            # whose proxyWidgets point at deleted interior ids) we recurse into
-            # the definition so the real editable inner inputs are reachable.
-            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph)
+            # Subgraph instance. Its promoted widgets are advertised at the
+            # instance address (``57.width``) — the value the frontend runs
+            # lives on the host (cql.promoted), so the interior widget behind
+            # a promotion is NOT advertised: ``57/13.width`` is exactly the
+            # "layer 2" address whose edits the surface overrides. Every
+            # other interior widget is reachable at ``<instance>/<inner>.<w>``
+            # (recursing for nested instances). A legacy template whose
+            # curated surface comes entirely from ``proxyWidgets`` (nothing
+            # linked) keeps its hand-picked view without recursion.
+            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow)
             for slot in declared:
-                add(slot)
-            if not fully_curated:
-                walk(sg.get("nodes") or [], node_path, depth + 1)
+                if (node_id, slot["name"]) not in exclude:
+                    add(slot)
+            promoted = [p for p in _promoted.promoted_inputs(sg, defs_by_id) if p.is_widget]
+            if fully_curated and not promoted:
+                continue
+            hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
+            walk(sg.get("nodes") or [], node_path, depth + 1, hidden)
 
-    walk(workflow.get("nodes") or [], "", 0)
+    walk(workflow.get("nodes") or [], "", 0, set())
     return slots
 
 
@@ -2709,41 +2735,97 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
 _UNRESOLVED = object()
 
 
-def _declared_subgraph_slots(instance: dict, sg: dict, instance_id: str, graph: Graph) -> tuple[list[dict], bool]:
-    """Build slots for a subgraph instance's curated proxy inputs.
+def _declared_subgraph_slots(
+    instance: dict, sg: dict, instance_id: str, graph: Graph, workflow: dict | None = None
+) -> tuple[list[dict], bool]:
+    """Build slots for a subgraph instance's promoted inputs.
+
+    A declared input that a boundary link feeds into an interior widget is a
+    promoted WIDGET (``cql.promoted``): its address is ``<instance>.<name>``
+    and its current value is the one the frontend runs — the host instance's
+    own value when materialized, else the interior default. When an outside
+    link feeds the instance input, the slot says so (``linked_from``): a
+    write must then go to that source node. Socket-only inputs (``VIDEO``…)
+    are link slots, not widget slots. A declared input the definition does
+    not back with a link falls back to the legacy ``proxyWidgets`` route.
 
     Returns ``(slots, fully_curated)`` where ``fully_curated`` is True only when
-    the instance declares at least one input and EVERY declared input resolves
-    to a real interior widget value (so the curated surface is complete and the
-    caller can skip recursion).
+    at least one widget slot exists and EVERY one resolved to a value (so the
+    curated surface is complete and the caller can skip recursion).
     """
+    from comfy_cli.cql import promoted as _promoted
+
     declared: list[dict] = []
-    inputs = sg.get("inputs") or []
     any_declared = False
     all_resolved = True
-    for inp in inputs:
+    defs = _subgraph_defs_by_id(workflow) if workflow is not None else {}
+    promoted_by_name = {p.name: p for p in _promoted.promoted_inputs(sg, defs)}
+    for inp in sg.get("inputs") or []:
         if not isinstance(inp, dict):
             continue
         inp_name = inp.get("name", "")
         if not inp_name:
             continue
+        pi = promoted_by_name.get(inp_name)
+        linked_from = None
+        if pi is not None and pi.is_widget and workflow is not None:
+            current = _promoted.host_value(instance, pi)
+            if current is _promoted.UNSET:
+                current = _promoted.source_value(workflow, sg, pi, graph, defs)
+            if current is _promoted.UNSET:
+                current = _UNRESOLVED
+            linked_from = _promoted.external_link(instance, inp_name)
+        elif pi is not None and pi.is_widget:
+            current = _UNRESOLVED
+        else:
+            legacy = _resolve_proxy_value(instance, sg, inp_name, graph)
+            if legacy is _UNRESOLVED and pi is not None and not pi.is_widget and pi.source_node is None:
+                # Declared but unbacked and unproxied — a socket or a dangling
+                # declaration. Not a widget slot either way.
+                continue
+            current = legacy
         any_declared = True
-        current = _resolve_proxy_value(instance, sg, inp_name, graph)
         if current is _UNRESOLVED:
             all_resolved = False
             continue
         inp_type = inp.get("type", {})
-        declared.append(
-            {
-                "address": f"{instance_id}.{inp_name}",
-                "name": inp_name,
-                "type": inp_type if isinstance(inp_type, str) else str(inp_type),
-                "current_value": current,
-                "instance_id": instance_id,
-                "node_type": instance.get("type", ""),
-            }
-        )
+        slot = {
+            "address": f"{instance_id}.{inp_name}",
+            "name": inp_name,
+            "type": inp_type if isinstance(inp_type, str) else str(inp_type),
+            "current_value": current,
+            "instance_id": instance_id,
+            "node_type": instance.get("type", ""),
+        }
+        if linked_from is not None:
+            slot["linked_from"] = linked_from
+        declared.append(slot)
     return declared, (any_declared and all_resolved)
+
+
+def promoted_source_port(sg: dict, pi: Any, defs: dict[str, dict], graph: Graph) -> tuple[str, Port | None]:
+    """``(interior class, Port)`` of the concrete widget behind promoted input
+    ``pi`` — the schema a host value is validated against."""
+    from comfy_cli.cql import promoted as _promoted
+
+    target = _promoted.deepest_source(sg, pi, defs)
+    if target is None:
+        return "", None
+    path, widget = target
+    current_sg = sg
+    node: dict | None = None
+    for seg in path:
+        node = next((n for n in current_sg.get("nodes") or [] if str(n.get("id")) == seg), None)
+        if node is None:
+            return "", None
+        nxt = defs.get(str(node.get("type", "")))
+        if nxt is not None:
+            current_sg = nxt
+    class_type = str(node.get("type", "")) if node else ""
+    m = graph.node(class_type)
+    if m is None:
+        return class_type, None
+    return class_type, next((p for p in m.inputs if p.name == widget), None)
 
 
 def _resolve_proxy_value(instance: dict, subgraph: dict, input_name: str, graph: Graph):
@@ -3109,50 +3191,42 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
     # Always split on the FIRST dot so multi-dot input names are preserved.
     node_path, input_name = addr.split(".", 1)
     segments = node_path.split(_SUBGRAPH_PATH_SEP)
-
     defs_by_id = _subgraph_defs_by_id(workflow)
 
-    # --- Nested form: descend the subgraph path and write the interior widget. ---
-    if len(segments) > 1:
-        # _resolve_node_path forks every shared definition along the path (each
-        # non-terminal hop) before the terminal write, so sibling instances at
-        # any nesting depth stay independent.
-        target = _resolve_node_path(workflow, segments, defs_by_id)
-        return _write_widget(target, input_name, value, graph, extend=False)
+    from comfy_cli.cql import promoted as _promoted
 
-    instance_id = segments[0]
-    nodes = workflow.get("nodes") or []
-    instance = next((n for n in nodes if isinstance(n, dict) and str(n.get("id", "")) == instance_id), None)
-    if instance is None:
-        raise ValueError(f"node {instance_id} not found in workflow")
-
-    node_type = instance.get("type", "")
-    sg = defs_by_id.get(node_type)
-
-    # --- Curated subgraph proxy input (legacy ``<id>.<declaredInput>``). ---
-    if sg is not None:
-        proxy = (instance.get("properties") or {}).get("proxyWidgets") or []
-        interior_id = None
-        for entry in proxy:
-            if not isinstance(entry, list) or len(entry) < 2:
-                continue
-            name = entry[1] if isinstance(entry[1], str) else str(entry[1])
-            if name == input_name:
-                interior_id = str(entry[0])
-                break
-        if interior_id is None:
-            raise ValueError(
-                f"no proxyWidget mapping for {addr}; "
-                f"address an interior input directly, e.g. {instance_id}/<innerId>.<input> "
-                f"(run `comfy workflow slots` to list them)"
-            )
-        inode = next(
-            (n for n in (sg.get("nodes") or []) if isinstance(n, dict) and str(n.get("id", "")) == interior_id),
-            None,
-        )
-        if inode is None:
-            raise ValueError(f"interior node {interior_id} not found in subgraph")
-        return _write_widget(inode, input_name, value, graph, extend=False)
-
-    # --- Direct mode: regular top-level node. ---
-    return _write_widget(instance, input_name, value, graph, extend=True)
+    # One resolution for every address form — the same one set-widget uses —
+    # so a promoted widget's value lands on the host (or the outside node that
+    # feeds it), an unpromoted interior widget lands in the definition, and a
+    # plain node lands on itself. See ``cql.promoted.resolve_write``.
+    target = _promoted.resolve_write(workflow, graph, segments, input_name)
+    if target.kind == "host":
+        # Fork every shared definition along the path before writing so a
+        # nested host's siblings stay independent (a top-level host has no
+        # non-terminal hop and is not forked — its values are its own).
+        instance = _resolve_node_path(workflow, target.segments, defs_by_id)
+        sg = _subgraph_defs_by_id(workflow).get(str(instance.get("type", "")))
+        pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
+        _class, port = promoted_source_port(sg, pi, _subgraph_defs_by_id(workflow), graph)
+        warnings: list[dict] = []
+        if port is not None:
+            err = port.validate_shape(value)
+            if err:
+                raise ValueError(err)
+            warnings = [dict(w, field=addr) for w in port.validate_catalog(value)]
+        _promoted.set_host_value(workflow, instance, target.widget, value, graph)
+        return warnings
+    if target.kind == "interior":
+        inner = _resolve_node_path(workflow, target.segments, defs_by_id)
+        return _write_widget(inner, target.widget, value, graph, extend=False)
+    if target.kind == "legacy_primitive":
+        node = target.node
+        values = node.get("widgets_values")
+        values = list(values) if isinstance(values, list) else []
+        if not values:
+            values.append(None)
+        values[0] = value
+        node["widgets_values"] = values
+        return []
+    # --- Direct mode: a regular top-level node (or the primitive feeding a promoted input). ---
+    return _write_widget(target.node, target.widget, value, graph, extend=True)

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -589,6 +589,26 @@ def _is_wildcard_type(type_id: str) -> bool:
     return type_id in _WILDCARD_TYPES or type_id.startswith(_WILDCARD_TYPE_PREFIX)
 
 
+def _edge_types_compatible(src_type: str, dst_type: str) -> bool:
+    """Whether an output socket of ``src_type`` may drive an input of ``dst_type``.
+
+    A wildcard on either end (``*``, ``COMFY_MATCHTYPE_V3``) always matches.
+    Otherwise defer to the converter's ``_is_valid_connection`` — the mirror of
+    the frontend's ``isValidConnection`` — which expands a COMMA-SEPARATED
+    union on both ends (``INT,FLOAT`` on a math operand, ``MESH,FILE_3D_GLB,…``
+    on a 3D importer) before comparing. Comparing the raw strings reported a
+    ``FLOAT`` output into an ``INT,FLOAT`` input as ``edge_type_mismatch``:
+    12 of the 23 such warnings in a 3-day prod window were this shape, on
+    edges the frontend draws and the server runs.
+    """
+    if _is_wildcard_type(src_type) or _is_wildcard_type(dst_type):
+        return True
+    # Lazy: workflow_to_api imports this module at load time.
+    from comfy_cli.workflow_to_api import _is_valid_connection
+
+    return _is_valid_connection(src_type, dst_type)
+
+
 def _is_dynamic_combo_type(type_id: str) -> bool:
     """V3 dynamic-combo types (e.g. ``COMFY_DYNAMICCOMBO_V3``): a selector
     widget whose chosen option contributes its own sub-inputs. Same rule the
@@ -1625,9 +1645,13 @@ class Graph:
                     if port is not None:
                         src_type = src_m.outputs[out_idx].type
                         dst_type = port.type
-                        if not _is_wildcard_type(src_type) and not _is_wildcard_type(dst_type) and src_type != dst_type:
+                        if not _edge_types_compatible(src_type, dst_type):
                             # Find the correct index for the expected type
-                            correct = [f"[{i}]" for i, p in enumerate(src_m.outputs) if p.type == dst_type]
+                            correct = [
+                                f"[{i}]"
+                                for i, p in enumerate(src_m.outputs)
+                                if _edge_types_compatible(p.type, dst_type)
+                            ]
                             hint = (
                                 f"use {src_class}{correct[0]} instead"
                                 if correct

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -67,6 +67,29 @@ _AUDIO_UI_CLASSES = frozenset(
 # its own extension keyed on the ``audio`` input; ``file_upload`` (3D loaders)
 # and ``mesh_upload`` attach nothing.
 _IMAGE_UPLOAD_FLAGS = frozenset({"image_upload", "animated_image_upload", "video_upload"})
+# File extensions that identify a COMBO's option list as a listing of the
+# server's INPUT folder rather than an install-time vocabulary. The core
+# loaders mark such ports with ``<kind>_upload``; a custom pack that ships its
+# own upload button does not (VideoHelperSuite builds ``VHS_LoadVideo.video``
+# from ``folder_paths.get_input_directory()`` filtered by its
+# ``video_extensions`` and attaches the button by class name in ``VHS.core.js``,
+# so object_info carries a bare ``[["bedroom.mp4"]]``). The listing itself is
+# the evidence: every option is a media file name, which a model folder
+# (``.safetensors``/``.ckpt``/``.gguf``) or a plain enum (``alpha``/``red``)
+# never is. Families mirror what the frontend's upload widgets accept — image,
+# animated image, video, audio, 3D model.
+_INPUT_FILE_EXTENSIONS = frozenset(
+    {
+        # image / animated image
+        "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "avif", "apng",
+        # video (VHS ``video_extensions`` + core LoadVideo)
+        "mp4", "webm", "mkv", "mov", "avi", "m4v",
+        # audio
+        "mp3", "wav", "ogg", "flac", "m4a", "aac", "opus",
+        # 3D
+        "glb", "gltf", "obj", "fbx", "stl", "ply", "usdz",
+    }
+)  # fmt: skip
 # ``Comfy.Preview3D`` / ``Comfy.SaveGLB`` inject a ``PREVIEW_3D`` ``image`` widget.
 _PREVIEW_3D_CLASSES = frozenset({"SaveGLB", "Preview3D"})
 
@@ -98,6 +121,10 @@ class PortOptions:
     # an upload button and the declared options are the server's *installed input
     # files*, not an install-time enum. See ``Port.is_upload_backed``.
     upload: bool = False
+    # True when object_info carried ANY ``<kind>_upload`` key, true or false —
+    # an explicit declaration either way, which ``Port.is_upload_backed`` obeys
+    # over the option-listing heuristic it otherwise falls back to.
+    upload_declared: bool = False
     # The ``<kind>_upload`` flag names that were set (``("image_upload",)``),
     # so callers can tell WHICH frontend upload extension claims the input.
     upload_flags: tuple[str, ...] = ()
@@ -265,8 +292,24 @@ class Port:
         port is left unconstrained and the real membership check is the
         server's at run time. The sibling ``LoadImageMask.channel`` carries no
         marker and stays a normal, constrained enum.
+
+        The marker is the CORE loaders' contract. A custom pack that ships its
+        own upload button (VideoHelperSuite: ``VHS_LoadVideo.video`` is the
+        input folder filtered by ``video_extensions``, button attached by class
+        name in ``VHS.core.js``) reaches object_info as a bare option list, and
+        the enum check then refused every content hash an agent uploaded to
+        Comfy Cloud (``'<64hex>.mp4' not in 1 known options for video``) — a
+        whole multi-shot assembly killed at ``run`` preflight. When the catalog
+        declares nothing, the listing itself decides: a list made entirely of
+        media file names is a folder listing (see
+        :data:`_INPUT_FILE_EXTENSIONS`). An explicit ``<kind>_upload: false``
+        still wins over that heuristic.
         """
-        return self.type == "COMBO" and self.options.upload
+        if self.type != "COMBO":
+            return False
+        if self.options.upload_declared:
+            return self.options.upload
+        return _is_input_file_listing(self.enum_values)
 
     def canonical_combo(self, value: Any) -> Any | None:
         """Map a *mangled* COMBO value to the real option it clearly means, or
@@ -656,6 +699,30 @@ def _upload_marked(opts_raw: dict) -> bool:
     return any(isinstance(k, str) and k.endswith("_upload") and bool(v) for k, v in opts_raw.items())
 
 
+def _upload_declared(opts_raw: dict) -> bool:
+    """True when the options dict carries an upload marker key at all — set
+    either way. ``image_upload: false`` is a declaration, not an absence."""
+    return any(isinstance(k, str) and k.endswith("_upload") for k in opts_raw)
+
+
+def _is_input_file_listing(values: list[Any]) -> bool:
+    """True when a COMBO's option list reads as a listing of the server's input
+    folder: non-empty, and EVERY option is a file name carrying one of
+    :data:`_INPUT_FILE_EXTENSIONS`. One non-file option (a ``none`` sentinel,
+    a bare label) makes it a vocabulary that happens to contain file names.
+    """
+    if not values:
+        return False
+    for v in values:
+        if not isinstance(v, str):
+            return False
+        name = v.rsplit("/", 1)[-1]
+        stem, dot, ext = name.rpartition(".")
+        if not dot or not stem or ext.lower() not in _INPUT_FILE_EXTENSIONS:
+            return False
+    return True
+
+
 def _parse_port_options(opts_raw: dict) -> PortOptions:
     template_raw = opts_raw.get("template")
     return PortOptions(
@@ -668,6 +735,7 @@ def _parse_port_options(opts_raw: dict) -> PortOptions:
         force_input=bool(opts_raw.get("forceInput", False)),
         template=template_raw if isinstance(template_raw, dict) else None,
         upload=_upload_marked(opts_raw),
+        upload_declared=_upload_declared(opts_raw),
         upload_flags=tuple(
             sorted(k for k, v in opts_raw.items() if isinstance(k, str) and k.endswith("_upload") and bool(v))
         ),

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2721,6 +2721,8 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             if fully_curated and not promoted:
                 continue
             hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
+            # …and the interior widgets a pending legacy repair will own.
+            hidden |= _promoted.planned_hidden_sources(workflow, node, graph, defs_by_id)
             walk(sg.get("nodes") or [], node_path, depth + 1, hidden, sg)
 
     walk(workflow.get("nodes") or [], "", 0, set(), workflow)
@@ -2808,6 +2810,32 @@ def _declared_subgraph_slots(
         if linked_from is not None:
             slot["linked_from"] = linked_from
         declared.append(slot)
+    if workflow is not None:
+        # Legacy ``proxyWidgets`` promotions the definition does not back
+        # yet: the frontend repairs them into linked inputs on load, so they
+        # are advertised where they will live — ``<instance>.<name>`` with the
+        # value the frontend shows (legacy host value, else the interior
+        # source). Reads never mutate; the first write performs the repair.
+        advertised = {s["name"] for s in declared}
+        for entry in _promoted.plan_proxy_migration(workflow, instance, graph, defs):
+            if not entry.repairable or entry.name in advertised:
+                continue
+            advertised.add(entry.name)
+            any_declared = True
+            current = _promoted.entry_effective_value(workflow, sg, entry, graph, defs)
+            if current is _promoted.UNSET:
+                all_resolved = False
+                continue
+            declared.append(
+                {
+                    "address": f"{instance_id}.{entry.name}",
+                    "name": entry.name,
+                    "type": str(entry.type),
+                    "current_value": current,
+                    "instance_id": instance_id,
+                    "node_type": instance.get("type", ""),
+                }
+            )
     return declared, (any_declared and all_resolved)
 
 
@@ -3214,7 +3242,10 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
         # non-terminal hop and is not forked — its values are its own).
         instance = _resolve_node_path(workflow, target.segments, defs_by_id)
         sg = _subgraph_defs_by_id(workflow).get(str(instance.get("type", "")))
-        pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
+        if target.repair is not None:
+            pi = target.repair.as_promoted_input(sg)
+        else:
+            pi = _promoted.find_promoted(sg, _subgraph_defs_by_id(workflow), target.widget)
         _class, port = promoted_source_port(sg, pi, _subgraph_defs_by_id(workflow), graph)
         warnings: list[dict] = []
         if port is not None:
@@ -3222,6 +3253,12 @@ def _apply_one_slot_impl(workflow: dict, addr: str, value: Any, graph: Graph) ->
             if err:
                 raise ValueError(err)
             warnings = [dict(w, field=addr) for w in port.validate_catalog(value)]
+        if target.repair is not None:
+            # A legacy ``proxyWidgets`` promotion: run the frontend's forward
+            # migration on this instance first (forking a shared definition,
+            # since the repair mutates it), exactly as the op path does.
+            _isolate_shared_subgraph(workflow, instance, _subgraph_defs_by_id(workflow))
+            _promoted.flush_proxy_migration(workflow, instance, graph, instance_path=list(target.segments))
         _promoted.set_host_value(workflow, instance, target.widget, value, graph)
         return warnings
     if target.kind == "interior":

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2688,7 +2688,7 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
 
     from comfy_cli.cql import promoted as _promoted
 
-    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]]) -> None:
+    def walk(nodes: list, prefix: str, depth: int, exclude: set[tuple[str, str]], scope: dict) -> None:
         if depth > _MAX_SUBGRAPH_DEPTH:
             return
         for node in nodes:
@@ -2713,7 +2713,7 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             # (recursing for nested instances). A legacy template whose
             # curated surface comes entirely from ``proxyWidgets`` (nothing
             # linked) keeps its hand-picked view without recursion.
-            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow)
+            declared, fully_curated = _declared_subgraph_slots(node, sg, node_id, graph, workflow, scope)
             for slot in declared:
                 if (node_id, slot["name"]) not in exclude:
                     add(slot)
@@ -2721,9 +2721,9 @@ def _extract_frontend_slots(workflow: dict, graph: Graph) -> list[dict]:
             if fully_curated and not promoted:
                 continue
             hidden = {(str(p.source_node), str(p.source_widget or p.source_input)) for p in promoted}
-            walk(sg.get("nodes") or [], node_path, depth + 1, hidden)
+            walk(sg.get("nodes") or [], node_path, depth + 1, hidden, sg)
 
-    walk(workflow.get("nodes") or [], "", 0, set())
+    walk(workflow.get("nodes") or [], "", 0, set(), workflow)
     return slots
 
 
@@ -2736,7 +2736,12 @@ _UNRESOLVED = object()
 
 
 def _declared_subgraph_slots(
-    instance: dict, sg: dict, instance_id: str, graph: Graph, workflow: dict | None = None
+    instance: dict,
+    sg: dict,
+    instance_id: str,
+    graph: Graph,
+    workflow: dict | None = None,
+    scope: dict | None = None,
 ) -> tuple[list[dict], bool]:
     """Build slots for a subgraph instance's promoted inputs.
 
@@ -2774,7 +2779,10 @@ def _declared_subgraph_slots(
                 current = _promoted.source_value(workflow, sg, pi, graph, defs)
             if current is _promoted.UNSET:
                 current = _UNRESOLVED
-            linked_from = _promoted.external_link(instance, inp_name)
+            # Only a LIVE link counts (the workflow's for a top-level instance,
+            # the containing definition's for a nested one); a dangling id is
+            # what the frontend drops on load, so the host value runs.
+            linked_from = _promoted.live_external_link(scope if scope is not None else workflow, instance, inp_name)
         elif pi is not None and pi.is_widget:
             current = _UNRESOLVED
         else:

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -261,16 +261,28 @@ def source_value(workflow: dict, sg: dict, pi: PromotedInput, graph, defs: dict[
     return _interior_widget_value(inner, str(pi.source_widget), graph)
 
 
+def effective_value_for(
+    workflow: dict, instance: dict, sg: dict, pi: PromotedInput, graph, defs: dict[str, dict]
+) -> Any:
+    """:func:`effective_value` for a caller that already holds the resolved
+    ``PromotedInput`` and the definition index — the host value when
+    materialized, else the interior source value (:data:`UNSET` when even that
+    cannot be read). No name lookup, no re-walk of ``promoted_inputs``: a
+    renderer iterating every promoted input of every instance calls this once
+    per widget without re-deriving what its own loop produced."""
+    value = host_value(instance, pi)
+    if value is not UNSET:
+        return value
+    return source_value(workflow, sg, pi, graph, defs)
+
+
 def _effective(workflow: dict, instance: dict, sg: dict, name: str, graph, defs: dict[str, dict]) -> Any:
     pi = find_promoted(sg, defs, name)
     if pi is None:
         raise ValueError(f"{name!r} is not a promoted input of subgraph {sg.get('id')}")
     if not pi.is_widget:
         raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
-    value = host_value(instance, pi)
-    if value is not UNSET:
-        return value
-    return source_value(workflow, sg, pi, graph, defs)
+    return effective_value_for(workflow, instance, sg, pi, graph, defs)
 
 
 def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -162,9 +162,36 @@ def instance_input(instance: dict, name: str) -> dict | None:
 
 
 def external_link(instance: dict, name: str) -> Any:
-    """The link id feeding the instance's input ``name`` from outside, else None."""
+    """The RAW link id serialized on the instance's input ``name``, else None.
+    Prefer :func:`live_external_link`: a serialized id whose link no longer
+    exists is one the frontend drops on load, i.e. the input is unlinked."""
     entry = instance_input(instance, name)
     return None if entry is None else entry.get("link")
+
+
+def link_exists(scope: dict, link_id: Any) -> bool:
+    """Whether ``link_id`` is a live link in ``scope`` — the workflow (top-level
+    links are ``[id, src, slot, dst, slot, type]`` arrays) or a subgraph
+    definition (interior links are ``{"id": …}`` dicts)."""
+    for link in scope.get("links") or []:
+        if isinstance(link, dict):
+            if link.get("id") == link_id:
+                return True
+        elif isinstance(link, (list, tuple)) and link and link[0] == link_id:
+            return True
+    return False
+
+
+def live_external_link(scope: dict, instance: dict, name: str) -> Any:
+    """The link id feeding the instance's input ``name`` from outside, if that
+    link exists in ``scope`` (the workflow for a top-level instance, the
+    containing definition for a nested one); else None. A dangling id is
+    treated as unlinked everywhere — ``set-widget``, ``slots`` and the
+    converter must agree on what runs."""
+    link_id = external_link(instance, name)
+    if link_id is None or not link_exists(scope, link_id):
+        return None
+    return link_id
 
 
 def _quarantine_entries(instance: dict) -> list[dict]:
@@ -478,8 +505,8 @@ def resolve_write(
                 f"promoted input {widget!r} on subgraph node {node_str} is a link input ({pi.type}), not a widget — "
                 f"wire it with `comfy workflow connect <file> <node>.<output> {node_str}.{widget}`"
             )
-        link_id = external_link(node, widget)
-        if link_id is not None and _link_exists(workflow, link_id):
+        link_id = live_external_link(workflow, node, widget)
+        if link_id is not None:
             return trace_upstream_write(workflow, graph, link_id, given, redirected_from=redirected_from or given)
         # No link, or a dangling link id the frontend drops on load: the host
         # value is what runs.
@@ -493,10 +520,6 @@ def resolve_write(
         f"promoted widgets: {', '.join(names) if names else '(none)'} "
         f"(or address an interior widget directly, e.g. {node_str}/<innerId>.<input>)"
     )
-
-
-def _link_exists(workflow: dict, link_id: Any) -> bool:
-    return any(isinstance(x, (list, tuple)) and x and x[0] == link_id for x in workflow.get("links") or [])
 
 
 def trace_upstream_write(

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -94,7 +94,9 @@ def promoted_inputs(sg: dict, defs: dict[str, dict], depth: int = 0) -> list[Pro
             continue
         name = str(inp.get("name") or "")
         type_id = inp.get("type")
-        type_str = type_id if isinstance(type_id, str) else str(type_id)
+        # A missing or non-string declared type is UNKNOWN (""), never the
+        # repr of whatever was there — callers treat "" as "accept the source".
+        type_str = type_id if isinstance(type_id, str) else ""
         source: tuple[str, str, str | None, bool] | None = None
         for link_id in inp.get("linkIds") or []:
             if not isinstance(link_id, (int, str)):

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -1352,15 +1352,27 @@ def flush_proxy_migration(
         source = _inner_node(sg, e.source_node)
         slot_index = e.slot_index
         if slot_index is None:
-            source.setdefault("inputs", []).append(
-                {
+            if e.source_input is not None:
+                # A nested instance backs the widget with its OWN host input
+                # for the projecting subgraph input (``getSlotFromWidget``
+                # over ``promotedInputWidget``): the slot carries that input's
+                # name, or the outer definition could never resolve the
+                # promotion through the inner one.
+                entry = {
+                    "name": e.source_input,
+                    "type": e.type,
+                    "widget": {"name": e.source_input},
+                    "link": None,
+                }
+            else:
+                entry = {
                     "localized_name": e.widget,
                     "name": e.widget,
                     "type": e.type,
                     "widget": {"name": e.widget},
                     "link": None,
                 }
-            )
+            source.setdefault("inputs", []).append(entry)
             slot_index = len(source["inputs"]) - 1
         new_input = _add_subgraph_input(sg, ids[e.key]["input"], str(e.name), str(e.type), e.label)
         _add_boundary_link(sg, new_input, ids[e.key]["links"][0], source, slot_index, str(e.type))
@@ -1382,9 +1394,12 @@ def flush_proxy_migration(
             quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
             continue
         targets = _primitive_targets(sg, primitive)
-        for link in [x for x in sg.get("links") or [] if str(x.get("origin_id")) == primitive_id]:
-            if link.get("origin_slot") == 0:
-                _remove_link(sg, link.get("id"))
+        for link in [
+            x
+            for x in sg.get("links") or []
+            if isinstance(x, dict) and str(x.get("origin_id")) == primitive_id and x.get("origin_slot") == 0
+        ]:
+            _remove_link(sg, link.get("id"))
         link_ids = ids[first.key]["links"]
         if len(link_ids) < len(targets):
             link_ids = repair_ids(instance_path, first.source_node, first.widget, len(targets))["links"]

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -1,0 +1,544 @@
+"""Promoted subgraph widgets — the host-owned value model.
+
+The frontend (``ComfyUI_frontend`` ADR 0009 *"Subgraph promoted widgets use
+linked inputs"*, ``SubgraphNode.ts``) represents a promoted widget as a
+**linked subgraph input**:
+
+* the subgraph definition declares the input (``definitions.subgraphs[].inputs``);
+* a boundary link (origin ``-10``, the subgraph input node) feeds it into an
+  interior node's widget-backed input (an ``inputs[]`` entry carrying a
+  ``widget`` marker), or into a nested subgraph instance's own promoted input;
+* the HOST instance owns the value: ``widgets_values[i]`` on the instance is
+  consumed positionally by the i-th subgraph input that resolves to a widget
+  (``_applyPromotedWidgetValues`` on load, ``serializeFromStoreState`` on
+  save). Socket-only inputs (``VIDEO``, ``MODEL``, an unlinked declaration)
+  own no slot.
+
+The interior widget is only a schema/default provider — *"the host/exterior
+value wins over the interior/source value during repair, persistence, and
+prompt serialization"*. ``properties.proxyWidgets`` is legacy load-time input
+the frontend consumes on migration; it is honored here only as a fallback for
+a name the definition does not declare as an input.
+
+Everything in this module is a pure function over workflow JSON. It never
+mutates a subgraph definition: a promoted value is edited on the instance,
+so sibling instances of a shared definition stay independent by construction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: LiteGraph's id for the virtual subgraph *input* node inside a definition.
+SUBGRAPH_INPUT_NODE_ID = -10
+
+#: Recursion cap for nested promotion chains (an inner instance promoting a
+#: deeper instance's input). Mirrors the frontend's own bounded traversal.
+_MAX_NESTED_PROMOTION_DEPTH = 32
+
+#: Sentinel: "no value is materialized here" (distinct from a stored ``None``).
+UNSET: Any = object()
+
+
+@dataclass(frozen=True)
+class PromotedInput:
+    """One declared subgraph input, as the host instance sees it.
+
+    ``value_index`` is the position in the host's ``widgets_values`` (``None``
+    for a socket-only input). ``source_node``/``source_input`` name the
+    interior input the first resolving boundary link targets;
+    ``source_widget`` is that input's widget name (``None`` when the source is
+    a nested instance's promoted input — ``nested`` is then ``True``).
+    """
+
+    name: str
+    type: str
+    index: int
+    value_index: int | None
+    source_node: str | None = None
+    source_input: str | None = None
+    source_widget: str | None = None
+    nested: bool = False
+
+    @property
+    def is_widget(self) -> bool:
+        return self.value_index is not None
+
+
+def defs_by_id(workflow: dict) -> dict[str, dict]:
+    """Subgraph definitions keyed by id (with the engine's unique-name fallback)."""
+    from comfy_cli.cql.engine import _subgraph_defs_by_id
+
+    return _subgraph_defs_by_id(workflow)
+
+
+def promoted_inputs(sg: dict, defs: dict[str, dict], depth: int = 0) -> list[PromotedInput]:
+    """Every declared input of definition ``sg`` in declaration order, with the
+    host value slot each widget-backed one owns — the frontend's own rule
+    (``SubgraphNode._resolveInputWidget``): walk the input's ``linkIds`` in
+    order and take the first boundary link whose interior target is a
+    widget-backed input, or a nested instance's promoted widget input."""
+    inner = {str(n.get("id")): n for n in sg.get("nodes") or [] if isinstance(n, dict)}
+    # Only hashable ids can be looked up; a malformed (list/dict) id is skipped
+    # rather than crashing conversion of the whole workflow.
+    links = {
+        link.get("id"): link
+        for link in sg.get("links") or []
+        if isinstance(link, dict) and isinstance(link.get("id"), (int, str))
+    }
+    out: list[PromotedInput] = []
+    value_index = 0
+    for idx, inp in enumerate(sg.get("inputs") or []):
+        if not isinstance(inp, dict):
+            continue
+        name = str(inp.get("name") or "")
+        type_id = inp.get("type")
+        type_str = type_id if isinstance(type_id, str) else str(type_id)
+        source: tuple[str, str, str | None, bool] | None = None
+        for link_id in inp.get("linkIds") or []:
+            if not isinstance(link_id, (int, str)):
+                continue
+            link = links.get(link_id)
+            if not isinstance(link, dict):
+                continue
+            target = inner.get(str(link.get("target_id")))
+            if target is None:
+                continue
+            target_inputs = target.get("inputs") or []
+            slot = link.get("target_slot")
+            entry = target_inputs[slot] if isinstance(slot, int) and 0 <= slot < len(target_inputs) else None
+            if not isinstance(entry, dict):
+                continue
+            inner_def = defs.get(str(target.get("type", "")))
+            if inner_def is not None:
+                # The target is itself a subgraph instance: its input entry
+                # carries a widget marker when promoted, but the concrete
+                # widget lives deeper — resolve through its own promotion.
+                if depth < _MAX_NESTED_PROMOTION_DEPTH:
+                    inner_by_name = {p.name: p for p in promoted_inputs(inner_def, defs, depth + 1)}
+                    inner_pi = inner_by_name.get(str(entry.get("name")))
+                    if inner_pi is not None and inner_pi.is_widget:
+                        source = (str(target.get("id")), str(entry.get("name")), None, True)
+                        break
+                continue
+            marker = entry.get("widget")
+            if marker:
+                widget_name = marker.get("name") if isinstance(marker, dict) else None
+                source = (str(target.get("id")), str(entry.get("name")), str(widget_name or entry.get("name")), False)
+                break
+        if source is None:
+            out.append(PromotedInput(name=name, type=type_str, index=idx, value_index=None))
+            continue
+        node_id, input_name, widget_name, nested = source
+        out.append(
+            PromotedInput(
+                name=name,
+                type=type_str,
+                index=idx,
+                value_index=value_index,
+                source_node=node_id,
+                source_input=input_name,
+                source_widget=widget_name,
+                nested=nested,
+            )
+        )
+        value_index += 1
+    return out
+
+
+def find_promoted(sg: dict, defs: dict[str, dict], name: str) -> PromotedInput | None:
+    return next((p for p in promoted_inputs(sg, defs) if p.name == name), None)
+
+
+def instance_input(instance: dict, name: str) -> dict | None:
+    """The instance's serialized ``inputs[]`` entry for subgraph input ``name``."""
+    for entry in instance.get("inputs") or []:
+        if isinstance(entry, dict) and entry.get("name") == name:
+            return entry
+    return None
+
+
+def external_link(instance: dict, name: str) -> Any:
+    """The link id feeding the instance's input ``name`` from outside, else None."""
+    entry = instance_input(instance, name)
+    return None if entry is None else entry.get("link")
+
+
+def _quarantine_entries(instance: dict) -> list[dict]:
+    raw = (instance.get("properties") or {}).get("proxyWidgetErrorQuarantine")
+    return [e for e in raw if isinstance(e, dict)] if isinstance(raw, list) else []
+
+
+def host_value(instance: dict, pi: PromotedInput) -> Any:
+    """The value the host instance materialized for ``pi``, or :data:`UNSET`.
+
+    Order is the frontend's (``_applyPromotedWidgetValues``): a quarantined
+    legacy entry's ``hostValue`` for this name first, then the positional
+    ``widgets_values`` slot.
+    """
+    if not pi.is_widget:
+        return UNSET
+    for entry in reversed(_quarantine_entries(instance)):
+        original = entry.get("originalEntry")
+        if (
+            isinstance(original, list)
+            and len(original) >= 2
+            and str(original[0]) == "-1"
+            and original[1] == pi.name
+            and "hostValue" in entry
+        ):
+            return entry["hostValue"]
+    values = instance.get("widgets_values")
+    if isinstance(values, list) and pi.value_index < len(values):
+        return values[pi.value_index]
+    return UNSET
+
+
+def _interior_widget_value(node: dict, widget: str, graph) -> Any:
+    """Read ``widget`` off an interior node's positional ``widgets_values``."""
+    from comfy_cli.cql.engine import _widgets_as_positional
+
+    node_type = str(node.get("type", ""))
+    values = _widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    order = graph.widget_order_for_node(node_type, values) if graph is not None else []
+    if widget in order:
+        idx = order.index(widget)
+        return values[idx] if idx < len(values) else None
+    return UNSET
+
+
+def source_value(workflow: dict, sg: dict, pi: PromotedInput, graph, defs: dict[str, dict] | None = None) -> Any:
+    """The interior value ``pi`` falls back to when the host has none: the
+    interior widget, or — through a nested instance — that instance's own
+    effective value. :data:`UNSET` when the source cannot be read."""
+    if pi.source_node is None:
+        return UNSET
+    defs = defs if defs is not None else defs_by_id(workflow)
+    inner = next((n for n in sg.get("nodes") or [] if str(n.get("id")) == pi.source_node), None)
+    if inner is None:
+        return UNSET
+    if pi.nested:
+        # The frontend seeds a host widget promoted THROUGH an inner instance
+        # from the deepest concrete widget (``_resolveNestedPromotedSource`` →
+        # ``resolveConcretePromotedWidget``), not from the inner host's value.
+        inner_def = defs.get(str(inner.get("type", "")))
+        if inner_def is None or pi.source_input is None:
+            return UNSET
+        inner_pi = find_promoted(inner_def, defs, pi.source_input)
+        if inner_pi is None:
+            return UNSET
+        return source_value(workflow, inner_def, inner_pi, graph, defs)
+    return _interior_widget_value(inner, str(pi.source_widget), graph)
+
+
+def _effective(workflow: dict, instance: dict, sg: dict, name: str, graph, defs: dict[str, dict]) -> Any:
+    pi = find_promoted(sg, defs, name)
+    if pi is None:
+        raise ValueError(f"{name!r} is not a promoted input of subgraph {sg.get('id')}")
+    if not pi.is_widget:
+        raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
+    value = host_value(instance, pi)
+    if value is not UNSET:
+        return value
+    return source_value(workflow, sg, pi, graph, defs)
+
+
+def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
+    """The value the frontend runs for promoted input ``name`` on ``instance``
+    when nothing outside feeds it: the host value if materialized, else the
+    interior source value (:data:`UNSET` if even that cannot be read).
+
+    Raises ``ValueError`` for a name the definition does not declare, or one
+    that is a socket-only input.
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    return _effective(workflow, instance, sg, name, graph, defs)
+
+
+def set_host_value(workflow: dict, instance: dict, name: str, value: Any, graph) -> Any:
+    """Write ``value`` as the host-owned value of promoted input ``name``.
+
+    Materializes the host's ``widgets_values`` to one entry per widget-backed
+    input (in declaration order, seeded from each input's current effective
+    value) so the positional array the frontend restores stays aligned, then
+    sets the one slot. A quarantined legacy ``hostValue`` for the same name is
+    rewritten too, because the frontend reads it first. The interior
+    definition is never touched. Returns the previous effective value.
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    pis = promoted_inputs(sg, defs)
+    pi = next((p for p in pis if p.name == name), None)
+    if pi is None:
+        raise ValueError(f"{name!r} is not a promoted input of subgraph node {instance.get('id')}")
+    if not pi.is_widget:
+        raise ValueError(f"promoted input {name!r} on subgraph node {instance.get('id')} is a link input, not a widget")
+    old = _effective(workflow, instance, sg, name, graph, defs)
+    widget_backed = [p for p in pis if p.is_widget]
+    current = instance.get("widgets_values")
+    values = list(current) if isinstance(current, list) else []
+    for other in widget_backed:
+        if other.value_index >= len(values):
+            seeded = host_value(instance, other)
+            if seeded is UNSET:
+                seeded = source_value(workflow, sg, other, graph, defs)
+            values.append(None if seeded is UNSET else seeded)
+    values[pi.value_index] = value
+    instance["widgets_values"] = values
+    for entry in _quarantine_entries(instance):
+        original = entry.get("originalEntry")
+        if isinstance(original, list) and len(original) >= 2 and str(original[0]) == "-1" and original[1] == name:
+            if "hostValue" in entry:
+                entry["hostValue"] = value
+    return None if old is UNSET else old
+
+
+def deepest_source(sg: dict, pi: PromotedInput, defs: dict[str, dict]) -> tuple[list[str], str] | None:
+    """``(interior node path, widget name)`` of the concrete widget behind
+    ``pi`` — through any chain of nested instances. ``None`` when unresolvable."""
+    path: list[str] = []
+    current_sg, current = sg, pi
+    for _ in range(_MAX_NESTED_PROMOTION_DEPTH):
+        if current.source_node is None:
+            return None
+        path.append(current.source_node)
+        if not current.nested:
+            return path, str(current.source_widget)
+        inner = next((n for n in current_sg.get("nodes") or [] if str(n.get("id")) == current.source_node), None)
+        inner_def = defs.get(str(inner.get("type", ""))) if inner is not None else None
+        if inner_def is None or current.source_input is None:
+            return None
+        nxt = find_promoted(inner_def, defs, current.source_input)
+        if nxt is None:
+            return None
+        current_sg, current = inner_def, nxt
+    return None
+
+
+def host_widgets_values(instance: dict) -> list[Any]:
+    values = instance.get("widgets_values")
+    return list(values) if isinstance(values, list) else []
+
+
+# --------------------------------------------------------------------------- #
+# Where a widget write lands
+# --------------------------------------------------------------------------- #
+
+#: Frontend virtual nodes that pass a value through (``Reroute``) or hold one
+#: without a server schema (``PrimitiveNode``, ``widgets_values[0]``).
+REROUTE_TYPE = "Reroute"
+LEGACY_PRIMITIVE_TYPE = "PrimitiveNode"
+_MAX_REROUTE_HOPS = 64
+
+
+@dataclass
+class WriteTarget:
+    """The place a ``set-widget``/``set-slot`` address resolves to.
+
+    ``kind`` is ``top`` (an ordinary node's widget — possibly the SOURCE node a
+    promoted input is wired from), ``host`` (a subgraph instance's own value
+    for a promoted input; ``segments`` is the instance path, one segment when
+    top-level), ``interior`` (an unpromoted interior widget; ``segments`` is
+    the interior node path), or ``legacy_primitive`` (a schema-less frontend
+    ``PrimitiveNode``). ``redirected_from`` is the address the caller gave when
+    it was not the effective one.
+    """
+
+    kind: str
+    node: dict | None = None
+    widget: str | None = None
+    segments: list[str] | None = None
+    redirected_from: str | None = None
+
+
+def _find_top(workflow: dict, node_id: Any) -> dict | None:
+    for n in workflow.get("nodes") or []:
+        if isinstance(n, dict) and (n.get("id") == node_id or str(n.get("id")) == str(node_id)):
+            return n
+    return None
+
+
+def _navigate(workflow: dict, segments: list[str], defs: dict[str, dict]) -> dict:
+    node = _find_top(workflow, segments[0])
+    if node is None:
+        raise ValueError(f"node {segments[0]} not found in workflow")
+    for seg in segments[1:]:
+        sg = defs.get(str(node.get("type", "")))
+        if sg is None:
+            raise ValueError(f"node {node.get('id')} is not a subgraph; cannot descend to {seg!r}")
+        node = next((n for n in sg.get("nodes") or [] if isinstance(n, dict) and str(n.get("id")) == str(seg)), None)
+        if node is None:
+            raise ValueError(f"interior node {seg} not found in subgraph {sg.get('id')}")
+    return node
+
+
+def legacy_proxy_interior(instance: dict, widget: str) -> str | None:
+    """The interior node id a legacy ``proxyWidgets`` entry routes ``widget`` to."""
+    for entry in (instance.get("properties") or {}).get("proxyWidgets") or []:
+        if isinstance(entry, list) and len(entry) >= 2 and str(entry[1]) == widget and str(entry[0]) != "-1":
+            return str(entry[0])
+    return None
+
+
+def resolve_write(
+    workflow: dict, graph, segments: list[str], widget: str, *, redirected_from: str | None = None
+) -> WriteTarget:
+    """Resolve a widget address to the place whose value the graph runs.
+
+    * ``<instance>.<promoted>`` — the host instance's own value (ADR 0009)…
+      unless an outside link feeds that input, in which case the write follows
+      the link to its source (a primitive's single widget, through reroutes);
+      a source that is not a primitive is refused by name, because no widget
+      write could take effect.
+    * ``<instance>/<inner>.<widget>`` whose interior input is fed by the
+      subgraph input node (``-10``) — the same host value, so it redirects
+      there (``redirected_from`` records the given address). An interior
+      widget fed by another interior node is refused the same way.
+    * any other interior widget — written in the definition, as before.
+    * a promoted name the definition does not declare as an input but the
+      legacy ``proxyWidgets`` still route — the interior, as before.
+    """
+    defs = defs_by_id(workflow)
+    if len(segments) > 1:
+        target = _navigate(workflow, segments, defs)
+        parent = _navigate(workflow, segments[:-1], defs)
+        parent_def = defs.get(str(parent.get("type", "")))
+        target_def = defs.get(str(target.get("type", "")))
+        given = f"{'/'.join(segments)}.{widget}"
+        entry = next(
+            (
+                i
+                for i in target.get("inputs") or []
+                if isinstance(i, dict)
+                and (
+                    (isinstance(i.get("widget"), dict) and i["widget"].get("name") == widget)
+                    or (i.get("name") == widget and (i.get("widget") or target_def is not None))
+                )
+            ),
+            None,
+        )
+        link_id = entry.get("link") if entry is not None else None
+        if link_id is not None and parent_def is not None:
+            link = next(
+                (x for x in parent_def.get("links") or [] if isinstance(x, dict) and x.get("id") == link_id), None
+            )
+            if link is not None and link.get("origin_id") == SUBGRAPH_INPUT_NODE_ID:
+                sg_inputs = parent_def.get("inputs") or []
+                origin_slot = link.get("origin_slot")
+                sg_input = (
+                    sg_inputs[origin_slot]
+                    if isinstance(origin_slot, int) and 0 <= origin_slot < len(sg_inputs)
+                    else None
+                )
+                if isinstance(sg_input, dict) and sg_input.get("name"):
+                    return resolve_write(
+                        workflow, graph, segments[:-1], str(sg_input["name"]), redirected_from=redirected_from or given
+                    )
+            if link is not None:
+                origin = link.get("origin_id")
+                origin_node = next((n for n in parent_def.get("nodes") or [] if str(n.get("id")) == str(origin)), None)
+                raise ValueError(
+                    f"{given} is fed by interior node {'/'.join(segments[:-1])}/{origin} "
+                    f"({origin_node.get('type') if origin_node else '?'}) — that link supplies the value, so a widget "
+                    f"write there would be ignored; edit that node's own widgets instead (see `comfy workflow slots`)"
+                )
+        if target_def is not None:
+            pi = find_promoted(target_def, defs, widget)
+            if pi is not None and pi.is_widget:
+                return WriteTarget(
+                    "host", node=target, widget=widget, segments=segments, redirected_from=redirected_from
+                )
+        return WriteTarget("interior", widget=widget, segments=segments, redirected_from=redirected_from)
+
+    node_str = segments[0]
+    node = _find_top(workflow, node_str)
+    if node is None:
+        raise ValueError(f"node {node_str} not found in workflow")
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
+        return WriteTarget("top", node=node, widget=widget, redirected_from=redirected_from)
+    given = f"{node_str}.{widget}"
+    pi = find_promoted(sg, defs, widget)
+    if pi is not None:
+        if not pi.is_widget:
+            legacy = legacy_proxy_interior(node, widget)
+            if legacy is not None:
+                return WriteTarget(
+                    "interior", widget=widget, segments=[node_str, legacy], redirected_from=redirected_from
+                )
+            raise ValueError(
+                f"promoted input {widget!r} on subgraph node {node_str} is a link input ({pi.type}), not a widget — "
+                f"wire it with `comfy workflow connect <file> <node>.<output> {node_str}.{widget}`"
+            )
+        link_id = external_link(node, widget)
+        if link_id is not None and _link_exists(workflow, link_id):
+            return trace_upstream_write(workflow, graph, link_id, given, redirected_from=redirected_from or given)
+        # No link, or a dangling link id the frontend drops on load: the host
+        # value is what runs.
+        return WriteTarget("host", node=node, widget=widget, segments=[node_str], redirected_from=redirected_from)
+    legacy = legacy_proxy_interior(node, widget)
+    if legacy is not None:
+        return WriteTarget("interior", widget=widget, segments=[node_str, legacy], redirected_from=redirected_from)
+    names = [p.name for p in promoted_inputs(sg, defs) if p.is_widget]
+    raise ValueError(
+        f"promoted input {widget!r} not found on subgraph node {node_str}; "
+        f"promoted widgets: {', '.join(names) if names else '(none)'} "
+        f"(or address an interior widget directly, e.g. {node_str}/<innerId>.<input>)"
+    )
+
+
+def _link_exists(workflow: dict, link_id: Any) -> bool:
+    return any(isinstance(x, (list, tuple)) and x and x[0] == link_id for x in workflow.get("links") or [])
+
+
+def trace_upstream_write(
+    workflow: dict, graph, link_id: Any, given: str, *, redirected_from: str | None
+) -> WriteTarget:
+    """Follow the link feeding a promoted input to the widget that is its source
+    of truth: a primitive's single value widget (``PrimitiveInt.value``, a
+    legacy ``PrimitiveNode``), through any ``Reroute`` chain. Anything else
+    computes the value (``ResolutionSelector``, ``GetImageSize``, another
+    subgraph's output), so a widget write could not take effect — refused
+    with the driver named so the caller edits it or rewires."""
+    from comfy_cli.cql.engine import FRONTEND_MARKER_SLOTS, _widgets_as_positional
+
+    defs = defs_by_id(workflow)
+    links = workflow.get("links") or []
+    for _ in range(_MAX_REROUTE_HOPS):
+        link = next((x for x in links if isinstance(x, (list, tuple)) and len(x) >= 3 and x[0] == link_id), None)
+        if link is None:
+            raise ValueError(f"{given} is fed by link {link_id}, which does not exist in the workflow")
+        src_id, src_slot = link[1], link[2]
+        src = _find_top(workflow, src_id)
+        if src is None:
+            raise ValueError(f"{given} is fed by node {src_id}, which does not exist in the workflow")
+        src_type = str(src.get("type", ""))
+        if src_type == REROUTE_TYPE:
+            inputs = src.get("inputs") or []
+            link_id = inputs[0].get("link") if inputs and isinstance(inputs[0], dict) else None
+            if link_id is None:
+                raise ValueError(f"{given} is fed by Reroute {src_id}, which has no input — connect a primitive to it")
+            continue
+        if src_type == LEGACY_PRIMITIVE_TYPE:
+            outputs = src.get("outputs") or []
+            marker = outputs[0].get("widget") if outputs and isinstance(outputs[0], dict) else None
+            name = marker.get("name") if isinstance(marker, dict) and marker.get("name") else "value"
+            return WriteTarget("legacy_primitive", node=src, widget=str(name), redirected_from=redirected_from)
+        m = graph.node(src_type) if graph is not None and src_type not in defs else None
+        if m is not None:
+            widgets = _widgets_as_positional(src.get("widgets_values"), graph, src_type)
+            order = [n for n in graph.widget_order_for_node(src_type, widgets) if n not in FRONTEND_MARKER_SLOTS]
+            if len(order) == 1:
+                return WriteTarget("top", node=src, widget=order[0], redirected_from=redirected_from)
+        raise ValueError(
+            f"{given} is driven by node {src_id} ({src_type}) output {src_slot} — that link supplies the value, "
+            f"so writing the widget would be ignored. Edit node {src_id}'s own widgets (see `comfy workflow slots`), "
+            f"or connect a primitive (e.g. PrimitiveInt) to {given} and set its value."
+        )
+    raise ValueError(f"{given}: reroute chain too deep")

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -17,17 +17,24 @@ linked inputs"*, ``SubgraphNode.ts``) represents a promoted widget as a
 The interior widget is only a schema/default provider — *"the host/exterior
 value wins over the interior/source value during repair, persistence, and
 prompt serialization"*. ``properties.proxyWidgets`` is legacy load-time input
-the frontend consumes on migration; it is honored here only as a fallback for
-a name the definition does not declare as an input.
+the frontend consumes on migration. A legacy entry the definition does not
+back with a linked input is repaired the way the frontend repairs it on load
+(:func:`flush_proxy_migration`, the "forward migration" section below) before
+a write lands on it; an entry the migration cannot repair is quarantined and
+its interior widget stays the live one.
 
-Everything in this module is a pure function over workflow JSON. It never
-mutates a subgraph definition: a promoted value is edited on the instance,
-so sibling instances of a shared definition stay independent by construction.
+Everything in this module is a pure function over workflow JSON. A promoted
+value is edited on the instance — the definition is touched only by the
+forward migration, which the op layer runs on an isolated (forked) copy when
+the definition is shared, so sibling instances stay independent.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib as _hashlib
+import re as _re
+import uuid as _uuid
+from dataclasses import dataclass, field
 from typing import Any
 
 #: LiteGraph's id for the virtual subgraph *input* node inside a definition.
@@ -290,6 +297,11 @@ def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
     when nothing outside feeds it: the host value if materialized, else the
     interior source value (:data:`UNSET` if even that cannot be read).
 
+    A legacy ``proxyWidgets`` promotion the definition does not back yet
+    reads as the frontend will show it after its own migration: the legacy
+    positional host value, else the interior source (the address is the
+    input name the repair mints — see :func:`plan_proxy_migration`).
+
     Raises ``ValueError`` for a name the definition does not declare, or one
     that is a socket-only input.
     """
@@ -297,6 +309,13 @@ def effective_value(workflow: dict, instance: dict, name: str, graph) -> Any:
     sg = defs.get(str(instance.get("type", "")))
     if sg is None:
         raise ValueError(f"node {instance.get('id')} is not a subgraph instance")
+    pi = find_promoted(sg, defs, name)
+    if pi is None or not pi.is_widget:
+        pending = next(
+            (e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable and e.name == name), None
+        )
+        if pending is not None:
+            return entry_effective_value(workflow, sg, pending, graph, defs)
     return _effective(workflow, instance, sg, name, graph, defs)
 
 
@@ -396,6 +415,11 @@ class WriteTarget:
     widget: str | None = None
     segments: list[str] | None = None
     redirected_from: str | None = None
+    #: A ``host`` target whose promotion is still a legacy ``proxyWidgets``
+    #: entry: the write must first run :func:`flush_proxy_migration` on the
+    #: instance. This is the entry it repairs; ``widget`` is the input name
+    #: the repair mints.
+    repair: Any = None
 
 
 def _find_top(workflow: dict, node_id: Any) -> dict | None:
@@ -442,8 +466,14 @@ def resolve_write(
       there (``redirected_from`` records the given address). An interior
       widget fed by another interior node is refused the same way.
     * any other interior widget — written in the definition, as before.
-    * a promoted name the definition does not declare as an input but the
-      legacy ``proxyWidgets`` still route — the interior, as before.
+    * a name only the legacy ``proxyWidgets`` route — a promotion the
+      frontend's load-time migration turns into a linked input. The host,
+      after the same repair (``repair`` names the entry; see
+      :func:`flush_proxy_migration`). An interior address the repair would
+      own (the entry's source widget, a primitive's fan-out target) redirects
+      there too. An entry the migration cannot repair (quarantined — e.g.
+      ``control_after_generate``, which has no backing input slot) keeps the
+      interior widget as the live one, so the write lands there as before.
     """
     defs = defs_by_id(workflow)
     if len(segments) > 1:
@@ -452,6 +482,17 @@ def resolve_write(
         parent_def = defs.get(str(parent.get("type", "")))
         target_def = defs.get(str(target.get("type", "")))
         given = f"{'/'.join(segments)}.{widget}"
+        if parent_def is not None:
+            pending = planned_repair_for_interior(workflow, parent, graph, str(target.get("id")), widget, defs)
+            if pending is not None:
+                return WriteTarget(
+                    "host",
+                    node=parent,
+                    widget=str(pending.name),
+                    segments=segments[:-1],
+                    redirected_from=redirected_from or given,
+                    repair=pending,
+                )
         entry = next(
             (
                 i
@@ -506,6 +547,17 @@ def resolve_write(
         return WriteTarget("top", node=node, widget=widget, redirected_from=redirected_from)
     given = f"{node_str}.{widget}"
     pi = find_promoted(sg, defs, widget)
+    if pi is None or not pi.is_widget:
+        pending = planned_repair(workflow, node, graph, widget, defs)
+        if pending is not None:
+            return WriteTarget(
+                "host",
+                node=node,
+                widget=str(pending.name),
+                segments=[node_str],
+                redirected_from=redirected_from or (given if pending.name != widget else None),
+                repair=pending,
+            )
     if pi is not None:
         if not pi.is_widget:
             legacy = legacy_proxy_interior(node, widget)
@@ -579,3 +631,863 @@ def trace_upstream_write(
             f"or connect a primitive (e.g. PrimitiveInt) to {given} and set its value."
         )
     raise ValueError(f"{given}: reroute chain too deep")
+
+
+# --------------------------------------------------------------------------- #
+# Legacy ``properties.proxyWidgets`` → linked inputs: the forward migration
+# --------------------------------------------------------------------------- #
+#
+# A port of the frontend's ``flushProxyWidgetMigration``
+# (``src/core/graph/subgraph/migration/proxyWidgetMigration.ts``; ADR 0009
+# "Forward migration", "Primitive-node repair", "Proxy widget error
+# quarantine", "Serialization"). The frontend runs it on every subgraph host
+# when a workflow loads; the CLI runs it on the one instance whose legacy
+# promotion a write is about to edit, so that write can land on the HOST
+# value like every other promoted widget instead of on the interior node.
+#
+# Per entry ``[sourceNodeId, sourceWidgetName(, disambiguator)]``:
+#
+# * already represented by a linked subgraph input → consumed (``alreadyLinked``);
+# * a ``$$``-prefixed name or a preview pseudo-widget → a display-only preview
+#   exposure: no input, no value. The frontend moves it into its
+#   preview-exposure store; the CLI leaves the entry in ``proxyWidgets`` so the
+#   frontend's own load-time migration (which also auto-exposes preview nodes
+#   when ``previewExposures`` is unset) produces exactly the state it would
+#   have produced from the untouched file;
+# * a ``PrimitiveNode`` source → ONE subgraph input for its whole fan-out, every
+#   former target reconnected to it, the primitive left in place but inert
+#   (``primitiveBypass``; all-or-quarantine);
+# * any other value widget → a subgraph input named after the widget
+#   (``nextUniqueName`` on collision), a boundary link from the subgraph input
+#   node (``-10``) into the widget's backing input slot, and the host value
+#   (``createSubgraphInput``);
+# * anything unrepairable → ``properties.proxyWidgetErrorQuarantine`` with
+#   ``{originalEntry, reason, hostValue?, attemptedAtVersion: 1}``.
+#
+# Host values come from the instance's pre-migration ``widgets_values``
+# POSITIONALLY BY ``proxyWidgets`` ORDER (``pickHostValue``) — a hole (no
+# such index) means "keep the interior default". Consumed and quarantined
+# entries are removed from ``proxyWidgets``; canonical saves never re-emit
+# them.
+#
+# Determinism: every id the repair mints (the subgraph input's uuid, each
+# boundary link id) is DERIVED from ``(instance path, source node, widget)``
+# — never random, never a counter — so two replicas replaying the same op, or
+# two replicas independently repairing the same entry, produce byte-identical
+# documents (the convergence requirement of :mod:`comfy_cli.workflow_ops`).
+
+QUARANTINE_PROPERTY = "proxyWidgetErrorQuarantine"
+PROXY_BYPASS_MARKER_PROPERTY = "proxyBypassedToSubgraphInput"
+QUARANTINE_VERSION = 1
+CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview"
+
+#: ``isPreviewPseudoWidget``: a ``$$`` name, or a ``serialize:false`` widget of
+#: type ``preview``/``video``/``audioUI``. The catalog carries no frontend-only
+#: widgets, so the CLI projects the type rule onto the one such widget the
+#: engine already models by name (``FRONTEND_MARKER_SLOTS``): ``audioUI``.
+_PREVIEW_PSEUDO_WIDGET_NAMES = frozenset({"audioUI"})
+
+#: The legacy ``PrimitiveNode`` has no server schema: its value widget is named
+#: ``value`` and, when the target widget carries one, a linked
+#: ``control_after_generate`` follows it in ``widgets_values``.
+_PRIMITIVE_WIDGET_ORDER = ("value", "control_after_generate")
+
+#: ``LEGACY_PROXY_WIDGET_PREFIX_PATTERN``: an older save could prefix a nested
+#: widget name with its node id (``"12:seed"``).
+_LEGACY_PREFIX_RE = _re.compile(r"^\s*(\d+)\s*:\s*(.+)$")
+
+#: Minted link ids share the op model's leaderless range (see
+#: ``workflow_ops.mint_id``): always above any frontend counter id, always
+#: inside JS ``Number.MAX_SAFE_INTEGER``.
+_LINK_ID_FLOOR = 1 << 40
+_LINK_ID_BITS = 52
+
+PLAN_ALREADY_LINKED = "alreadyLinked"
+PLAN_CREATE = "createSubgraphInput"
+PLAN_PRIMITIVE = "primitiveBypass"
+PLAN_PREVIEW = "previewExposure"
+PLAN_QUARANTINE = "quarantine"
+
+
+def next_unique_name(name: str, existing: Any = ()) -> str:
+    """``nextUniqueName``: ``seed`` → ``seed_1`` → ``seed_2`` … while taken."""
+    existing = list(existing)
+    base, i = name, 1
+    while name in existing:
+        name = f"{base}_{i}"
+        i += 1
+    return name
+
+
+@dataclass
+class LegacyEntry:
+    """One ``proxyWidgets`` tuple with the migration's decision for it.
+
+    ``name`` is the subgraph input the entry resolves to: the linked input for
+    ``alreadyLinked``, the (collision-free) input the flush will mint for
+    ``createSubgraphInput``/``primitiveBypass``. ``host_value`` is the legacy
+    positional host value (:data:`UNSET` for a hole). ``targets`` are a
+    primitive's ``(target node id, slot)`` fan-out in reconnect order.
+    """
+
+    original: list
+    index: int
+    source_node: str
+    widget: str
+    disambiguator: str | None
+    plan: str
+    name: str | None = None
+    reason: str | None = None
+    host_value: Any = UNSET
+    type: str | None = None
+    targets: list[tuple[str, int]] = field(default_factory=list)
+    source_input: str | None = None  # a nested instance source: the input it projects
+    slot_index: int | None = None  # createSubgraphInput: the backing input slot (None → synthesize)
+    label: str | None = None
+
+    @property
+    def repairable(self) -> bool:
+        return self.plan in (PLAN_CREATE, PLAN_PRIMITIVE)
+
+    @property
+    def key(self) -> str:
+        return f"{self.source_node}.{self.widget}"
+
+    def as_promoted_input(self, sg: dict) -> PromotedInput:
+        """A schema-only view of the input the repair mints, so the same
+        validation/source-port lookup a linked promotion gets applies."""
+        if self.plan == PLAN_PRIMITIVE:
+            tid, slot = self.targets[0]
+            target = next((n for n in sg.get("nodes") or [] if str(n.get("id")) == tid), None)
+            entry = (target.get("inputs") or [])[slot] if target is not None else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            widget = marker.get("name") if isinstance(marker, dict) and marker.get("name") else entry.get("name")
+            return PromotedInput(
+                name=str(self.name),
+                type=str(self.type),
+                index=-1,
+                value_index=-1,
+                source_node=tid,
+                source_input=str(entry.get("name")) if isinstance(entry, dict) else None,
+                source_widget=str(widget),
+            )
+        nested = self.source_input is not None
+        return PromotedInput(
+            name=str(self.name),
+            type=str(self.type),
+            index=-1,
+            value_index=-1,
+            source_node=self.source_node,
+            source_input=self.source_input if nested else self.widget,
+            source_widget=None if nested else self.widget,
+            nested=nested,
+        )
+
+
+@dataclass
+class FlushReport:
+    consumed: list[list] = field(default_factory=list)
+    created: list[str] = field(default_factory=list)
+    quarantined: list[dict] = field(default_factory=list)
+    remaining: list[list] = field(default_factory=list)
+
+
+def _proxy_tuples(instance: dict) -> list[list]:
+    """``parseProxyWidgets``: the whole property must parse (an array of
+    2/3-string tuples) or none of it migrates."""
+    raw = (instance.get("properties") or {}).get("proxyWidgets")
+    if not isinstance(raw, list):
+        return []
+    out: list[list] = []
+    for entry in raw:
+        if not isinstance(entry, list) or len(entry) not in (2, 3) or not all(isinstance(x, str) for x in entry):
+            return []
+        out.append(list(entry))
+    return out
+
+
+def _inner_node(sg: dict, node_id: Any) -> dict | None:
+    return next((n for n in sg.get("nodes") or [] if isinstance(n, dict) and str(n.get("id")) == str(node_id)), None)
+
+
+def _node_widget_names(node: dict, graph) -> list[str]:
+    """The widgets the frontend would find on ``node`` (``node.widgets``)."""
+    if str(node.get("type", "")) == LEGACY_PRIMITIVE_TYPE:
+        return list(_PRIMITIVE_WIDGET_ORDER)
+    if graph is None:
+        return []
+    from comfy_cli.cql.engine import _widgets_as_positional
+
+    node_type = str(node.get("type", ""))
+    values = _widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    return list(graph.widget_order_for_node(node_type, values))
+
+
+def _node_widget_value(node: dict, widget: str, graph) -> Any:
+    order = _node_widget_names(node, graph)
+    if widget not in order:
+        return UNSET
+    values = node.get("widgets_values")
+    if str(node.get("type", "")) != LEGACY_PRIMITIVE_TYPE and graph is not None:
+        from comfy_cli.cql.engine import _widgets_as_positional
+
+        values = _widgets_as_positional(values, graph, str(node.get("type", "")))
+    if not isinstance(values, list):
+        return UNSET
+    idx = order.index(widget)
+    return values[idx] if idx < len(values) else UNSET
+
+
+def _is_preview_pseudo_widget(widget: str) -> bool:
+    return widget.startswith("$$") or widget in _PREVIEW_PSEUDO_WIDGET_NAMES
+
+
+def _promotion_source(sg: dict, inp: dict, defs: dict[str, dict]) -> tuple[str, str] | None:
+    """``resolvePromotionSource``: the ``(interior node, widget)`` a subgraph
+    input projects — the first of its links that lands on a nested instance's
+    input or on a widget-backed input slot."""
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    for link_id in inp.get("linkIds") or []:
+        link = links.get(link_id) if isinstance(link_id, (int, str)) else None
+        if link is None:
+            continue
+        target = _inner_node(sg, link.get("target_id"))
+        if target is None:
+            continue
+        entries = target.get("inputs") or []
+        slot = link.get("target_slot")
+        entry = entries[slot] if isinstance(slot, int) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            continue
+        if str(target.get("type", "")) in defs:
+            return str(target.get("id")), str(entry.get("name"))
+        marker = entry.get("widget")
+        if isinstance(marker, dict) and marker.get("name"):
+            return str(target.get("id")), str(marker["name"])
+    return None
+
+
+def _find_host_input_for_promotion(sg: dict, defs: dict[str, dict], node_id: str, widget: str) -> str | None:
+    for inp in sg.get("inputs") or []:
+        if isinstance(inp, dict) and _promotion_source(sg, inp, defs) == (node_id, widget):
+            return str(inp.get("name"))
+    return None
+
+
+def _subgraph_input_target(inner_def: dict, defs: dict[str, dict], input_name: str) -> tuple[str, str] | None:
+    """``resolveSubgraphInputTarget``: what a nested instance's input projects."""
+    inp = next((i for i in inner_def.get("inputs") or [] if isinstance(i, dict) and i.get("name") == input_name), None)
+    return _promotion_source(inner_def, inp, defs) if inp is not None else None
+
+
+def _can_resolve_legacy_proxy(sg: dict, defs: dict[str, dict], node_id: str, widget: str, graph) -> bool:
+    """``resolveConcretePromotedWidget(...).status === 'resolved'``: walk
+    through nested instances to a concrete interior widget."""
+    current_sg, current_id, current_widget = sg, node_id, widget
+    for _ in range(_MAX_NESTED_PROMOTION_DEPTH):
+        node = _inner_node(current_sg, current_id)
+        if node is None:
+            return False
+        inner_def = defs.get(str(node.get("type", "")))
+        if inner_def is not None:
+            target = _subgraph_input_target(inner_def, defs, current_widget)
+            if target is None:
+                return False
+            current_sg, (current_id, current_widget) = inner_def, target
+            continue
+        return current_widget in _node_widget_names(node, graph)
+    return False
+
+
+def _normalize_entry(
+    sg: dict, defs: dict[str, dict], node_id: str, widget: str, disambiguator: str | None, graph
+) -> tuple[str, str, str | None]:
+    """``normalizeLegacyProxyWidgetEntry``: strip ``<id>:`` prefixes off a
+    widget name that does not resolve as written, surfacing the deepest
+    prefix as the disambiguator."""
+    if _can_resolve_legacy_proxy(sg, defs, node_id, widget, graph):
+        return node_id, widget, disambiguator
+    remaining, deepest = widget, None
+    while True:
+        m = _LEGACY_PREFIX_RE.match(remaining)
+        if m is None:
+            break
+        deepest, remaining = m.group(1), m.group(2)
+    return node_id, remaining, deepest or disambiguator
+
+
+def _resolve_source_widget(
+    sg: dict, source: dict, widget: str, disambiguator: str | None, defs: dict[str, dict], graph
+) -> tuple[str, str | None] | None:
+    """``resolveSourceWidget``: ``(widget name, projecting input name)``.
+
+    On a nested instance the widget is one of its widget-backed promoted
+    inputs (matched by what the input projects, or by the input's own name);
+    on an ordinary node it is one of the node's widgets — plus the virtual
+    canvas preview every image node can expose (``getPromotableWidgets``).
+    """
+    inner_def = defs.get(str(source.get("type", "")))
+    if inner_def is not None:
+        by_name = {p.name: p for p in promoted_inputs(inner_def, defs)}
+        for inp in inner_def.get("inputs") or []:
+            if not isinstance(inp, dict):
+                continue
+            target = _subgraph_input_target(inner_def, defs, str(inp.get("name")))
+            if disambiguator is not None:
+                hit = target is not None and target[1] == widget and target[0] == disambiguator
+            else:
+                hit = inp.get("name") == widget or (target is not None and target[1] == widget)
+            if not hit:
+                continue
+            pi = by_name.get(str(inp.get("name")))
+            return (widget, str(inp.get("name"))) if pi is not None and pi.is_widget else None
+        return None
+    if widget in _node_widget_names(source, graph) or widget == CANVAS_IMAGE_PREVIEW_WIDGET:
+        return widget, None
+    return None
+
+
+def _slot_for_widget(source: dict, widget: str, projecting_input: str | None, defs: dict[str, dict], graph):
+    """``getSlotFromWidget``: ``(index, entry, type)`` of the input slot backing
+    ``widget``. The serialized ``inputs[]`` may omit an unlinked widget slot
+    the runtime node still has (older saves); then ``index`` is ``None`` and
+    the flush appends one with ``type``. ``None`` when no slot backs it — a
+    frontend-only widget such as ``control_after_generate``."""
+    entries = source.get("inputs") or []
+    inner_def = defs.get(str(source.get("type", "")))
+    if inner_def is not None:
+        name = projecting_input or widget
+        for idx, entry in enumerate(entries):
+            if isinstance(entry, dict) and entry.get("name") == name:
+                return idx, entry, str(entry.get("type") or "*")
+        pi = find_promoted(inner_def, defs, name)
+        return (None, None, pi.type) if pi is not None else None
+    for idx, entry in enumerate(entries):
+        marker = entry.get("widget") if isinstance(entry, dict) else None
+        if isinstance(marker, dict) and marker.get("name") == widget:
+            return idx, entry, str(entry.get("type") or "*")
+    m = graph.node(str(source.get("type", ""))) if graph is not None else None
+    port = next((p for p in m.inputs if p.name == widget), None) if m is not None else None
+    if port is None or port.is_link:
+        return None
+    return None, None, str(port.type)
+
+
+def _primitive_targets(sg: dict, primitive: dict) -> list[tuple[str, int]]:
+    """Every existing link out of the primitive's output 0, in link order."""
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    outputs = primitive.get("outputs") or []
+    listed = outputs[0].get("links") if outputs and isinstance(outputs[0], dict) else None
+    ordered = [links[i] for i in listed if i in links] if isinstance(listed, list) else []
+    if not ordered:
+        ordered = [
+            x
+            for x in links.values()
+            if str(x.get("origin_id")) == str(primitive.get("id")) and x.get("origin_slot") == 0
+        ]
+    return [(str(x.get("target_id")), x.get("target_slot")) for x in ordered if isinstance(x.get("target_slot"), int)]
+
+
+def _types_compatible(a: str, b: str) -> bool:
+    return a == b or a == "*" or b == "*"
+
+
+def plan_proxy_migration(workflow: dict, instance: dict, graph, defs: dict[str, dict] | None = None) -> list:
+    """The migration's decision for every ``proxyWidgets`` entry of
+    ``instance`` — a dry run of :func:`flush_proxy_migration`, in entry order,
+    with the input names the flush will mint (creates first, then primitive
+    cohorts, each ``nextUniqueName``-collision-free against what precedes it).
+    Empty when the instance has no (valid) legacy entries."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    tuples = _proxy_tuples(instance)
+    if sg is None or not tuples:
+        return []
+    host_values = instance.get("widgets_values")
+    host_values = host_values if isinstance(host_values, list) else None
+
+    normalized = [_normalize_entry(sg, defs, t[0], t[1], t[2] if len(t) > 2 else None, graph) for t in tuples]
+    cohort = [(n[0], n[1]) for n in normalized]
+    entries: list[LegacyEntry] = []
+    for index, (original, (node_id, widget, disambiguator)) in enumerate(zip(tuples, normalized)):
+        host_value = host_values[index] if host_values is not None and index < len(host_values) else UNSET
+        e = LegacyEntry(original, index, node_id, widget, disambiguator, PLAN_QUARANTINE, host_value=host_value)
+        entries.append(e)
+        linked = _find_host_input_for_promotion(sg, defs, node_id, widget)
+        if linked is not None:
+            matches = [p for p in promoted_inputs(sg, defs) if p.name == linked]
+            if len(matches) > 1:
+                e.reason = "ambiguousSubgraphInput"
+            elif not matches or not matches[0].is_widget:
+                e.reason = "missingSubgraphInput"
+            else:
+                e.plan, e.name, e.type = PLAN_ALREADY_LINKED, linked, matches[0].type
+            continue
+        source = _inner_node(sg, node_id)
+        if source is None:
+            e.reason = "missingSourceNode"
+            continue
+        if str(source.get("type", "")) == LEGACY_PRIMITIVE_TYPE:
+            bypassed = (source.get("properties") or {}).get(PROXY_BYPASS_MARKER_PROPERTY)
+            if isinstance(bypassed, str):
+                existing = next((p for p in promoted_inputs(sg, defs) if p.name == bypassed), None)
+                if existing is not None:
+                    if existing.is_widget:
+                        e.plan, e.name, e.type = PLAN_ALREADY_LINKED, bypassed, existing.type
+                    else:
+                        e.reason = "missingSubgraphInput"
+                    continue
+            targets = _primitive_targets(sg, source)
+            # ``cohortDuplicatesPrimitive``: two entries naming this primitive
+            # (whatever their widget) still form a cohort to validate.
+            if targets or sum(1 for n in cohort if n[0] == node_id) >= 2:
+                e.plan, e.targets = PLAN_PRIMITIVE, targets
+            else:
+                e.reason = "unlinkedSourceWidget"
+            continue
+        resolved = _resolve_source_widget(sg, source, widget, disambiguator, defs, graph)
+        if resolved is None:
+            e.reason = "missingSourceWidget"
+            continue
+        widget_name, projecting = resolved
+        if widget.startswith("$$") or _is_preview_pseudo_widget(widget_name):
+            e.plan = PLAN_PREVIEW
+            continue
+        slot = _slot_for_widget(source, widget_name, projecting, defs, graph)
+        if slot is None:
+            e.reason = "missingSubgraphInput"  # the widget has no backing input slot
+            continue
+        idx, entry, slot_type = slot
+        e.plan, e.type, e.slot_index, e.source_input = PLAN_CREATE, slot_type, idx, projecting
+        if isinstance(entry, dict) and entry.get("label") is not None:
+            e.label = str(entry["label"])
+
+    # Names, in flush order: creates as they come, then one input per primitive
+    # cohort (validated all-or-quarantine, exactly like ``repairPrimitive``).
+    existing = [str(i.get("name")) for i in sg.get("inputs") or [] if isinstance(i, dict)]
+    for e in entries:
+        if e.plan == PLAN_CREATE:
+            e.name = next_unique_name(e.widget, existing)
+            existing.append(e.name)
+    cohorts: dict[str, list[LegacyEntry]] = {}
+    for e in entries:
+        if e.plan == PLAN_PRIMITIVE:
+            cohorts.setdefault(e.source_node, []).append(e)
+    for primitive_id, members in cohorts.items():
+        primitive = _inner_node(sg, primitive_id)
+        failure = _validate_primitive_cohort(sg, primitive, members)
+        if failure is not None:
+            for e in members:
+                e.plan, e.reason, e.targets = PLAN_QUARANTINE, "primitiveBypassFailed", []
+            continue
+        outputs = primitive.get("outputs") or []
+        output_type = str(outputs[0].get("type") or "*")
+        title = primitive.get("title")
+        base = title if isinstance(title, str) and title and title != LEGACY_PRIMITIVE_TYPE else members[0].widget
+        name = next_unique_name(base, existing)
+        existing.append(name)
+        for e in members:
+            e.name, e.type = name, output_type
+    return entries
+
+
+def _validate_primitive_cohort(sg: dict, primitive: dict | None, members: list) -> str | None:
+    """``validateCohort`` + the pre-mutation checks of ``repairPrimitive``:
+    one primitive, one widget name, every target present and type-compatible."""
+    first = members[0]
+    if any(m.widget != first.widget for m in members):
+        return "cohort validation failed"
+    if primitive is None or str(primitive.get("type", "")) != LEGACY_PRIMITIVE_TYPE:
+        return "node is not a PrimitiveNode"
+    targets = _primitive_targets(sg, primitive)
+    if not targets:
+        return "no targets to reconnect"
+    outputs = primitive.get("outputs") or []
+    if not outputs or not isinstance(outputs[0], dict):
+        return "primitive has no output"
+    output_type = str(outputs[0].get("type") or "*")
+    for tid, slot in targets:
+        target = _inner_node(sg, tid)
+        entries = target.get("inputs") if target is not None else None
+        entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            return "target slot missing"
+        if not _types_compatible(str(entry.get("type") or "*"), output_type):
+            return "target slot type incompatible"
+    return None
+
+
+def planned_repair(workflow: dict, instance: dict, graph, widget: str, defs: dict[str, dict] | None = None):
+    """The repairable legacy entry a host address ``<instance>.<widget>`` names:
+    by the input name the repair will mint, else by the legacy tuple's own
+    widget name (an alias the caller reports as a redirect)."""
+    plan = [e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable]
+    by_name = next((e for e in plan if e.name == widget), None)
+    return by_name if by_name is not None else next((e for e in plan if e.widget == widget), None)
+
+
+def planned_repair_for_interior(
+    workflow: dict, instance: dict, graph, inner_id: str, widget: str, defs: dict[str, dict] | None = None
+):
+    """The repairable legacy entry whose value the interior address
+    ``<instance>/<inner>.<widget>`` would edit: the entry's own source widget,
+    or one of a primitive's fan-out targets."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    if sg is None:
+        return None
+    for e in plan_proxy_migration(workflow, instance, graph, defs):
+        if not e.repairable:
+            continue
+        if e.source_node == inner_id and e.widget == widget:
+            return e
+        for tid, slot in e.targets:
+            target = _inner_node(sg, tid)
+            entries = target.get("inputs") if target is not None else None
+            entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            if tid == inner_id and isinstance(marker, dict) and marker.get("name") == widget:
+                return e
+    return None
+
+
+def planned_hidden_sources(workflow: dict, instance: dict, graph, defs: dict[str, dict] | None = None) -> set:
+    """``(interior node, widget)`` pairs a pending repair will own — the
+    interior addresses whose edits the host surface overrides."""
+    defs = defs if defs is not None else defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    hidden: set[tuple[str, str]] = set()
+    if sg is None:
+        return hidden
+    for e in plan_proxy_migration(workflow, instance, graph, defs):
+        if not e.repairable:
+            continue
+        hidden.add((e.source_node, e.widget))
+        for tid, slot in e.targets:
+            target = _inner_node(sg, tid)
+            entries = target.get("inputs") if target is not None else None
+            entry = entries[slot] if isinstance(entries, list) and 0 <= slot < len(entries) else None
+            marker = entry.get("widget") if isinstance(entry, dict) else None
+            if isinstance(marker, dict) and marker.get("name"):
+                hidden.add((tid, str(marker["name"])))
+    return hidden
+
+
+def entry_effective_value(workflow: dict, sg: dict, entry: LegacyEntry, graph, defs: dict[str, dict]) -> Any:
+    """What the frontend shows for the entry after its own migration: the
+    legacy positional host value when present, else the source widget's
+    current value (a primitive's own value for a bypass)."""
+    if entry.host_value is not UNSET:
+        return entry.host_value
+    if entry.plan == PLAN_PRIMITIVE:
+        primitive = _inner_node(sg, entry.source_node)
+        return _node_widget_value(primitive, entry.widget, graph) if primitive is not None else UNSET
+    return source_value(workflow, sg, entry.as_promoted_input(sg), graph, defs)
+
+
+def repair_ids(instance_path: list, source_node: str, widget: str, n_links: int) -> dict:
+    """The ids a repair of ``(source_node, widget)`` on the instance at
+    ``instance_path`` mints: the subgraph input's uuid and one link id per
+    boundary link. Derived with SHA-256 from the identifiers alone (like
+    ``engine._deterministic_fork_id``), so they are stable across processes
+    and replicas."""
+    seed = "\x00".join(["proxy-repair", *[str(s) for s in instance_path], str(source_node), str(widget)])
+    input_id = str(_uuid.UUID(bytes=_hashlib.sha256(seed.encode()).digest()[:16], version=4))
+    links = []
+    for k in range(n_links):
+        digest = _hashlib.sha256(f"{seed}\x00link{k}".encode()).digest()
+        links.append(_LINK_ID_FLOOR | (int.from_bytes(digest[:8], "big") & ((1 << _LINK_ID_BITS) - 1)))
+    return {"input": input_id, "links": links}
+
+
+def plan_repair_ids(instance_path: list, plan: list) -> dict[str, dict]:
+    """Every repairable entry's ids, keyed ``<source node>.<widget>``."""
+    out: dict[str, dict] = {}
+    for e in plan:
+        if e.repairable and e.key not in out:
+            out[e.key] = repair_ids(instance_path, e.source_node, e.widget, max(1, len(e.targets)))
+    return out
+
+
+def _remove_link(sg: dict, link_id: Any) -> None:
+    link = next((x for x in sg.get("links") or [] if isinstance(x, dict) and x.get("id") == link_id), None)
+    if link is None:
+        return
+    sg["links"] = [x for x in sg.get("links") or [] if x is not link]
+    origin = link.get("origin_id")
+    if origin == SUBGRAPH_INPUT_NODE_ID:
+        for inp in sg.get("inputs") or []:
+            if isinstance(inp, dict) and isinstance(inp.get("linkIds"), list) and link_id in inp["linkIds"]:
+                inp["linkIds"] = [x for x in inp["linkIds"] if x != link_id]
+    else:
+        origin_node = _inner_node(sg, origin)
+        outputs = origin_node.get("outputs") if origin_node is not None else None
+        slot = link.get("origin_slot")
+        if isinstance(outputs, list) and isinstance(slot, int) and 0 <= slot < len(outputs):
+            links = outputs[slot].get("links")
+            if isinstance(links, list):
+                outputs[slot]["links"] = [x for x in links if x != link_id]
+    target = _inner_node(sg, link.get("target_id"))
+    entries = target.get("inputs") if target is not None else None
+    slot = link.get("target_slot")
+    if isinstance(entries, list) and isinstance(slot, int) and 0 <= slot < len(entries):
+        if isinstance(entries[slot], dict) and entries[slot].get("link") == link_id:
+            entries[slot]["link"] = None
+
+
+def _add_boundary_link(sg: dict, new_input: dict, link_id: Any, target: dict, slot: int, slot_type: str) -> None:
+    """``SubgraphInput.connect``: replace whatever fed the slot with a link
+    from the subgraph input node, as the frontend serializes one."""
+    entries = target["inputs"]
+    existing = entries[slot].get("link")
+    if existing is not None:
+        _remove_link(sg, existing)
+    origin_slot = next(i for i, inp in enumerate(sg["inputs"]) if inp is new_input)
+    sg.setdefault("links", []).append(
+        {
+            "id": link_id,
+            "origin_id": SUBGRAPH_INPUT_NODE_ID,
+            "origin_slot": origin_slot,
+            "target_id": target.get("id"),
+            "target_slot": slot,
+            "type": slot_type,
+        }
+    )
+    entries[slot]["link"] = link_id
+    new_input.setdefault("linkIds", []).append(link_id)
+    state = sg.get("state")
+    if isinstance(state, dict):
+        last = state.get("lastLinkId")
+        state["lastLinkId"] = max(last if isinstance(last, int) else 0, link_id)
+
+
+def _add_subgraph_input(sg: dict, input_id: str, name: str, slot_type: str, label: str | None) -> dict:
+    """``Subgraph.addInput`` as the frontend serializes a ``SubgraphInput``
+    (``id``, ``name``, ``type``, ``linkIds``; ``label`` when the source slot
+    carried one). ``pos`` is layout the input node assigns on load."""
+    new_input: dict = {"id": input_id, "name": name, "type": slot_type, "linkIds": []}
+    if label is not None:
+        new_input["label"] = label
+    sg.setdefault("inputs", []).append(new_input)
+    return new_input
+
+
+def _add_host_input(instance: dict, name: str, slot_type: str, label: str | None) -> None:
+    """The host's own ``inputs[]`` entry for a new promoted widget input —
+    the shape a post-migration save carries (``audio_minimax_music_3.json``
+    node 37). Left alone when the instance already serializes one."""
+    if instance_input(instance, name) is not None:
+        return
+    entry: dict = {"name": name, "type": slot_type, "widget": {"name": name}, "link": None}
+    if label is not None:
+        entry = {"label": label, **entry}
+    instance.setdefault("inputs", []).append(entry)
+
+
+def _quarantine_entry(entry: LegacyEntry, reason: str) -> dict:
+    out = {"originalEntry": list(entry.original), "reason": reason, "attemptedAtVersion": QUARANTINE_VERSION}
+    if entry.host_value is not UNSET:
+        out["hostValue"] = entry.host_value
+    return out
+
+
+def flush_proxy_migration(
+    workflow: dict, instance: dict, graph, ids: dict[str, dict] | None = None, instance_path: list | None = None
+) -> FlushReport:
+    """Run the forward migration on ``instance`` IN PLACE (its definition, its
+    interior nodes, its own ``inputs``/``widgets_values``/``properties``).
+
+    ``ids`` are the minted ids per repairable entry (:func:`plan_repair_ids`);
+    derived from ``instance_path`` when not given. Idempotent: an instance
+    without legacy value entries is left untouched. The definition is
+    mutated — callers isolate a shared definition first (the op layer does,
+    via ``engine._isolate_shared_subgraph``).
+    """
+    defs = defs_by_id(workflow)
+    sg = defs.get(str(instance.get("type", "")))
+    report = FlushReport()
+    if sg is None or not _proxy_tuples(instance):
+        return report
+    if graph is None:
+        # Without the catalog no interior widget can be resolved, and the
+        # honest answer to that is not "quarantine everything".
+        raise ValueError(
+            f"repairing the legacy proxyWidgets of subgraph node {instance.get('id')} needs the node catalog"
+        )
+    plan = plan_proxy_migration(workflow, instance, graph, defs)
+    if not plan:
+        return report
+    instance_path = instance_path if instance_path is not None else [str(instance.get("id"))]
+    ids = dict(ids or {})
+    for e in plan:
+        if e.repairable and e.key not in ids:
+            ids[e.key] = repair_ids(instance_path, e.source_node, e.widget, max(1, len(e.targets)))
+
+    # Values the host already carries, read the way ``configure`` applies them
+    # (positionally over the linked inputs) — before the structure changes.
+    pre = {p.name: host_value(instance, p) for p in promoted_inputs(sg, defs) if p.is_widget}
+    applied: dict[str, Any] = {}
+    quarantine: list[dict] = []
+    remaining: list[list] = []
+    cohorts: dict[str, list[LegacyEntry]] = {}
+    for e in plan:
+        if e.plan == PLAN_PREVIEW:
+            remaining.append(list(e.original))
+            continue
+        if e.plan == PLAN_QUARANTINE:
+            if e.reason != "primitiveBypassFailed":
+                quarantine.append(_quarantine_entry(e, str(e.reason)))
+            else:
+                cohorts.setdefault(e.source_node, []).append(e)
+            continue
+        report.consumed.append(list(e.original))
+        if e.plan == PLAN_ALREADY_LINKED:
+            if e.host_value is not UNSET:
+                applied[str(e.name)] = e.host_value
+            continue
+        if e.plan == PLAN_PRIMITIVE:
+            cohorts.setdefault(e.source_node, []).append(e)
+            continue
+        # createSubgraphInput
+        source = _inner_node(sg, e.source_node)
+        slot_index = e.slot_index
+        if slot_index is None:
+            source.setdefault("inputs", []).append(
+                {
+                    "localized_name": e.widget,
+                    "name": e.widget,
+                    "type": e.type,
+                    "widget": {"name": e.widget},
+                    "link": None,
+                }
+            )
+            slot_index = len(source["inputs"]) - 1
+        new_input = _add_subgraph_input(sg, ids[e.key]["input"], str(e.name), str(e.type), e.label)
+        _add_boundary_link(sg, new_input, ids[e.key]["links"][0], source, slot_index, str(e.type))
+        _add_host_input(instance, str(e.name), str(e.type), e.label)
+        report.created.append(str(e.name))
+        if e.host_value is not UNSET:
+            applied[str(e.name)] = e.host_value
+
+    for primitive_id, members in cohorts.items():
+        if members[0].plan == PLAN_QUARANTINE:
+            quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
+            continue
+        first = members[0]
+        primitive = _inner_node(sg, primitive_id)
+        # ``repairPrimitive`` re-validates against the graph as it is NOW: a
+        # ``createSubgraphInput`` above may have taken over one of the
+        # primitive's targets, so the fan-out is collected again.
+        if _validate_primitive_cohort(sg, primitive, members) is not None:
+            quarantine.extend(_quarantine_entry(m, "primitiveBypassFailed") for m in members)
+            continue
+        targets = _primitive_targets(sg, primitive)
+        for link in [x for x in sg.get("links") or [] if str(x.get("origin_id")) == primitive_id]:
+            if link.get("origin_slot") == 0:
+                _remove_link(sg, link.get("id"))
+        link_ids = ids[first.key]["links"]
+        if len(link_ids) < len(targets):
+            link_ids = repair_ids(instance_path, first.source_node, first.widget, len(targets))["links"]
+        new_input = _add_subgraph_input(sg, ids[first.key]["input"], str(first.name), str(first.type), None)
+        for k, (tid, slot) in enumerate(targets):
+            target = _inner_node(sg, tid)
+            _add_boundary_link(sg, new_input, link_ids[k], target, slot, str(target["inputs"][slot].get("type") or "*"))
+        _add_host_input(instance, str(first.name), str(first.type), None)
+        primitive.setdefault("properties", {})[PROXY_BYPASS_MARKER_PROPERTY] = str(first.name)
+        report.created.append(str(first.name))
+        unique: list[LegacyEntry] = []
+        for m in members:
+            if not any(
+                (u.source_node, u.widget, u.disambiguator) == (m.source_node, m.widget, m.disambiguator) for u in unique
+            ):
+                unique.append(m)
+        valued = next((u for u in unique if u.host_value is not UNSET), None)
+        if valued is not None:
+            applied[str(first.name)] = valued.host_value
+        else:
+            seed = _node_widget_value(primitive, first.widget, graph)
+            if seed is not UNSET:
+                applied[str(first.name)] = seed
+
+    if not report.consumed and not quarantine:
+        return report  # previews only: nothing to consume, nothing to write
+
+    # ``appendQuarantine``: a ``-1`` entry's host value lands on the input of
+    # that name; entries are deduplicated by their original tuple.
+    props = instance.setdefault("properties", {})
+    existing_q = [q for q in props.get(QUARANTINE_PROPERTY) or [] if isinstance(q, dict)]
+    for q in quarantine:
+        if q["originalEntry"][0] == "-1" and "hostValue" in q:
+            applied[str(q["originalEntry"][1])] = q["hostValue"]
+        if not any(x.get("originalEntry") == q["originalEntry"] for x in existing_q):
+            existing_q.append(q)
+            report.quarantined.append(q)
+    if existing_q:
+        props[QUARANTINE_PROPERTY] = existing_q
+    if remaining:
+        props["proxyWidgets"] = remaining
+    else:
+        props.pop("proxyWidgets", None)
+    report.remaining = remaining
+
+    # The host array, positional over the (now repaired) widget-backed inputs:
+    # migrated values first, then what the host already carried, then the
+    # interior default — the serialization the frontend writes after its flush.
+    values: list[Any] = []
+    for p in promoted_inputs(sg, defs):
+        if not p.is_widget:
+            continue
+        value = applied.get(p.name, pre.get(p.name, UNSET))
+        if value is UNSET:
+            value = source_value(workflow, sg, p, graph, defs)
+        values.append(None if value is UNSET else value)
+    instance["widgets_values"] = values
+    return report
+
+
+def boundary_widget_targets(sg: dict, pi: PromotedInput, defs: dict[str, dict]) -> list[tuple[list[str], str]]:
+    """Every concrete ``(interior node path, widget)`` a promoted input feeds —
+    all of its boundary links, through nested instances. A repaired primitive
+    fan-out has several; :func:`deepest_source` reports only the first."""
+    inputs = sg.get("inputs") or []
+    inp = inputs[pi.index] if 0 <= pi.index < len(inputs) and isinstance(inputs[pi.index], dict) else None
+    if inp is None:
+        single = deepest_source(sg, pi, defs)
+        return [single] if single is not None else []
+    return _boundary_targets(sg, inp, defs, 0)
+
+
+def _boundary_targets(sg: dict, inp: dict, defs: dict[str, dict], depth: int) -> list[tuple[list[str], str]]:
+    if depth > _MAX_NESTED_PROMOTION_DEPTH:
+        return []
+    links = {x.get("id"): x for x in sg.get("links") or [] if isinstance(x, dict)}
+    out: list[tuple[list[str], str]] = []
+    for link_id in inp.get("linkIds") or []:
+        link = links.get(link_id) if isinstance(link_id, (int, str)) else None
+        target = _inner_node(sg, link.get("target_id")) if link is not None else None
+        if target is None:
+            continue
+        entries = target.get("inputs") or []
+        slot = link.get("target_slot")
+        entry = entries[slot] if isinstance(slot, int) and 0 <= slot < len(entries) else None
+        if not isinstance(entry, dict):
+            continue
+        tid = str(target.get("id"))
+        inner_def = defs.get(str(target.get("type", "")))
+        if inner_def is not None:
+            inner_inp = next(
+                (
+                    i
+                    for i in inner_def.get("inputs") or []
+                    if isinstance(i, dict) and i.get("name") == entry.get("name")
+                ),
+                None,
+            )
+            if inner_inp is not None:
+                out.extend(([tid, *path], w) for path, w in _boundary_targets(inner_def, inner_inp, defs, depth + 1))
+            continue
+        marker = entry.get("widget")
+        if marker:
+            widget = marker.get("name") if isinstance(marker, dict) else None
+            out.append(([tid], str(widget or entry.get("name"))))
+    return out

--- a/comfy_cli/cql/promoted.py
+++ b/comfy_cli/cql/promoted.py
@@ -483,6 +483,12 @@ def resolve_write(
         target_def = defs.get(str(target.get("type", "")))
         given = f"{'/'.join(segments)}.{widget}"
         if parent_def is not None:
+            # Checked BEFORE the interior-feeder refusal below on purpose: a
+            # widget a legacy entry owns is repaired by the frontend on load,
+            # and that repair replaces any interior link feeding its slot
+            # (see ``plan_proxy_migration``), so the host value — not the
+            # feeder — is what will run. The same slot with no legacy entry
+            # keeps its feeder and is refused.
             pending = planned_repair_for_interior(workflow, parent, graph, str(target.get("id")), widget, defs)
             if pending is not None:
                 return WriteTarget(
@@ -966,6 +972,12 @@ def _slot_for_widget(source: dict, widget: str, projecting_input: str | None, de
         marker = entry.get("widget") if isinstance(entry, dict) else None
         if isinstance(marker, dict) and marker.get("name") == widget:
             return idx, entry, str(entry.get("type") or "*")
+    # An older save can serialize the widget's slot by ``name`` alone (no
+    # marker): that IS the backing slot — the flush restores its marker —
+    # never a reason to append a duplicate beside it.
+    for idx, entry in enumerate(entries):
+        if isinstance(entry, dict) and entry.get("widget") is None and entry.get("name") == widget:
+            return idx, entry, str(entry.get("type") or "*")
     m = graph.node(str(source.get("type", ""))) if graph is not None else None
     port = next((p for p in m.inputs if p.name == widget), None) if m is not None else None
     if port is None or port.is_link:
@@ -1055,9 +1067,18 @@ def plan_proxy_migration(workflow: dict, instance: dict, graph, defs: dict[str, 
             continue
         slot = _slot_for_widget(source, widget_name, projecting, defs, graph)
         if slot is None:
-            e.reason = "missingSubgraphInput"  # the widget has no backing input slot
+            # The widget has no backing input slot (``control_after_generate``).
+            # ``missingSubgraphInput`` is the frontend's own reason code for
+            # this case — ``repairCreateSubgraphInput``: "source widget has no
+            # backing input slot; quarantining" → ``reason: 'missingSubgraphInput'``.
+            e.reason = "missingSubgraphInput"
             continue
         idx, entry, slot_type = slot
+        # A slot already fed by an interior link is repaired all the same: the
+        # frontend calls ``SubgraphInput.connect(slot, node)`` unconditionally
+        # and ``connect`` replaces the incumbent link (``replaceLinkTopology``
+        # + ``_disconnectNodeInput``), so the boundary link takes the slot over
+        # and the interior feeder is dropped — see ``_add_boundary_link``.
         e.plan, e.type, e.slot_index, e.source_input = PLAN_CREATE, slot_type, idx, projecting
         if isinstance(entry, dict) and entry.get("label") is not None:
             e.label = str(entry["label"])
@@ -1123,7 +1144,22 @@ def planned_repair(workflow: dict, instance: dict, graph, widget: str, defs: dic
     widget name (an alias the caller reports as a redirect)."""
     plan = [e for e in plan_proxy_migration(workflow, instance, graph, defs) if e.repairable]
     by_name = next((e for e in plan if e.name == widget), None)
-    return by_name if by_name is not None else next((e for e in plan if e.widget == widget), None)
+    if by_name is not None:
+        return by_name
+    aliased: list[LegacyEntry] = []
+    for e in plan:
+        if e.widget == widget and all(a.name != e.name for a in aliased):
+            aliased.append(e)
+    if len(aliased) > 1:
+        # Two entries share the legacy widget name (two primitives both named
+        # ``value``): never pick one silently — name the minted inputs.
+        node_id = instance.get("id")
+        raise ValueError(
+            f"{node_id}.{widget} is ambiguous: {len(aliased)} legacy promotions on subgraph node {node_id} share "
+            f"the widget name {widget!r}; address one by its input name — "
+            f"{', '.join(f'{node_id}.{a.name}' for a in aliased)}"
+        )
+    return aliased[0] if aliased else None
 
 
 def planned_repair_for_interior(
@@ -1351,6 +1387,14 @@ def flush_proxy_migration(
         # createSubgraphInput
         source = _inner_node(sg, e.source_node)
         slot_index = e.slot_index
+        if slot_index is not None and not isinstance(source["inputs"][slot_index].get("widget"), dict):
+            # A slot serialized by name alone: give it back the marker a
+            # converted widget carries, in the frontend's key order.
+            found = source["inputs"][slot_index]
+            marked = {k: v for k, v in found.items() if k != "link"}
+            marked["widget"] = {"name": e.source_input or e.widget}
+            marked["link"] = found.get("link")
+            source["inputs"][slot_index] = marked
         if slot_index is None:
             if e.source_input is not None:
                 # A nested instance backs the widget with its OWN host input

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -922,9 +922,18 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "check COMFY_API_BASE_URL points at the Comfy API; the existing cached catalog is still usable",
     ),
     ErrorCode(
+        "emit_workflow_unsupported_model",
+        "`generate --emit-workflow` has no ComfyUI partner-node mapping for the requested model "
+        "(`details.model`); most of the proxy catalog is proxy-only. `details.supported` lists the "
+        "aliases that can be emitted — the same set `generate list` flags with `emit_supported: true`.",
+        "pick a model with `emit_supported: true` in `comfy --json generate list`, or drop "
+        "--emit-workflow and call the model through the proxy",
+    ),
+    ErrorCode(
         "emit_workflow_failed",
-        "`generate --emit-workflow` could not build the partner-node workflow.",
-        "check the model name and that all required inputs are provided",
+        "`generate --emit-workflow` could not build the partner-node workflow for a supported model "
+        "(missing/invalid inputs, or the destination path could not be written).",
+        "check that all required inputs are provided and the destination path is writable",
     ),
     # --- custom node registry ------------------------------------------------
     ErrorCode(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -362,6 +362,14 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "sign in with `comfy cloud login` and re-run with `--where cloud`",
     ),
     ErrorCode(
+        "asset_not_found",
+        "Comfy Cloud has no asset with the content hash passed to `assets library ensure` "
+        "(`details.hash`). A file NAME is not a hash: the library is keyed by the sha256 the "
+        "upload computed, which `assets library ls` reports per asset.",
+        "pass the `hash` from `comfy --json assets library ls --name <file>`, or upload the file "
+        "first with `comfy upload <file> --where cloud`",
+    ),
+    ErrorCode(
         "template_fetch_failed",
         "Fetching the per-template workflow JSON from `Comfy-Org/workflow_templates` failed.",
         "check network; if 404, the gallery and templates dir are out of sync — report upstream",

--- a/comfy_cli/schemas/generate_list.json
+++ b/comfy_cli/schemas/generate_list.json
@@ -11,7 +11,7 @@
       "description": "One record per model, ordered by (partner, id) — the same order the human table renders.",
       "items": {
         "type": "object",
-        "required": ["alias", "id", "partner", "category", "mode", "summary"],
+        "required": ["alias", "id", "partner", "category", "mode", "summary", "emit_supported"],
         "properties": {
           "alias": {
             "type": "string",
@@ -37,6 +37,10 @@
           "summary": {
             "type": "string",
             "description": "Full one-line description from the openapi spec — never truncated."
+          },
+          "emit_supported": {
+            "type": "boolean",
+            "description": "Whether `comfy generate <alias> --emit-workflow <path>` can render this model as a ComfyUI partner node (a runnable workflow) instead of calling the proxy. False for most of the catalog: asking for --emit-workflow on such a model fails with `emit_workflow_unsupported_model`, whose `details.supported` lists the aliases that can."
           }
         }
       }

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -652,12 +652,31 @@ def _set_widget_impl(
         extra["redirected_from"] = target.redirected_from
     if target.kind == "host":
         instance = target.node
+        widget = str(target.widget)
         defs = _engine._subgraph_defs_by_id(workflow)
         sg = defs[str(instance.get("type", ""))]
-        pi = _promoted.find_promoted(sg, defs, widget)
+        promoted_meta: dict[str, Any] = {"instance_path": list(target.segments)}
+        if target.repair is not None:
+            # A legacy ``proxyWidgets`` promotion (see ``cql.promoted``
+            # "forward migration"): apply repairs the instance's definition
+            # first — with ids DERIVED from the instance path and the entry,
+            # carried here so any replica mints the same input and links —
+            # and only then writes the host value. The schema/old value come
+            # from the interior widget the repair will link.
+            entry = target.repair
+            plan = _promoted.plan_proxy_migration(workflow, instance, graph, defs)
+            promoted_meta["repair"] = {
+                "entry": list(entry.original),
+                "ids": _promoted.plan_repair_ids(list(target.segments), plan),
+            }
+            pi = entry.as_promoted_input(sg)
+            old = _promoted.entry_effective_value(workflow, sg, entry, graph, defs)
+        else:
+            pi = _promoted.find_promoted(sg, defs, widget)
+            promoted_meta["value_index"] = pi.value_index
+            old = _promoted.effective_value(workflow, instance, widget, graph)
         inner_type, port = _engine.promoted_source_port(sg, pi, defs, graph)
         value, norm_note = _normalize_combo(graph, inner_type, port.name if port else widget, value)
-        old = _promoted.effective_value(workflow, instance, widget, graph)
         warnings: list[dict] = []
         if port is not None:
             err = port.validate_shape(value)
@@ -675,12 +694,18 @@ def _set_widget_impl(
             widget=widget,
             value=value,
             old=None if old is _promoted.UNSET else old,
-            promoted={"value_index": pi.value_index, "instance_path": list(target.segments)},
+            promoted=promoted_meta,
             **extra,
         )
         if warnings:
             op["warnings"] = warnings
         workflow = apply_op(workflow, op, graph)
+        if target.repair is not None:
+            # The slot only exists after the repair (and the instance may sit
+            # on a freshly forked definition): read it back from the document.
+            repaired = _engine._subgraph_defs_by_id(workflow)
+            sg = repaired[str(instance.get("type", ""))]
+            op["promoted"]["value_index"] = _promoted.find_promoted(sg, repaired, widget).value_index
         # The materialized host array, for an applier that stores the instance
         # opaquely (no catalog entry for a subgraph type): it can replace the
         # positional array wholesale instead of decomposing it by name. Read
@@ -1826,7 +1851,20 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
             return  # instance concurrently deleted => no-op (delete wins)
         defs_by_id = _engine._subgraph_defs_by_id(workflow)
         instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
-        if defs_by_id.get(str(instance.get("type", ""))) is not None:
+        repair = promoted_write.get("repair")
+        if repair:
+            # Legacy ``proxyWidgets`` promotion: repair the instance's
+            # definition (the frontend's forward migration) before the host
+            # write. The definition is MUTATED, so a shared one is forked
+            # first (deterministic fork id), and the input/link ids come from
+            # the op — replay anywhere yields the same document. Re-resolved
+            # against the current graph: an entry another replica already
+            # repaired is consumed as already linked.
+            _engine._isolate_shared_subgraph(workflow, instance, _engine._subgraph_defs_by_id(workflow))
+            _promoted.flush_proxy_migration(
+                workflow, instance, graph, ids=repair.get("ids") or None, instance_path=instance_path
+            )
+        if _engine._subgraph_defs_by_id(workflow).get(str(instance.get("type", ""))) is not None:
             _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
         else:
             # Not a subgraph instance (a frontend-only PrimitiveNode): a plain

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1944,8 +1944,14 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
     if grow is not None:
         # Autogrow is NOT a shared register: every grow mints its own slot keyed
         # by ``grow_id``, so two concurrent grows onto one base both survive and
-        # there is nothing to gate (§1.2 / amendment v1.2's carve-out).
-        if _find_by_str(workflow, op["from_node"]) is None:
+        # there is nothing to gate (§1.2 / amendment v1.2's carve-out) — a
+        # deleted source simply means nothing to wire. A PROMOTED grow IS a
+        # register (§14.2), so it must reach the gate below even when its
+        # source is gone: bailing here would make the incumbent depend on
+        # whether the concurrent delete of this op's source had arrived yet.
+        # Delete wins over the LINK, not over the claim — the entry is left
+        # empty at the ``src is None`` check further down.
+        if not grow.get("promoted") and _find_by_str(workflow, op["from_node"]) is None:
             return
         # Autogrow: grow a concrete slot and wire it. Keyed by ``grow_id`` (the
         # link id) so replay is idempotent AND non-clobbering — a concurrent
@@ -2600,7 +2606,7 @@ def _resolve_input_target(
     # (a concrete ``to_slot`` op would find no slot, be dropped, and never
     # replay). Apply reuses the entry by name; type-checked against the
     # declared input type.
-    if workflow is not None and isinstance(slot, str):
+    if workflow is not None and isinstance(slot, (str, int)) and not isinstance(slot, bool):
         promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
         if promoted_grow is not None:
             return None, promoted_grow
@@ -2710,10 +2716,14 @@ def _resolve_input_target(
     raise ValueError(f"input {slot!r} not found on node {node.get('id')}; inputs: {names}")
 
 
-def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: str | None) -> dict | None:
+def _resolve_promoted_target(workflow: dict, node: dict, slot: Any, elem_type: str | None) -> dict | None:
     """The input to materialize on subgraph instance ``node`` for a connect to
     its declared input ``slot`` (see ``cql.promoted``). ``None`` when ``node``
-    is not an instance or ``slot`` is not one of its definition's inputs."""
+    is not an instance or ``slot`` is not one of its definition's inputs.
+
+    An INDEX (``57.1``) that lands on an already-materialized entry for a
+    declared input is the same input as its name (``57.width``): it maps onto
+    the name so both addresses share one register (§14.2)."""
     from comfy_cli.cql import engine as _engine
     from comfy_cli.cql import promoted as _promoted
 
@@ -2721,6 +2731,13 @@ def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: s
     sg = defs.get(str(node.get("type", "")))
     if sg is None:
         return None
+    if isinstance(slot, int) or (isinstance(slot, str) and slot.lstrip("-").isdigit()):
+        ins = node.get("inputs") or []
+        idx = int(slot)
+        entry = ins[idx] if 0 <= idx < len(ins) and isinstance(ins[idx], dict) else None
+        if entry is None or not entry.get("name"):
+            return None
+        slot = str(entry["name"])
     pi = _promoted.find_promoted(sg, defs, slot)
     if pi is None:
         return None

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1883,11 +1883,13 @@ def _apply_positional_write(node: dict, positional: dict, value: Any) -> None:
     values = node.get("widgets_values")
     values = list(values) if isinstance(values, list) else []
     seed = positional.get("host_widgets_values")
-    if len(values) <= idx:
-        if isinstance(seed, list) and len(seed) > len(values):
-            values.extend(seed[len(values) :])
-        while len(values) <= idx:
-            values.append(None)
+    # A receiver holding a truncated array takes the payload's tail whether or
+    # not the written index is inside it — otherwise replicas keep different
+    # opaque state for the same node.
+    if isinstance(seed, list) and len(seed) > len(values):
+        values.extend(seed[len(values) :])
+    while len(values) <= idx:
+        values.append(None)
     values[idx] = value
     node["widgets_values"] = values
 
@@ -2589,6 +2591,19 @@ def _resolve_input_target(
       the API converter reads the link and skips the widget by name.
     """
     ins = node.get("inputs") or []
+    # Promoted subgraph input (``57.width``): the definition declares it, so it
+    # is a link input on the instance even before the instance carries an
+    # ``inputs[]`` entry for it — the frontend rebuilds those from the
+    # definition on load. ALWAYS addressed as a promoted grow, even once the
+    # entry exists: the register is the declared name, so a replica that
+    # receives a later connect before the materializing one still lands it
+    # (a concrete ``to_slot`` op would find no slot, be dropped, and never
+    # replay). Apply reuses the entry by name; type-checked against the
+    # declared input type.
+    if workflow is not None and isinstance(slot, str):
+        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
+        if promoted_grow is not None:
+            return None, promoted_grow
     # Concrete slot (index or exact name) that is NOT an autogrow base.
     try:
         idx = _resolve_input_slot(node, None, slot)
@@ -2605,15 +2620,6 @@ def _resolve_input_target(
         return idx, None
     except ValueError:
         pass
-    # Promoted subgraph input (``57.width``): the definition declares it, so it
-    # is a link input on the instance even before the instance carries an
-    # ``inputs[]`` entry for it — the frontend rebuilds those from the
-    # definition on load. Materialize it (widget marker when it backs a
-    # widget) and wire it; type-checked against the declared input type.
-    if workflow is not None and isinstance(slot, str):
-        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
-        if promoted_grow is not None:
-            return None, promoted_grow
     # Dotted autogrow key (images.image0) or a base that has no concrete slot yet.
     if isinstance(slot, str):
         base = slot.split(".", 1)[0]

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -637,16 +637,76 @@ def _set_widget_impl(
     base_version: int = 0,
 ) -> tuple[dict, dict]:
     from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
 
-    # Subgraph-aware: a subgraph instance's *promoted* input (flat ``57.text`` —
-    # exactly what ``comfy workflow slots`` advertises) or an interior node
-    # (nested ``57/27.text``) resolves INTO the subgraph definition. Both forms
-    # reuse the CQL engine's slot resolver so set-widget and slots agree. The op
-    # carries the resolved interior ``path`` + ``inner_widget`` so apply/replay is
-    # deterministic and writes back into the definition (the change persists).
-    sub = _subgraph_write_target(workflow, node_id, widget)
-    if sub is not None:
-        segments, inner_widget = sub
+    # Subgraph-aware. A promoted widget's value lives on the HOST instance
+    # (ADR 0009: the host value wins over the interior default at run time),
+    # and when an outside node feeds the promoted input, on THAT node — never
+    # on the interior node the legacy ``proxyWidgets`` route pointed at. So a
+    # flat ``57.width``, the interior ``57/13.width`` it backs, and a primitive
+    # wired into ``57.width`` all resolve to the one place the frontend runs.
+    # Unpromoted interior widgets (``57/3.cfg``) still write the definition.
+    target = _resolve_widget_write(workflow, graph, node_id, widget)
+    extra: dict[str, Any] = {}
+    if target.redirected_from is not None:
+        extra["redirected_from"] = target.redirected_from
+    if target.kind == "host":
+        instance = target.node
+        defs = _engine._subgraph_defs_by_id(workflow)
+        sg = defs[str(instance.get("type", ""))]
+        pi = _promoted.find_promoted(sg, defs, widget)
+        inner_type, port = _engine.promoted_source_port(sg, pi, defs, graph)
+        value, norm_note = _normalize_combo(graph, inner_type, port.name if port else widget, value)
+        old = _promoted.effective_value(workflow, instance, widget, graph)
+        warnings: list[dict] = []
+        if port is not None:
+            err = port.validate_shape(value)
+            if err:
+                raise ValueError(err)
+            warnings = [dict(w, field=f"{'/'.join(target.segments)}.{widget}") for w in port.validate_catalog(value)]
+            _refuse_fatal(warnings)
+        if norm_note:
+            warnings = [norm_note, *warnings]
+        op = _new_op(
+            "set_widget",
+            actor,
+            base_version,
+            node_id=instance.get("id") if len(target.segments) == 1 else "/".join(target.segments),
+            widget=widget,
+            value=value,
+            old=None if old is _promoted.UNSET else old,
+            promoted={"value_index": pi.value_index, "instance_path": list(target.segments)},
+            **extra,
+        )
+        if warnings:
+            op["warnings"] = warnings
+        workflow = apply_op(workflow, op, graph)
+        # The materialized host array, for an applier that stores the instance
+        # opaquely (no catalog entry for a subgraph type): it can replace the
+        # positional array wholesale instead of decomposing it by name.
+        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(target.node)
+        return workflow, op
+    if target.kind == "legacy_primitive":
+        src = target.node
+        values = src.get("widgets_values")
+        old = values[0] if isinstance(values, list) and values else None
+        op = _new_op(
+            "set_widget",
+            actor,
+            base_version,
+            node_id=src.get("id"),
+            widget=target.widget,
+            value=value,
+            old=old,
+            legacy_primitive=True,
+            **extra,
+        )
+        return apply_op(workflow, op, graph), op
+    if target.kind == "top" and target.redirected_from is not None:
+        node_id = target.node.get("id")
+        widget = target.widget
+    if target.kind == "interior":
+        segments, inner_widget = target.segments, target.widget
         target = _navigate_subgraph_path(workflow, segments)  # read-only: current value + schema
         inner_type = target.get("type", "")
         value, norm_note = _normalize_combo(graph, inner_type, inner_widget, value)
@@ -669,6 +729,7 @@ def _set_widget_impl(
             old=old,
             path=[str(s) for s in segments],
             inner_widget=inner_widget,
+            **extra,
         )
         if warnings:
             op["warnings"] = warnings
@@ -691,10 +752,38 @@ def _set_widget_impl(
         widget=widget,
         value=value,
         old=old,
+        **extra,
     )
     if warnings:
         op["warnings"] = warnings
     return apply_op(workflow, op, graph), op
+
+
+def _refuse_fatal(warnings: list[dict]) -> None:
+    from comfy_cli.cql.engine import FATAL_FINDING_CODES
+
+    for w in warnings:
+        if w.get("code") in FATAL_FINDING_CODES:
+            raise FatalFindingError(w)
+
+
+def _resolve_widget_write(workflow: dict, graph, node_id: Any, widget: str):
+    """Where a set-widget address lands — see ``cql.promoted.resolve_write``.
+    The ``<outer>:<inner>`` alias UI→API lowering mints is accepted like the
+    editable ``<outer>/<inner>`` path."""
+    from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
+
+    node_str = str(node_id)
+    if _engine._SUBGRAPH_PATH_SEP in node_str:
+        segments = node_str.split(_engine._SUBGRAPH_PATH_SEP)
+    elif ":" in node_str and _find_by_str(workflow, node_str) is None:
+        segments = node_str.split(":")
+    else:
+        if _find(workflow, node_id) is None and _find_by_str(workflow, node_str) is None:
+            _require(workflow, node_id)  # canonical not-found error
+        segments = [node_str]
+    return _promoted.resolve_write(workflow, graph, segments, widget)
 
 
 def _subgraph_write_target(workflow: dict, node_id: Any, widget: str) -> tuple[list[str], str] | None:
@@ -854,8 +943,17 @@ def _promoted_widget_error(workflow: dict, node: dict, slot: Any) -> ValueError 
 
     if not isinstance(slot, str):
         return None
-    if _engine._subgraph_defs_by_id(workflow).get(str(node.get("type", ""))) is None:
+    defs = _engine._subgraph_defs_by_id(workflow)
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
         return None
+    from comfy_cli.cql import promoted as _promoted
+
+    pi = _promoted.find_promoted(sg, defs, slot)
+    if pi is not None and (
+        pi.is_widget or pi.source_node is not None or _promoted.legacy_proxy_interior(node, slot) is None
+    ):
+        return None  # a declared input: connect handles it (materialize + wire)
     try:
         target = _subgraph_write_target(workflow, node.get("id"), slot)
     except ValueError:
@@ -910,7 +1008,7 @@ def _connect_impl(
     dst = _require(workflow, to_node)
     out_idx, link_type = _resolve_output_slot(src, graph, from_slot)
     try:
-        in_idx, grow = _resolve_input_target(dst, graph, to_slot, link_type)
+        in_idx, grow = _resolve_input_target(dst, graph, to_slot, link_type, workflow=workflow)
     except ValueError as e:
         promoted = _promoted_widget_error(workflow, dst, to_slot)
         if promoted is not None:
@@ -1705,6 +1803,34 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
     # dropped, so the surviving value is the same in any apply order.
     if not _lww_gate(workflow, op):
         return
+    promoted_write = op.get("promoted")
+    if promoted_write:
+        # Host-owned value of a promoted subgraph input (cql.promoted). The
+        # instance path is one segment for a top-level instance; a nested host
+        # descends (forking shared definitions en route, like interior writes).
+        from comfy_cli.cql import engine as _engine
+        from comfy_cli.cql import promoted as _promoted
+
+        instance_path = [str(s) for s in promoted_write.get("instance_path") or [str(op["node_id"])]]
+        if _find_by_str(workflow, instance_path[0]) is None:
+            return  # instance concurrently deleted => no-op (delete wins)
+        defs_by_id = _engine._subgraph_defs_by_id(workflow)
+        instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
+        _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        _lww_commit(workflow, op)
+        return
+    if op.get("legacy_primitive"):
+        node = _find_by_str(workflow, op["node_id"])
+        if node is None:
+            return
+        values = node.get("widgets_values")
+        values = list(values) if isinstance(values, list) else []
+        if not values:
+            values.append(None)
+        values[0] = op["value"]
+        node["widgets_values"] = values
+        _lww_commit(workflow, op)
+        return
     path = op.get("path")
     if path:
         # Subgraph interior write. A concurrently-deleted instance => no-op
@@ -1797,9 +1923,15 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
         # schema's own element names, when the catalog carries a template).
         ins = dst.setdefault("inputs", [])
         to_idx = next((k for k, i in enumerate(ins) if i.get("grow_id") == op["link_id"]), None)
+        if to_idx is None and grow.get("promoted"):
+            # A promoted subgraph input is ONE register named by the definition:
+            # a concurrent connect that already materialized it shares the entry.
+            to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
         if to_idx is None:
             inputcount = grow.get("inputcount")
-            if inputcount is not None:
+            if grow.get("promoted"):
+                name = grow["name"]
+            elif inputcount is not None:
                 # Bare-key family (see _next_inputcount_name): a collision must
                 # still grow the next free BARE key, never autogrow's dotted
                 # base.elemN fallback — that name is meaningless for this family.
@@ -2392,7 +2524,9 @@ def _inputcount_family_match(graph, node_type: str, slot: str) -> tuple[str, int
     return elem, n
 
 
-def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -> tuple[int | None, dict | None]:
+def _resolve_input_target(
+    node: dict, graph, slot: Any, elem_type: str | None, workflow: dict | None = None
+) -> tuple[int | None, dict | None]:
     """Resolve a connect target. Returns ``(index, None)`` for a concrete input,
     or ``(None, grow)`` where ``grow`` is the input slot to append (autogrow slot,
     or a widget converted to an input).
@@ -2423,6 +2557,15 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
         return idx, None
     except ValueError:
         pass
+    # Promoted subgraph input (``57.width``): the definition declares it, so it
+    # is a link input on the instance even before the instance carries an
+    # ``inputs[]`` entry for it — the frontend rebuilds those from the
+    # definition on load. Materialize it (widget marker when it backs a
+    # widget) and wire it; type-checked against the declared input type.
+    if workflow is not None and isinstance(slot, str):
+        promoted_grow = _resolve_promoted_target(workflow, node, slot, elem_type)
+        if promoted_grow is not None:
+            return None, promoted_grow
     # Dotted autogrow key (images.image0) or a base that has no concrete slot yet.
     if isinstance(slot, str):
         base = slot.split(".", 1)[0]
@@ -2511,6 +2654,36 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             )
     names = [i.get("name") for i in ins]
     raise ValueError(f"input {slot!r} not found on node {node.get('id')}; inputs: {names}")
+
+
+def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: str | None) -> dict | None:
+    """The input to materialize on subgraph instance ``node`` for a connect to
+    its declared input ``slot`` (see ``cql.promoted``). ``None`` when ``node``
+    is not an instance or ``slot`` is not one of its definition's inputs."""
+    from comfy_cli.cql import engine as _engine
+    from comfy_cli.cql import promoted as _promoted
+
+    defs = _engine._subgraph_defs_by_id(workflow)
+    sg = defs.get(str(node.get("type", "")))
+    if sg is None:
+        return None
+    pi = _promoted.find_promoted(sg, defs, slot)
+    if pi is None:
+        return None
+    if not pi.is_widget and pi.source_node is None and _promoted.legacy_proxy_interior(node, slot) is not None:
+        # Declared but unbacked, and a legacy proxy routes the name to an
+        # interior widget: still a value, not a link (the frontend repairs it
+        # into a linked input on load). set-widget owns it.
+        return None
+    if elem_type and not _types_compatible(elem_type, pi.type):
+        raise ValueError(
+            f"type mismatch: {elem_type} output cannot connect to {pi.type} input {slot!r} "
+            f"of subgraph node {node.get('id')}"
+        )
+    grow: dict[str, Any] = {"name": slot, "type": pi.type, "promoted": True}
+    if pi.is_widget:
+        grow["widget"] = slot
+    return grow
 
 
 def _resolve_schema_autogrow(

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -691,6 +691,9 @@ def _set_widget_impl(
         op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(written)
         return workflow, op
     if target.kind == "legacy_primitive":
+        # A frontend-only PrimitiveNode has no catalog entry, so every
+        # replica stores it opaquely (positional): carry the same positional
+        # payload a host write carries, and apply it the same way.
         src = target.node
         values = src.get("widgets_values")
         old = values[0] if isinstance(values, list) and values else None
@@ -703,9 +706,12 @@ def _set_widget_impl(
             value=value,
             old=old,
             legacy_primitive=True,
+            promoted={"value_index": 0, "instance_path": [str(src.get("id"))]},
             **extra,
         )
-        return apply_op(workflow, op, graph), op
+        workflow = apply_op(workflow, op, graph)
+        op["promoted"]["host_widgets_values"] = list(src.get("widgets_values") or [])
+        return workflow, op
     if target.kind == "top" and target.redirected_from is not None:
         node_id = target.node.get("id")
         widget = target.widget
@@ -1820,19 +1826,20 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
             return  # instance concurrently deleted => no-op (delete wins)
         defs_by_id = _engine._subgraph_defs_by_id(workflow)
         instance = _engine._resolve_node_path(workflow, instance_path, defs_by_id)
-        _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        if defs_by_id.get(str(instance.get("type", ""))) is not None:
+            _promoted.set_host_value(workflow, instance, op["widget"], op["value"], graph)
+        else:
+            # Not a subgraph instance (a frontend-only PrimitiveNode): a plain
+            # positional write, aligned from the op's materialized array.
+            _apply_positional_write(instance, promoted_write, op["value"])
         _lww_commit(workflow, op)
         return
     if op.get("legacy_primitive"):
+        # Pre-payload shape (no ``promoted`` block): widgets_values[0].
         node = _find_by_str(workflow, op["node_id"])
         if node is None:
             return
-        values = node.get("widgets_values")
-        values = list(values) if isinstance(values, list) else []
-        if not values:
-            values.append(None)
-        values[0] = op["value"]
-        node["widgets_values"] = values
+        _apply_positional_write(node, {"value_index": 0}, op["value"])
         _lww_commit(workflow, op)
         return
     path = op.get("path")
@@ -1863,6 +1870,26 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
         widgets.extend([None] * (idx + 1 - len(widgets)))
     widgets[idx] = op["value"]
     _lww_commit(workflow, op)
+
+
+def _apply_positional_write(node: dict, positional: dict, value: Any) -> None:
+    """Write ``value`` at ``positional["value_index"]`` of an opaquely stored
+    node's ``widgets_values``, extending a shorter array from the op's own
+    ``host_widgets_values`` so alignment is preserved (the same rule the
+    doc-host applier follows for a node without a catalog entry)."""
+    idx = positional.get("value_index")
+    if not isinstance(idx, int) or isinstance(idx, bool) or idx < 0:
+        return
+    values = node.get("widgets_values")
+    values = list(values) if isinstance(values, list) else []
+    seed = positional.get("host_widgets_values")
+    if len(values) <= idx:
+        if isinstance(seed, list) and len(seed) > len(values):
+            values.extend(seed[len(values) :])
+        while len(values) <= idx:
+            values.append(None)
+    values[idx] = value
+    node["widgets_values"] = values
 
 
 def _apply_inputcount_bump(workflow: dict, dst: dict, op: dict, graph, widget: str, value: Any) -> None:
@@ -1927,10 +1954,23 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
         # schema's own element names, when the catalog carries a template).
         ins = dst.setdefault("inputs", [])
         to_idx = next((k for k, i in enumerate(ins) if i.get("grow_id") == op["link_id"]), None)
-        if to_idx is None and grow.get("promoted"):
-            # A promoted subgraph input is ONE register named by the definition:
-            # a concurrent connect that already materialized it shares the entry.
-            to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
+        if grow.get("promoted"):
+            # A promoted subgraph input is ONE register named by the definition
+            # (``("input", to_node, "grow", name)``), not a fresh slot per
+            # connect: gate it exactly like a concrete input so the occupant is
+            # decided by stamp, not arrival order, and the doc-host applier
+            # (comfy-multi-player) converges with this replica. The claim is
+            # unconditional once the gate passes (see the concrete branch).
+            if to_idx is None and not _lww_gate(workflow, op):
+                return
+            _lww_commit(workflow, op)
+            if to_idx is None:
+                to_idx = next((k for k, i in enumerate(ins) if i.get("name") == grow["name"]), None)
+            if to_idx is not None:
+                prev = ins[to_idx].get("link")
+                if prev is not None and prev != op["link_id"]:
+                    _remove_link(workflow, prev)
+                ins[to_idx]["grow_id"] = op["link_id"]  # the register follows the winner
         if to_idx is None:
             inputcount = grow.get("inputcount")
             if grow.get("promoted"):
@@ -2156,6 +2196,10 @@ def _write_target(op: dict) -> tuple:
             # Two autogrow connects onto the same base share a target (their
             # relative order in the batch is the sequence decision the merge
             # consumer must make); distinct bases don't collide.
+            if grow.get("promoted"):
+                # A promoted subgraph input is one register per declared NAME
+                # (names may contain dots: ``images.image0``), never per base.
+                return ("input", str(op["to_node"]), "grow", str(grow["name"]))
             # The group is everything before the LAST dot: a group nested
             # under a dynamic combo (``model.reference_images.image_1``) must
             # not share a target with its sibling (``model.reference_videos``).

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -683,8 +683,12 @@ def _set_widget_impl(
         workflow = apply_op(workflow, op, graph)
         # The materialized host array, for an applier that stores the instance
         # opaquely (no catalog entry for a subgraph type): it can replace the
-        # positional array wholesale instead of decomposing it by name.
-        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(target.node)
+        # positional array wholesale instead of decomposing it by name. Read
+        # from the instance apply WROTE — a nested host inside a shared
+        # definition was forked on the way down, so the dict captured during
+        # resolution is the pre-fork sibling, not the written one.
+        written = _engine._resolve_node_path(workflow, list(target.segments), _engine._subgraph_defs_by_id(workflow))
+        op["promoted"]["host_widgets_values"] = _promoted.host_widgets_values(written)
         return workflow, op
     if target.kind == "legacy_primitive":
         src = target.node
@@ -2675,12 +2679,15 @@ def _resolve_promoted_target(workflow: dict, node: dict, slot: str, elem_type: s
         # interior widget: still a value, not a link (the frontend repairs it
         # into a linked input on load). set-widget owns it.
         return None
-    if elem_type and not _types_compatible(elem_type, pi.type):
+    # A declared input with no usable type (missing or non-string in the
+    # save) is reachable, not a mismatch: skip the check and stamp the slot
+    # with the source type, as the frontend would infer it.
+    if elem_type and pi.type and not _types_compatible(elem_type, pi.type):
         raise ValueError(
             f"type mismatch: {elem_type} output cannot connect to {pi.type} input {slot!r} "
             f"of subgraph node {node.get('id')}"
         )
-    grow: dict[str, Any] = {"name": slot, "type": pi.type, "promoted": True}
+    grow: dict[str, Any] = {"name": slot, "type": pi.type or elem_type or "*", "promoted": True}
     if pi.is_widget:
         grow["widget"] = slot
     return grow

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -880,11 +880,9 @@ def _render_subgraph_instance_line(
             if link_id is not None:
                 text = _promoted_widget_link_text(pi.name, link_id, nid, ctx, annotations, prim_hits, warnings)
             if text is None:
-                try:
-                    value = _promoted.effective_value(state.workflow, node, pi.name, ctx.graph)
-                except ValueError as e:  # the definition index disagrees with itself: say so, print None
-                    warnings.append(f"node {ctx.qualify(nid)}: promoted widget {pi.name!r} unreadable: {e}")
-                    value = _promoted.UNSET
+                # ``pi`` and the definition index are this loop's own; the
+                # name-lookup entry point would re-derive both per widget.
+                value = _promoted.effective_value_for(state.workflow, node, sg_def, pi, ctx.graph, state.promoted_defs)
                 text = py_literal(None if value is _promoted.UNSET else value)
         elif pi.source_node is None and link_id is None and ctx.graph is not None:
             # Declared but backed by no boundary link: a legacy template still
@@ -1043,7 +1041,7 @@ class _State:
         self.defs_by_id = defs_by_id
         # The whole workflow and cql.promoted's own definition index: a
         # promoted widget's effective value is resolved from the HOST instance
-        # against its definition (``promoted.effective_value``), at any depth.
+        # against its definition (``promoted.effective_value_for``), at any depth.
         self.workflow: dict = workflow if workflow is not None else {}
         self.promoted_defs: dict[str, dict] = _promoted.defs_by_id(self.workflow)
         self.warnings = warnings

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -17,6 +17,18 @@ as an indented block addressed as ``<first instance address>/<inner id>`` —
 fully qualified through every nesting level, matching
 ``workflow_ops._navigate_subgraph_path``.
 
+Two rules keep the printed names the ones the editors take:
+
+* a regular node's widgets print by their value-aware names
+  (``Graph.widget_order_for_node``: ``model``, ``model.resolution``, …); an
+  auto-grow group (``COMFY_AUTOGROW_V3``) owns no widget slot — its grown
+  slots print as links, one open slot stays visible, and the line comment
+  names the group with its element type;
+* a subgraph instance's promoted widgets (``cql.promoted``) print their
+  EFFECTIVE value — the host's, else the interior default — under the
+  instance address (``57.width``); the interior line keeps ``IN.width`` and
+  the definition header says where that value lives.
+
 See the design: decisions D1-D13 (Obsidian, "workflow print (design, 2026-08-25)").
 """
 
@@ -28,7 +40,8 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from comfy_cli.cql.engine import _expand_widget_entries, _widgets_as_positional
+from comfy_cli.cql import promoted as _promoted
+from comfy_cli.cql.engine import _UNRESOLVED, _expand_widget_entries, _resolve_proxy_value, _widgets_as_positional
 from comfy_cli.workflow_to_api import is_subgraph_uuid
 
 if TYPE_CHECKING:
@@ -528,6 +541,57 @@ def _place_arg(name: str, text: str, args: list[str], extra: dict[str, str]) -> 
         extra[name] = text
 
 
+def _autogrow_annotation(group: Any, inputs: list[dict]) -> str:
+    """The line-comment marker for one auto-grow group: its name, the socket
+    type every grown slot carries, and the schema's capacity — so a reader
+    knows the group exists (and what to wire into it) even before anything is
+    connected. The element type comes from the schema template; a catalog
+    that omits it falls back to the type litegraph stamped on a grown slot."""
+    elem = group.autogrow_element_type
+    if not elem:
+        prefix = f"{group.name}."
+        elem = next(
+            (
+                str(inp["type"])
+                for inp in inputs
+                if str(inp.get("name") or "").startswith(prefix) and isinstance(inp.get("type"), str) and inp["type"]
+            ),
+            "any",
+        )
+    _lo, hi = group.autogrow_limits
+    return f" {group.name} grows {elem}" + (f" (max {hi})" if hi is not None else "")
+
+
+def _ensure_open_autogrow_slot(group: Any, inputs: list[dict], extra: dict[str, str]) -> None:
+    """Show ONE open slot for ``group`` when none of its serialized slots is
+    free and the schema allows another — the frontend keeps exactly that free
+    trailing slot on a loaded node, so a UI-built and an agent-built node
+    (whose ``inputs[]`` only carry what ``connect`` grew) print alike, and the
+    printed name is the one ``connect`` accepts next. Inserted right after the
+    group's last existing slot so the group stays contiguous. Never touches the
+    workflow itself."""
+    from comfy_cli.workflow_ops import _autogrow_elem_name, _first_free_autogrow_index
+
+    prefix = f"{group.name}."
+    members = [str(inp.get("name") or "") for inp in inputs if str(inp.get("name") or "").startswith(prefix)]
+    if any(extra.get(name) == "None" for name in members):
+        return
+    _lo, hi = group.autogrow_limits
+    if hi is not None and len(members) >= hi:
+        return
+    template = group.autogrow_template
+    n = _first_free_autogrow_index(set(members), group.name, template)
+    slot = f"{group.name}.{_autogrow_elem_name(group.name, n, template)}"
+    items = list(extra.items())
+    last = max((i for i, (k, _v) in enumerate(items) if k in members), default=None)
+    if last is None:
+        extra[slot] = "None"
+        return
+    items.insert(last + 1, (slot, "None"))
+    extra.clear()
+    extra.update(items)
+
+
 def _build_args(
     node: dict, m: Any, ctx: _RenderCtx, warnings: list[str]
 ) -> tuple[list[str], bool, list[str], list[tuple]]:
@@ -537,7 +601,16 @@ def _build_args(
     ``unknown`` is True when the class isn't in the catalog (or there is no
     catalog), ``annotations`` are suffix strings to append to the line
     comment, and ``prim_hits`` are ``(qualified_primitive_id, qualified_skip_reason)``
-    pairs for PrimitiveNode-into-widget splices found here."""
+    pairs for PrimitiveNode-into-widget splices found here.
+
+    Widgets print by their VALUE-AWARE names (``Graph.widget_order_for_node``):
+    a dynamic combo's selector followed by the selected option's sub-widgets
+    (``model.resolution``…), read at the frontend's positions. A link-only
+    sub-input (a ``COMFY_AUTOGROW_V3`` group) owns no widget slot, so it never
+    prints as a value: its grown slots print as links, one open slot is kept
+    visible (``_ensure_open_autogrow_slot``), and the group itself is named in
+    the line comment with its element type (``_autogrow_annotation``).
+    """
     nid = str(node.get("id"))
     args: list[str] = []
     extra: dict[str, str] = {}
@@ -553,6 +626,20 @@ def _build_args(
             warnings.append(f"node {ctx.qualify(nid)}: ignoring malformed input entry {inp!r}")
             continue
         inputs.append(inp)
+
+    class_type = node.get("type", "")
+    widgets_values = node.get("widgets_values")
+    unknown = m is None
+    if unknown:
+        positional = widgets_values if isinstance(widgets_values, list) else []
+        groups: list = []
+    else:
+        positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
+        # The auto-grow groups this node exposes for its CURRENT selection —
+        # a group nested under a dynamic combo disappears when the selector
+        # moves to an option without it.
+        groups = ctx.graph.autogrow_groups(class_type, positional)
+    group_names = {g.name for g in groups}
 
     # Pre-pass: widget-backed inputs. A LIVE link to a real, printable node is
     # the truth — it's printed as a ref in the link pass below and skipped in
@@ -604,6 +691,11 @@ def _build_args(
                 _place_arg(name, live_link_refs[name], args, extra)
             continue  # otherwise: printed in the widget pass instead
         link_id = inp.get("link")
+        # An auto-grow group's BASE entry (``images`` on an agent-built
+        # BatchImagesNode) is the group itself, not a wireable slot: its slots
+        # are the grown ``images.image0`` entries, handled with the group below.
+        if link_id is None and name in group_names:
+            continue
         if link_id is None:
             _place_arg(name, "None", args, extra)
             continue
@@ -619,16 +711,15 @@ def _build_args(
             annotations.append(ann)
         _place_arg(name, ref if ref is not None else "None", args, extra)
 
-    class_type = node.get("type", "")
-    widgets_values = node.get("widgets_values")
-    unknown = m is None
+    for group in groups:
+        _ensure_open_autogrow_slot(group, inputs, extra)
+        annotations.append(_autogrow_annotation(group, inputs))
+
     if unknown:
-        positional = widgets_values if isinstance(widgets_values, list) else []
         if positional:
             args.append(f"widgets={py_literal(positional)}")
         warnings.append(f"node {ctx.qualify(nid)}: class {class_type!r} not in catalog; widgets printed positionally")
     else:
-        positional = _widgets_as_positional(widgets_values, ctx.graph, class_type)
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
             arg_name = "control_after_generate" if entry.port is None else entry.name
@@ -676,17 +767,75 @@ def _subgraph_instance_name(node: dict, sg_def: dict | None, type_uuid: str) -> 
     return type_uuid
 
 
+def _promoted_widget_link_text(
+    iname: str,
+    link_id: Any,
+    nid: str,
+    ctx: _RenderCtx,
+    annotations: list[str],
+    prim_hits: list[tuple],
+    warnings: list[str],
+) -> str | None:
+    """What an outside link into a promoted WIDGET input prints as — the same
+    rules a regular node's widget-backed input follows (``_build_args``'s
+    pre-pass): a live link to a printable node is the value (its ref), the
+    enclosing definition's input proxy is ``IN.<name>``, a PrimitiveNode keeps
+    the stored value with a ``from primitive`` marker, and a dead-end Reroute
+    keeps it with an ``unlinked`` marker. ``None`` means "print the value"."""
+    link = ctx.link_map.get(str(link_id))
+    if link is None:
+        return None
+    src_id, src_slot, _tgt_id, _tgt_slot = link
+    outcome = _resolve_source(
+        src_id, src_slot, ctx.nodes_by_id, ctx.reroute_sources, ctx.set_sources, ctx.get_vars, ctx.proxy_in_id
+    )
+    if outcome[0] == "ok":
+        rid_s = str(outcome[1])
+        if rid_s not in ctx.printable_ids:
+            return None
+        src_node = ctx.nodes_by_id.get(rid_s)
+        binding = ctx.binding_by_id.get(rid_s)
+        if src_node is None or binding is None:
+            return None
+        ref, edge_warning = _edge_ref(binding, src_node, src_node.get("type", ""), outcome[2], ctx)
+        if edge_warning:
+            warnings.append(edge_warning)
+        if src_node.get("mode") == 4:
+            annotations.append(f" {iname} via bypassed {rid_s}")
+        return ref
+    if outcome[0] == "in_proxy":
+        return ctx.in_ref(outcome[1])
+    if outcome[0] == "primitive_no_widget":
+        annotations.append(f" {iname} from primitive {outcome[1]}")
+        prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
+    elif outcome[0] == "dead_reroute":
+        annotations.append(f" {iname} unlinked via reroute {outcome[1]}")
+    return None
+
+
 def _render_subgraph_instance_line(
-    node: dict, type_uuid: str, sg_def: dict, binding: str, ctx: _RenderCtx, warnings: list[str]
+    node: dict, type_uuid: str, sg_def: dict, binding: str, ctx: _RenderCtx, state: _State
 ) -> tuple:
-    """A subgraph instance's own line: exposed link inputs by name (or, when
-    the name isn't a Python identifier, collected into a trailing ``**{}``);
-    widget-backed exposed inputs print positionally from ``widgets_values``
-    (subgraphs are never in the catalog) unless their link resolves to the
-    enclosing definition's own input proxy, in which case that ref is used.
-    Gets the same ``mode=bypass``/``mode=mute`` suffix as a regular node.
-    Any D9 annotation from resolving a link input (e.g. a dead-end Reroute)
-    is appended to the line, same as a regular node. Returns ``(line, prim_hits)``."""
+    """A subgraph instance's own line, argument per declared subgraph input in
+    declaration order (non-identifier names collected into a trailing
+    ``**{}``):
+
+    * a promoted WIDGET input (``cql.promoted``: a declared input a boundary
+      link feeds into an interior widget) prints its EFFECTIVE value — the
+      host instance's own value when materialized, else the interior default
+      — under the name ``set-widget <instance>.<name>`` takes. The host's
+      positional ``widgets_values`` are read the way the frontend reads them
+      (one slot per widget-backed input, in declaration order), never by the
+      instance's serialized ``inputs[]``, which only lists what the UI showed.
+      An outside link into it prints as that link instead (the link is what
+      runs), with the same PrimitiveNode/Reroute markers a regular node gets;
+    * a socket input prints its link (or ``None``).
+
+    A declared input no boundary link backs falls back to the legacy
+    ``proxyWidgets`` route, exactly as ``slots`` does. Any instance
+    ``inputs[]`` entry the definition does not declare prints last, by link.
+    Gets the same ``mode=`` suffix and D9 annotations as a regular node.
+    Returns ``(line, prim_hits)``."""
     nid = str(node.get("id"))
     name_str = _subgraph_instance_name(node, sg_def, type_uuid)
     bracket = json.dumps(name_str, ensure_ascii=False)
@@ -694,54 +843,67 @@ def _render_subgraph_instance_line(
     annotations: list[str] = []
     args: list[str] = []
     extra: dict[str, str] = {}
+    warnings = state.warnings
 
     inputs = [inp for inp in node.get("inputs") or [] if isinstance(inp, dict)]
-    link_inputs = [inp for inp in inputs if "widget" not in inp]
-    widget_inputs = [inp for inp in inputs if "widget" in inp]
+    by_name: dict[str, dict] = {}
+    for inp in inputs:
+        iname = inp.get("name")
+        if isinstance(iname, str) and iname not in by_name:
+            by_name[iname] = inp
+    rendered: set[str] = set()
 
-    for inp in link_inputs:
-        iname = inp.get("name") or ""
-        ref = None
-        link_id = inp.get("link")
-        if link_id is not None:
-            link = ctx.link_map.get(str(link_id))
-            if link is not None:
-                src_id, src_slot, _tgt_id, _tgt_slot = link
-                ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
-                if warn:
-                    warnings.append(warn)
-                if ann:
-                    annotations.append(ann)
-        _place_arg(iname, ref if ref is not None else "None", args, extra)
+    def socket_text(iname: str, link_id: Any) -> str:
+        link = ctx.link_map.get(str(link_id)) if link_id is not None else None
+        if link is None:
+            return "None"
+        src_id, src_slot, _tgt_id, _tgt_slot = link
+        ref, ann, warn = _resolve_edge_text(src_id, src_slot, iname, nid, ctx)
+        if warn:
+            warnings.append(warn)
+        if ann:
+            annotations.append(ann)
+        return ref if ref is not None else "None"
 
-    widgets_values = node.get("widgets_values")
-    positional = widgets_values if isinstance(widgets_values, list) else []
-    for k, inp in enumerate(widget_inputs):
+    for pi in _promoted.promoted_inputs(sg_def, state.promoted_defs):
+        rendered.add(pi.name)
+        entry = by_name.get(pi.name)
+        link_id = entry.get("link") if entry is not None else None
+        text = None
+        if pi.is_widget:
+            if link_id is not None:
+                text = _promoted_widget_link_text(pi.name, link_id, nid, ctx, annotations, prim_hits, warnings)
+            if text is None:
+                try:
+                    value = _promoted.effective_value(state.workflow, node, pi.name, ctx.graph)
+                except ValueError as e:  # the definition index disagrees with itself: say so, print None
+                    warnings.append(f"node {ctx.qualify(nid)}: promoted widget {pi.name!r} unreadable: {e}")
+                    value = _promoted.UNSET
+                text = py_literal(None if value is _promoted.UNSET else value)
+        elif pi.source_node is None and link_id is None and ctx.graph is not None:
+            # Declared but backed by no boundary link: a legacy template still
+            # routes it through ``proxyWidgets`` to an interior widget — the
+            # same fallback ``slots`` applies (``_declared_subgraph_slots``).
+            value = _resolve_proxy_value(node, sg_def, pi.name, ctx.graph)
+            if value is not _UNRESOLVED:
+                text = py_literal(value)
+        if text is None:
+            text = socket_text(pi.name, link_id)
+        _place_arg(pi.name, text, args, extra)
+
+    for inp in inputs:
         iname = inp.get("name") or ""
-        override = None
+        if iname in rendered:
+            continue
+        rendered.add(iname)
         link_id = inp.get("link")
-        if link_id is not None:
-            link = ctx.link_map.get(str(link_id))
-            if link is not None:
-                src_id, src_slot, _tgt_id, _tgt_slot = link
-                outcome = _resolve_source(
-                    src_id,
-                    src_slot,
-                    ctx.nodes_by_id,
-                    ctx.reroute_sources,
-                    ctx.set_sources,
-                    ctx.get_vars,
-                    ctx.proxy_in_id,
-                )
-                if outcome[0] == "in_proxy":
-                    override = ctx.in_ref(outcome[1])
-                elif outcome[0] == "primitive_no_widget":
-                    prim_hits.append((ctx.qualify(outcome[1]), f"inlined into {ctx.qualify(nid)}.{iname}"))
-        if override is not None:
-            text = override
+        text = None
+        if "widget" in inp and link_id is not None:
+            text = _promoted_widget_link_text(iname, link_id, nid, ctx, annotations, prim_hits, warnings)
+            if text is None:
+                text = "None"
         else:
-            value = positional[k] if k < len(positional) else None
-            text = py_literal(value)
+            text = socket_text(iname, link_id)
         _place_arg(iname, text, args, extra)
 
     if extra:
@@ -826,6 +988,24 @@ def _definition_header(def_id: str, sg_def: dict, state: _State) -> str:
     )
 
 
+def _promoted_header_line(def_id: str, sg_def: dict, state: _State) -> str | None:
+    """The line under a definition's header that names its promoted WIDGETS —
+    the ``IN.<name>`` references the interior lines below carry. Their values
+    live on the instance (``cql.promoted``), so it spells out the address to
+    edit (``57.<name>``) and the one NOT to (``57/<id>.<name>``, the interior
+    widget the host value overrides). ``None`` when nothing is promoted as a
+    widget (socket-only inputs are links, not values)."""
+    pis = [p for p in _promoted.promoted_inputs(sg_def, state.promoted_defs) if p.is_widget]
+    if not pis:
+        return None
+    first = state.first_instance_by_def.get(def_id, def_id)
+    names = ", ".join(_member_ref("IN", p.name) for p in pis)
+    return (
+        f"#   promoted widgets: {names} — each is the instance's own value: "
+        f"edit {first}.<name>, never {first}/<id>.<name>"
+    )
+
+
 def _def_links(sg_def: dict) -> dict[str, tuple]:
     """Normalise a definition's dict-shaped links into the array-tuple form
     used everywhere else: ``{str(link_id): (origin_id, origin_slot, target_id, target_slot)}``."""
@@ -847,9 +1027,19 @@ class _State:
     that end up on the returned ``PrintResult``."""
 
     def __init__(
-        self, defs_by_id: dict[str, dict], warnings: list[str], skipped: list[dict], bindings: dict[str, str]
+        self,
+        defs_by_id: dict[str, dict],
+        warnings: list[str],
+        skipped: list[dict],
+        bindings: dict[str, str],
+        workflow: dict | None = None,
     ) -> None:
         self.defs_by_id = defs_by_id
+        # The whole workflow and cql.promoted's own definition index: a
+        # promoted widget's effective value is resolved from the HOST instance
+        # against its definition (``promoted.effective_value``), at any depth.
+        self.workflow: dict = workflow if workflow is not None else {}
+        self.promoted_defs: dict[str, dict] = _promoted.defs_by_id(self.workflow)
         self.warnings = warnings
         self.skipped = skipped
         self.bindings = bindings
@@ -943,7 +1133,7 @@ def _render_nodes(
             sg_def = defs_by_id.get(t)
             addr = ctx.qualify(nid)
             if sg_def is not None:
-                line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state.warnings)
+                line, prim_hits = _render_subgraph_instance_line(n, t, sg_def, name, ctx, state)
                 for prim_id, reason in prim_hits:
                     state.primitive_reason.setdefault(prim_id, reason)
                 state.register_instance(t, ctx.owner_def, nid, addr, depth)
@@ -1081,9 +1271,12 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     links = workflow.get("links") or []
 
     definitions = workflow.get("definitions")
+    promoted_workflow = workflow
     if definitions is not None and not isinstance(definitions, dict):
         warnings.append("workflow: ignoring non-object definitions block")
         definitions = None
+        # cql.promoted indexes the same block; hand it the sanitized view.
+        promoted_workflow = {**workflow, "definitions": None}
     subgraphs = definitions.get("subgraphs") if definitions else None
     defs_by_id = {sg.get("id"): sg for sg in (subgraphs or []) if isinstance(sg, dict) and sg.get("id")}
 
@@ -1126,7 +1319,7 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
     )
 
     skipped: list[dict] = []
-    state = _State(defs_by_id, warnings, skipped, bindings)
+    state = _State(defs_by_id, warnings, skipped, bindings, promoted_workflow)
 
     lines = _render_nodes(order, ctx, graph, defs_by_id, binding_by_id, state, depth=1)
 
@@ -1152,6 +1345,9 @@ def render_py(workflow: dict, graph: Graph | None) -> PrintResult:
         node_count += block_count
     for def_id in state.def_order:
         lines.append(_definition_header(def_id, defs_by_id[def_id], state))
+        promoted_line = _promoted_header_line(def_id, defs_by_id[def_id], state)
+        if promoted_line is not None:
+            lines.append(promoted_line)
         lines.extend("    " + bl for bl in block_lines_by_def[def_id])
 
     source = "\n".join(lines) + "\n"

--- a/comfy_cli/workflow_print.py
+++ b/comfy_cli/workflow_print.py
@@ -722,7 +722,13 @@ def _build_args(
     else:
         entries = _expand_widget_entries(m, positional)
         for idx, entry in enumerate(entries):
-            arg_name = "control_after_generate" if entry.port is None else entry.name
+            if entry.frontend_injected:
+                # ``upload`` / ``audioUI`` / PREVIEW_3D ``image``: a frontend
+                # button or DOM slot with no schema port and no editable
+                # value (``slots`` omits it, every write surface refuses it).
+                # It owns a positional slot, so it is walked — never printed.
+                continue
+            arg_name = entry.name
             if arg_name in live_link_refs:
                 continue  # already printed in the link pass above
             if arg_name in widget_overrides:

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -223,7 +223,9 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             current = inputs.get(widget)
             if isinstance(current, list) and len(current) == 2:
                 continue  # wired from inside the definition: the link wins
-            inputs[widget] = value
+            # Same wrapping every widget value gets, so a two-item list host
+            # value is never read back as a ``[node, slot]`` link.
+            inputs[widget] = _wrap_widget_value(value)
 
     for node in workflow.get("nodes") or []:
         if not isinstance(node, dict):

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -197,7 +197,12 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
     """
     from comfy_cli.cql import promoted as _promoted
 
-    def visit(instance: dict, sg: dict, prefix: str, depth: int) -> None:
+    def visit(instance: dict, sg: dict, scope: dict, prefix: str, depth: int) -> None:
+        # ``scope`` holds the links that can feed THIS instance's inputs: the
+        # workflow for a top-level instance, the containing definition for a
+        # nested one. A serialized link id that no longer exists there is one
+        # the frontend drops on load — the input is unlinked and the host value
+        # runs, exactly as ``resolve_write`` and ``slots`` treat it.
         if depth > _MAX_SUBGRAPH_ITERATIONS or instance.get("mode") in (_MODE_MUTED, _MODE_BYPASS):
             return
         for inner in sg.get("nodes") or []:
@@ -205,9 +210,9 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
                 continue
             inner_def = subgraph_defs.get(str(inner.get("type", "")))
             if inner_def is not None:
-                visit(inner, inner_def, f"{prefix}:{inner.get('id')}", depth + 1)
+                visit(inner, inner_def, sg, f"{prefix}:{inner.get('id')}", depth + 1)
         for pi in _promoted.promoted_inputs(sg, subgraph_defs):
-            if not pi.is_widget or _promoted.external_link(instance, pi.name) is not None:
+            if not pi.is_widget or _promoted.live_external_link(scope, instance, pi.name) is not None:
                 continue
             value = _promoted.host_value(instance, pi)
             if value is _promoted.UNSET:
@@ -232,7 +237,7 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             continue
         sg = subgraph_defs.get(str(node.get("type", "")))
         if sg is not None:
-            visit(node, sg, str(node.get("id")), 0)
+            visit(node, sg, workflow, str(node.get("id")), 0)
 
 
 def _has_group_nodes(workflow: dict) -> bool:

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -178,7 +178,59 @@ def convert_ui_to_api(workflow: dict, object_info: dict) -> dict:
             logger.exception("Failed to convert node id=%s type=%s; skipping", node_id_str, node_type)
 
     _strip_orphan_link_inputs(api_prompt)
+    _overlay_promoted_host_values(api_prompt, workflow, subgraph_defs)
     return api_prompt
+
+
+def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_defs: dict[str, dict]) -> None:
+    """Apply host-owned promoted widget values onto the expanded interior nodes.
+
+    A promoted widget's value lives on the HOST instance (``widgets_values``
+    positional over the widget-backed subgraph inputs — ADR 0009); the
+    interior widget is only its default. Expansion above copied the interior
+    default, so a post-migration save (host prompt filled in, interior
+    ``caption`` still ``''``) would submit the wrong prompt. Precedence, as the
+    frontend serializes it: a link feeding the instance input wins (already
+    reattached), else the host value when materialized, else the interior.
+    Inner instances are visited first so an outer host wins over an inner one;
+    an inner input promoted further (linked from ``-10``) is left to the outer.
+    """
+    from comfy_cli.cql import promoted as _promoted
+
+    def visit(instance: dict, sg: dict, prefix: str, depth: int) -> None:
+        if depth > _MAX_SUBGRAPH_ITERATIONS or instance.get("mode") in (_MODE_MUTED, _MODE_BYPASS):
+            return
+        for inner in sg.get("nodes") or []:
+            if not isinstance(inner, dict):
+                continue
+            inner_def = subgraph_defs.get(str(inner.get("type", "")))
+            if inner_def is not None:
+                visit(inner, inner_def, f"{prefix}:{inner.get('id')}", depth + 1)
+        for pi in _promoted.promoted_inputs(sg, subgraph_defs):
+            if not pi.is_widget or _promoted.external_link(instance, pi.name) is not None:
+                continue
+            value = _promoted.host_value(instance, pi)
+            if value is _promoted.UNSET:
+                continue
+            target = _promoted.deepest_source(sg, pi, subgraph_defs)
+            if target is None:
+                continue
+            path, widget = target
+            entry = api_prompt.get(":".join([prefix, *path]))
+            if not isinstance(entry, dict):
+                continue
+            inputs = entry.setdefault("inputs", {})
+            current = inputs.get(widget)
+            if isinstance(current, list) and len(current) == 2:
+                continue  # wired from inside the definition: the link wins
+            inputs[widget] = value
+
+    for node in workflow.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        sg = subgraph_defs.get(str(node.get("type", "")))
+        if sg is not None:
+            visit(node, sg, str(node.get("id")), 0)
 
 
 def _has_group_nodes(workflow: dict) -> bool:

--- a/comfy_cli/workflow_to_api.py
+++ b/comfy_cli/workflow_to_api.py
@@ -217,20 +217,19 @@ def _overlay_promoted_host_values(api_prompt: dict, workflow: dict, subgraph_def
             value = _promoted.host_value(instance, pi)
             if value is _promoted.UNSET:
                 continue
-            target = _promoted.deepest_source(sg, pi, subgraph_defs)
-            if target is None:
-                continue
-            path, widget = target
-            entry = api_prompt.get(":".join([prefix, *path]))
-            if not isinstance(entry, dict):
-                continue
-            inputs = entry.setdefault("inputs", {})
-            current = inputs.get(widget)
-            if isinstance(current, list) and len(current) == 2:
-                continue  # wired from inside the definition: the link wins
-            # Same wrapping every widget value gets, so a two-item list host
-            # value is never read back as a ``[node, slot]`` link.
-            inputs[widget] = _wrap_widget_value(value)
+            # Every interior widget the input feeds — a repaired primitive
+            # fan-out links one host value into several targets.
+            for path, widget in _promoted.boundary_widget_targets(sg, pi, subgraph_defs):
+                entry = api_prompt.get(":".join([prefix, *path]))
+                if not isinstance(entry, dict):
+                    continue
+                inputs = entry.setdefault("inputs", {})
+                current = inputs.get(widget)
+                if isinstance(current, list) and len(current) == 2:
+                    continue  # wired from inside the definition: the link wins
+                # Same wrapping every widget value gets, so a two-item list
+                # host value is never read back as a ``[node, slot]`` link.
+                inputs[widget] = _wrap_widget_value(value)
 
     for node in workflow.get("nodes") or []:
         if not isinstance(node, dict):

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -414,7 +414,7 @@ Current contract, pinned:
   never random — and the instance's `type` is repointed, so two replicas
   replaying the same op produce byte-identical graphs and sibling instances
   are never aliased.
-* **Promoted widgets are HOST writes** (BE-10305; `cql.promoted`). A
+* **Promoted widgets are HOST writes** (`cql.promoted`). A
   `set_widget` on a promoted input carries `promoted: {instance_path,
   value_index}` instead of `path`, and its LWW target is the host register
   `("widget", "57", "text")` — the flat form, the nested interior form of the

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -742,7 +742,7 @@ A write to a promoted input is a top-level `set_widget` on the INSTANCE
 (`node_id`, `widget` = the declared input name; no `path`/`inner_widget`)
 carrying
 
-```
+```json
 "promoted": {"value_index": <int>, "instance_path": [<id>, …],
              "host_widgets_values": [<full materialized array>]}
 ```
@@ -767,7 +767,7 @@ time); a merge consumer treats them as distinct targets.
 A `connect` whose target is a declared subgraph input the instance does not
 yet carry an `inputs[]` entry for carries
 
-```
+```json
 "grow": {"name": <declared input name>, "type": <declared type>,
          "promoted": true, "widget": <name, only when the input backs a widget>}
 ```
@@ -780,9 +780,11 @@ stamp owns the entry in either apply order, `grow_id` follows the winner, the
 loser's link is retired, and the claim is unconditional once the gate passes.
 Apply reuses an existing entry by name (a concurrent materialization shares
 it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
-verbatim — no numbering. Once materialized, a later connect to the same name
-resolves it as a concrete slot (`to_slot`) on the concrete register; both
-sides agree, and this is not drift.
+verbatim — no numbering. Every connect to a declared promoted input is this
+promoted grow, even once the entry exists: the register is the declared name
+for the life of the input, so a replica that receives a later connect before
+the materializing one still lands it (a concrete `to_slot` op would find no
+slot, be dropped with its `op_id` consumed, and never replay).
 
 ### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
 

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -414,6 +414,20 @@ Current contract, pinned:
   never random — and the instance's `type` is repointed, so two replicas
   replaying the same op produce byte-identical graphs and sibling instances
   are never aliased.
+* **Promoted widgets are HOST writes** (BE-10305; `cql.promoted`). A
+  `set_widget` on a promoted input carries `promoted: {instance_path,
+  value_index}` instead of `path`, and its LWW target is the host register
+  `("widget", "57", "text")` — the flat form, the nested interior form of the
+  widget the input links, and the flattened alias all converge there. A
+  legacy `properties.proxyWidgets` entry the definition does not back with a
+  linked input is first repaired the way the frontend's forward migration
+  repairs it on load (`promoted.flush_proxy_migration`): the op additionally
+  carries `promoted.repair = {entry, ids}` where `ids` maps every repairable
+  entry of that instance to the subgraph-input uuid and boundary-link ids the
+  repair mints, derived with SHA-256 from `(instance path, source node,
+  widget)` — deterministic, never random — so replay on any replica produces
+  a byte-identical document. The repair mutates the definition, so a shared
+  one is forked first exactly like an interior write.
 * OPEN: the shared-definition forking semantics above are apply-time behavior
   that rewrites `instance.type` without an explicit op saying so. A full
   specification (fork visibility, interaction with concurrent interior writes
@@ -804,3 +818,13 @@ A write that resolves to a frontend-only `PrimitiveNode` (no catalog entry;
 §14.1 `promoted` payload with `value_index: 0` and `instance_path` = the node
 id, so an opaque store applies it as a plain positional write. Apply treats a
 `promoted` payload on a non-instance node as that positional write.
+
+### 14.4 Legacy `proxyWidgets` entries are repaired before the host write
+
+A `properties.proxyWidgets` entry the definition does not back with a linked
+input is repaired first — the frontend's own forward migration
+(`proxyWidgetMigration.ts`), ported as `promoted.flush_proxy_migration` — and
+the op additionally carries `promoted.repair = {entry, ids}` with the
+subgraph-input and boundary-link ids the repair mints, derived by SHA-256 from
+`(instance path, source node, widget)` so replay anywhere is byte-identical.
+The pinned contract text in §8.7 states the full rule.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -723,3 +723,71 @@ rebuilds the executable graph — the API prompt — not the canvas decoration.
 
 **No change to §§2-8.** No op kind was added, removed, or re-scoped;
 `FROZEN_OPS` / `DEFERRED_OPS` / `BATCHABLE_OPS` are untouched.
+
+## 14. Amendment v1.5 — 2026-08-28 (promoted subgraph inputs: host writes, one register per declared input, opaque positional writes)
+
+The frontend (ComfyUI_frontend ADR 0009) keeps a promoted subgraph widget's
+value on the HOST instance — `widgets_values[i]` on the instance, positional
+over the definition's inputs that resolve to an interior widget — and runs
+that value over the interior default. Interior `path` writes (§8.7) therefore
+never reached the canvas for a promoted widget. Both sides (this repo,
+comfy-multi-player Amendment A15) now speak the shapes below; a subgraph
+instance's `type` is a definition UUID with no catalog entry, so every replica
+stores its widgets opaquely (positional) and these ops carry what an opaque
+store needs.
+
+### 14.1 `set_widget` host write: the `promoted` payload
+
+A write to a promoted input is a top-level `set_widget` on the INSTANCE
+(`node_id`, `widget` = the declared input name; no `path`/`inner_widget`)
+carrying
+
+```
+"promoted": {"value_index": <int>, "instance_path": [<id>, …],
+             "host_widgets_values": [<full materialized array>]}
+```
+
+`value_index` is the input's position among the definition's widget-backed
+inputs (socket-only inputs own no slot); `instance_path` is one segment for a
+top-level instance and the interior node path for a nested host, resolved and
+forked exactly like an interior `path`; `host_widgets_values` is the array
+after the write, seeded from each input's current effective value so the
+positional array stays aligned with the definition. Apply writes ONE slot,
+extending a shorter stored array from the payload. The register is the
+ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
+address and the interior address that backs it (`57/13.width`, which the
+minting side redirects to the host — `redirected_from` records the given
+address, informational) share one register. The host-write register and an
+interior `path` register for the interior widget behind the same promotion
+are deliberately NOT unified (that would need the promotion table at apply
+time); a merge consumer treats them as distinct targets.
+
+### 14.2 `connect` onto a promoted input: one register per declared name
+
+A `connect` whose target is a declared subgraph input the instance does not
+yet carry an `inputs[]` entry for carries
+
+```
+"grow": {"name": <declared input name>, "type": <declared type>,
+         "promoted": true, "widget": <name, only when the input backs a widget>}
+```
+
+Unlike autogrow (§1.2 carve-out), a promoted input is ONE register named by the
+definition — `("input", to_node, "grow", <full name>)`, never split on a dot
+(declared names such as `images.image0` contain one) — and is gated by
+`_lww_gate`/`_lww_commit` exactly like a concrete input (§11.1): the higher
+stamp owns the entry in either apply order, `grow_id` follows the winner, the
+loser's link is retired, and the claim is unconditional once the gate passes.
+Apply reuses an existing entry by name (a concurrent materialization shares
+it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
+verbatim — no numbering. Once materialized, a later connect to the same name
+resolves it as a concrete slot (`to_slot`) on the concrete register; both
+sides agree, and this is not drift.
+
+### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
+
+A write that resolves to a frontend-only `PrimitiveNode` (no catalog entry;
+`widgets_values[0]` holds the value) carries `legacy_primitive: true` AND the
+§14.1 `promoted` payload with `value_index: 0` and `instance_path` = the node
+id, so an opaque store applies it as a plain positional write. Apply treats a
+`promoted` payload on a non-instance node as that positional write.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -752,9 +752,12 @@ inputs (socket-only inputs own no slot); `instance_path` is one segment for a
 top-level instance and the interior node path for a nested host, resolved and
 forked exactly like an interior `path`; `host_widgets_values` is the array
 after the write, seeded from each input's current effective value so the
-positional array stays aligned with the definition. Apply writes ONE slot,
-extending a shorter stored array from the payload. The register is the
-ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
+positional array stays aligned with the definition. Apply writes ONE slot;
+a shorter stored array is extended from the payload as **best-effort
+repair** — only the written index is under the register, so two concurrent
+writes carrying different tails settle the tail by apply order (an accepted
+limitation: a truncated replica is no longer left truncated). The register is
+the ordinary `("widget", node_id, widget)` (§11.2 string identity), so the flat
 address and the interior address that backs it (`57/13.width`, which the
 minting side redirects to the host — `redirected_from` records the given
 address, informational) share one register. The host-write register and an
@@ -781,10 +784,18 @@ loser's link is retired, and the claim is unconditional once the gate passes.
 Apply reuses an existing entry by name (a concurrent materialization shares
 it) and otherwise appends `{name, type, link, grow_id[, widget:{name}]}`
 verbatim — no numbering. Every connect to a declared promoted input is this
-promoted grow, even once the entry exists: the register is the declared name
-for the life of the input, so a replica that receives a later connect before
-the materializing one still lands it (a concrete `to_slot` op would find no
-slot, be dropped with its `op_id` consumed, and never replay).
+promoted grow, even once the entry exists and even when addressed by INDEX
+(`57.1` landing on the materialized `width` entry maps onto the name at mint
+time): the register is the declared name for the life of the input, so a
+replica that receives a later connect before the materializing one still
+lands it (a concrete `to_slot` op would find no slot, be dropped with its
+`op_id` consumed, and never replay). The claim is unconditional once the
+gate passes: a promoted grow whose source was concurrently deleted still
+claims the register and leaves the entry empty (delete wins over the link,
+not over the claim — §11.1), so every interleaving converges. Scope: an op
+minted by a pre-v1.5 replica as a concrete `to_slot` onto such an input does
+not gate against the promoted register; both replicas must run v1.5 for the
+register to be shared.
 
 ### 14.3 Opaque positional writes: frontend-only `PrimitiveNode`
 

--- a/tests/comfy_cli/command/generate/test_emit.py
+++ b/tests/comfy_cli/command/generate/test_emit.py
@@ -204,7 +204,47 @@ def test_emitted_workflow_is_api_format_node_ids_are_strings():
         assert "inputs" in node
 
 
+def test_is_supported_answers_for_alias_and_canonical_id():
+    """The flag `generate list` exposes must agree with what `build_workflow`
+    accepts — alias or the canonical endpoint id the alias resolves to."""
+    assert emit.is_supported("flux-2") is True
+    assert emit.is_supported(spec.resolve_alias("flux-2")) is True
+    assert emit.is_supported("flux-pro") is False
+    assert emit.is_supported("bfl/flux-pro-1.1/generate") is False
+    assert emit.is_supported("no-such-model") is False
+
+
+def test_unsupported_model_raises_a_typed_error_carrying_the_supported_list():
+    with pytest.raises(emit.UnsupportedModelError) as ei:
+        emit.build_workflow("flux-pro", {"prompt": "x"})
+    assert ei.value.model == "flux-pro"
+    assert ei.value.supported == emit.supported_models()
+    assert isinstance(ei.value, emit.EmitError)  # callers catching the base still work
+
+
 # ─── CLI integration ──────────────────────────────────────────────────────
+
+
+def test_cli_emit_unsupported_model_has_its_own_error_code(runner, tmp_path, monkeypatch):
+    """The prod payload: `generate_workflow flux-pro` → `emit_workflow_failed`
+    "--emit-workflow does not support model 'flux-pro'. Supported: …". The
+    umbrella code also covers bad params and unwritable paths, so the agent
+    could not tell "pick another model" from "fix your arguments". Now it is
+    its own code, with the supported aliases as data, not prose."""
+    monkeypatch.delenv("COMFY_API_KEY", raising=False)
+    monkeypatch.setenv("COMFY_OUTPUT", "json")
+    out = tmp_path / "wf.json"
+    r = runner.invoke(cli_app, ["generate", "flux-pro", "--prompt", "x", "--emit-workflow", str(out)])
+    assert r.exit_code == 1
+    lines = [ln for ln in r.stdout.splitlines() if ln.strip().startswith("{")]
+    env = json.loads(lines[-1])
+    assert env["ok"] is False
+    err = env["error"]
+    assert err["code"] == "emit_workflow_unsupported_model"
+    assert err["details"]["model"] == "flux-pro"
+    assert err["details"]["supported"] == emit.supported_models()
+    assert "generate list" in err["hint"]
+    assert not out.exists()
 
 
 def test_cli_emit_writes_file_no_api_key(runner, tmp_path, monkeypatch):

--- a/tests/comfy_cli/command/generate/test_list_schema_envelope.py
+++ b/tests/comfy_cli/command/generate/test_list_schema_envelope.py
@@ -137,6 +137,24 @@ def test_list_honors_filters_and_echoes_them():
     assert {row["partner"] for row in data["models"]} == {"bfl"}
 
 
+def test_list_rows_say_whether_emit_workflow_supports_them():
+    """`--emit-workflow` renders only the handful of models that have a partner
+    node mapping, while `generate list` advertises the whole proxy catalog. An
+    agent that read the list and asked for `--emit-workflow` on `flux-pro` got
+    `emit_workflow_failed` with no way to know beforehand (Langfuse 2026-08-27).
+    Each row must carry the answer so the agent never has to try and see."""
+    from comfy_cli.command.generate import emit
+
+    data = _envelope(["--json", "generate", "list"])["data"]
+    for row in data["models"]:
+        assert isinstance(row["emit_supported"], bool), row
+    supported = {row["alias"] for row in data["models"] if row["emit_supported"]}
+    assert supported == set(emit.supported_models())
+    by_alias = {row["alias"]: row for row in data["models"]}
+    assert by_alias["flux-pro"]["emit_supported"] is False  # the prod case: no ComfyUI node for BFL Flux Pro 1.1
+    assert by_alias["flux-2"]["emit_supported"] is True
+
+
 def test_list_with_no_matches_is_an_empty_success_not_an_error():
     result = _run(["--json", "generate", "list", "--partner", "no-such-partner"])
     envelope = json.loads(result.stdout.splitlines()[-1])

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -1,0 +1,118 @@
+"""``comfy assets library`` error envelopes.
+
+Pins the 404 mapping for ``assets library ensure``. Found in prod (Langfuse
+2026-08-25, ``use_asset_as_input``): an agent passed a FILE NAME
+(``comfyorg_logo.png``) where the content hash belongs, the API answered 404,
+and the CLI reported ``workflow_not_found`` / "workflow not found (ensure)"
+with a hint to list *workflows* — the shared cloud-HTTP helper's 404 branch
+was written for the saved-workflow commands and hardcoded their vocabulary.
+The agent had to guess its way past a message about the wrong resource.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import error_codes
+from comfy_cli.caller import Caller
+from comfy_cli.command import assets_library
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+@pytest.fixture
+def cloud_target(monkeypatch: pytest.MonkeyPatch):
+    from comfy_cli.target import Target
+
+    fake = Target(
+        kind="cloud",
+        base_url="https://cloud.example.com",
+        path_prefix="/api",
+        history_path="history_v2",
+        jobs_path="jobs",
+        api_key="test-key",
+    )
+    monkeypatch.setattr("comfy_cli.target.resolve_target", lambda **kw: fake)
+    return fake
+
+
+def _run(args: list[str], capsys: pytest.CaptureFixture[str]) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(assets_library.app, args, standalone_mode=False)
+    captured = capsys.readouterr().out or result.stdout or ""
+    assert captured.strip(), f"no envelope on stdout (rc={result.exit_code}, exc={result.exception})"
+    return json.loads(captured.strip().splitlines()[-1])
+
+
+def _http_error(code: int, body: bytes = b""):
+    return urllib.error.HTTPError("https://cloud.example.com/api/assets/from-hash", code, "err", {}, io.BytesIO(body))
+
+
+def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, outcome):
+    calls: list[dict] = []
+
+    class _Resp:
+        status = 201
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, n=None):
+            return json.dumps(outcome).encode()
+
+    def _fake(req, timeout=None):
+        calls.append({"url": req.full_url, "method": req.get_method(), "body": req.data})
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake)
+    return calls
+
+
+class TestEnsure:
+    def test_404_is_asset_not_found_not_workflow_not_found(self, cloud_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, _http_error(404))
+        env = _run(["ensure", "--hash", "comfyorg_logo.png", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        err = env["error"]
+        assert err["code"] == "asset_not_found"
+        assert error_codes.is_registered(err["code"])
+        assert "workflow" not in err["message"].lower()
+        assert "comfyorg_logo.png" in err["message"]
+        # The remediation names the asset commands, not `workflow list`.
+        assert "assets library ls" in err["hint"]
+        assert "workflow list" not in err["hint"]
+        assert err["details"]["hash"] == "comfyorg_logo.png"
+        assert err["details"]["operation"] == "ensure"
+
+    def test_401_is_still_cloud_unauthorized(self, cloud_target, monkeypatch, capsys):
+        _patch_urlopen(monkeypatch, _http_error(401))
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["error"]["code"] == "cloud_unauthorized"
+
+    def test_success_reports_id_hash_and_created_new(self, cloud_target, monkeypatch, capsys):
+        calls = _patch_urlopen(monkeypatch, {"id": "asset-1", "hash": "a" * 64})
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["ok"] is True
+        assert env["data"] == {"id": "asset-1", "hash": "a" * 64, "created_new": True}
+        assert calls[0]["url"].endswith("/api/assets/from-hash") and calls[0]["method"] == "POST"

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -677,11 +677,23 @@ _SG_UUID = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
 
 
 def _subgraph_workflow() -> dict:
-    """A minimal curated subgraph template (derived from a fetched gallery
-    template): a top-level subgraph instance `57` whose promoted `text`/`seed`/
-    `steps` route through `proxyWidgets` to interior CLIPTextEncode `27` and
-    KSampler `3`, plus a plain top-level node `9` so we can prove top-level edits
-    still work alongside subgraph edits."""
+    """A minimal LEGACY subgraph template, shaped like the pre-ADR-0009 saves
+    in the gallery (e.g. ``flux_dev_checkpoint_example.json`` node 56 → 52):
+    a top-level subgraph instance `57` whose promoted `text`/`seed`/`steps`
+    exist ONLY as `properties.proxyWidgets` entries routing to interior
+    CLIPTextEncode `27` and KSampler `3` — the definition declares no input
+    for them — plus a plain top-level node `9` so we can prove top-level edits
+    still work alongside subgraph edits.
+
+    History: an earlier version of this fixture also DECLARED `text`/`seed`/
+    `steps` as (unlinked) subgraph inputs. The frontend never writes that
+    shape for a promotion — a declared input nobody links is a dangling
+    socket — and under the frontend's forward migration (which the CLI now
+    runs before writing a legacy promotion) such a declaration collides with
+    the input the repair mints, so `text` would become `text_1`
+    (``nextUniqueName``). See ``test_declared_unlinked_socket_collides_with_the_repair``
+    for that pin; the realistic shape is what the rest of the class uses.
+    """
     return {
         "last_node_id": 60,
         "last_link_id": 0,
@@ -709,15 +721,12 @@ def _subgraph_workflow() -> dict:
                 {
                     "id": _SG_UUID,
                     "name": "Text to Image",
-                    "inputs": [
-                        {"name": "text", "type": "STRING"},
-                        {"name": "seed", "type": "INT"},
-                        {"name": "steps", "type": "INT"},
-                    ],
+                    "inputs": [],
                     "nodes": [
                         {"id": 27, "type": "CLIPTextEncode", "widgets_values": ["old prompt"]},
                         {"id": 3, "type": "KSampler", "widgets_values": [42, "fixed", 20, 8.0, "euler", "normal", 1.0]},
                     ],
+                    "links": [],
                 }
             ]
         },
@@ -729,48 +738,95 @@ def _interior(wf: dict, inner_id) -> dict:
     return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
 
 
+def _instance(wf: dict, node_id=57) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
 class TestSetWidgetSubgraph:
-    def test_flat_promoted_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
-        """`57.text` — the exact address `slots` advertises — writes CLIPTextEncode 27."""
+    """Legacy ``proxyWidgets`` promotions under the migration semantics.
+
+    These pins changed with the legacy-proxy repair. Before, ``57.text``
+    followed ``proxyWidgets`` into CLIPTextEncode 27 and wrote its
+    ``widgets_values`` — the "layer 2" edit BE-10305 is about: the frontend's
+    load-time migration re-seeds the host from that interior value, so it
+    *looked* right, but the value lived where no other promoted write puts
+    it and ``comfy run`` had no host value to submit. Now the write mirrors
+    the frontend exactly: the definition gains a linked input per legacy
+    entry (``text``/``seed``/``steps``, boundary-linked from the subgraph
+    input node), the instance carries the value, and the interior widget is
+    only the default. The op is a HOST write (no ``path``), carrying the
+    repair it performed so a replica replays to the same document.
+    """
+
+    def test_flat_promoted_address_repairs_and_writes_the_host(self, patched_graph, tmp_path, capsys):
+        """`57.text` — the exact address `slots` advertises — writes the HOST value
+        of the input the repair mints for CLIPTextEncode 27's `text`."""
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.text", "a cat on a bicycle"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
         assert op["op"] == "set_widget"
         assert op["node_id"] == 57
+        assert op["widget"] == "text"
         assert op["value"] == "a cat on a bicycle"
         assert op["old"] == "old prompt"
-        # op is self-describing + replayable: resolved interior path + widget.
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        # op is self-describing + replayable: a host write plus the repair it ran.
+        assert "path" not in op
+        assert op["promoted"]["instance_path"] == ["57"]
+        assert op["promoted"]["value_index"] == 0
+        assert op["promoted"]["repair"]["entry"] == ["27", "text"]
+        assert set(op["promoted"]["repair"]["ids"]) == {"27.text", "3.seed", "3.steps"}
         # CRDT stamping preserved.
         assert isinstance(op["op_id"], str) and op["op_id"]
         assert op["stamp"] == [0, "cli"]
-        # value landed on the interior node, in the definition (persists on disk).
+        # on disk: the definition is repaired, the host owns the value, the
+        # interior widget keeps its default, the legacy route is consumed.
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a cat on a bicycle"
+        sg = wf["definitions"]["subgraphs"][0]
+        assert [i["name"] for i in sg["inputs"]] == ["text", "seed", "steps"]
+        assert [(ln["origin_id"], ln["origin_slot"], ln["target_id"]) for ln in sg["links"]] == [
+            (-10, 0, 27),
+            (-10, 1, 3),
+            (-10, 2, 3),
+        ]
+        assert _interior(wf, 27)["inputs"] == [
+            {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {"name": "text"},
+                "link": sg["links"][0]["id"],
+            }
+        ]
+        assert _instance(wf)["widgets_values"] == ["a cat on a bicycle", 42, 20]
+        assert _interior(wf, 27)["widgets_values"][0] == "old prompt"
+        assert "proxyWidgets" not in _instance(wf)["properties"]
 
-    def test_flat_promoted_int_input_writes_ksampler(self, patched_graph, tmp_path, capsys):
+    def test_flat_promoted_int_input_writes_the_host_slot(self, patched_graph, tmp_path, capsys):
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.seed", "12345"], capsys)
         assert env["ok"] is True, env
-        assert env["data"]["op"]["path"] == ["57", "3"]
+        assert env["data"]["op"]["promoted"]["value_index"] == 1
         wf = json.loads(path.read_text())
-        assert _interior(wf, 3)["widgets_values"][0] == 12345  # seed is index 0
+        assert _instance(wf)["widgets_values"] == ["old prompt", 12345, 20]
+        assert _interior(wf, 3)["widgets_values"][0] == 42  # interior default untouched
 
-    def test_nested_interior_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
-        """`57/27.text` (the nested form the skill documents) hits the same widget."""
+    def test_nested_interior_address_is_redirected_to_the_host(self, patched_graph, tmp_path, capsys):
+        """`57/27.text` (the nested form the skill documents) is the widget a
+        legacy promotion owns: the write is redirected to the host, like the
+        interior address of any linked promotion."""
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57/27.text", "a nested cat"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
-        assert op["node_id"] == "57/27"
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        assert op["node_id"] == 57 and op["widget"] == "text"
+        assert op["redirected_from"] == "57/27.text"
+        assert "path" not in op
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a nested cat"
+        assert _instance(wf)["widgets_values"][0] == "a nested cat"
+        assert _interior(wf, 27)["widgets_values"][0] == "old prompt"
 
-    def test_flattened_colon_address_writes_interior_node(self, patched_graph, tmp_path, capsys):
+    def test_flattened_colon_address_is_redirected_to_the_host(self, patched_graph, tmp_path, capsys):
         """`57:27.text` — the FLATTENED id namespace `validate` and server
         node_errors report after UI→API lowering (workflow_to_api composes inner
         ids as `<outer>:<inner>`) — is accepted as an alias for `57/27.text`.
@@ -780,10 +836,10 @@ class TestSetWidgetSubgraph:
         env = _run(["set-widget", str(path), "57:27.text", "a flattened cat"], capsys)
         assert env["ok"] is True, env
         op = env["data"]["op"]
-        assert op["path"] == ["57", "27"]
-        assert op["inner_widget"] == "text"
+        assert op["node_id"] == 57 and op["widget"] == "text"
+        assert op["redirected_from"] == "57/27.text"
         wf = json.loads(path.read_text())
-        assert _interior(wf, 27)["widgets_values"][0] == "a flattened cat"
+        assert _instance(wf)["widgets_values"][0] == "a flattened cat"
 
     def test_flattened_colon_converges_with_nested_form(self):
         """`57:27.text` and `57/27.text` resolve to the SAME CRDT write target."""
@@ -800,29 +856,68 @@ class TestSetWidgetSubgraph:
         assert "interior node 99 not found" in env["error"]["message"]
 
     def test_flat_and_nested_share_a_conflict_target(self):
-        """Flat `57.text` and nested `57/27.text` land on the same interior
-        widget, so their ops must resolve to the SAME CRDT write target (they
+        """Flat `57.text` and nested `57/27.text` land on the same host value,
+        so their ops must resolve to the SAME CRDT write target (they
         converge — one does not silently clobber the other undetected)."""
         wf = _subgraph_workflow()
         _, flat = workflow_ops.set_widget(copy.deepcopy(wf), _graph(), 57, "text", "A")
         _, nested = workflow_ops.set_widget(copy.deepcopy(wf), _graph(), "57/27", "text", "B")
-        assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested)
+        assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested) == ("widget", "57", "text")
         assert workflow_ops.detect_conflict(flat, nested) is True  # different values, same target
+
+    def test_repair_replays_identically_on_a_fresh_copy(self):
+        base = _subgraph_workflow()
+        applied, op = workflow_ops.set_widget(copy.deepcopy(base), _graph(), 57, "seed", 7)
+        replayed = workflow_ops.apply_op(copy.deepcopy(base), op, _graph())
+        for w in (applied, replayed):
+            w.pop("_applied_ops", None)
+            w.pop("_widget_stamps", None)
+        assert json.dumps(replayed, sort_keys=True) == json.dumps(applied, sort_keys=True)
 
     def test_slots_and_set_widget_agree(self, patched_graph, monkeypatch, tmp_path, capsys):
         """The self-consistency the bug broke: every flat address `slots` emits
-        for the subgraph instance is accepted by set-widget."""
+        for the subgraph instance is accepted by set-widget — before the repair
+        (the legacy entries are advertised where the frontend will show them)
+        and after it (they are ordinary promoted widgets)."""
         # slots resolves its graph via workflow.py's _get_graph; set-widget via
         # workflow_edit.py's. patched_graph covers the latter; patch the former too.
         monkeypatch.setattr(workflow_cmd, "_get_graph", lambda *a, **kw: _graph())
         path = _write(tmp_path, _subgraph_workflow())
         slots_env = _run(["slots", str(path)], capsys)
-        addrs = [s["address"] for s in slots_env["data"]["slots"] if str(s["address"]).startswith("57.")]
+        by_addr = {s["address"]: s for s in slots_env["data"]["slots"]}
+        addrs = [a for a in by_addr if a.startswith("57.")]
         assert addrs, slots_env  # the instance's promoted inputs are advertised flat
+        assert by_addr["57.text"]["current_value"] == "old prompt"
+        assert "57/27.text" not in by_addr  # the interior behind a promotion is not advertised
         for addr in ("57.text", "57.seed", "57.steps"):
             assert addr in addrs
             env = _run(["set-widget", str(path), addr, "3" if addr != "57.text" else "x"], capsys)
             assert env["ok"] is True, (addr, env)
+        slots_env = _run(["slots", str(path)], capsys)
+        after = {s["address"]: s for s in slots_env["data"]["slots"]}
+        assert after["57.text"]["current_value"] == "x" and after["57.seed"]["current_value"] == 3
+
+    def test_declared_unlinked_socket_collides_with_the_repair(self, patched_graph, tmp_path, capsys):
+        """The shape this fixture USED to have: `text` declared as a subgraph
+        input nobody links, plus the legacy `['27','text']` entry. The frontend's
+        migration keeps the dangling socket and mints `text_1` for the widget
+        (``nextUniqueName``); addressing `57.text` still reaches the widget —
+        by its legacy source-widget name — and reports the redirect."""
+        wf = _subgraph_workflow()
+        wf["definitions"]["subgraphs"][0]["inputs"] = [{"name": "text", "type": "STRING"}]
+        path = _write(tmp_path, wf)
+        env = _run(["set-widget", str(path), "57.text", "a cat"], capsys)
+        assert env["ok"] is True, env
+        op = env["data"]["op"]
+        assert op["widget"] == "text_1" and op["redirected_from"] == "57.text"
+        saved = json.loads(path.read_text())
+        assert [i["name"] for i in saved["definitions"]["subgraphs"][0]["inputs"]] == [
+            "text",
+            "text_1",
+            "seed",
+            "steps",
+        ]
+        assert _instance(saved)["widgets_values"] == ["a cat", 42, 20]
 
     def test_unknown_promoted_input_errors_cleanly(self, patched_graph, tmp_path, capsys):
         path = _write(tmp_path, _subgraph_workflow())
@@ -835,9 +930,9 @@ class TestSetWidgetSubgraph:
         path = _write(tmp_path, _subgraph_workflow())
         env = _run(["set-widget", str(path), "57.seed", '"notanumber"'], capsys)
         assert env["ok"] is False
-        # unchanged on disk (edit rejected before write).
+        # unchanged on disk (edit rejected before write — and before any repair).
         wf = json.loads(path.read_text())
-        assert _interior(wf, 3)["widgets_values"][0] == 42
+        assert wf == _subgraph_workflow()
 
     def test_top_level_edit_still_works_with_subgraphs_present(self, patched_graph, tmp_path, capsys):
         """A plain top-level node in a workflow that also contains subgraphs is

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -1245,6 +1245,48 @@ class TestClear:
         on_disk = json.loads(path.read_text())
         assert on_disk["nodes"] == [] and on_disk["links"] == [] and on_disk["groups"] == []
 
+    # Prod (Langfuse 2026-08-26): `generate --emit-workflow` left an API-format
+    # draft in the tab's scratch file; `apply_ops` then `clear_canvas` both
+    # failed `workflow_not_frontend_format`, and the agent had to abandon the
+    # tab. Clearing discards the content, so its format cannot be a reason to
+    # refuse — the empty document that results is frontend-format regardless.
+    _API_DRAFT = {
+        "1": {"class_type": "GeminiImageNode", "inputs": {"prompt": "a fox", "seed": 1}},
+        "2": {"class_type": "SaveImage", "inputs": {"images": ["1", 0], "filename_prefix": "generate"}},
+    }
+
+    def test_clear_accepts_an_api_format_draft(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, self._API_DRAFT)
+        env = _run(["clear", str(path)], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["op"]["op"] == "clear"
+        on_disk = json.loads(path.read_text())
+        assert on_disk["nodes"] == [] and on_disk["links"] == [] and on_disk["groups"] == []
+        # The API-format node entries are gone: the file is an editable
+        # frontend document now, so the next add-node/apply succeeds.
+        assert "1" not in on_disk and "2" not in on_disk
+        env = _run(["add-node", str(path), "KSampler"], capsys)
+        assert env["ok"] is True, env
+
+    def test_reset_doc_accepts_an_api_format_draft(self, patched_graph, tmp_path, capsys):
+        path = _write(tmp_path, self._API_DRAFT)
+        env = _run(["reset-doc", str(path), "--confirm"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["op"]["op"] == "reset_doc"
+        on_disk = json.loads(path.read_text())
+        assert on_disk["nodes"] == [] and on_disk["links"] == []
+        assert on_disk["last_node_id"] == 0 and on_disk["last_link_id"] == 0
+        assert "1" not in on_disk and "2" not in on_disk
+
+    def test_clear_still_refuses_a_non_workflow_document(self, patched_graph, tmp_path, capsys):
+        """Accepting either format is not accepting anything: a JSON list is
+        not a workflow of either kind."""
+        path = tmp_path / "w.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        env = _run(["clear", str(path)], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_not_frontend_format"
+
 
 # ---------------------------------------------------------------------------
 # invariant: the edit surface operates on UI (frontend) format ONLY

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -677,7 +677,7 @@ _SG_UUID = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
 
 
 def _subgraph_workflow() -> dict:
-    """A minimal LEGACY subgraph template, shaped like the pre-ADR-0009 saves
+    """A minimal LEGACY subgraph template, shaped like the pre-ADR 0009 saves
     in the gallery (e.g. ``flux_dev_checkpoint_example.json`` node 56 → 52):
     a top-level subgraph instance `57` whose promoted `text`/`seed`/`steps`
     exist ONLY as `properties.proxyWidgets` entries routing to interior
@@ -747,7 +747,7 @@ class TestSetWidgetSubgraph:
 
     These pins changed with the legacy-proxy repair. Before, ``57.text``
     followed ``proxyWidgets`` into CLIPTextEncode 27 and wrote its
-    ``widgets_values`` — the "layer 2" edit BE-10305 is about: the frontend's
+    ``widgets_values`` — the "layer 2" edit the subgraph-editing report is about: the frontend's
     load-time migration re-seeds the host from that interior value, so it
     *looked* right, but the value lived where no other promoted write puts
     it and ``comfy run`` had no host value to submit. Now the write mirrors

--- a/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
+++ b/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
@@ -160,13 +160,46 @@ def test_primitive_fanout_write_lands_on_the_host_and_previews_stay(graph):
     assert [e[1] for e in inst["properties"]["proxyWidgets"]] == ["$$canvas-image-preview"] * 3
 
 
-def test_legacy_source_widget_name_addresses_a_primitive_repair_too(graph):
-    """``143.value`` — the legacy tuple's own widget name — is accepted as an
-    alias for the input the repair mints (``resolution`` here is the primitive
-    the FIRST ``value`` entry names), reported as a redirect."""
+def test_ambiguous_legacy_alias_is_refused_with_the_minted_names(graph):
+    """``143.value`` — the legacy tuple's own widget name — is an alias for
+    the input the repair mints. Two primitives share it here, so guessing it
+    is refused with both real addresses instead of silently picking one;
+    with one entry left the alias redirects."""
     wf = _load(RECOMPOSER)
+    before = _stripped(wf)
+    with pytest.raises(ValueError) as e:
+        workflow_ops.set_widget(wf, graph, 143, "value", "1K")
+    assert "143.resolution" in str(e.value) and "143.aspect_ratio" in str(e.value)
+    assert _stripped(wf) == before
+    inst = _node(wf, 143)
+    inst["properties"]["proxyWidgets"] = [x for x in inst["properties"]["proxyWidgets"] if x != ["142", "value"]]
     wf, op = workflow_ops.set_widget(wf, graph, 143, "value", "1K")
     assert op["widget"] == "resolution" and op["redirected_from"] == "143.value"
+
+
+def test_interior_address_owned_by_a_legacy_entry_is_redirected_even_when_link_fed(graph):
+    """``143/135.choice`` fed by interior node 2: with no legacy entry naming
+    it the widget write is refused (the link supplies the value). With the
+    legacy entry, the frontend's own migration replaces that link with the
+    boundary link on load, so the host value is what will run — the write is
+    redirected there and the feeder link is dropped, as the frontend drops it."""
+    wf = _load(RECOMPOSER)
+    sg = _def_of(wf, _node(wf, 143))
+    sg["links"].append(
+        {"id": 999001, "origin_id": 2, "origin_slot": 0, "target_id": 135, "target_slot": 0, "type": "STRING"}
+    )
+    _interior(wf, 143, 135)["inputs"][0]["link"] = 999001
+    _interior(wf, 143, 2)["outputs"][0]["links"].append(999001)
+    unowned = copy.deepcopy(wf)
+    _node(unowned, 143)["properties"]["proxyWidgets"] = [["156", "value"], ["142", "value"]]
+    with pytest.raises(ValueError, match="fed by interior node 143/2"):
+        promoted.resolve_write(unowned, graph, ["143", "135"], "choice")
+    target = promoted.resolve_write(wf, graph, ["143", "135"], "choice")
+    assert target.kind == "host" and target.widget == "choice" and target.redirected_from == "143/135.choice"
+    assert target.repair is not None and target.repair.original == ["135", "choice"]
+    # (``choice`` is a COMBO the catalog lists no options for, so the write
+    # itself is refused by validation; the flush that drops the feeder link is
+    # pinned in tests/comfy_cli/cql/test_proxy_migration.py.)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
+++ b/tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py
@@ -1,0 +1,318 @@
+"""``set-widget`` / ``set-slot`` on a legacy ``proxyWidgets`` promotion the
+subgraph definition does NOT back with a linked input.
+
+Before: the write followed ``proxyWidgets`` into the interior node — an edit
+under layer 2 that the frontend's load-time migration then re-seeds the host
+from (so it *appeared* to work) but that diverged from every other promoted
+write and left no host value for ``comfy run`` to submit.
+
+After: the write first performs the frontend's forward migration on that
+instance (``cql.promoted.flush_proxy_migration`` — a port of
+``flushProxyWidgetMigration``), turning the legacy entry into a linked
+subgraph input, and then writes the HOST value like any other promoted widget.
+The op carries the deterministic ids the repair minted, so replaying it on
+another replica produces a byte-identical document.
+
+Fixtures are verbatim gallery templates — see ``tests/comfy_cli/cql/test_proxy_migration.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph, _deterministic_fork_id
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+from comfy_cli.workflow_to_api import convert_ui_to_api
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_legacy_proxy.json"
+
+RECOMPOSER = "templates_graphic_design_recomposer.json"
+EXTENSION = "template_horizontal_vertical_extension.json"
+FLUX = "flux_dev_checkpoint_example.json"
+FLUX_SEED = 53943644181156
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _node(wf: dict, node_id: Any) -> dict:
+    return next(n for n in wf["nodes"] if str(n["id"]) == str(node_id))
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+def _interior(wf: dict, instance_id: Any, inner_id: Any) -> dict:
+    sg = _def_of(wf, _node(wf, instance_id))
+    return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
+
+
+def _stripped(wf: dict) -> str:
+    w = copy.deepcopy(wf)
+    w.pop("_applied_ops", None)
+    w.pop("_widget_stamps", None)
+    return json.dumps(w, sort_keys=True)
+
+
+# --------------------------------------------------------------------------- #
+# the write lands on the host, after repairing the definition
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_write_repairs_the_definition_and_writes_the_host(graph):
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    inst = _node(wf, 56)
+    sg = _def_of(wf, inst)
+    assert [i["name"] for i in sg["inputs"]][-1] == "seed"
+    assert inst["widgets_values"][-1] == 5
+    assert _interior(wf, 56, 52)["widgets_values"][0] == FLUX_SEED  # interior is only the default
+    assert "proxyWidgets" not in inst["properties"]
+    assert "path" not in op
+    assert op["node_id"] == 56 and op["widget"] == "seed"
+    assert op["old"] == FLUX_SEED
+    assert op["promoted"]["value_index"] == 7
+    assert op["promoted"]["host_widgets_values"][-1] == 5
+    repair = op["promoted"]["repair"]
+    assert repair["entry"] == ["52", "seed"]
+    assert repair["ids"] == {"52.seed": promoted.repair_ids(["56"], "52", "seed", 1)}
+    assert repair["ids"]["52.seed"]["links"][0] == sg["inputs"][-1]["linkIds"][0]
+
+
+def test_interior_address_of_a_legacy_promotion_is_redirected_to_the_host(graph):
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, "56/52", "seed", 5)
+    assert op["node_id"] == 56 and op["widget"] == "seed"
+    assert op["redirected_from"] == "56/52.seed"
+    assert _node(wf, 56)["widgets_values"][-1] == 5
+    assert _interior(wf, 56, 52)["widgets_values"][0] == FLUX_SEED
+
+
+def test_flat_and_interior_forms_share_one_write_target(graph):
+    wf = _load(FLUX)
+    _, flat = workflow_ops.set_widget(copy.deepcopy(wf), graph, 56, "seed", 1)
+    _, nested = workflow_ops.set_widget(copy.deepcopy(wf), graph, "56/52", "seed", 2)
+    assert workflow_ops._write_target(flat) == workflow_ops._write_target(nested) == ("widget", "56", "seed")
+    assert workflow_ops.detect_conflict(flat, nested) is True
+
+
+def test_unrepairable_legacy_entry_still_writes_the_interior_and_leaves_the_document_alone(graph):
+    """``control_after_generate`` has no backing input slot: the frontend
+    quarantines it and the interior widget stays the live one, so the write
+    lands there and no repair is triggered."""
+    wf = _load(FLUX)
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "control_after_generate", "fixed")
+    assert op["path"] == ["56", "52"] and op["inner_widget"] == "control_after_generate"
+    assert _interior(wf, 56, 52)["widgets_values"][1] == "fixed"
+    inst = _node(wf, 56)
+    assert len(inst["properties"]["proxyWidgets"]) == 9
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+
+
+def test_repair_quarantines_the_unrepairable_sibling_entries(graph):
+    wf = _load(FLUX)
+    wf, _ = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _node(wf, 56)["properties"]["proxyWidgetErrorQuarantine"] == [
+        {"originalEntry": ["52", "control_after_generate"], "reason": "missingSubgraphInput", "attemptedAtVersion": 1}
+    ]
+
+
+def test_type_mismatch_is_refused_before_any_repair(graph):
+    wf = _load(FLUX)
+    before = _stripped(wf)
+    with pytest.raises(ValueError):
+        workflow_ops.set_widget(wf, graph, 56, "seed", "notanumber")
+    assert _stripped(wf) == before
+
+
+def test_primitive_fanout_write_lands_on_the_host_and_previews_stay(graph):
+    wf = _load(RECOMPOSER)
+    wf, op = workflow_ops.set_widget(wf, graph, 143, "resolution", "1K")
+    inst = _node(wf, 143)
+    assert op["widget"] == "resolution" and op["old"] == "2K"
+    assert op["promoted"]["repair"]["entry"] == ["156", "value"]
+    assert inst["widgets_values"] == ["Nano Banana 2", "1K", "16:9"]
+    assert _interior(wf, 143, 156)["widgets_values"][0] == "2K"  # the primitive is inert, untouched
+
+    wf = _load(EXTENSION)
+    wf, op = workflow_ops.set_widget(wf, graph, 252, "aspect_ratio", "1:1 (Square)")
+    inst = _node(wf, 252)
+    assert inst["widgets_values"] == ["1:1 (Square)"]
+    assert [e[1] for e in inst["properties"]["proxyWidgets"]] == ["$$canvas-image-preview"] * 3
+
+
+def test_legacy_source_widget_name_addresses_a_primitive_repair_too(graph):
+    """``143.value`` — the legacy tuple's own widget name — is accepted as an
+    alias for the input the repair mints (``resolution`` here is the primitive
+    the FIRST ``value`` entry names), reported as a redirect."""
+    wf = _load(RECOMPOSER)
+    wf, op = workflow_ops.set_widget(wf, graph, 143, "value", "1K")
+    assert op["widget"] == "resolution" and op["redirected_from"] == "143.value"
+
+
+# --------------------------------------------------------------------------- #
+# replay: deterministic on another replica; shared definitions are forked
+# --------------------------------------------------------------------------- #
+
+
+def test_repair_op_replays_to_a_byte_identical_document(graph):
+    for name, node_id, widget, value in ((FLUX, 56, "seed", 5), (RECOMPOSER, 143, "aspect_ratio", "1:1")):
+        base = _load(name)
+        applied, op = workflow_ops.set_widget(copy.deepcopy(base), graph, node_id, widget, value)
+        replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+        assert _stripped(replayed) == _stripped(applied)
+        # idempotent: a second delivery is a no-op
+        assert _stripped(workflow_ops.apply_op(replayed, op, graph)) == _stripped(applied)
+
+
+def test_concurrent_repairs_of_one_instance_converge(graph):
+    base = _load(RECOMPOSER)
+    _, a = workflow_ops.set_widget(copy.deepcopy(base), graph, 143, "resolution", "1K", actor="a")
+    _, b = workflow_ops.set_widget(copy.deepcopy(base), graph, 143, "aspect_ratio", "1:1", actor="b")
+    ab = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), a, graph), b, graph)
+    ba = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), b, graph), a, graph)
+    assert _stripped(ab) == _stripped(ba)
+    assert _node(ab, 143)["widgets_values"] == ["Nano Banana 2", "1K", "1:1"]
+
+
+def test_shared_definition_is_forked_not_mutated(graph):
+    wf = _load(FLUX)
+    sibling = copy.deepcopy(_node(wf, 56))
+    sibling["id"] = 156
+    wf["nodes"].append(sibling)
+    original_def_id = sibling["type"]
+    original_def = copy.deepcopy(_def_of(wf, sibling))
+    wf, op = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _node(wf, 56)["type"] == _deterministic_fork_id(original_def_id, 56)
+    assert _node(wf, 156)["type"] == original_def_id
+    assert _def_of(wf, _node(wf, 156)) == original_def
+    assert _node(wf, 156)["properties"]["proxyWidgets"] == sibling["properties"]["proxyWidgets"]
+    assert [i["name"] for i in _def_of(wf, _node(wf, 56))["inputs"]][-1] == "seed"
+    # the sibling repairs independently: it now owns the original definition
+    # alone, so that one is repaired in place and the fork stays as it was
+    forked = copy.deepcopy(_def_of(wf, _node(wf, 56)))
+    wf, _ = workflow_ops.set_widget(wf, graph, 156, "seed", 6)
+    assert _node(wf, 156)["type"] == original_def_id
+    assert [i["name"] for i in _def_of(wf, _node(wf, 156))["inputs"]][-1] == "seed"
+    assert _def_of(wf, _node(wf, 56)) == forked
+    assert _node(wf, 56)["widgets_values"][-1] == 5 and _node(wf, 156)["widgets_values"][-1] == 6
+
+
+# --------------------------------------------------------------------------- #
+# the converter runs the host value
+# --------------------------------------------------------------------------- #
+
+
+def _api(wf: dict) -> dict:
+    return convert_ui_to_api(wf, json.loads(OBJECT_INFO.read_text()))
+
+
+def test_converter_emits_the_host_value_after_repair(graph):
+    wf = _load(FLUX)
+    assert _api(wf)["56:52"]["inputs"]["seed"] == FLUX_SEED
+    wf, _ = workflow_ops.set_widget(wf, graph, 56, "seed", 5)
+    assert _api(wf)["56:52"]["inputs"]["seed"] == 5
+
+
+def test_converter_applies_a_fanned_out_host_value_to_every_target(graph):
+    wf = _load(RECOMPOSER)
+    wf, _ = workflow_ops.set_widget(wf, graph, 143, "aspect_ratio", "1:1")
+    api = _api(wf)
+    assert api["143:130"]["inputs"]["aspect_ratio"] == "1:1"
+    assert api["143:157"]["inputs"]["model.aspect_ratio"] == "1:1"
+
+
+# --------------------------------------------------------------------------- #
+# reads: slots advertise the promotion at the host, before any repair
+# --------------------------------------------------------------------------- #
+
+
+def test_slots_advertise_a_legacy_promotion_at_the_host_address(graph):
+    wf = _load(FLUX)
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["56.seed"]["current_value"] == FLUX_SEED
+    assert slots["56.seed"]["type"] == "INT"
+    assert "56/52.seed" not in slots  # layer 2: the surface value wins
+    assert "56/52.cfg" in slots  # unpromoted interior widgets stay reachable
+    assert "56.control_after_generate" not in slots  # quarantined: never a host widget
+
+
+def test_slots_advertise_primitive_fanouts_under_their_planned_name(graph):
+    wf = _load(RECOMPOSER)
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["143.resolution"]["current_value"] == "2K"
+    assert slots["143.aspect_ratio"]["current_value"] == "16:9"
+    assert slots["143.choice"]["current_value"] == "Nano Banana 2"
+    assert "143/130.resolution" not in slots and "143/157.model.resolution" not in slots
+
+
+def test_set_slot_path_repairs_like_set_widget(graph):
+    via_op, _ = workflow_ops.set_widget(_load(FLUX), graph, 56, "seed", 5)
+    via_slot, warnings = graph.apply_slots(_load(FLUX), {"56.seed": 5})
+    assert warnings == []
+    assert _stripped(via_slot) == _stripped(via_op)
+
+
+def test_effective_value_reads_an_unrepaired_legacy_promotion(graph):
+    wf = _load(FLUX)
+    assert promoted.effective_value(wf, _node(wf, 56), "seed", graph) == FLUX_SEED
+    with pytest.raises(ValueError):
+        promoted.effective_value(wf, _node(wf, 56), "control_after_generate", graph)
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(workflow_cmd.app, args, standalone_mode=False)
+    out = capsys.readouterr().out
+    if not out.strip():
+        out = result.stdout or ""
+    for line in reversed([ln for ln in out.strip().splitlines() if ln.strip()]):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={out[:600]})")
+
+
+def test_cli_set_widget_repairs_then_slots_show_the_host_value(tmp_path, capsys):
+    path = tmp_path / "flux.json"
+    path.write_text(json.dumps(_load(FLUX)))
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    before = {s["address"]: s for s in env["data"]["slots"]}
+    assert before["56.seed"]["current_value"] == FLUX_SEED
+    env = _run(["set-widget", str(path), "56.seed", "5", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    assert env["data"]["op"]["promoted"]["repair"]["entry"] == ["52", "seed"]
+    saved = json.loads(path.read_text())
+    assert "proxyWidgets" not in _node(saved, 56)["properties"]
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    after = {s["address"]: s for s in env["data"]["slots"]}
+    assert after["56.seed"]["current_value"] == 5

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -175,7 +175,9 @@ def test_connect_type_mismatch_into_a_promoted_input_is_refused(graph):
 def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
     wf, prim = _with_primitive(graph)
     wf, first = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
-    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    # every connect to a promoted input shares one LWW register, so a later
+    # connect carries a later base_version (the CLI's --base-version)
+    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width", base_version=1)
     assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
     assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
     assert first["link_id"] not in {link[0] for link in wf["links"]}  # replaced, not duplicated
@@ -439,4 +441,57 @@ def test_legacy_primitive_write_carries_a_positional_payload(graph):
     assert op["legacy_primitive"] is True
     assert op["promoted"] == {"value_index": 0, "instance_path": [str(legacy)], "host_widgets_values": [512, "fixed"]}
     replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+    assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]
+
+
+def test_later_connect_to_a_materialized_promoted_input_stays_on_the_declared_register(graph):
+    """Once ``57.width`` is materialized, a later connect to it must still be
+    a promoted grow on ``("input", 57, "grow", "width")`` — not a concrete
+    ``to_slot`` op. Otherwise a replica that receives the later op FIRST finds
+    no such slot, drops it (consuming its op_id), then installs the older
+    link from the materializing op: the newer link can never replay."""
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    wf, first = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=0)
+    wf, second = workflow_ops.connect(wf, graph, b, "INT", 57, "width", actor="a", base_version=1)
+    assert second.get("grow", {}).get("promoted") is True
+    assert second["to_slot"] is None
+    assert workflow_ops._write_target(second) == workflow_ops._write_target(first)
+    for order in ((first, second), (second, first)):
+        replica = copy.deepcopy(base)
+        for op in order:
+            replica = workflow_ops.apply_op(replica, op, graph)
+        entries = [i for i in _node(replica, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1 and entries[0]["link"] == second["link_id"]
+        assert {link[0] for link in replica["links"]} & {first["link_id"], second["link_id"]} == {second["link_id"]}
+
+
+def test_positional_replay_extends_a_partially_present_array_from_the_payload(graph):
+    """A receiver holding a truncated opaque array (``[1024]``) must end up
+    with the payload's tail too, or replicas diverge on the node's state."""
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    receiver = copy.deepcopy(wf)
+    _node(receiver, legacy)["widgets_values"] = [1024]
+    _, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    replayed = workflow_ops.apply_op(receiver, op, graph)
     assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -1,0 +1,307 @@
+"""``set-widget`` / ``connect`` on promoted subgraph widgets (BE-10305 scenarios 1 & 2).
+
+Scenario 1 — *"the agent edited the widget under layer 2, not on the surface;
+the value on the surface overwrites it and the user never sees it."* The
+frontend serializes a promoted widget's value on the HOST instance
+(ADR 0009); ``set-widget 57.width`` used to follow ``proxyWidgets`` into the
+interior node, a value the frontend neither runs nor displays. The write must
+land on the host — and when an outside node feeds the promoted input
+(*"users even have number or text boxes connected to the promoted widget"*),
+on that node's widget, because the link is what the graph runs.
+
+Scenario 2 — *"wire something outside to the promoted widget, e.g. Int node to
+width — the agent cannot do that yet."* A promoted widget IS a subgraph input,
+so ``connect`` materializes it on the instance and wires it.
+
+The rule, in one line: never edit a subgraph's interior for a promoted value —
+edit what it is linked to.
+
+Fixtures: verbatim gallery templates (``fixtures/gallery``) plus source-node
+shapes copied from the wild (``PrimitiveNode`` from
+``templates-multiple_consistent_shots-nb_pro.json``, ``Reroute`` from
+``template_contact_sheet-step_3.app.json``).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_subgraph_promoted.json"
+
+Z_IMAGE_HOST_DEFAULTS = [
+    "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. ",
+    1024,
+    1024,
+    0,
+    8,
+    "z_image_turbo_bf16.safetensors",
+    "qwen_3_4b.safetensors",
+    "ae.safetensors",
+]
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _node(wf: dict, node_id: Any) -> dict:
+    return next(n for n in wf["nodes"] if str(n["id"]) == str(node_id))
+
+
+def _interior(wf: dict, instance_id: Any, inner_id: Any) -> dict:
+    inst = _node(wf, instance_id)
+    sg = next(d for d in wf["definitions"]["subgraphs"] if d["id"] == inst["type"])
+    return next(n for n in sg["nodes"] if str(n["id"]) == str(inner_id))
+
+
+def _input(node: dict, name: str) -> dict:
+    return next(i for i in node.get("inputs") or [] if i["name"] == name)
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: the write lands on the host, not the interior
+# --------------------------------------------------------------------------- #
+
+
+def test_promoted_address_writes_the_host_value(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    expected = list(Z_IMAGE_HOST_DEFAULTS)
+    expected[1] = 768
+    assert _node(wf, 57)["widgets_values"] == expected
+    assert _interior(wf, 57, 13)["widgets_values"] == [1024, 1024, 1]
+    assert op["node_id"] == 57
+    assert op["widget"] == "width"
+    assert op["old"] == 1024
+    assert "path" not in op
+    assert op["promoted"]["value_index"] == 1
+    assert op["promoted"]["host_widgets_values"] == expected
+
+
+def test_interior_address_of_a_promoted_widget_is_redirected_to_the_host(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, "57/13", "width", 768)
+    assert _node(wf, 57)["widgets_values"][1] == 768
+    assert _interior(wf, 57, 13)["widgets_values"][0] == 1024
+    assert op["node_id"] == 57
+    assert op["widget"] == "width"
+    assert op["redirected_from"] == "57/13.width"
+
+
+def test_unpromoted_interior_widget_still_writes_the_interior(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, op = workflow_ops.set_widget(wf, graph, "57/3", "cfg", 2.0)
+    assert op["path"] == ["57", "3"]
+    assert _interior(wf, 57, 3)["widgets_values"][3] == 2.0
+    assert _node(wf, 57)["widgets_values"] == []
+
+
+def test_post_migration_host_write_touches_one_slot(graph):
+    wf = _load("audio_minimax_music_3.json")
+    before = list(_node(wf, 37)["widgets_values"])
+    wf, op = workflow_ops.set_widget(wf, graph, 37, "max_duration", 90)
+    after = _node(wf, 37)["widgets_values"]
+    assert after[2] == 90 and after[:2] == before[:2] and after[3:] == before[3:]
+    assert op["old"] == 60
+    assert _interior(wf, 37, 13)["widgets_values"][2] == 222  # interior default untouched
+
+
+def test_socket_only_promoted_input_is_not_a_widget(graph):
+    wf = _load("api_seedance2_5_video_extend.json")
+    with pytest.raises(ValueError, match="link input"):
+        workflow_ops.set_widget(wf, graph, 39, "clip_to_resize", "x")
+
+
+def test_host_write_replays_idempotently_and_targets_one_register(graph):
+    wf = _load("image_z_image_turbo.json")
+    base = copy.deepcopy(wf)
+    wf, op_host = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    _, op_interior = workflow_ops.set_widget(copy.deepcopy(base), graph, "57/13", "width", 512)
+    assert workflow_ops._write_target(op_host) == workflow_ops._write_target(op_interior)
+    replayed = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), op_host, graph), op_host, graph)
+    assert _node(replayed, 57)["widgets_values"][1] == 768
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: wire an outside node onto the promoted widget
+# --------------------------------------------------------------------------- #
+
+
+def _with_primitive(graph, value: int = 640):
+    wf = _load("image_z_image_turbo.json")
+    wf, prim = workflow_ops.add_node(wf, graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, graph, prim["node_id"], "value", value)
+    return wf, prim["node_id"]
+
+
+def test_connect_materializes_the_promoted_input_and_wires_it(graph):
+    wf, prim = _with_primitive(graph)
+    wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    width = _input(_node(wf, 57), "width")
+    assert width["type"] == "INT"
+    assert width["widget"] == {"name": "width"}
+    assert width["link"] == op["link_id"]
+    assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
+    link = next(link for link in wf["links"] if link[0] == op["link_id"])
+    assert link[1] == prim and link[3] == 57
+
+
+def test_connect_type_mismatch_into_a_promoted_input_is_refused(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, text = workflow_ops.add_node(wf, graph, "PrimitiveStringMultiline")
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, text["node_id"], "STRING", 57, "width")
+
+
+def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
+    wf, prim = _with_primitive(graph)
+    wf, first = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
+    assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1, nuance: follow the link to the source of truth
+# --------------------------------------------------------------------------- #
+
+
+def test_set_widget_follows_the_link_to_the_primitive(graph):
+    wf, prim = _with_primitive(graph)
+    wf, _ = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    # A later write to the same register carries a later base_version (the
+    # CLI's --base-version); equal stamps tie-break by op_id under LWW.
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512, base_version=1)
+    assert op["node_id"] == prim
+    assert op["widget"] == "value"
+    assert op["redirected_from"] == "57.width"
+    assert _node(wf, prim)["widgets_values"][0] == 512
+    assert _node(wf, 57)["widgets_values"] == []  # host untouched: the link is the truth
+
+
+def test_set_widget_follows_a_reroute_chain(graph):
+    wf, prim = _with_primitive(graph)
+    # Reroute as the frontend serializes it (template_contact_sheet-step_3.app.json node 394)
+    wf["last_node_id"] = max(int(n["id"]) for n in wf["nodes"] if isinstance(n["id"], int)) + 1
+    reroute_id = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": reroute_id,
+            "type": "Reroute",
+            "pos": [0, 0],
+            "size": [75, 26],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [{"name": "", "type": "*", "widget": {"name": "value"}, "link": None}],
+            "outputs": [{"name": "", "type": "INT", "links": []}],
+            "properties": {"showOutputText": False, "horizontal": False},
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, prim, "INT", reroute_id, 0)
+    wf, _ = workflow_ops.connect(wf, graph, reroute_id, 0, 57, "width")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512, base_version=1)
+    assert op["node_id"] == prim
+    assert _node(wf, prim)["widgets_values"][0] == 512
+
+
+def test_set_widget_follows_the_link_to_a_legacy_primitive_node(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    # PrimitiveNode as the frontend serializes it (templates-multiple_consistent_shots-nb_pro.json node 7)
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    assert op["node_id"] == legacy
+    assert _node(wf, legacy)["widgets_values"][0] == 512
+
+
+def test_set_widget_refuses_a_driver_it_cannot_edit(graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, sel = workflow_ops.add_node(wf, graph, "ResolutionSelector")
+    wf, _ = workflow_ops.connect(wf, graph, sel["node_id"], "width", 57, "width")
+    with pytest.raises(ValueError) as e:
+        workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    msg = str(e.value)
+    assert "ResolutionSelector" in msg and str(sel["node_id"]) in msg
+    assert _node(wf, 57)["widgets_values"] == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(workflow_cmd.app, args, standalone_mode=False)
+    out = capsys.readouterr().out
+    if not out.strip():
+        out = result.stdout or ""
+    for line in reversed([ln for ln in out.strip().splitlines() if ln.strip()]):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={out[:600]})")
+
+
+def test_cli_set_widget_then_slots_show_the_new_host_value(tmp_path, capsys):
+    path = tmp_path / "z.json"
+    path.write_text(json.dumps(_load("image_z_image_turbo.json")))
+    env = _run(["set-widget", str(path), "57.width", "768", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    assert env["data"]["op"]["node_id"] == 57 and "path" not in env["data"]["op"]
+    env = _run(["slots", str(path), "--input", str(OBJECT_INFO)], capsys)
+    slots = {s["address"]: s for s in env["data"]["slots"]}
+    assert slots["57.width"]["current_value"] == 768
+    assert slots["57.height"]["current_value"] == 1024
+
+
+def test_cli_connect_int_node_to_promoted_width(tmp_path, capsys):
+    path = tmp_path / "z.json"
+    path.write_text(json.dumps(_load("image_z_image_turbo.json")))
+    env = _run(["add-node", str(path), "PrimitiveInt", "--input", str(OBJECT_INFO)], capsys)
+    prim = env["data"]["op"]["node_id"]
+    env = _run(["connect", str(path), f"{prim}.INT", "57.width", "--input", str(OBJECT_INFO)], capsys)
+    assert env["ok"] is True, env
+    saved = json.loads(path.read_text())
+    assert _input(_node(saved, 57), "width")["link"] == env["data"]["op"]["link_id"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -178,6 +178,7 @@ def test_connect_to_an_already_materialized_promoted_input_reuses_it(graph):
     wf, second = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
     assert [i["name"] for i in _node(wf, 57)["inputs"]] == ["text", "width"]
     assert _input(_node(wf, 57), "width")["link"] == second["link_id"]
+    assert first["link_id"] not in {link[0] for link in wf["links"]}  # replaced, not duplicated
 
 
 # --------------------------------------------------------------------------- #
@@ -305,3 +306,77 @@ def test_cli_connect_int_node_to_promoted_width(tmp_path, capsys):
     assert env["ok"] is True, env
     saved = json.loads(path.read_text())
     assert _input(_node(saved, 57), "width")["link"] == env["data"]["op"]["link_id"]
+
+
+# --------------------------------------------------------------------------- #
+# Review findings on #815
+# --------------------------------------------------------------------------- #
+
+
+def test_nested_host_payload_reflects_the_forked_instance(graph):
+    """A nested host inside a definition SHARED by two instances is forked on
+    write; the op's ``host_widgets_values`` must be read from the written
+    (forked) instance, not the pre-fork dict captured during resolution."""
+    wf = _load("image_z_image_turbo.json")
+    inner_sg = wf["definitions"]["subgraphs"][0]
+    outer_id = "0e0e0e0e-0000-4000-8000-000000000001"
+    outer = {
+        "id": outer_id,
+        "name": "Outer",
+        "inputs": [],
+        "outputs": [],
+        "widgets": [],
+        "links": [],
+        "nodes": [
+            {
+                "id": 7,
+                "type": inner_sg["id"],
+                "pos": [0, 0],
+                "size": [1, 1],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [],
+                "properties": {},
+                "widgets_values": [],
+            }
+        ],
+    }
+    wf["definitions"]["subgraphs"].append(outer)
+    for nid in (900, 901):  # two instances share the outer definition
+        wf["nodes"].append(
+            {
+                "id": nid,
+                "type": outer_id,
+                "pos": [0, 0],
+                "size": [1, 1],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [],
+                "properties": {},
+                "widgets_values": [],
+            }
+        )
+    wf, op = workflow_ops.set_widget(wf, graph, "900/7", "width", 640)
+    forked = _node(wf, 900)["type"]
+    assert forked != outer_id  # the shared definition was forked for instance 900
+    inner = next(
+        n for n in next(d for d in wf["definitions"]["subgraphs"] if d["id"] == forked)["nodes"] if n["id"] == 7
+    )
+    assert inner["widgets_values"][1] == 640
+    assert op["promoted"]["host_widgets_values"] == inner["widgets_values"]
+    # the sibling's definition is untouched
+    assert next(n for n in outer["nodes"] if n["id"] == 7)["widgets_values"] == []
+
+
+def test_connect_does_not_type_check_against_an_untyped_declared_input(graph):
+    wf, prim = _with_primitive(graph)
+    sg = next(d for d in wf["definitions"]["subgraphs"] if d["id"] == _node(wf, 57)["type"])
+    width = next(i for i in sg["inputs"] if i["name"] == "width")
+    del width["type"]
+    wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
+    assert _input(_node(wf, 57), "width")["link"] == op["link_id"]
+    assert op["grow"]["type"] == "INT"  # falls back to the source type

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -495,3 +495,57 @@ def test_positional_replay_extends_a_partially_present_array_from_the_payload(gr
     _, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
     replayed = workflow_ops.apply_op(receiver, op, graph)
     assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]
+
+
+# --------------------------------------------------------------------------- #
+# Review (annehe9) on #818
+# --------------------------------------------------------------------------- #
+
+
+def _apply_all(base: dict, ops: list[dict], graph) -> dict:
+    wf = copy.deepcopy(base)
+    for op in ops:
+        wf = workflow_ops.apply_op(wf, op, graph)
+    return wf
+
+
+def test_promoted_connect_claims_its_register_even_when_its_source_was_deleted(graph):
+    """Two promoted connects into ``57.width`` (stamps lo < hi) plus a delete
+    of the hi op's source, in all six orders: the hi op must claim the
+    register whether or not the delete arrived first (delete wins over the
+    LINK, not over the claim), so every order converges on one state —
+    one ``width`` entry, ``link=None``, ``grow_id=<hi>``."""
+    import itertools
+
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    _, op_lo = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=0)
+    _, op_hi = workflow_ops.connect(copy.deepcopy(base), graph, b, "INT", 57, "width", actor="b", base_version=1)
+    _, op_del = workflow_ops.delete_node(copy.deepcopy(base), graph, b, actor="c", base_version=2)
+    states = set()
+    for order in itertools.permutations((op_lo, op_hi, op_del)):
+        wf = _apply_all(base, list(order), graph)
+        states.add(json.dumps(workflow_ops.canonical(wf), sort_keys=True, default=str))
+        entries = [i for i in _node(wf, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1
+        assert entries[0]["link"] is None
+        assert entries[0]["grow_id"] == op_hi["link_id"]
+    assert len(states) == 1
+
+
+def test_index_address_of_a_materialized_promoted_input_shares_the_name_register(graph):
+    """``57.width`` and ``57.<index>`` name the same materialized input, so
+    they must gate against each other: the higher stamp wins in either order."""
+    base, prim = _with_primitive(graph)
+    base, _ = workflow_ops.connect(base, graph, prim, "INT", 57, "width")
+    base, other = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    other = other["node_id"]
+    idx = next(k for k, i in enumerate(_node(base, 57)["inputs"]) if i["name"] == "width")
+    _, by_name = workflow_ops.connect(copy.deepcopy(base), graph, other, "INT", 57, "width", actor="a", base_version=1)
+    _, by_index = workflow_ops.connect(copy.deepcopy(base), graph, prim, "INT", 57, idx, actor="b", base_version=2)
+    assert workflow_ops._write_target(by_index) == workflow_ops._write_target(by_name)
+    for order in ((by_name, by_index), (by_index, by_name)):
+        wf = _apply_all(base, list(order), graph)
+        assert _input(_node(wf, 57), "width")["link"] == by_index["link_id"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -380,3 +380,63 @@ def test_connect_does_not_type_check_against_an_untyped_declared_input(graph):
     wf, op = workflow_ops.connect(wf, graph, prim, "INT", 57, "width")
     assert _input(_node(wf, 57), "width")["link"] == op["link_id"]
     assert op["grow"]["type"] == "INT"  # falls back to the source type
+
+
+# Op shapes the doc-host applier (comfy-multi-player) needs to converge
+# --------------------------------------------------------------------------- #
+
+
+def test_concurrent_promoted_connects_converge_by_stamp(graph):
+    """Two replicas wire different primitives into ``57.width`` concurrently.
+    The promoted input is ONE register (``("input", 57, "grow", "width")``):
+    the higher stamp owns the entry in either apply order, ``grow_id`` follows
+    the winner, and the loser's link is not left dangling."""
+    base = _load("image_z_image_turbo.json")
+    base, a = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    base, b = workflow_ops.add_node(base, graph, "PrimitiveInt")
+    a, b = a["node_id"], b["node_id"]
+    _, op_hi = workflow_ops.connect(copy.deepcopy(base), graph, a, "INT", 57, "width", actor="a", base_version=1)
+    _, op_lo = workflow_ops.connect(copy.deepcopy(base), graph, b, "INT", 57, "width", actor="b", base_version=0)
+    assert workflow_ops._write_target(op_hi) == workflow_ops._write_target(op_lo) == ("input", "57", "grow", "width")
+    for order in ((op_hi, op_lo), (op_lo, op_hi)):
+        wf = copy.deepcopy(base)
+        for op in order:
+            wf = workflow_ops.apply_op(wf, op, graph)
+        entries = [i for i in _node(wf, 57)["inputs"] if i["name"] == "width"]
+        assert len(entries) == 1
+        assert entries[0]["link"] == op_hi["link_id"]
+        assert entries[0]["grow_id"] == op_hi["link_id"]
+        link_ids = {link[0] for link in wf["links"]}
+        assert op_hi["link_id"] in link_ids and op_lo["link_id"] not in link_ids
+
+
+def test_legacy_primitive_write_carries_a_positional_payload(graph):
+    """A frontend-only ``PrimitiveNode`` has no catalog entry, so the doc host
+    stores it opaquely: the op must carry the positional payload
+    (``promoted.value_index`` + ``host_widgets_values``) the applier writes,
+    exactly like a host write — and replay on a fresh copy must apply it."""
+    wf = _load("image_z_image_turbo.json")
+    wf["last_node_id"] += 1
+    legacy = wf["last_node_id"]
+    wf["nodes"].append(
+        {
+            "id": legacy,
+            "type": "PrimitiveNode",
+            "pos": [0, 0],
+            "size": [210, 82],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [{"name": "INT", "type": "INT", "widget": {"name": "width"}, "links": []}],
+            "properties": {"Run widget replace on values": False},
+            "widgets_values": [1024, "fixed"],
+        }
+    )
+    wf, _ = workflow_ops.connect(wf, graph, legacy, "INT", 57, "width")
+    base = copy.deepcopy(wf)
+    wf, op = workflow_ops.set_widget(wf, graph, 57, "width", 512)
+    assert op["legacy_primitive"] is True
+    assert op["promoted"] == {"value_index": 0, "instance_path": [str(legacy)], "host_widgets_values": [512, "fixed"]}
+    replayed = workflow_ops.apply_op(copy.deepcopy(base), op, graph)
+    assert _node(replayed, legacy)["widgets_values"] == [512, "fixed"]

--- a/tests/comfy_cli/command/test_workflow_edit_promoted.py
+++ b/tests/comfy_cli/command/test_workflow_edit_promoted.py
@@ -1,4 +1,4 @@
-"""``set-widget`` / ``connect`` on promoted subgraph widgets (BE-10305 scenarios 1 & 2).
+"""``set-widget`` / ``connect`` on promoted subgraph widgets (the "agent editing subgraph" report, scenarios 1 & 2).
 
 Scenario 1 — *"the agent edited the widget under layer 2, not on the surface;
 the value on the surface overwrites it and the user never sees it."* The

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -673,10 +673,17 @@ class TestSlotsNestedSubgraph:
         env = _run(["slots", str(path)], capsys)
         assert env["ok"] is True
         by_addr = {s["address"]: s for s in env["data"]["slots"]}
-        # The editable inner prompt + seed of the Gemini node inside instance 10.
+        # The editable inner prompt of the Gemini node inside instance 10.
         assert "10/9.prompt" in by_addr, f"missing nested prompt slot; got {sorted(by_addr)[:20]}"
-        assert "10/9.seed" in by_addr
-        assert by_addr["10/9.seed"]["current_value"] == 1
+        # Its ``seed`` is promoted by a legacy ``proxyWidgets`` entry
+        # (``['9','seed']``) the definition does not back with a linked input
+        # yet. The frontend repairs that into a host widget on load, so the
+        # slot is advertised where the frontend shows it — ``10.seed``, with
+        # the interior value as its current one — and the interior address is
+        # the "layer 2" the host overrides (see cql.promoted, forward migration).
+        assert "10.seed" in by_addr
+        assert by_addr["10.seed"]["current_value"] == 1
+        assert "10/9.seed" not in by_addr
 
     def test_nested_addresses_are_instance_scoped(self, patched_subgraph_graph, tmp_path, capsys):
         """Two instances of same-named ('New Subgraph') but DIFFERENT defs must
@@ -684,8 +691,8 @@ class TestSlotsNestedSubgraph:
         path = _write_workflow(tmp_path, _subgraph_workflow())
         env = _run(["slots", str(path)], capsys)
         by_addr = {s["address"]: s for s in env["data"]["slots"]}
-        assert by_addr["10/9.seed"]["current_value"] == 1
-        assert by_addr["19/9.seed"]["current_value"] == 2
+        assert by_addr["10.seed"]["current_value"] == 1
+        assert by_addr["19.seed"]["current_value"] == 2
 
     def test_slots_recurses_into_doubly_nested_subgraph(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -730,13 +737,28 @@ class TestSetSlotNestedSubgraph:
         assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_nested_does_not_touch_sibling_instance(self, patched_subgraph_graph, tmp_path, capsys):
+        """``10/9.seed`` is the interior widget a legacy ``proxyWidgets`` entry
+        promotes: the write repairs instance 10's definition the way the
+        frontend's load-time migration does (a linked ``seed`` input) and
+        lands on the HOST, leaving the interior widget as the default.
+        Before the repair semantics this wrote the interior widget — a value
+        the frontend's own migration would then re-seed the host from."""
         path = _write_workflow(tmp_path, _subgraph_workflow())
-        _run(["set-slot", str(path), "10/9.seed=777"], capsys)
+        env = _run(["set-slot", str(path), "10/9.seed=777"], capsys)
+        assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        # seed is widget index 2 (index 3 is control_after_generate).
-        assert _interior_node(wf, D33, 9)["widgets_values"][2] == 777
-        # The other instance's def must be untouched.
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        d33 = next(s for s in wf["definitions"]["subgraphs"] if s["id"] == D33)
+        assert [i["name"] for i in d33["inputs"]] == ["value", "images.image0", "aspect_ratio", "seed"]
+        assert host["widgets_values"][-1] == 777
+        assert _interior_node(wf, D33, 9)["widgets_values"][2] == 1  # interior default untouched
+        # the legacy route is consumed; its unrepairable ``-1`` entries are quarantined
+        assert "proxyWidgets" not in host["properties"]
+        assert [q["reason"] for q in host["properties"]["proxyWidgetErrorQuarantine"]] == ["missingSourceNode"] * 2
+        # The other instance (a different def) must be untouched.
         assert _interior_node(wf, F22, 9)["widgets_values"][2] == 2
+        sibling = next(n for n in wf["nodes"] if n["id"] == 19)
+        assert sibling["properties"]["proxyWidgets"] == [["-1", "value"], ["-1", "aspect_ratio"], ["9", "seed"]]
 
     def test_set_slot_doubly_nested(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -692,19 +692,42 @@ class TestSlotsNestedSubgraph:
         env = _run(["slots", str(path)], capsys)
         addrs = {s["address"] for s in env["data"]["slots"]}
         # instance 10 -> inner node 3 (Batch Prompt Iterator subgraph) -> inner
-        # node 7 (PrimitiveStringMultiline) widget "value".
-        assert "10/3/7.value" in addrs, f"missing doubly-nested slot; got {sorted(addrs)[:30]}"
+        # node 8 (RegexReplace): an unpromoted widget two levels down.
+        assert "10/3/8.regex_pattern" in addrs, f"missing doubly-nested slot; got {sorted(addrs)[:30]}"
+        # Inner node 7's ``value`` is promoted twice up (3.value -> 10.value):
+        # the value the frontend runs lives on host 10, so only that address
+        # is advertised — the interior copies are the "layer 2" that edits
+        # used to land on and the surface overrode.
+        assert "10.value" in addrs
+        assert "10/3.value" not in addrs
+        assert "10/3/7.value" not in addrs
 
 
 class TestSetSlotNestedSubgraph:
-    def test_set_slot_writes_into_subgraph_inner_node(self, patched_subgraph_graph, tmp_path, capsys):
+    def test_set_slot_refuses_a_link_driven_interior_widget(self, patched_subgraph_graph, tmp_path, capsys):
+        """GeminiImage2Node 9's ``prompt`` is fed by interior node 3 (the Batch
+        Prompt Iterator): writing the widget could never take effect, so the
+        write is refused and the driver named instead of silently landing on
+        a value the graph ignores."""
         path = _write_workflow(tmp_path, _subgraph_workflow())
         env = _run(["set-slot", str(path), '10/9.prompt="a red fox in snow"'], capsys)
+        assert env["ok"] is False, env
+        assert "10/3" in env["error"]["message"]
+        wf = json.loads(path.read_text())
+        assert _interior_node(wf, D33, 9)["widgets_values"][0] == ""
+
+    def test_set_slot_writes_the_promoted_host_value(self, patched_subgraph_graph, tmp_path, capsys):
+        """The prompt's source of truth is instance 10's promoted ``value``
+        (its outside link id dangles — the frontend drops it on load — so the
+        host value is what runs)."""
+        path = _write_workflow(tmp_path, _subgraph_workflow())
+        env = _run(["set-slot", str(path), '10.value="a red fox in snow"'], capsys)
         assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        gemini = _interior_node(wf, D33, 9)
-        # prompt is widget index 0 for GeminiImage2Node.
-        assert gemini["widgets_values"][0] == "a red fox in snow"
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        assert host["widgets_values"][0] == "a red fox in snow"
+        # nothing inside the definition was rewritten
+        assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_nested_does_not_touch_sibling_instance(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -720,8 +743,11 @@ class TestSetSlotNestedSubgraph:
         env = _run(["set-slot", str(path), '10/3/7.value="iterated prompt"'], capsys)
         assert env["ok"] is True, env
         wf = json.loads(path.read_text())
-        prim = _interior_node(wf, BATCH, 7)
-        assert prim["widgets_values"][0] == "iterated prompt"
+        # 7.value is promoted twice up (3.value -> 10.value): the write lands
+        # on host 10, the only place the frontend reads it from.
+        host = next(n for n in wf["nodes"] if n["id"] == 10)
+        assert host["widgets_values"][0] == "iterated prompt"
+        assert _interior_node(wf, BATCH, 7)["widgets_values"][0] == ""
 
     def test_set_slot_unknown_nested_inner_node(self, patched_subgraph_graph, tmp_path, capsys):
         path = _write_workflow(tmp_path, _subgraph_workflow())
@@ -743,7 +769,7 @@ class TestVaryNestedSubgraph:
         path = _write_workflow(tmp_path, _subgraph_workflow())
         out_dir = tmp_path / "out"
         env = _run(
-            ["vary", str(path), "--slot", '10/9.prompt=["cat","dog","fox"]', "--out-dir", str(out_dir)],
+            ["vary", str(path), "--slot", '10.value=["cat","dog","fox"]', "--out-dir", str(out_dir)],
             capsys,
         )
         assert env["ok"] is True
@@ -751,7 +777,7 @@ class TestVaryNestedSubgraph:
         prompts = []
         for f in sorted(out_dir.glob("*.json")):
             wf = json.loads(f.read_text())
-            prompts.append(_interior_node(wf, D33, 9)["widgets_values"][0])
+            prompts.append(next(n for n in wf["nodes"] if n["id"] == 10)["widgets_values"][0])
         assert prompts == ["cat", "dog", "fox"]
 
 

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -15,6 +15,7 @@ import pytest
 from comfy_cli.command.run.loader import _classify_api_workflow
 from comfy_cli.cql.engine import (
     Graph,
+    Port,
     _apply_one_slot,
     _extract_frontend_slots,
     _write_widget,
@@ -2110,6 +2111,124 @@ class TestValidateUploadBackedCombo:
             }
         )
         assert self._port(g, "VAELoader", "vae_name").canonical_combo("vae/ae.safetensors") == "ae.safetensors"
+
+
+class TestValidateUnmarkedInputFileCombo:
+    """A COMBO whose options are the server's INPUT-FOLDER listing is upload-
+    backed even when object_info carries no ``<kind>_upload`` marker.
+
+    Found in prod (Langfuse 2026-08-25, 3 ``run`` failures, one user): the
+    agent uploaded eight ``.mp4`` shots to Comfy Cloud, wired each content hash
+    into a ``VHS_LoadVideo.video`` widget, and ``comfy run`` refused every node
+    with ``unknown_enum_value '<64hex>.mp4' not in 1 known options for video
+    (did you mean: bedroom.mp4?)``. The whole assembly never rendered.
+
+    The marker is the frontend's contract for CORE loaders only. VideoHelperSuite
+    builds ``video`` from ``folder_paths.get_input_directory()`` filtered by its
+    ``video_extensions`` (``load_video_nodes.py``) and ships its OWN upload
+    button keyed on the class name (``VHS.core.js`` ``addUploadWidget``), so the
+    catalog for ``VHS_LoadVideo.video`` is just ``[["bedroom.mp4"]]`` — the same
+    input-folder listing ``LoadVideo.file`` shows with ``video_upload: true``.
+    What identifies the port is therefore the LISTING, not the flag: every
+    option is a media file name, which no install-time vocabulary (model
+    folders list ``.safetensors``, channel enums list ``alpha``/``red``) ever is.
+    """
+
+    @pytest.fixture
+    def graph(self) -> Graph:
+        from pathlib import Path
+
+        fixture = Path(__file__).parent.parent / "fixtures" / "object_info_vhs_loadvideo.json"
+        return Graph.from_object_info(json.loads(fixture.read_text()))
+
+    @staticmethod
+    def _port(g: Graph, class_type: str, name: str) -> Port:
+        return next(p for p in g.node(class_type).inputs if p.name == name)
+
+    def _assembly(self, video: str) -> dict[str, Any]:
+        return {
+            "2923786287638124": {
+                "class_type": "VHS_LoadVideo",
+                "inputs": {
+                    "video": video,
+                    "force_rate": 0,
+                    "custom_width": 0,
+                    "custom_height": 0,
+                    "frame_load_cap": 0,
+                    "skip_first_frames": 0,
+                    "select_every_nth": 1,
+                },
+            },
+            "2": {"class_type": "SaveImage", "inputs": {"images": ["2923786287638124", 0], "filename_prefix": "x"}},
+        }
+
+    def test_real_catalog_entry_carries_no_marker(self, graph):
+        """Pin the shape this exemption exists for: the production catalog's
+        ``VHS_LoadVideo.video`` is a bare option list, no marker of any kind."""
+        port = self._port(graph, "VHS_LoadVideo", "video")
+        assert port.type == "COMBO" and port.enum_values == ["bedroom.mp4"]
+        assert port.options.upload is False and port.options.upload_flags == ()
+
+    def test_uploaded_content_hash_is_accepted_on_unmarked_video_combo(self, graph):
+        port = self._port(graph, "VHS_LoadVideo", "video")
+        assert port.is_upload_backed is True
+        result = graph.validate_workflow(self._assembly("1f7db0ec" + "a" * 52 + "57b65.mp4"))
+        assert result["errors"] == [], result["errors"]
+        assert result["valid"] is True
+
+    def test_uploaded_hash_is_not_rewritten_to_the_sample_file(self, graph):
+        """``canonical_combo`` must not auto-correct the hash to ``bedroom.mp4``
+        either — that would render the sample instead of the user's shot."""
+        port = self._port(graph, "VHS_LoadVideo", "video")
+        assert port.canonical_combo("1f7db0ec" + "a" * 52 + "57b65.mp4") is None
+
+    def test_marked_and_unmarked_input_listings_agree(self, graph):
+        """The V3 core loader (marked) and the VHS loader (unmarked) list the
+        same input folder; they must reach the same verdict."""
+        assert self._port(graph, "LoadVideo", "file").is_upload_backed is True
+        assert self._port(graph, "VHS_LoadVideo", "video").is_upload_backed is True
+
+    def test_model_folder_listing_stays_a_constrained_enum(self, graph):
+        """The exemption keys off media file names. A checkpoint folder lists
+        ``.safetensors`` — install-time, static — and keeps the enum check."""
+        port = self._port(graph, "ImageOnlyCheckpointLoader", "ckpt_name")
+        assert port.is_upload_backed is False
+        assert [w["code"] for w in port.validate_catalog("a" * 64 + ".safetensors")] == ["unknown_enum_value"]
+
+    def test_plain_vocabulary_stays_a_constrained_enum(self, graph):
+        port = self._port(graph, "LoadImageMask", "channel")
+        assert port.is_upload_backed is False
+        assert [w["code"] for w in port.validate_catalog("alpha.png")] == ["unknown_enum_value"]
+
+    def test_explicit_false_marker_still_wins_over_the_listing(self):
+        """``image_upload: false`` is a declaration; the listing heuristic only
+        fills in when the catalog says nothing at all."""
+        g = Graph.from_object_info(
+            {
+                "LoadImage": {
+                    "input": {"required": {"image": [["beach.jpg"], {"image_upload": False}]}},
+                    "output": ["IMAGE"],
+                    "output_name": ["IMAGE"],
+                    "python_module": "nodes",
+                }
+            }
+        )
+        assert self._port(g, "LoadImage", "image").is_upload_backed is False
+
+    def test_listing_must_be_files_all_the_way_down(self):
+        """One non-file option (a sentinel like ``none``) means the list is a
+        vocabulary that happens to contain file names, not a folder listing."""
+        g = Graph.from_object_info(
+            {
+                "Picker": {
+                    "input": {"required": {"choice": [["none", "beach.jpg"]]}},
+                    "output": ["IMAGE"],
+                    "output_name": ["IMAGE"],
+                    "python_module": "nodes",
+                }
+            }
+        )
+        assert self._port(g, "Picker", "choice").is_upload_backed is False
 
 
 class TestValidateDynamicCombo:

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -3125,6 +3125,138 @@ class TestMatchTypeWildcard:
         assert not _is_wildcard_type("")
 
 
+class TestMultiTypeEdge:
+    """A socket type is a COMMA-SEPARATED UNION in ComfyUI: ``INT,FLOAT`` on a
+    math node's operand, ``MESH,FILE_3D_GLB,FILE_3D_GLTF,…`` on a 3D importer.
+    The edge check compared the raw strings, so a ``FLOAT`` output feeding an
+    ``INT,FLOAT`` input — a connection the frontend's ``isValidConnection``
+    accepts and the server runs — was reported as ``edge_type_mismatch``.
+
+    Langfuse 2026-08-25..28: 23 ``edge_type_mismatch`` warnings across 55
+    validate calls, 12 of them exactly this shape (``input 'b' expects
+    INT,FLOAT but PrimitiveFloat[0] produces FLOAT``; ``input 'model_3d'
+    expects FILE_3D_GLB,FILE_3D_GLTF,… but MeshyImageToModelNode[2] produces
+    FILE_3D_GLB``). Shapes copied from the cloud catalog (``SimpleMath+``,
+    ``PrimitiveFloat``).
+    """
+
+    @staticmethod
+    def _object_info() -> dict[str, Any]:
+        return {
+            "PrimitiveFloat": {
+                "input": {"required": {"value": ["FLOAT", {"min": -1e9, "max": 1e9, "step": 0.1}]}},
+                "input_order": {"required": ["value"]},
+                "output": ["FLOAT"],
+                "output_name": ["FLOAT"],
+                "name": "PrimitiveFloat",
+            },
+            "LoadImage": {
+                "input": {"required": {"image": [["a.png"]]}},
+                "input_order": {"required": ["image"]},
+                "output": ["IMAGE"],
+                "output_name": ["IMAGE"],
+                "name": "LoadImage",
+            },
+            "SimpleMath+": {
+                "input": {
+                    "required": {"value": ["STRING", {"multiline": False, "default": ""}]},
+                    "optional": {"a": ["INT,FLOAT", {"default": 0.0}], "b": ["INT,FLOAT", {"default": 0.0}]},
+                },
+                "input_order": {"required": ["value"], "optional": ["a", "b"]},
+                "output": ["INT", "FLOAT"],
+                "output_name": ["INT", "FLOAT"],
+                "name": "SimpleMath+",
+            },
+            # A union on the SOURCE side: one output socket typed as a union
+            # feeding a single-type input.
+            "UnionSource": {
+                "input": {"required": {}},
+                "input_order": {"required": []},
+                "output": ["INT,FLOAT"],
+                "output_name": ["number"],
+                "name": "UnionSource",
+            },
+            "IntSink": {
+                "input": {"required": {"n": ["INT", {}]}},
+                "input_order": {"required": ["n"]},
+                "output": [],
+                "output_name": [],
+                "output_node": True,
+                "name": "IntSink",
+            },
+            "PreviewAny": {
+                "input": {"required": {"source": ["*", {}]}},
+                "input_order": {"required": ["source"]},
+                "output": [],
+                "output_name": [],
+                "output_node": True,
+                "name": "PreviewAny",
+            },
+        }
+
+    @pytest.fixture
+    def graph(self) -> Graph:
+        return Graph.from_object_info(self._object_info())
+
+    @staticmethod
+    def _mismatches(result: dict) -> list[str]:
+        return [w["message"] for w in result["warnings"] if w["code"] == "edge_type_mismatch"]
+
+    def test_member_of_accept_list_is_not_a_mismatch(self, graph: Graph):
+        result = graph.validate_workflow(
+            {
+                "4": {"class_type": "PrimitiveFloat", "inputs": {"value": 1.5}},
+                "5": {"class_type": "SimpleMath+", "inputs": {"value": "a+b", "a": 1, "b": ["4", 0]}},
+                "6": {"class_type": "PreviewAny", "inputs": {"source": ["5", 1]}},
+            }
+        )
+        assert self._mismatches(result) == []
+
+    def test_union_source_into_member_input_is_not_a_mismatch(self, graph: Graph):
+        result = graph.validate_workflow(
+            {
+                "1": {"class_type": "UnionSource", "inputs": {}},
+                "2": {"class_type": "IntSink", "inputs": {"n": ["1", 0]}},
+            }
+        )
+        assert self._mismatches(result) == []
+
+    def test_type_outside_the_accept_list_still_warns(self, graph: Graph):
+        """The split must not turn the check permissive: IMAGE is in neither
+        half of ``INT,FLOAT``."""
+        result = graph.validate_workflow(
+            {
+                "1": {"class_type": "LoadImage", "inputs": {"image": "a.png"}},
+                "5": {"class_type": "SimpleMath+", "inputs": {"value": "a+b", "a": 1, "b": ["1", 0]}},
+                "6": {"class_type": "PreviewAny", "inputs": {"source": ["5", 1]}},
+            }
+        )
+        assert self._mismatches(result) == ["input 'b' expects INT,FLOAT but LoadImage[0] produces IMAGE"]
+
+    def test_hint_names_the_output_whose_type_is_in_the_accept_list(self, graph: Graph):
+        """When the source has a compatible output at another index, the hint
+        must find it through the same union-aware test (``[1]``=FLOAT here,
+        wired wrongly from a STRING)."""
+        oi = self._object_info()
+        oi["Splitter"] = {
+            "input": {"required": {}},
+            "input_order": {"required": []},
+            "output": ["STRING", "FLOAT"],
+            "output_name": ["text", "number"],
+            "name": "Splitter",
+        }
+        g = Graph.from_object_info(oi)
+        result = g.validate_workflow(
+            {
+                "1": {"class_type": "Splitter", "inputs": {}},
+                "5": {"class_type": "SimpleMath+", "inputs": {"value": "a+b", "a": 1, "b": ["1", 0]}},
+                "6": {"class_type": "PreviewAny", "inputs": {"source": ["5", 1]}},
+            }
+        )
+        [w] = [w for w in result["warnings"] if w["code"] == "edge_type_mismatch"]
+        assert w["hint"] == "use Splitter[1] instead"
+
+
 class TestUnreachableNodeIsVisible:
     """A node that reaches no output is pruned by the server, and every promoted
     check here skips pruned nodes — so such a graph could validate as

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -212,3 +212,25 @@ def test_slots_do_not_report_a_dangling_link_as_linked_from(graph):
     assert "linked_from" not in slots["37.caption"]
     assert slots["37.caption"]["current_value"].startswith("Global Metadata")
     assert promoted.live_external_link(wf, inst, "caption") is None
+
+
+def test_effective_value_for_skips_the_name_lookup(graph):
+    """``effective_value_for`` is ``effective_value`` for a caller that already
+    holds the ``PromotedInput`` and the definition index: host value when
+    materialized, else the interior source value — and it never re-walks
+    ``promoted_inputs`` (``find_promoted``) to relocate what it was handed."""
+    from unittest import mock
+
+    wf = json.loads((_FIXTURES / "gallery" / "image_z_image_turbo.json").read_text())
+    inst = next(n for n in wf["nodes"] if n["id"] == 57)
+    defs = promoted.defs_by_id(wf)
+    sg = defs[inst["type"]]
+    width = next(p for p in promoted.promoted_inputs(sg, defs) if p.name == "width")
+    with mock.patch.object(promoted, "promoted_inputs", side_effect=AssertionError("re-walked")):
+        assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == 1024  # interior default
+    promoted.set_host_value(wf, inst, "width", 768, graph)
+    with mock.patch.object(promoted, "promoted_inputs", side_effect=AssertionError("re-walked")):
+        assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == 768  # host wins
+    assert promoted.effective_value_for(wf, inst, sg, width, graph, defs) == promoted.effective_value(
+        wf, inst, "width", graph
+    )

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -1,4 +1,4 @@
-"""Promoted subgraph widgets: the host-owned value model (BE-10305 scenarios 1/2).
+"""Promoted subgraph widgets: the host-owned value model (the "agent editing subgraph" report, scenarios 1/2).
 
 The frontend (``ComfyUI_frontend`` ADR 0009, ``SubgraphNode.ts``) represents a
 promoted widget as a *linked subgraph input*: the subgraph definition declares

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -1,0 +1,204 @@
+"""Promoted subgraph widgets: the host-owned value model (BE-10305 scenarios 1/2).
+
+The frontend (``ComfyUI_frontend`` ADR 0009, ``SubgraphNode.ts``) represents a
+promoted widget as a *linked subgraph input*: the subgraph definition declares
+an input, a boundary link feeds it into an interior node's widget-backed input,
+and the HOST instance owns the value — ``widgets_values[i]`` on the instance,
+consumed positionally by the i-th subgraph input that resolves to a widget
+(``_applyPromotedWidgetValues`` / ``serializeFromStoreState``). Socket-only
+inputs (``VIDEO``, ``MODEL``) own no slot. The interior widget is only a
+schema/default provider: *"the host/exterior value wins over the
+interior/source value during repair, persistence, and prompt serialization."*
+
+Before this model existed in the CLI, every read and write followed the legacy
+``properties.proxyWidgets`` list to the interior node — so ``set-widget
+57.width 768`` edited a value the frontend never serializes, and ``comfy run``
+submitted the interior prompt on post-migration templates whose real prompt
+lives on the host.
+
+Fixtures are verbatim gallery templates (``tests/comfy_cli/fixtures/gallery``):
+
+* ``image_z_image_turbo.json`` — pre-migration save (frontend 0.3.73): proxies
+  already backed by linked inputs, no host values materialized.
+* ``audio_minimax_music_3.json`` — post-migration save: 8 host values that
+  differ from the interior defaults (interior caption is ``''``).
+* ``api_seedance2_5_video_extend.json`` — mixed: two ``VIDEO`` socket inputs
+  (no slot) and four widget inputs with host values.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_subgraph_promoted.json"
+
+Z_IMAGE_SG = "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _instance(wf: dict, node_id: int) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+# --------------------------------------------------------------------------- #
+# the model: which subgraph inputs own a host value slot, and where they land
+# --------------------------------------------------------------------------- #
+
+
+def test_z_image_every_declared_input_is_a_promoted_widget():
+    wf = _load("image_z_image_turbo.json")
+    sg = _def_of(wf, _instance(wf, 57))
+    pis = promoted.promoted_inputs(sg, promoted.defs_by_id(wf))
+    assert [p.name for p in pis] == ["text", "width", "height", "seed", "steps", "unet_name", "clip_name", "vae_name"]
+    assert [p.value_index for p in pis] == list(range(8))
+    width = next(p for p in pis if p.name == "width")
+    assert width.source_node == "13"
+    assert width.source_widget == "width"
+    assert width.type == "INT"
+
+
+def test_socket_inputs_own_no_host_slot():
+    wf = _load("api_seedance2_5_video_extend.json")
+    inst = _instance(wf, 39)
+    pis = promoted.promoted_inputs(_def_of(wf, inst), promoted.defs_by_id(wf))
+    assert [(p.name, p.value_index) for p in pis] == [
+        ("clip_to_resize", None),
+        ("base_video", None),
+        ("pad_second_video", 0),
+        ("interpolation", 1),
+        ("padding_color", 2),
+        ("drop_audio", 3),
+    ]
+    # the captured frontend save has exactly one value per widget-backed input
+    assert len(inst["widgets_values"]) == len([p for p in pis if p.value_index is not None])
+
+
+# --------------------------------------------------------------------------- #
+# reads: host value wins, interior is the fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_effective_value_is_the_host_value_when_materialized(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    caption = promoted.effective_value(wf, inst, "caption", graph)
+    assert caption.startswith("Global Metadata: Lo-fi hip-hop")
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 60
+    # interior default is NOT what the frontend runs
+    interior = next(n for n in _def_of(wf, inst)["nodes"] if n["id"] == 13)
+    assert interior["widgets_values"][0] == ""
+
+
+def test_effective_value_falls_back_to_the_interior_widget(graph):
+    wf = _load("image_z_image_turbo.json")
+    inst = _instance(wf, 57)
+    assert inst["widgets_values"] == []
+    assert promoted.effective_value(wf, inst, "width", graph) == 1024
+    assert promoted.effective_value(wf, inst, "steps", graph) == 8
+    assert promoted.effective_value(wf, inst, "unet_name", graph) == "z_image_turbo_bf16.safetensors"
+
+
+def test_quarantined_host_value_wins_by_name(graph):
+    """ADR 0009: a repaired-but-unresolved legacy entry keeps its host value in
+    ``proxyWidgetErrorQuarantine``; the frontend reads it before ``widgets_values``."""
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["properties"]["proxyWidgetErrorQuarantine"] = [
+        {
+            "originalEntry": ["-1", "max_duration"],
+            "reason": "missingSourceWidget",
+            "hostValue": 12,
+            "attemptedAtVersion": 1,
+        }
+    ]
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 12
+
+
+# --------------------------------------------------------------------------- #
+# writes: materialize the host array in subgraph-input order, never the interior
+# --------------------------------------------------------------------------- #
+
+
+def test_set_host_value_materializes_the_full_array_in_input_order(graph):
+    wf = _load("image_z_image_turbo.json")
+    inst = _instance(wf, 57)
+    before = copy.deepcopy(_def_of(wf, inst))
+    promoted.set_host_value(wf, inst, "width", 768, graph)
+    assert inst["widgets_values"] == [
+        "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. ",
+        768,
+        1024,
+        0,
+        8,
+        "z_image_turbo_bf16.safetensors",
+        "qwen_3_4b.safetensors",
+        "ae.safetensors",
+    ]
+    assert _def_of(wf, inst) == before  # interior untouched
+
+
+def test_set_host_value_updates_one_slot_of_an_existing_array(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    before = list(inst["widgets_values"])
+    promoted.set_host_value(wf, inst, "max_duration", 90, graph)
+    assert inst["widgets_values"][2] == 90
+    assert inst["widgets_values"][:2] == before[:2]
+    assert inst["widgets_values"][3:] == before[3:]
+
+
+def test_set_host_value_rewrites_a_shadowing_quarantine_value(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["properties"]["proxyWidgetErrorQuarantine"] = [
+        {
+            "originalEntry": ["-1", "max_duration"],
+            "reason": "missingSourceWidget",
+            "hostValue": 12,
+            "attemptedAtVersion": 1,
+        }
+    ]
+    promoted.set_host_value(wf, inst, "max_duration", 90, graph)
+    assert promoted.effective_value(wf, inst, "max_duration", graph) == 90
+
+
+# --------------------------------------------------------------------------- #
+# slots: the advertised surface reports the value the frontend will run
+# --------------------------------------------------------------------------- #
+
+
+def test_slots_report_host_values_on_a_post_migration_template(graph):
+    wf = _load("audio_minimax_music_3.json")
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert slots["37.caption"]["current_value"].startswith("Global Metadata: Lo-fi hip-hop")
+    assert slots["37.max_duration"]["current_value"] == 60
+    assert slots["37.switch"]["current_value"] is True
+
+
+def test_slots_skip_socket_inputs_and_flag_external_links(graph):
+    wf = _load("api_seedance2_5_video_extend.json")
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert "39.clip_to_resize" not in slots
+    assert slots["39.pad_second_video"]["current_value"] is False
+    assert slots["39.interpolation"]["current_value"] == "lanczos"

--- a/tests/comfy_cli/cql/test_promoted_inputs.py
+++ b/tests/comfy_cli/cql/test_promoted_inputs.py
@@ -202,3 +202,13 @@ def test_slots_skip_socket_inputs_and_flag_external_links(graph):
     assert "39.clip_to_resize" not in slots
     assert slots["39.pad_second_video"]["current_value"] is False
     assert slots["39.interpolation"]["current_value"] == "lanczos"
+
+
+def test_slots_do_not_report_a_dangling_link_as_linked_from(graph):
+    wf = _load("audio_minimax_music_3.json")
+    inst = _instance(wf, 37)
+    inst["inputs"].append({"name": "caption", "type": "STRING", "widget": {"name": "caption"}, "link": 999999})
+    slots = {s["address"]: s for s in graph.get_template_schema("t", wf)["slots"]}
+    assert "linked_from" not in slots["37.caption"]
+    assert slots["37.caption"]["current_value"].startswith("Global Metadata")
+    assert promoted.live_external_link(wf, inst, "caption") is None

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -410,6 +410,77 @@ def test_flush_ignores_a_malformed_link_entry(graph):
     assert json.dumps(wf, sort_keys=True) == json.dumps(clean, sort_keys=True)
 
 
+def _wire_interior_feeder_into_choice(sg: dict, link_id: int = 999001) -> None:
+    """Feed CustomCombo 135's ``choice`` slot from interior node 2
+    (PrimitiveStringMultiline) — the shape ``resolve_write`` refuses to
+    widget-write when no legacy entry names the slot."""
+    sg["links"].append(
+        {"id": link_id, "origin_id": 2, "origin_slot": 0, "target_id": 135, "target_slot": 0, "type": "STRING"}
+    )
+    _inner(sg, 135)["inputs"][0]["link"] = link_id
+    _inner(sg, 2)["outputs"][0]["links"].append(link_id)
+
+
+def test_flush_replaces_an_interior_link_feeding_the_source_slot(graph):
+    """A legacy entry whose backing slot is already fed by an interior link is
+    still repaired, and the boundary link REPLACES that link — exactly what
+    the frontend does: ``repairCreateSubgraphInput`` calls
+    ``SubgraphInput.connect(slot, node)`` unconditionally, and ``connect``
+    resolves ``inputLink(...)`` for the slot, ``replaceLinkTopology``s it and
+    ``_disconnectNodeInput``s the incumbent (``SubgraphInput.ts``). After the
+    frontend loads such a file the interior feeder is gone and the host value
+    runs, so this is the state a write has to target."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    _wire_interior_feeder_into_choice(sg)
+    assert _plans(wf, 143, graph)[("135", "choice")].plan == "createSubgraphInput"
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    boundary = ids["135.choice"]["links"][0]
+    assert _link(sg, 999001) is None
+    assert _inner(sg, 2)["outputs"][0]["links"] == [211, 247]
+    assert _inner(sg, 135)["inputs"][0]["link"] == boundary
+    assert _link(sg, boundary)["origin_id"] == -10
+    assert inst["widgets_values"][0] == "Nano Banana 2"
+
+
+def test_flush_reuses_a_slot_serialized_by_name_only(graph):
+    """An older save can serialize a widget's input slot with ``name`` but no
+    ``widget`` marker: that slot is the backing slot (matched by name), gets
+    its marker back, and is never duplicated."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    del _inner(sg, 135)["inputs"][0]["widget"]
+    entry = _plans(wf, 143, graph)[("135", "choice")]
+    assert entry.plan == "createSubgraphInput" and entry.slot_index == 0 and entry.label == "model"
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    assert _inner(sg, 135)["inputs"] == [
+        {
+            "label": "model",
+            "localized_name": "choice",
+            "name": "choice",
+            "type": "COMBO",
+            "widget": {"name": "choice"},
+            "link": ids["135.choice"]["links"][0],
+        }
+    ]
+    assert next(i for i in sg["inputs"] if i["name"] == "choice")["label"] == "model"
+
+
+def test_planned_repair_refuses_an_ambiguous_legacy_alias(graph):
+    """Two entries share the legacy widget name ``value`` (both primitives):
+    the alias is refused with the minted names, never resolved to one of them."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    with pytest.raises(ValueError, match=r"143\.resolution.*143\.aspect_ratio"):
+        promoted.planned_repair(wf, inst, graph, "value")
+    inst["properties"]["proxyWidgets"] = [e for e in inst["properties"]["proxyWidgets"] if e != ["142", "value"]]
+    assert promoted.planned_repair(wf, inst, graph, "value").name == "resolution"
+
+
 def test_flush_leaves_preview_exposures_in_place(graph):
     """``$$`` entries are display-only: no input, no value, and the entry stays
     in ``proxyWidgets`` for the frontend's own preview-exposure migration

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -1,0 +1,407 @@
+"""Legacy ``properties.proxyWidgets`` → linked-input repair: a port of the
+frontend's forward migration (``proxyWidgetMigration.ts``, ADR 0009).
+
+The frontend runs ``flushProxyWidgetMigration`` on every subgraph host at load
+time. The CLI runs the same flush on the instance whose legacy promotion a
+write is about to edit, so the write can land on the HOST value the way it
+does for every other promoted widget. These tests pin the port against real
+gallery templates (``tests/comfy_cli/fixtures/gallery``):
+
+* ``templates_graphic_design_recomposer.json`` — instance 143: a value widget
+  with a labelled backing slot (``['135','choice']``) plus two ``PrimitiveNode``
+  fan-outs (``['156','value']`` → two targets, ``['142','value']`` → two
+  targets), both primitives renamed by the user.
+* ``template_horizontal_vertical_extension.json`` — instance 252: three
+  ``$$canvas-image-preview`` exposures plus a value widget whose interior node
+  serializes no ``inputs[]`` at all (``['285','aspect_ratio']``).
+* ``flux_dev_checkpoint_example.json`` — instance 56: seven entries already
+  backed by linked inputs, ``['52','seed']`` repairable, and
+  ``['52','control_after_generate']`` — a frontend-only widget with no backing
+  input slot, which the frontend quarantines.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql import promoted
+from comfy_cli.cql.engine import Graph
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+OBJECT_INFO = _FIXTURES / "object_info_legacy_proxy.json"
+
+RECOMPOSER = "templates_graphic_design_recomposer.json"
+EXTENSION = "template_horizontal_vertical_extension.json"
+FLUX = "flux_dev_checkpoint_example.json"
+
+FLUX_SEED = 53943644181156
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(OBJECT_INFO.read_text()))
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _instance(wf: dict, node_id: int) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
+def _def_of(wf: dict, instance: dict) -> dict:
+    return next(d for d in wf["definitions"]["subgraphs"] if d["id"] == instance["type"])
+
+
+def _inner(sg: dict, node_id: int) -> dict:
+    return next(n for n in sg["nodes"] if n["id"] == node_id)
+
+
+def _link(sg: dict, link_id) -> dict | None:
+    return next((x for x in sg["links"] if x["id"] == link_id), None)
+
+
+def _plans(wf: dict, instance_id: int, graph) -> dict[tuple, promoted.LegacyEntry]:
+    return {tuple(e.original): e for e in promoted.plan_proxy_migration(wf, _instance(wf, instance_id), graph)}
+
+
+# --------------------------------------------------------------------------- #
+# nextUniqueName — the frontend's collision rule, ported verbatim
+# --------------------------------------------------------------------------- #
+
+
+def test_next_unique_name_appends_underscore_counter():
+    assert promoted.next_unique_name("seed", []) == "seed"
+    assert promoted.next_unique_name("seed", ["seed"]) == "seed_1"
+    assert promoted.next_unique_name("seed", ["seed", "seed_1"]) == "seed_2"
+    # the counter restarts from the BASE name, never from an existing suffix
+    assert promoted.next_unique_name("seed", ["seed", "seed_2"]) == "seed_1"
+
+
+# --------------------------------------------------------------------------- #
+# classification (``classify`` in the frontend)
+# --------------------------------------------------------------------------- #
+
+
+def test_flux_plan_classifies_linked_repairable_and_unrepairable(graph):
+    wf = _load(FLUX)
+    plans = _plans(wf, 56, graph)
+    linked = [e for e in plans.values() if e.plan == "alreadyLinked"]
+    assert [e.name for e in linked] == ["text", "width", "height", "unet_name", "clip_name1", "clip_name2", "vae_name"]
+    seed = plans[("52", "seed")]
+    assert seed.plan == "createSubgraphInput"
+    assert seed.name == "seed"
+    assert seed.type == "INT"
+    assert seed.host_value is promoted.UNSET  # widgets_values is [] — a hole
+    cag = plans[("52", "control_after_generate")]
+    assert cag.plan == "quarantine"
+    assert cag.reason == "missingSubgraphInput"  # a widget with no backing input slot
+
+
+def test_recomposer_plan_repairs_primitive_fanouts_under_the_user_title(graph):
+    wf = _load(RECOMPOSER)
+    plans = _plans(wf, 143, graph)
+    choice = plans[("135", "choice")]
+    assert choice.plan == "createSubgraphInput" and choice.name == "choice" and choice.type == "COMBO"
+    resolution = plans[("156", "value")]
+    assert resolution.plan == "primitiveBypass"
+    assert resolution.name == "resolution"  # the primitive's user title, not its widget name
+    assert resolution.type == "COMBO"
+    assert resolution.targets == [("130", 4), ("157", 2)]
+    aspect = plans[("142", "value")]
+    assert aspect.plan == "primitiveBypass" and aspect.name == "aspect_ratio"
+    assert aspect.targets == [("130", 3), ("157", 1)]
+
+
+def test_extension_plan_keeps_previews_out_of_the_value_path(graph):
+    wf = _load(EXTENSION)
+    plans = _plans(wf, 252, graph)
+    previews = [e for e in plans.values() if e.plan == "previewExposure"]
+    assert [tuple(e.original) for e in previews] == [
+        ("233", "$$canvas-image-preview"),
+        ("232", "$$canvas-image-preview"),
+        ("234", "$$canvas-image-preview"),
+    ]
+    aspect = plans[("285", "aspect_ratio")]
+    assert aspect.plan == "createSubgraphInput" and aspect.type == "COMBO"
+
+
+def test_plan_quarantines_missing_node_missing_widget_and_host_self_reference(graph):
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["properties"]["proxyWidgets"] = [["999", "seed"], ["52", "nope"], ["-1", "width"]]
+    inst["widgets_values"] = [1, 2, 640]
+    plans = _plans(wf, 56, graph)
+    assert plans[("999", "seed")].plan == "quarantine" and plans[("999", "seed")].reason == "missingSourceNode"
+    assert plans[("52", "nope")].reason == "missingSourceWidget"
+    # ``-1`` names the host itself: no interior node has that id, so the
+    # frontend quarantines it too — but its host value is preserved.
+    minus_one = plans[("-1", "width")]
+    assert minus_one.reason == "missingSourceNode"
+    assert minus_one.host_value == 640
+
+
+def test_plan_quarantines_a_primitive_cohort_with_mixed_widget_names(graph):
+    """``['156','value']`` + ``['156','control_after_generate']`` name ONE
+    primitive with two widgets: the frontend's cohort validation fails and
+    every entry of the cohort is quarantined (all-or-quarantine)."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    inst["properties"]["proxyWidgets"].append(["156", "control_after_generate"])
+    plans = _plans(wf, 143, graph)
+    assert plans[("156", "value")].plan == "quarantine"
+    assert plans[("156", "value")].reason == "primitiveBypassFailed"
+    assert plans[("156", "control_after_generate")].reason == "primitiveBypassFailed"
+    # the other primitive is unaffected
+    assert plans[("142", "value")].plan == "primitiveBypass"
+
+
+def test_plan_quarantines_a_primitive_with_no_fanout(graph):
+    wf = _load(RECOMPOSER)
+    sg = _def_of(wf, _instance(wf, 143))
+    sg["links"] = [x for x in sg["links"] if x["origin_id"] != 156]
+    _inner(sg, 156)["outputs"][0]["links"] = []
+    assert _plans(wf, 143, graph)[("156", "value")].reason == "unlinkedSourceWidget"
+
+
+def test_plan_uses_a_unique_name_when_the_widget_name_is_taken(graph):
+    wf = _load(FLUX)
+    sg = _def_of(wf, _instance(wf, 56))
+    sg["inputs"].append({"id": "x", "name": "seed", "type": "INT", "linkIds": []})
+    assert _plans(wf, 56, graph)[("52", "seed")].name == "seed_1"
+
+
+# --------------------------------------------------------------------------- #
+# flush: the structural repair
+# --------------------------------------------------------------------------- #
+
+
+def test_flush_creates_the_input_the_boundary_link_and_the_host_value(graph):
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    sg = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["56"], promoted.plan_proxy_migration(wf, inst, graph))
+    report = promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+
+    assert report.created == ["seed"]
+    new_input = sg["inputs"][-1]
+    link_id = ids["52.seed"]["links"][0]
+    assert new_input == {"id": ids["52.seed"]["input"], "name": "seed", "type": "INT", "linkIds": [link_id]}
+    assert _link(sg, link_id) == {
+        "id": link_id,
+        "origin_id": -10,
+        "origin_slot": 7,
+        "target_id": 52,
+        "target_slot": 4,
+        "type": "INT",
+    }
+    # the interior input entry is created the way the frontend serializes a
+    # converted widget (flux_dev_checkpoint_example.json node 50 ``width``)
+    ksampler = _inner(sg, 52)
+    assert ksampler["inputs"][4] == {
+        "localized_name": "seed",
+        "name": "seed",
+        "type": "INT",
+        "widget": {"name": "seed"},
+        "link": link_id,
+    }
+    assert ksampler["widgets_values"][0] == FLUX_SEED  # interior untouched
+    assert sg["state"]["lastLinkId"] >= link_id
+    # host: the instance carries the value, materialized in subgraph-input order
+    pis = promoted.promoted_inputs(sg, promoted.defs_by_id(wf))
+    assert [p.name for p in pis if p.is_widget][-1] == "seed"
+    assert inst["widgets_values"][-1] == FLUX_SEED
+    assert inst["inputs"][-1] == {"name": "seed", "type": "INT", "widget": {"name": "seed"}, "link": None}
+    # consumed: canonical saves do not re-emit repaired entries
+    assert "proxyWidgets" not in inst["properties"]
+    assert inst["properties"]["proxyWidgetErrorQuarantine"] == [
+        {"originalEntry": ["52", "control_after_generate"], "reason": "missingSubgraphInput", "attemptedAtVersion": 1}
+    ]
+
+
+def test_flush_reads_legacy_host_values_by_proxy_position(graph):
+    """A pre-migration save stores host values positionally by ``proxyWidgets``
+    order (``pickHostValue``): those win over the interior defaults, for
+    already-linked and freshly created inputs alike."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    # proxy order: text, width, height, unet_name, clip_name1, clip_name2, vae_name, seed, c_a_g
+    inst["widgets_values"] = [None, 640]
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    by_name = {p.name: p for p in promoted.promoted_inputs(sg, promoted.defs_by_id(wf))}
+    assert promoted.host_value(inst, by_name["width"]) == 640
+    assert promoted.host_value(inst, by_name["text"]) is None  # an explicit null is a value, not a hole
+    assert promoted.host_value(inst, by_name["height"]) == 1024  # hole → interior default
+    assert promoted.host_value(inst, by_name["seed"]) == FLUX_SEED  # hole → seeded from the source widget
+
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["widgets_values"] = [None] * 7 + [777]
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    by_name = {p.name: p for p in promoted.promoted_inputs(sg, promoted.defs_by_id(wf))}
+    assert promoted.host_value(inst, by_name["seed"]) == 777  # a legacy host value beats the interior
+
+
+def test_flush_preserves_the_source_slot_label(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    choice = next(i for i in sg["inputs"] if i["name"] == "choice")
+    assert choice["label"] == "model"
+    assert promoted.instance_input(inst, "choice")["label"] == "model"
+
+
+def test_flush_synthesizes_the_interior_input_entry_when_none_is_serialized(graph):
+    wf = _load(EXTENSION)
+    inst = _instance(wf, 252)
+    sg = _def_of(wf, inst)
+    assert _inner(sg, 285).get("inputs") == []
+    ids = promoted.plan_repair_ids(["252"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    link_id = ids["285.aspect_ratio"]["links"][0]
+    assert _inner(sg, 285)["inputs"] == [
+        {
+            "localized_name": "aspect_ratio",
+            "name": "aspect_ratio",
+            "type": "COMBO",
+            "widget": {"name": "aspect_ratio"},
+            "link": link_id,
+        }
+    ]
+    assert _link(sg, link_id)["target_slot"] == 0
+    assert inst["widgets_values"] == ["9:16 (Portrait Widescreen)"]
+
+
+def test_flush_leaves_preview_exposures_in_place(graph):
+    """``$$`` entries are display-only: no input, no value, and the entry stays
+    in ``proxyWidgets`` for the frontend's own preview-exposure migration
+    (which also auto-exposes preview nodes when ``previewExposures`` is unset)."""
+    wf = _load(EXTENSION)
+    inst = _instance(wf, 252)
+    before = copy.deepcopy(inst["properties"]["proxyWidgets"])
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.remaining == before[:3]
+    assert inst["properties"]["proxyWidgets"] == before[:3]
+    assert "previewExposures" not in inst["properties"]
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+    assert [i["name"] for i in _def_of(wf, inst)["inputs"]] == ["image", "aspect_ratio"]
+
+
+def test_flush_bypasses_a_primitive_fanout_through_one_input(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["143"], promoted.plan_proxy_migration(wf, inst, graph))
+    report = promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+
+    assert report.created == ["choice", "resolution", "aspect_ratio"]  # creates first, then primitive cohorts
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "resolution", "aspect_ratio"]
+    resolution = sg["inputs"][2]
+    links = ids["156.value"]["links"]
+    assert resolution == {"id": ids["156.value"]["input"], "name": "resolution", "type": "COMBO", "linkIds": links}
+    # former primitive links are gone; every target is reconnected in target order
+    assert _link(sg, 243) is None and _link(sg, 246) is None
+    assert _link(sg, links[0]) == {
+        "id": links[0],
+        "origin_id": -10,
+        "origin_slot": 2,
+        "target_id": 130,
+        "target_slot": 4,
+        "type": "COMBO",
+    }
+    assert _link(sg, links[1])["target_id"] == 157 and _link(sg, links[1])["target_slot"] == 2
+    assert _inner(sg, 130)["inputs"][4]["link"] == links[0]
+    assert _inner(sg, 157)["inputs"][2]["link"] == links[1]
+    # the primitive stays, disconnected and inert, marked with its bypass
+    primitive = _inner(sg, 156)
+    assert primitive["outputs"][0]["links"] == []
+    assert primitive["properties"]["proxyBypassedToSubgraphInput"] == "resolution"
+    assert primitive["widgets_values"] == ["2K", "fixed", ""]
+    # host values: seeded from the source widgets (the primitive's own value)
+    assert inst["widgets_values"] == ["Nano Banana 2", "2K", "16:9"]
+    assert "proxyWidgets" not in inst["properties"]
+
+
+def test_flush_repairs_creates_before_primitive_cohorts(graph):
+    """Entry order is the frontend's: value widgets first, primitive cohorts
+    after — so a value entry naming a primitive's own target takes that
+    target over (its link is replaced), the cohort is re-collected against
+    the mutated graph, and the primitive's input is named around the
+    collision (``resolution`` → ``resolution_1``)."""
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    inst["properties"]["proxyWidgets"].insert(1, ["130", "resolution"])
+    promoted.flush_proxy_migration(wf, inst, graph)
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "resolution", "resolution_1", "aspect_ratio"]
+    by_name = {i["name"]: i for i in sg["inputs"]}
+    assert _inner(sg, 130)["inputs"][4]["link"] == by_name["resolution"]["linkIds"][0]
+    assert [_link(sg, x)["target_id"] for x in by_name["resolution_1"]["linkIds"]] == [157]
+    assert _link(sg, 243) is None and _link(sg, 246) is None
+    assert inst["widgets_values"] == ["Nano Banana 2", "2K", "2K", "16:9"]
+
+
+def test_flush_coalesces_duplicate_primitive_entries(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    inst["properties"]["proxyWidgets"].append(["156", "value"])
+    promoted.flush_proxy_migration(wf, inst, graph)
+    sg = _def_of(wf, inst)
+    assert [i["name"] for i in sg["inputs"]].count("resolution") == 1
+    assert "proxyWidgetErrorQuarantine" not in inst["properties"]
+
+
+def test_flush_quarantines_a_type_incompatible_primitive_target(graph):
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    _inner(sg, 157)["inputs"][2]["type"] = "STRING"
+    promoted.flush_proxy_migration(wf, inst, graph)
+    assert [i["name"] for i in sg["inputs"]] == ["images", "choice", "aspect_ratio"]
+    assert _link(sg, 243) is not None and _link(sg, 246) is not None  # untouched: all-or-quarantine
+    assert {tuple(q["originalEntry"]): q["reason"] for q in inst["properties"]["proxyWidgetErrorQuarantine"]} == {
+        ("156", "value"): "primitiveBypassFailed"
+    }
+
+
+def test_flush_is_idempotent_and_deterministic(graph):
+    wf = _load(RECOMPOSER)
+    a, b = copy.deepcopy(wf), copy.deepcopy(wf)
+    promoted.flush_proxy_migration(a, _instance(a, 143), graph)
+    promoted.flush_proxy_migration(b, _instance(b, 143), graph)
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+    once = json.dumps(a, sort_keys=True)
+    report = promoted.flush_proxy_migration(a, _instance(a, 143), graph)
+    assert report.created == [] and report.quarantined == []
+    assert json.dumps(a, sort_keys=True) == once
+
+
+def test_flush_consumes_an_entry_a_previous_repair_already_linked(graph):
+    """Replaying a repair against a document another replica already repaired
+    finds the entry ``alreadyLinked`` and changes nothing structural."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    promoted.flush_proxy_migration(wf, inst, graph)
+    inst["properties"]["proxyWidgets"] = [["52", "seed"]]
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.created == []
+    assert report.consumed == [["52", "seed"]]
+    assert [i["name"] for i in _def_of(wf, inst)["inputs"]].count("seed") == 1
+
+
+def test_repair_ids_are_stable_across_processes():
+    ids = promoted.repair_ids(["56"], "52", "seed", 1)
+    again = promoted.repair_ids(["56"], "52", "seed", 1)
+    assert ids == again
+    assert ids["links"][0] >= 1 << 40  # the op model's leaderless id range
+    assert promoted.repair_ids(["156"], "52", "seed", 1) != ids  # another instance, other ids
+    assert promoted.repair_ids(["56"], "52", "seed", 2)["links"][0] == ids["links"][0]

--- a/tests/comfy_cli/cql/test_proxy_migration.py
+++ b/tests/comfy_cli/cql/test_proxy_migration.py
@@ -71,6 +71,67 @@ def _plans(wf: dict, instance_id: int, graph) -> dict[tuple, promoted.LegacyEntr
     return {tuple(e.original): e for e in promoted.plan_proxy_migration(wf, _instance(wf, instance_id), graph)}
 
 
+OUTER = "0f6b0a4e-outer-0000-0000-000000000001"
+INNER = "0f6b0a4e-inner-0000-0000-000000000002"
+
+
+def _nested_legacy_workflow(entries: list[list[str]]) -> dict:
+    """Synthetic: a legacy promotion whose SOURCE is a nested subgraph instance
+    (top 10 → OUTER's node 5, an INNER instance) and whose projecting input
+    (``prompt_text``) is named differently from the widget it projects
+    (CLIPTextEncode 27's ``text``). Node 5 serializes no ``inputs[]`` — the
+    older-save shape — so the repair must synthesize the slot. Node/link
+    shapes are copied from ``flux_dev_checkpoint_example.json``."""
+    return {
+        "last_node_id": 10,
+        "last_link_id": 0,
+        "nodes": [{"id": 10, "type": OUTER, "inputs": [], "outputs": [], "properties": {"proxyWidgets": entries}}],
+        "links": [],
+        "definitions": {
+            "subgraphs": [
+                {
+                    "id": OUTER,
+                    "name": "Outer",
+                    "state": {"lastGroupId": 0, "lastNodeId": 5, "lastLinkId": 0, "lastRerouteId": 0},
+                    "inputs": [],
+                    "outputs": [],
+                    "nodes": [{"id": 5, "type": INNER, "inputs": [], "outputs": [], "widgets_values": []}],
+                    "links": [],
+                },
+                {
+                    "id": INNER,
+                    "name": "Inner",
+                    "state": {"lastGroupId": 0, "lastNodeId": 27, "lastLinkId": 1, "lastRerouteId": 0},
+                    "inputs": [{"id": "i1", "name": "prompt_text", "type": "STRING", "linkIds": [1]}],
+                    "outputs": [],
+                    "nodes": [
+                        {
+                            "id": 27,
+                            "type": "CLIPTextEncode",
+                            "inputs": [
+                                {"name": "clip", "type": "CLIP", "link": None},
+                                {"name": "text", "type": "STRING", "widget": {"name": "text"}, "link": 1},
+                            ],
+                            "outputs": [{"name": "CONDITIONING", "type": "CONDITIONING", "links": []}],
+                            "widgets_values": ["hi"],
+                        }
+                    ],
+                    "links": [
+                        {
+                            "id": 1,
+                            "origin_id": -10,
+                            "origin_slot": 0,
+                            "target_id": 27,
+                            "target_slot": 1,
+                            "type": "STRING",
+                        }
+                    ],
+                },
+            ]
+        },
+    }
+
+
 # --------------------------------------------------------------------------- #
 # nextUniqueName — the frontend's collision rule, ported verbatim
 # --------------------------------------------------------------------------- #
@@ -177,6 +238,32 @@ def test_plan_uses_a_unique_name_when_the_widget_name_is_taken(graph):
     assert _plans(wf, 56, graph)[("52", "seed")].name == "seed_1"
 
 
+def test_plan_normalizes_a_node_prefixed_widget_name(graph):
+    """An older save could prefix the widget name with its node id
+    (``normalizeLegacyProxyWidgetEntry``): the prefix is stripped and kept as
+    the disambiguator; the repair claims the bare widget."""
+    wf = _load(FLUX)
+    inst = _instance(wf, 56)
+    inst["properties"]["proxyWidgets"] = [["52", "52:seed"]]
+    entry = _plans(wf, 56, graph)[("52", "52:seed")]
+    assert entry.plan == "createSubgraphInput"
+    assert entry.widget == "seed"
+    assert entry.disambiguator == "52"
+    assert entry.name == "seed"
+    assert entry.key == "52.seed"
+
+
+def test_plan_resolves_a_nested_instance_source_by_disambiguator(graph):
+    """Through a nested instance the disambiguator must name the interior
+    node the projecting input lands on (``resolveSourceWidget``)."""
+    wf = _nested_legacy_workflow([["5", "27:text"], ["5", "99:text"]])
+    plans = _plans(wf, 10, graph)
+    hit = plans[("5", "27:text")]
+    assert hit.plan == "createSubgraphInput"
+    assert (hit.widget, hit.disambiguator, hit.source_input, hit.type) == ("text", "27", "prompt_text", "STRING")
+    assert plans[("5", "99:text")].reason == "missingSourceWidget"
+
+
 # --------------------------------------------------------------------------- #
 # flush: the structural repair
 # --------------------------------------------------------------------------- #
@@ -279,6 +366,48 @@ def test_flush_synthesizes_the_interior_input_entry_when_none_is_serialized(grap
     ]
     assert _link(sg, link_id)["target_slot"] == 0
     assert inst["widgets_values"] == ["9:16 (Portrait Widescreen)"]
+
+
+def test_flush_synthesizes_a_nested_instance_slot_under_its_projecting_input(graph):
+    """The slot a nested instance backs a promoted widget with is its own
+    host input — named after the PROJECTING INPUT, not the interior widget
+    (``getSlotFromWidget(promotedInputWidget(input))``). Only that name lets
+    the outer definition resolve the promotion through the inner one."""
+    wf = _nested_legacy_workflow([["5", "text"]])
+    inst = _instance(wf, 10)
+    outer = _def_of(wf, inst)
+    ids = promoted.plan_repair_ids(["10"], promoted.plan_proxy_migration(wf, inst, graph))
+    promoted.flush_proxy_migration(wf, inst, graph, ids=ids)
+    link_id = ids["5.text"]["links"][0]
+    assert _inner(outer, 5)["inputs"] == [
+        {"name": "prompt_text", "type": "STRING", "widget": {"name": "prompt_text"}, "link": link_id}
+    ]
+    assert _link(outer, link_id)["target_slot"] == 0
+    pis = promoted.promoted_inputs(outer, promoted.defs_by_id(wf))
+    assert [(p.name, p.value_index, p.nested, p.source_node, p.source_input) for p in pis] == [
+        ("text", 0, True, "5", "prompt_text")
+    ]
+    assert inst["widgets_values"] == ["hi"]
+    promoted.set_host_value(wf, inst, "text", "yo", graph)
+    assert promoted.effective_value(wf, inst, "text", graph) == "yo"
+    # the outer promotion resolves through the inner one to the concrete widget
+    assert promoted.deepest_source(outer, pis[0], promoted.defs_by_id(wf)) == (["5", "27"], "text")
+
+
+def test_flush_ignores_a_malformed_link_entry(graph):
+    """A stray non-dict among ``links`` is skipped like everywhere else in the
+    module, not stack-traced — the primitive repair scans links too."""
+    clean = _load(RECOMPOSER)
+    promoted.flush_proxy_migration(clean, _instance(clean, 143), graph)
+    wf = _load(RECOMPOSER)
+    inst = _instance(wf, 143)
+    sg = _def_of(wf, inst)
+    sg["links"].insert(0, ["not", "a", "link"])
+    report = promoted.flush_proxy_migration(wf, inst, graph)
+    assert report.created == ["choice", "resolution", "aspect_ratio"]
+    assert sg["links"][0] == ["not", "a", "link"]
+    sg["links"].pop(0)
+    assert json.dumps(wf, sort_keys=True) == json.dumps(clean, sort_keys=True)
 
 
 def test_flush_leaves_preview_exposures_in_place(graph):

--- a/tests/comfy_cli/fixtures/gallery/README.md
+++ b/tests/comfy_cli/fixtures/gallery/README.md
@@ -11,7 +11,7 @@ Refresh with:
 
 ```bash
 cd tests/comfy_cli/fixtures/gallery
-for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend; do
+for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend templates_graphic_design_recomposer template_horizontal_vertical_extension flux_dev_checkpoint_example; do
   curl -sfL "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/${f}.json" -o "${f}.json"
 done
 ```
@@ -30,3 +30,18 @@ promoted-widget tests (`tests/comfy_cli/cql/test_promoted_inputs.py`,
 `tests/comfy_cli/test_workflow_to_api_promoted.py`); their node classes are
 covered by `../object_info_subgraph_promoted.json`, a trimmed copy of the
 cloud catalog entries (tooltips stripped, structure verbatim).
+
+`templates_graphic_design_recomposer.json` (two `PrimitiveNode` fan-outs and a
+labelled value widget promoted only through legacy `proxyWidgets`),
+`template_horizontal_vertical_extension.json` (three `$$canvas-image-preview`
+exposures plus a value widget whose interior node serializes no `inputs[]`)
+and `flux_dev_checkpoint_example.json` (seven linked promotions, one
+repairable `seed`, one unrepairable `control_after_generate`) back the
+legacy-proxy repair tests (`tests/comfy_cli/cql/test_proxy_migration.py`,
+`tests/comfy_cli/command/test_workflow_edit_legacy_proxy.py`) — the port of the
+frontend's `proxyWidgetMigration.ts`. Their node classes are covered by
+`../object_info_legacy_proxy.json`, built the same way as
+`object_info_subgraph_promoted.json`: for every class the three templates use,
+the cloud catalog entry (`services/ingest/data/object_info.json`) verbatim with
+every `tooltip` key stripped; frontend-only classes (`MarkdownNote`, `Note`,
+`PrimitiveNode`) have no catalog entry and are omitted.

--- a/tests/comfy_cli/fixtures/gallery/README.md
+++ b/tests/comfy_cli/fixtures/gallery/README.md
@@ -11,7 +11,7 @@ Refresh with:
 
 ```bash
 cd tests/comfy_cli/fixtures/gallery
-for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed; do
+for f in 02_qwen_Image_edit_subgraphed 05_audio_ace_step_1_t2a_song_subgraphed image_z_image_turbo audio_minimax_music_3 api_seedance2_5_video_extend; do
   curl -sfL "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/main/templates/${f}.json" -o "${f}.json"
 done
 ```
@@ -20,3 +20,13 @@ done
 `/object_info` covering only the node types the qwen fixture uses (frontend-only
 `MarkdownNote` excluded, matching a real server response), used to exercise slot
 extraction. If a refresh changes the qwen template's node set, extend it to match.
+
+`image_z_image_turbo.json` (pre-migration save: proxies backed by linked
+inputs, no host values), `audio_minimax_music_3.json` (post-migration save:
+host values differ from the interior defaults) and
+`api_seedance2_5_video_extend.json` (socket + widget inputs mixed) back the
+promoted-widget tests (`tests/comfy_cli/cql/test_promoted_inputs.py`,
+`tests/comfy_cli/command/test_workflow_edit_promoted.py`,
+`tests/comfy_cli/test_workflow_to_api_promoted.py`); their node classes are
+covered by `../object_info_subgraph_promoted.json`, a trimmed copy of the
+cloud catalog entries (tooltips stripped, structure verbatim).

--- a/tests/comfy_cli/fixtures/gallery/api_seedance2_5_video_extend.json
+++ b/tests/comfy_cli/fixtures/gallery/api_seedance2_5_video_extend.json
@@ -1,0 +1,1467 @@
+{
+  "id": "7a06a6de-067d-4d41-b7bf-7d6add20ec8c",
+  "revision": 0,
+  "last_node_id": 43,
+  "last_link_id": 86,
+  "nodes": [
+    {
+      "id": 16,
+      "type": "SaveVideo",
+      "pos": [
+        500,
+        7850
+      ],
+      "size": [
+        700,
+        381.890625
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 31
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "video/Seedance2.5_video_extend",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 35,
+      "type": "LoadVideo",
+      "pos": [
+        -640,
+        7850
+      ],
+      "size": [
+        330,
+        470
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            27,
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": [
+        "sloth_bullfight.mp4",
+        "image"
+      ]
+    },
+    {
+      "id": 36,
+      "type": "Video Slice",
+      "pos": [
+        -260,
+        7850
+      ],
+      "size": [
+        270,
+        150
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 27
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            30
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Video Slice"
+      },
+      "widgets_values": [
+        0,
+        5,
+        false
+      ]
+    },
+    {
+      "id": 38,
+      "type": "ByteDance2ReferenceNodeV2",
+      "pos": [
+        60,
+        7850
+      ],
+      "size": [
+        400,
+        550.484375
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "showAdvanced": false,
+      "inputs": [
+        {
+          "label": "image_1",
+          "name": "model.reference_images.image_1",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        },
+        {
+          "label": "video_1",
+          "name": "model.reference_videos.video_1",
+          "shape": 7,
+          "type": "VIDEO",
+          "link": 30
+        },
+        {
+          "label": "video_2",
+          "name": "model.reference_videos.video_2",
+          "shape": 7,
+          "type": "VIDEO",
+          "link": null
+        },
+        {
+          "label": "audio_1",
+          "name": "model.reference_audios.audio_1",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "label": "asset_1",
+          "name": "model.reference_assets.asset_1",
+          "shape": 7,
+          "type": "STRING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            31,
+            86
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ByteDance2ReferenceNodeV2"
+      },
+      "widgets_values": [
+        "Seedance 2.5",
+        "Continuing from the previous shot, live-action western rodeo, dusty arena, golden hour. The raging bull calms down and stops, the buzzer rings. The sloth in the cowboy hat hops off the bull's back, lands steadily in the dust, slowly dusts off his hat, then strolls away unhurriedly with a deadpan expression. Slow motion, dust floating in warm sunlight, cheering crowd roars and waves hats in the background. Steadicam follow shot. Western arena music swells. No black frames, no text overlays.",
+        "720p",
+        "adaptive",
+        5,
+        true,
+        "extend",
+        "mp4",
+        true,
+        false,
+        1672978219,
+        "fixed",
+        false
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 39,
+      "type": "d9aa59a4-3784-4796-9f1b-5b467fb41fa1",
+      "pos": [
+        1250,
+        7850
+      ],
+      "size": [
+        290,
+        190
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "base_video",
+          "name": "clip_to_resize",
+          "type": "VIDEO",
+          "link": 76
+        },
+        {
+          "label": "second_video",
+          "name": "base_video",
+          "type": "VIDEO",
+          "link": 86
+        },
+        {
+          "label": "pad_second_video",
+          "name": "pad_second_video",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "pad_second_video"
+          },
+          "link": null
+        },
+        {
+          "label": "drop_audio",
+          "name": "drop_audio",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "drop_audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "merged_video",
+          "type": "VIDEO",
+          "links": [
+            78
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.21.1",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65,
+        "previewExposures": []
+      },
+      "widgets_values": [
+        false,
+        "lanczos",
+        "white",
+        false
+      ]
+    },
+    {
+      "id": 40,
+      "type": "SaveVideo",
+      "pos": [
+        1590,
+        7850
+      ],
+      "size": [
+        700,
+        381.890625
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 78
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": []
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "video/Seedance2.5_video_extend_merged",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 41,
+      "type": "MarkdownNote",
+      "pos": [
+        -1180,
+        7850
+      ],
+      "size": [
+        500,
+        940.6875
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: Video Extend",
+      "properties": {},
+      "widgets_values": [
+        "**Input Assets** \n- [sloth_bullfight.mp4](https://raw.githubusercontent.com/Comfy-Org/workflow_templates/refs/heads/main/input/sloth_bullfight.mp4)\n\nThis template extends an existing video forward or backward for a new segment (default 5 seconds). The model keeps the character, scene, aspect ratio, and overall style consistent with your source footage. Only the new segment is generated; the source video is not included in the output.\n\n**How to write the prompt:**\n\n1. **State the extension intent first.** Begin with phrases like \"Continuing from the previous shot\" or \"Extend forward from the source video\" so the model knows this is a continuation, not a new video.\n\n2. **Describe only the new segment.** Don't re-describe the whole scene. Write what happens in the 5 seconds you're adding, e.g., the character lands, reacts, walks away.\n\n3. **Keep the character and environment consistent.** Reference the same character and outfit from the source (\"the same sloth in the cowboy hat\"), and stay in the same location and style.\n\n4. **One camera move, one lighting keyword.** Pick a single camera movement (slow push in, steadicam follow, low angle) and one lighting term (golden hour cinematography). One strong keyword beats a pile of adjectives.\n\n5. **Add audio.** Seedance generates sound natively. Describe the music and sound effects at the end (\"western arena music swells\").\n\n6. **Close with constraints.** End with \"No black frames, no text overlays\" to keep the output clean.\n\n**Example:**\n\n> Continuing from the previous shot, live-action western rodeo, dusty arena, golden hour. The raging bull calms down and stops, the buzzer rings. The sloth in the cowboy hat hops off the bull's back, lands steadily in the dust, slowly dusts off his hat, then strolls away unhurriedly with a deadpan expression. Slow motion, dust floating in warm sunlight, cheering crowd roars and waves hats in the background. Steadicam follow shot. Western arena music swells. No black frames, no text overlays.\n\n## Report Issue\n\nNote: Please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud updates follow stable releases, so some nightly-supported models may not be available yet.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/comfyanonymous/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      27,
+      35,
+      0,
+      36,
+      0,
+      "VIDEO"
+    ],
+    [
+      30,
+      36,
+      0,
+      38,
+      1,
+      "VIDEO"
+    ],
+    [
+      31,
+      38,
+      0,
+      16,
+      0,
+      "VIDEO"
+    ],
+    [
+      76,
+      35,
+      0,
+      39,
+      0,
+      "VIDEO"
+    ],
+    [
+      78,
+      39,
+      0,
+      40,
+      0,
+      "VIDEO"
+    ],
+    [
+      86,
+      38,
+      0,
+      39,
+      1,
+      "VIDEO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "d9aa59a4-3784-4796-9f1b-5b467fb41fa1",
+        "version": 1,
+        "state": {
+          "lastGroupId": 2,
+          "lastNodeId": 43,
+          "lastLinkId": 86,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Merge Videos",
+        "description": "Concatenates two videos end-to-end with optional resize, letterbox padding, and audio merge or drop.",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1990,
+            700,
+            152.5546875,
+            168
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1210,
+            614,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "2fb09e41-c5fa-4654-b9d2-569b59626ec4",
+            "name": "clip_to_resize",
+            "type": "VIDEO",
+            "linkIds": [
+              50
+            ],
+            "localized_name": "clip_to_resize",
+            "label": "base_video",
+            "pos": [
+              -1861.4453125,
+              724
+            ]
+          },
+          {
+            "id": "017f8d09-7900-4dc9-b95c-0cab31bcde7d",
+            "name": "base_video",
+            "type": "VIDEO",
+            "linkIds": [
+              51
+            ],
+            "localized_name": "base_video",
+            "label": "second_video",
+            "pos": [
+              -1861.4453125,
+              744
+            ]
+          },
+          {
+            "id": "a39894ce-1785-4037-b39c-b40d2e470c43",
+            "name": "pad_second_video",
+            "type": "BOOLEAN",
+            "linkIds": [
+              59
+            ],
+            "localized_name": "pad_second_video",
+            "label": "pad_second_video",
+            "pos": [
+              -1861.4453125,
+              764
+            ]
+          },
+          {
+            "id": "b4fb86cb-8d87-4193-8533-88a57df50e18",
+            "name": "interpolation",
+            "type": "COMBO",
+            "linkIds": [
+              60
+            ],
+            "pos": [
+              -1861.4453125,
+              784
+            ]
+          },
+          {
+            "id": "2413a2e2-cfdc-4d1d-9e2e-81e7acdf35e3",
+            "name": "padding_color",
+            "type": "COMBO",
+            "linkIds": [
+              62
+            ],
+            "pos": [
+              -1861.4453125,
+              804
+            ]
+          },
+          {
+            "id": "338b1e09-0efb-424f-949b-e730a0aa8527",
+            "name": "drop_audio",
+            "type": "BOOLEAN",
+            "linkIds": [
+              63
+            ],
+            "localized_name": "drop_audio",
+            "label": "drop_audio",
+            "pos": [
+              -1861.4453125,
+              824
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "be99efc6-7fb3-4059-93d0-136dc8cc8faf",
+            "name": "merged_video",
+            "type": "VIDEO",
+            "linkIds": [
+              16
+            ],
+            "localized_name": "merged_video",
+            "pos": [
+              1234,
+              638
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 11,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              -990,
+              1230
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 63
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 10,
+            "type": "EmptyAudio",
+            "pos": [
+              -990,
+              1060
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  22
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptyAudio",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              60,
+              44100,
+              2
+            ]
+          },
+          {
+            "id": 3,
+            "type": "ComfySwitchNode",
+            "pos": [
+              -370,
+              1010
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "AUDIO",
+                "link": 79
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "AUDIO",
+                "link": 22
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 14
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "AUDIO",
+                "links": [
+                  12
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 6,
+            "type": "ResizeAndPadImage",
+            "pos": [
+              -400,
+              440
+            ],
+            "size": [
+              270,
+              210
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 39
+              },
+              {
+                "localized_name": "target_width",
+                "name": "target_width",
+                "type": "INT",
+                "widget": {
+                  "name": "target_width"
+                },
+                "link": 4
+              },
+              {
+                "localized_name": "target_height",
+                "name": "target_height",
+                "type": "INT",
+                "widget": {
+                  "name": "target_height"
+                },
+                "link": 5
+              },
+              {
+                "localized_name": "padding_color",
+                "name": "padding_color",
+                "type": "COMBO",
+                "widget": {
+                  "name": "padding_color"
+                },
+                "link": 62
+              },
+              {
+                "localized_name": "interpolation",
+                "name": "interpolation",
+                "type": "COMBO",
+                "widget": {
+                  "name": "interpolation"
+                },
+                "link": 60
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  75
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ResizeAndPadImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              512,
+              512,
+              "white",
+              "lanczos"
+            ]
+          },
+          {
+            "id": 8,
+            "type": "CreateVideo",
+            "pos": [
+              880,
+              280
+            ],
+            "size": [
+              270,
+              140
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 19
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "shape": 7,
+                "type": "AUDIO",
+                "link": 12
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "fps"
+                },
+                "link": 15
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VIDEO",
+                "name": "VIDEO",
+                "type": "VIDEO",
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CreateVideo",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              30,
+              8
+            ]
+          },
+          {
+            "id": 2,
+            "type": "GetVideoComponents",
+            "pos": [
+              -1590,
+              460
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video",
+                "name": "video",
+                "type": "VIDEO",
+                "link": 51
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "links": [
+                  39,
+                  54
+                ]
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "type": "AUDIO",
+                "links": [
+                  83
+                ]
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "links": null
+              },
+              {
+                "localized_name": "bit_depth",
+                "name": "bit_depth",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetVideoComponents",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 27,
+            "type": "ComfySwitchNode",
+            "pos": [
+              60,
+              70
+            ],
+            "size": [
+              280,
+              130
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "IMAGE",
+                "link": 54
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "IMAGE",
+                "link": 75
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 56
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "IMAGE",
+                "links": [
+                  55
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 1,
+            "type": "GetVideoComponents",
+            "pos": [
+              -1600,
+              30
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video",
+                "name": "video",
+                "type": "VIDEO",
+                "link": 50
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "links": [
+                  3,
+                  17
+                ]
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "type": "AUDIO",
+                "links": [
+                  84
+                ]
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "links": [
+                  15
+                ]
+              },
+              {
+                "localized_name": "bit_depth",
+                "name": "bit_depth",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetVideoComponents",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 7,
+            "type": "GetImageSize",
+            "pos": [
+              -1000,
+              480
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 3
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  4
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  5
+                ]
+              },
+              {
+                "localized_name": "batch_size",
+                "name": "batch_size",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GetImageSize",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 28,
+            "type": "PrimitiveBoolean",
+            "pos": [
+              -1590,
+              190
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 59
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  56
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "PrimitiveBoolean",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              false
+            ]
+          },
+          {
+            "id": 13,
+            "type": "BatchImagesNode",
+            "pos": [
+              530,
+              10
+            ],
+            "size": [
+              230,
+              120
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "image0",
+                "localized_name": "images.image0",
+                "name": "images.image0",
+                "type": "IMAGE",
+                "link": 17
+              },
+              {
+                "label": "image1",
+                "localized_name": "images.image1",
+                "name": "images.image1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 55
+              },
+              {
+                "label": "image2",
+                "localized_name": "images.image2",
+                "name": "images.image2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  19
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "BatchImagesNode",
+              "cnr_id": "comfy-core",
+              "ver": "0.21.1",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 42,
+            "type": "AudioConcat",
+            "pos": [
+              -990,
+              900
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "audio1",
+                "name": "audio1",
+                "type": "AUDIO",
+                "link": 83
+              },
+              {
+                "localized_name": "audio2",
+                "name": "audio2",
+                "type": "AUDIO",
+                "link": 84
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  79
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "AudioConcat"
+            },
+            "widgets_values": [
+              "after"
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Audio",
+            "bounding": [
+              -1000,
+              820,
+              915,
+              496
+            ],
+            "color": "#3f789e",
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 22,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 14,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 39,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 4,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 6,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 5,
+            "origin_id": 7,
+            "origin_slot": 1,
+            "target_id": 6,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 3,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 17,
+            "origin_id": 1,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 19,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 12,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 15,
+            "origin_id": 1,
+            "origin_slot": 2,
+            "target_id": 8,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 16,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 50,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 51,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 2,
+            "target_slot": 0,
+            "type": "VIDEO"
+          },
+          {
+            "id": 54,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 55,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 56,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 59,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 28,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 60,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 6,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 62,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 6,
+            "target_slot": 3,
+            "type": "COMBO"
+          },
+          {
+            "id": 63,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 75,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 79,
+            "origin_id": 42,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 83,
+            "origin_id": 2,
+            "origin_slot": 1,
+            "target_id": 42,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 84,
+            "origin_id": 1,
+            "origin_slot": 1,
+            "target_id": 42,
+            "target_slot": 1,
+            "type": "AUDIO"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.48.7",
+    "ds": {
+      "scale": 0.4153414702717205,
+      "offset": [
+        1504.195224019496,
+        -6911.375448598833
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/audio_minimax_music_3.json
+++ b/tests/comfy_cli/fixtures/gallery/audio_minimax_music_3.json
@@ -1,0 +1,1123 @@
+{
+  "id": "08882d3e-437d-43da-b498-083de04a60a6",
+  "revision": 0,
+  "last_node_id": 43,
+  "last_link_id": 63,
+  "nodes": [
+    {
+      "id": 35,
+      "type": "SaveAudioAdvanced",
+      "pos": [
+        2150,
+        630
+      ],
+      "size": [
+        750,
+        160
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 42
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.31.0"
+      },
+      "widgets_values": [
+        "audio/audio_minimax_music3",
+        "mp3",
+        "V0"
+      ]
+    },
+    {
+      "id": 37,
+      "type": "ac99f841-a3de-4329-9564-953b81cf9e16",
+      "pos": [
+        1620,
+        630
+      ],
+      "size": [
+        490,
+        540
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "tiled_decode",
+          "name": "switch",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "switch"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            42
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.31.0",
+        "previewExposures": []
+      },
+      "widgets_values": [
+        "Global Metadata: Lo-fi hip-hop, chillhop. 78 BPM, D flat major, major scale with jazzy extensions. Laid-back and dreamy throughout, a gentle warm drift with a subtle late-night glow that deepens in the middle and dissolves softly at the end. Studying, raining-outside, headphones-on late-night listening. Bedroom production: muddy warm texture, heavy vinyl crackle, tape hiss and wow-flutter pitch wobble, low-passed dusty mix, soft-clipped drums, everything slightly detuned and cozy.\n\nVocal Details: Soft androgynous vocal, hushed half-sung half-spoken delivery, sitting low in the mix like another instrument, lazy behind-the-beat phrasing, gentle breathy timbre. Sparse murmured double-tracked harmonies, occasional wordless \"mmm\" and \"ooh\" hums drenched in tape delay and warm spring reverb. Long stretches with no vocals at all.\n\nArrangement: Dusty boom-bap drums with a soft thumping kick, cracked snare with lazy swing, brushed hi-hats, low round sub bass. Warm Rhodes piano chords with slow chorus wobble as the harmonic bed, mellow jazzy guitar licks answering the vocal lines, constant vinyl crackle as texture. Intro: rain and vinyl noise, solo Rhodes chords fading in, drums slipping in halfway. Verses: minimal — drums, bass, Rhodes, soft guitar fills between lines. Instrumental sections: guitar and Rhodes trade relaxed jazzy phrases over the beat, occasional muted trumpet ghost notes far in the background. Bridge: drums drop away to rain, crackle, and floating detuned Rhodes, then the beat eases back in. Outro: elements fade one by one until only vinyl crackle and a last unresolved Rhodes chord remain.",
+        "[Intro]\nMmm...\n(rain on the window)\nOoh...\n\n[Verse]\nMidnight and the canvas glows\nDragging little wires where the current flows\nType a quiet dream, let the sampler drift\nNoise into a picture, like the fog just lifts\nTwenty slow steps, I'm in no hurry now\nLatents turning colors and I don't know how\nEvery render's like a polaroid I found\nSoft focus memories, no sound\n\n[Instrumental]\n\n[Verse]\nQueue another frame, let the motion breathe\nPictures start to move like the falling leaves\nVideo drifting by at twenty-four\nLittle animations on my bedroom floor\nSeed after seed like the rain outside\nSome of them are keepers, some I let slide\nSave the ones that feel like a Sunday slow\nNode to node to node... and off we go\n\n[Chorus]\nMmm... let it render on\n(take your time, take your time)\nOoh... by the morning it'll all be done\n(one more queue, one more try)\n\n[Instrumental]\n\n[Bridge]\nRain keeps drawing pictures on the glass...\nMy machine keeps dreaming...\nNeither of us fast...\n\n[Chorus]\nMmm... let it render on\n(take your time, take your time)\nOoh... by the morning it'll all be done\n(one more queue, one more try)\n\n[Instrumental]\n\n[Outro]\nMmm...\n(node to node)\nOoh... goodnight",
+        60,
+        197122968890040,
+        "minimax_music3_dit_fp16.safetensors",
+        "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+        "minimax_music3_dav.safetensors",
+        true
+      ]
+    },
+    {
+      "id": 39,
+      "type": "MarkdownNote",
+      "pos": [
+        1050,
+        630
+      ],
+      "size": [
+        520,
+        660
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Note: MiniMax Music 3",
+      "properties": {},
+      "widgets_values": [
+        "## MiniMax Music 3\n\nA music generation model by MiniMax that creates complete songs up to 5 minutes long with stable structure and high audio quality. Two inputs drive it: **Caption** (structured music description: style, mood, vocals, arrangement) and **Lyrics** (with `[intro]` `[verse]` `[chorus]` `[bridge]` `[outro]` tags controlling song structure).\n\n### Parameters\n\n| Parameter | Description |\n|---|---|\n| Caption | Music description. Write it in three sections — Global Metadata → Vocal Details → Arrangement. The more specific, the closer the result. |\n| Lyrics | Song lyrics + section tags. Tags are the only executable structural instructions; the lyric text itself only conveys mood. |\n| max_duration | Target song length in seconds (default 120 = 2 minutes; the model supports up to ~300 s / 5 minutes). Longer songs take more time and VRAM. |\n| seed | Random seed for the generation. Keep it fixed to reproduce the same song; change it to get a different take. |\n| Model files | diffusion model / text encoder / VAE.|\n| Tiled decode | Decode the audio VAE in overlapping tiles to drastically cut VRAM usage — helpful for long songs on low-VRAM GPUs. Slightly slower, with a small risk of seams at tile boundaries; turn it off on high-VRAM GPUs for the best quality. |\n\n### Prompt Writing Guide\n\nYou can find an official [Music Caption Rewriter Skill here](https://github.com/MiniMax-AI/MiniMax-Music3)"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 40,
+      "type": "MarkdownNote",
+      "pos": [
+        560,
+        630
+      ],
+      "size": [
+        440,
+        680
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "## Model Links\n\n**diffusion_models**\n- [minimax_music3_dit_int8_convrot.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_int8_convrot.safetensors) # For low VRAM\n- [minimax_music3_dit_fp16.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_fp16.safetensors)\n\n**text_encoders**\n\n- [minimax_music3_text_encoder_pruned_int8_convrot.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors)\n\n**vae**\n\n- [minimax_music3_dav.safetensors](https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/vae/minimax_music3_dav.safetensors)\n\n\n## Model Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 diffusion_models/\n│   │   ├── minimax_music3_dit_int8_convrot.safetensors # For low VRAM\n│   │   └── minimax_music3_dit_fp16.safetensors\n│   ├── 📂 text_encoders/\n│   │   └── minimax_music3_text_encoder_pruned_int8_convrot.safetensors\n│   └── 📂 vae/\n│       └── minimax_music3_dav.safetensors\n```\n\n## Report Issue\n\nNote: Please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud updates follow stable releases, so some nightly-supported models may not be available yet.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/comfyanonymous/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      42,
+      37,
+      0,
+      35,
+      0,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "ac99f841-a3de-4329-9564-953b81cf9e16",
+        "version": 1,
+        "state": {
+          "lastGroupId": 0,
+          "lastNodeId": 43,
+          "lastLinkId": 63,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Music (MiniMax Music 3)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            320,
+            820,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            3210,
+            380,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "9f92b5c5-dadc-4b0f-84d9-b5ed2b3a0842",
+            "name": "caption",
+            "type": "STRING",
+            "linkIds": [
+              45
+            ],
+            "pos": [
+              424,
+              844
+            ]
+          },
+          {
+            "id": "bb9d2920-ba98-4c51-be7d-4b5736b14407",
+            "name": "lyrics",
+            "type": "STRING",
+            "linkIds": [
+              46
+            ],
+            "pos": [
+              424,
+              864
+            ]
+          },
+          {
+            "id": "be60d2f1-fc99-4ed6-a057-130a7b83945f",
+            "name": "max_duration",
+            "type": "FLOAT",
+            "linkIds": [
+              47
+            ],
+            "pos": [
+              424,
+              884
+            ]
+          },
+          {
+            "id": "a7f66596-0413-4906-a08f-475af0521252",
+            "name": "seed",
+            "type": "INT",
+            "linkIds": [
+              54
+            ],
+            "pos": [
+              424,
+              904
+            ]
+          },
+          {
+            "id": "cbfb7b7b-357f-44ab-80cb-8748020a9880",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              55
+            ],
+            "pos": [
+              424,
+              924
+            ]
+          },
+          {
+            "id": "ec2e20dc-2e7b-4147-922f-5f5f26ac9854",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              56
+            ],
+            "pos": [
+              424,
+              944
+            ]
+          },
+          {
+            "id": "eeefaa94-f342-415e-96e7-eb13dcccbac0",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              57
+            ],
+            "pos": [
+              424,
+              964
+            ]
+          },
+          {
+            "id": "6da74b03-27d0-487e-b8d6-f94018b2ca9a",
+            "name": "switch",
+            "type": "BOOLEAN",
+            "linkIds": [
+              63
+            ],
+            "label": "tiled_decode",
+            "pos": [
+              424,
+              984
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "82bef6fd-2dee-4579-b4ed-7d679d18279f",
+            "name": "AUDIO",
+            "type": "AUDIO",
+            "linkIds": [
+              62
+            ],
+            "localized_name": "AUDIO",
+            "pos": [
+              3234,
+              404
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 6,
+            "type": "UNETLoader",
+            "pos": [
+              700,
+              380
+            ],
+            "size": [
+              480,
+              90
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "showAdvanced": false,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 55
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  6
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "UNETLoader",
+              "models": [
+                {
+                  "name": "minimax_music3_dit_fp16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/diffusion_models/minimax_music3_dit_fp16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_dit_fp16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 13,
+            "type": "MiniMaxMusic3TextEncode",
+            "pos": [
+              1230,
+              380
+            ],
+            "size": [
+              500,
+              750
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 18
+              },
+              {
+                "localized_name": "caption",
+                "name": "caption",
+                "type": "STRING",
+                "widget": {
+                  "name": "caption"
+                },
+                "link": 45
+              },
+              {
+                "localized_name": "lyrics",
+                "name": "lyrics",
+                "type": "STRING",
+                "widget": {
+                  "name": "lyrics"
+                },
+                "link": 46
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 52
+              },
+              {
+                "localized_name": "max_duration",
+                "name": "max_duration",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "max_duration"
+                },
+                "link": 47
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  15,
+                  16
+                ]
+              },
+              {
+                "localized_name": "seconds",
+                "name": "seconds",
+                "type": "FLOAT",
+                "links": [
+                  20
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "MiniMaxMusic3TextEncode"
+            },
+            "widgets_values": [
+              "",
+              "",
+              222,
+              "fixed",
+              60,
+              1.7,
+              50
+            ]
+          },
+          {
+            "id": 3,
+            "type": "CLIPLoader",
+            "pos": [
+              700,
+              550
+            ],
+            "size": [
+              480,
+              120
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 56
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  18
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "CLIPLoader",
+              "models": [
+                {
+                  "name": "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+                  "directory": "text_encoders"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_text_encoder_pruned_int8_convrot.safetensors",
+              "minimax",
+              "default"
+            ]
+          },
+          {
+            "id": 7,
+            "type": "VAELoader",
+            "pos": [
+              700,
+              750
+            ],
+            "size": [
+              480,
+              70
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 57
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  13,
+                  59
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAELoader",
+              "models": [
+                {
+                  "name": "minimax_music3_dav.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/MiniMax-Music-3/resolve/main/vae/minimax_music3_dav.safetensors",
+                  "directory": "vae"
+                }
+              ]
+            },
+            "widgets_values": [
+              "minimax_music3_dav.safetensors"
+            ]
+          },
+          {
+            "id": 10,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              1820,
+              540
+            ],
+            "size": [
+              230,
+              40
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 16
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  8
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "ConditioningZeroOut"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 15,
+            "type": "EmptyMiniMaxMusic3LatentAudio",
+            "pos": [
+              1780,
+              380
+            ],
+            "size": [
+              350,
+              90
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "seconds",
+                "name": "seconds",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "seconds"
+                },
+                "link": 20
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  21
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "EmptyMiniMaxMusic3LatentAudio"
+            },
+            "widgets_values": [
+              120,
+              1
+            ]
+          },
+          {
+            "id": 9,
+            "type": "KSampler",
+            "pos": [
+              2170,
+              380
+            ],
+            "size": [
+              370,
+              270
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 6
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 15
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 8
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 21
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 53
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  12,
+                  58
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "KSampler"
+            },
+            "widgets_values": [
+              1111111112,
+              "fixed",
+              30,
+              1.7,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 12,
+            "type": "VAEDecodeAudio",
+            "pos": [
+              2590,
+              380
+            ],
+            "size": [
+              230,
+              60
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 12
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 13
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  60
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAEDecodeAudio"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 38,
+            "type": "SeedNode",
+            "pos": [
+              890,
+              970
+            ],
+            "size": [
+              270,
+              90
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 54
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "links": [
+                  52,
+                  53
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "SeedNode"
+            },
+            "widgets_values": [
+              0,
+              "randomize"
+            ]
+          },
+          {
+            "id": 42,
+            "type": "VAEDecodeAudioTiled",
+            "pos": [
+              2580,
+              500
+            ],
+            "size": [
+              280,
+              110
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 58
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 59
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "AUDIO",
+                "name": "AUDIO",
+                "type": "AUDIO",
+                "links": [
+                  61
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "VAEDecodeAudioTiled"
+            },
+            "widgets_values": [
+              1536,
+              64
+            ]
+          },
+          {
+            "id": 43,
+            "type": "ComfySwitchNode",
+            "pos": [
+              2600,
+              690
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "AUDIO",
+                "link": 60
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "AUDIO",
+                "link": 61
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 63
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "AUDIO",
+                "links": [
+                  62
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.31.0",
+              "Node name for S&R": "ComfySwitchNode"
+            },
+            "widgets_values": [
+              false
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 18,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 16,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 20,
+            "origin_id": 13,
+            "origin_slot": 1,
+            "target_id": 15,
+            "target_slot": 0,
+            "type": "FLOAT"
+          },
+          {
+            "id": 6,
+            "origin_id": 6,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 15,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 8,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 21,
+            "origin_id": 15,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 12,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 13,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 12,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 45,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 46,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 13,
+            "target_slot": 2,
+            "type": "STRING"
+          },
+          {
+            "id": 47,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 13,
+            "target_slot": 4,
+            "type": "FLOAT"
+          },
+          {
+            "id": 52,
+            "origin_id": 38,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 3,
+            "type": "INT"
+          },
+          {
+            "id": 53,
+            "origin_id": 38,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 54,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 38,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 55,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 6,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 56,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 57,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 58,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 42,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 59,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 42,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 60,
+            "origin_id": 12,
+            "origin_slot": 0,
+            "target_id": 43,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 61,
+            "origin_id": 42,
+            "origin_slot": 0,
+            "target_id": 43,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 62,
+            "origin_id": 43,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "AUDIO"
+          },
+          {
+            "id": 63,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 43,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          }
+        ],
+        "extra": {}
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7901285864132895,
+      "offset": [
+        -390.5963888708135,
+        -245.41184011189858
+      ]
+    },
+    "frontendVersion": "1.48.7",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/flux_dev_checkpoint_example.json
+++ b/tests/comfy_cli/fixtures/gallery/flux_dev_checkpoint_example.json
@@ -1,0 +1,969 @@
+{
+  "id": "9879cb25-f885-4a02-ba58-5a5b8eda769a",
+  "revision": 0,
+  "last_node_id": 56,
+  "last_link_id": 76,
+  "nodes": [
+    {
+      "id": 40,
+      "type": "MarkdownNote",
+      "pos": [
+        -730,
+        630
+      ],
+      "size": [
+        540,
+        887.15625
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "For Local User",
+      "properties": {},
+      "widgets_values": [
+        "Guide: [Subgraph](https://docs.comfy.org/interface/features/subgraph)\n\n## Model links\n\n**text_encoders**\n\n- [clip_l.safetensors](https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors)\n- [t5xxl_fp16.safetensors](https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors)\n\n**diffusion_models**\n\n- [flux1-dev.safetensors](https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev.safetensors)\n\n**vae**\n\n- [ae.safetensors](https://huggingface.co/Comfy-Org/Lumina_Image_2.0_Repackaged/resolve/main/split_files/vae/ae.safetensors)\n\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 text_encoders/\n│   │      ├── clip_l.safetensors\n│   │      └── t5xxl_fp16.safetensors\n│   ├── 📂 diffusion_models/\n│   │      └── flux1-dev.safetensors\n│   └── 📂 vae/\n│          └── ae.safetensors\n```\n\n## Report issue\n\nNote: please update ComfyUI first ([guide](https://docs.comfy.org/installation/update_comfyui)) and prepare required models. Desktop/Cloud will be updated after the stable release; nightly-supported models may not be included yet, please wait for the next stable release.\n\n- Cannot run / runtime errors: [ComfyUI/issues](https://github.com/Comfy-Org/ComfyUI/issues)\n- UI / frontend issues: [ComfyUI_frontend/issues](https://github.com/Comfy-Org/ComfyUI_frontend/issues)\n- Workflow issues: [workflow_templates/issues](https://github.com/Comfy-Org/workflow_templates/issues)\n\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        460.000012246621,
+        629.9999713116897
+      ],
+      "size": [
+        630,
+        680
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 72
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.4.0",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "Flux.1_Dev"
+      ]
+    },
+    {
+      "id": 56,
+      "type": "e2a55522-bf16-4d9f-a222-5b8788ef2982",
+      "pos": [
+        -110.00000931000295,
+        630.0000115388268
+      ],
+      "size": [
+        510,
+        640
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            72
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "51",
+            "text"
+          ],
+          [
+            "50",
+            "width"
+          ],
+          [
+            "50",
+            "height"
+          ],
+          [
+            "48",
+            "unet_name"
+          ],
+          [
+            "49",
+            "clip_name1"
+          ],
+          [
+            "49",
+            "clip_name2"
+          ],
+          [
+            "47",
+            "vae_name"
+          ],
+          [
+            "52",
+            "seed"
+          ],
+          [
+            "52",
+            "control_after_generate"
+          ]
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        },
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1"
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      72,
+      56,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "e2a55522-bf16-4d9f-a222-5b8788ef2982",
+        "version": 1,
+        "state": {
+          "lastGroupId": 3,
+          "lastNodeId": 56,
+          "lastLinkId": 76,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Image (Flux.1 Dev)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -1130,
+            410,
+            120,
+            180
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            760,
+            680,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "669e384e-5e26-4291-9bac-e1d1f04b4a16",
+            "name": "text",
+            "type": "STRING",
+            "linkIds": [
+              68
+            ],
+            "label": "prompt",
+            "pos": [
+              -1030,
+              430
+            ]
+          },
+          {
+            "id": "5a5c0b01-5836-4ca6-a24f-68c0a4fb9802",
+            "name": "width",
+            "type": "INT",
+            "linkIds": [
+              69
+            ],
+            "pos": [
+              -1030,
+              450
+            ]
+          },
+          {
+            "id": "5e01104a-ed7f-457b-aaee-934e8ecc088d",
+            "name": "height",
+            "type": "INT",
+            "linkIds": [
+              70
+            ],
+            "pos": [
+              -1030,
+              470
+            ]
+          },
+          {
+            "id": "61106c75-ce1d-46dc-94a8-7b6de0e930d2",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              73
+            ],
+            "pos": [
+              -1030,
+              490
+            ]
+          },
+          {
+            "id": "88aaaea3-31c1-47cd-ad83-2a9414a3122d",
+            "name": "clip_name1",
+            "type": "COMBO",
+            "linkIds": [
+              74
+            ],
+            "pos": [
+              -1030,
+              510
+            ]
+          },
+          {
+            "id": "323e0873-f219-4307-a95d-2c1b92e5b60c",
+            "name": "clip_name2",
+            "type": "COMBO",
+            "linkIds": [
+              75
+            ],
+            "pos": [
+              -1030,
+              530
+            ]
+          },
+          {
+            "id": "fbc1372b-943f-43a9-a772-020630f409ab",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              76
+            ],
+            "pos": [
+              -1030,
+              550
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "2185cb4d-8689-4cf8-b345-75319fb46a8e",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              9
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              780,
+              700
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 47,
+            "type": "VAELoader",
+            "pos": [
+              -780,
+              620
+            ],
+            "size": [
+              270,
+              108
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 76
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  58
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "ae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/Lumina_Image_2.0_Repackaged/resolve/main/split_files/vae/ae.safetensors",
+                  "directory": "vae"
+                }
+              ]
+            },
+            "widgets_values": [
+              "ae.safetensors"
+            ]
+          },
+          {
+            "id": 48,
+            "type": "UNETLoader",
+            "pos": [
+              -780,
+              150
+            ],
+            "size": [
+              270,
+              108
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 73
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  61
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "flux1-dev.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ]
+            },
+            "widgets_values": [
+              "flux1-dev.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 49,
+            "type": "DualCLIPLoader",
+            "pos": [
+              -780,
+              350
+            ],
+            "size": [
+              270,
+              175.984375
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name1",
+                "name": "clip_name1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name1"
+                },
+                "link": 74
+              },
+              {
+                "localized_name": "clip_name2",
+                "name": "clip_name2",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name2"
+                },
+                "link": 75
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  64
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "DualCLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40",
+              "models": [
+                {
+                  "name": "clip_l.safetensors",
+                  "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors",
+                  "directory": "text_encoders"
+                },
+                {
+                  "name": "t5xxl_fp16.safetensors",
+                  "url": "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors",
+                  "directory": "text_encoders"
+                }
+              ]
+            },
+            "widgets_values": [
+              "clip_l.safetensors",
+              "t5xxl_fp16.safetensors",
+              "flux",
+              "default"
+            ]
+          },
+          {
+            "id": 50,
+            "type": "EmptySD3LatentImage",
+            "pos": [
+              -800,
+              870
+            ],
+            "size": [
+              270,
+              168
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 69
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 70
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  51
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptySD3LatentImage",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [
+              1024,
+              1024,
+              1
+            ]
+          },
+          {
+            "id": 51,
+            "type": "CLIPTextEncode",
+            "pos": [
+              -439.999938141949,
+              160.00001459060425
+            ],
+            "size": [
+              450,
+              500
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 64
+              },
+              {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {
+                  "name": "text"
+                },
+                "link": 68
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  65,
+                  66
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1"
+            },
+            "widgets_values": [
+              "Beautiful photography of a gorgeous-haired female artist, natural and authentic, her hair styled in a messy casual bun, smiling joyfully and looking directly at the camera, cinematic lighting, soft natural daylight, shallow depth of field, warm gentle tones, film grain, high detail, 8K, realistic portrait\n"
+            ],
+            "color": "#232",
+            "bgcolor": "#353"
+          },
+          {
+            "id": 52,
+            "type": "KSampler",
+            "pos": [
+              70.00043027350216,
+              110.00000338120918
+            ],
+            "size": [
+              360,
+              630
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 61
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 65
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 63
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 51
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  52
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [
+              53943644181156,
+              "randomize",
+              20,
+              1,
+              "euler",
+              "simple",
+              1
+            ]
+          },
+          {
+            "id": 53,
+            "type": "VAEDecode",
+            "pos": [
+              80,
+              810
+            ],
+            "size": [
+              340,
+              96
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 52
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 58
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  9
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 54,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              -220,
+              720
+            ],
+            "size": [
+              225,
+              72
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 66
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  63
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ConditioningZeroOut",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {}
+              },
+              "cnr_id": "comfy-core",
+              "ver": "0.3.40"
+            },
+            "widgets_values": [],
+            "color": "#223",
+            "bgcolor": "#335"
+          }
+        ],
+        "groups": [
+          {
+            "id": 1,
+            "title": "Step 1 - Load Models Here",
+            "bounding": [
+              -820,
+              70,
+              350,
+              680
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 2,
+            "title": "Step 2 - Image Size",
+            "bounding": [
+              -820,
+              770,
+              350,
+              310
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step 3 - Prompt",
+            "bounding": [
+              -450,
+              70,
+              480,
+              680
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 52,
+            "origin_id": 52,
+            "origin_slot": 0,
+            "target_id": 53,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 58,
+            "origin_id": 47,
+            "origin_slot": 0,
+            "target_id": 53,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 61,
+            "origin_id": 48,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 63,
+            "origin_id": 54,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 51,
+            "origin_id": 50,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 9,
+            "origin_id": 53,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 64,
+            "origin_id": 49,
+            "origin_slot": 0,
+            "target_id": 51,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 65,
+            "origin_id": 51,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 66,
+            "origin_id": 51,
+            "origin_slot": 0,
+            "target_id": 54,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 68,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 51,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 69,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 50,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 70,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 50,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 73,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 48,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 74,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 49,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 75,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 49,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 76,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 47,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ds": {
+            "scale": 0.7513148009015777,
+            "offset": [
+              1726.1426909346173,
+              146.66925047394233
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6352941176470595,
+      "offset": [
+        879.7861322211784,
+        -201.76040190950405
+      ]
+    },
+    "frontendVersion": "1.41.13",
+    "workflowRendererVersion": "LG",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/image_z_image_turbo.json
+++ b/tests/comfy_cli/fixtures/gallery/image_z_image_turbo.json
@@ -1,0 +1,1064 @@
+{
+  "id": "9ae6082b-c7f4-433c-9971-7a8f65a3ea65",
+  "revision": 0,
+  "last_node_id": 61,
+  "last_link_id": 75,
+  "nodes": [
+    {
+      "id": 35,
+      "type": "MarkdownNote",
+      "pos": [
+        -420.00005528861476,
+        199.99998755061938
+      ],
+      "size": [
+        510,
+        771.953125
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Model link",
+      "properties": {},
+      "widgets_values": [
+        "## Report workflow issue\n\nIf you found any issues when running this workflow, [report template issue here](https://github.com/Comfy-Org/workflow_templates/issues)\n\n\n## Model links\n\n**text_encoders**\n\n- [qwen_3_4b.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors)\n\n**diffusion_models**\n\n- [z_image_turbo_bf16.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors)\n\n**vae**\n\n- [ae.safetensors](https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors)\n\n\nModel Storage Location\n\n```\n📂 ComfyUI/\n├── 📂 models/\n│   ├── 📂 text_encoders/\n│   │      └── qwen_3_4b.safetensors\n│   ├── 📂 diffusion_models/\n│   │      └── z_image_turbo_bf16.safetensors\n│   └── 📂 vae/\n│          └── ae.safetensors\n```\n"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 9,
+      "type": "SaveImage",
+      "pos": [
+        569.9998957637683,
+        199.99998755061938
+      ],
+      "size": [
+        780,
+        660
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 62
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage",
+        "cnr_id": "comfy-core",
+        "ver": "0.3.64",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": [
+        "z-image-turbo"
+      ]
+    },
+    {
+      "id": 57,
+      "type": "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1",
+      "pos": [
+        130,
+        200
+      ],
+      "size": [
+        400,
+        470
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "prompt",
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            62
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "27",
+            "text"
+          ],
+          [
+            "13",
+            "width"
+          ],
+          [
+            "13",
+            "height"
+          ],
+          [
+            "3",
+            "seed"
+          ],
+          [
+            "3",
+            "steps"
+          ],
+          [
+            "28",
+            "unet_name"
+          ],
+          [
+            "30",
+            "clip_name"
+          ],
+          [
+            "29",
+            "vae_name"
+          ],
+          [
+            "3",
+            "control_after_generate"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.3.73",
+        "enableTabs": false,
+        "tabWidth": 65,
+        "tabXOffset": 10,
+        "hasSecondTab": false,
+        "secondTabText": "Send Back",
+        "secondTabOffset": 80,
+        "secondTabWidth": 65
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      62,
+      57,
+      0,
+      9,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "f2fdebf6-dfaf-43b6-9eb2-7f70613cfdc1",
+        "version": 1,
+        "state": {
+          "lastGroupId": 4,
+          "lastNodeId": 61,
+          "lastLinkId": 75,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Text to Image (Z-Image-Turbo)",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -560,
+            480,
+            120,
+            200
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1670,
+            320,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "fb178669-e742-4a53-8a69-7df59834dfd8",
+            "name": "text",
+            "type": "STRING",
+            "linkIds": [
+              34
+            ],
+            "label": "prompt",
+            "pos": [
+              -460,
+              500
+            ]
+          },
+          {
+            "id": "dd780b3c-23e9-46ff-8469-156008f42e5a",
+            "name": "width",
+            "type": "INT",
+            "linkIds": [
+              35
+            ],
+            "pos": [
+              -460,
+              520
+            ]
+          },
+          {
+            "id": "7b08d546-6bb0-4ef9-82e9-ffae5e1ee6bc",
+            "name": "height",
+            "type": "INT",
+            "linkIds": [
+              36
+            ],
+            "pos": [
+              -460,
+              540
+            ]
+          },
+          {
+            "id": "f77677f7-6bf6-4c19-a71f-c4a553d5981e",
+            "name": "seed",
+            "type": "INT",
+            "linkIds": [
+              71
+            ],
+            "pos": [
+              -460,
+              560
+            ]
+          },
+          {
+            "id": "ef9a9fb1-5983-4bc9-a60b-cf5aec48bff1",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              72
+            ],
+            "pos": [
+              -460,
+              580
+            ]
+          },
+          {
+            "id": "a20a1b30-785f-4a04-bb6d-3d61adab9764",
+            "name": "unet_name",
+            "type": "COMBO",
+            "linkIds": [
+              73
+            ],
+            "pos": [
+              -460,
+              600
+            ]
+          },
+          {
+            "id": "4af8fc2b-4655-4086-8240-45f8cb38c6f6",
+            "name": "clip_name",
+            "type": "COMBO",
+            "linkIds": [
+              74
+            ],
+            "pos": [
+              -460,
+              620
+            ]
+          },
+          {
+            "id": "4d518693-2807-439c-9cb6-cffd23ccba2c",
+            "name": "vae_name",
+            "type": "COMBO",
+            "linkIds": [
+              75
+            ],
+            "pos": [
+              -460,
+              640
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "1fa72a21-ce00-4952-814e-1f2ffbe87d1d",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              16
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1690,
+              340
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 30,
+            "type": "CLIPLoader",
+            "pos": [
+              29.99986879338951,
+              422.66401138970815
+            ],
+            "size": [
+              270,
+              141.328125
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip_name",
+                "name": "clip_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name"
+                },
+                "link": 74
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  28
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "qwen_3_4b.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors",
+                  "directory": "text_encoders"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "qwen_3_4b.safetensors",
+              "lumina2",
+              "default"
+            ]
+          },
+          {
+            "id": 29,
+            "type": "VAELoader",
+            "pos": [
+              29.99986879338951,
+              649.9999131978064
+            ],
+            "size": [
+              270,
+              106.65625
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": 75
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  27
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAELoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "ae.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors",
+                  "directory": "vae"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "ae.safetensors"
+            ]
+          },
+          {
+            "id": 33,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              629.9998362150791,
+              959.999861458308
+            ],
+            "size": [
+              225,
+              72
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 32
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  33
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ConditioningZeroOut",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 8,
+            "type": "VAEDecode",
+            "pos": [
+              1319.9997837897204,
+              229.99998088352976
+            ],
+            "size": [
+              225,
+              96
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 14
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 27
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "VAEDecode",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 28,
+            "type": "UNETLoader",
+            "pos": [
+              29.99986879338951,
+              229.99998088352976
+            ],
+            "size": [
+              270,
+              106.65625
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "unet_name",
+                "name": "unet_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "unet_name"
+                },
+                "link": 73
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  26
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "UNETLoader",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "models": [
+                {
+                  "name": "z_image_turbo_bf16.safetensors",
+                  "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors",
+                  "directory": "diffusion_models"
+                }
+              ],
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "z_image_turbo_bf16.safetensors",
+              "default"
+            ]
+          },
+          {
+            "id": 27,
+            "type": "CLIPTextEncode",
+            "pos": [
+              399.9978589832622,
+              229.99946973987727
+            ],
+            "size": [
+              450,
+              650
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "clip",
+                "name": "clip",
+                "type": "CLIP",
+                "link": 28
+              },
+              {
+                "localized_name": "text",
+                "name": "text",
+                "type": "STRING",
+                "widget": {
+                  "name": "text"
+                },
+                "link": 34
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  30,
+                  32
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CLIPTextEncode",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.73",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              "Latina female with thick wavy hair, harbor boats and pastel houses behind. Breezy seaside light, warm tones, cinematic close-up. "
+            ]
+          },
+          {
+            "id": 13,
+            "type": "EmptySD3LatentImage",
+            "pos": [
+              39.999933078393155,
+              889.9999101400169
+            ],
+            "size": [
+              260,
+              168
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 35
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 36
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  17
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "EmptySD3LatentImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              1024,
+              1024,
+              1
+            ]
+          },
+          {
+            "id": 11,
+            "type": "ModelSamplingAuraFlow",
+            "pos": [
+              949.9997988929108,
+              229.99998088352976
+            ],
+            "size": [
+              310,
+              104
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 26
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "slot_index": 0,
+                "links": [
+                  13
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ModelSamplingAuraFlow",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              3
+            ]
+          },
+          {
+            "id": 3,
+            "type": "KSampler",
+            "pos": [
+              949.9997988929108,
+              399.9999517059391
+            ],
+            "size": [
+              320,
+              341.328125
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 13
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 30
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 33
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 17
+              },
+              {
+                "localized_name": "seed",
+                "name": "seed",
+                "type": "INT",
+                "widget": {
+                  "name": "seed"
+                },
+                "link": 71
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 72
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "slot_index": 0,
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "KSampler",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "enableTabs": false,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "hasSecondTab": false,
+              "secondTabText": "Send Back",
+              "secondTabOffset": 80,
+              "secondTabWidth": 65
+            },
+            "widgets_values": [
+              0,
+              "randomize",
+              8,
+              1,
+              "res_multistep",
+              "simple",
+              1
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 2,
+            "title": "Step2 - Image size",
+            "bounding": [
+              10,
+              820,
+              320,
+              280
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 3,
+            "title": "Step3 - Prompt",
+            "bounding": [
+              360,
+              130,
+              530,
+              970
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          },
+          {
+            "id": 4,
+            "title": "Step1 - Load models",
+            "bounding": [
+              0,
+              130,
+              330,
+              660
+            ],
+            "color": "#3f789e",
+            "font_size": 24,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 32,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 33,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 26,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 14,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 27,
+            "origin_id": 29,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 13,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 30,
+            "origin_id": 27,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 33,
+            "origin_id": 33,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 17,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": 3,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 28,
+            "origin_id": 30,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 0,
+            "type": "CLIP"
+          },
+          {
+            "id": 16,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 34,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 27,
+            "target_slot": 1,
+            "type": "STRING"
+          },
+          {
+            "id": 35,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 36,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 13,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 71,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 3,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 72,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 3,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 73,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 28,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 74,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 30,
+            "target_slot": 0,
+            "type": "COMBO"
+          },
+          {
+            "id": 75,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 29,
+            "target_slot": 0,
+            "type": "COMBO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.6731331717151416,
+      "offset": [
+        841.4738691917171,
+        312.8272327558304
+      ]
+    },
+    "frontendVersion": "1.42.15",
+    "workflowRendererVersion": "LG",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/template_horizontal_vertical_extension.json
+++ b/tests/comfy_cli/fixtures/gallery/template_horizontal_vertical_extension.json
@@ -1,0 +1,1484 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "revision": 0,
+  "last_node_id": 304,
+  "last_link_id": 641,
+  "nodes": [
+    {
+      "id": 248,
+      "type": "GetVideoComponents",
+      "pos": [
+        1829.9999084472656,
+        509.99999618530273
+      ],
+      "size": [
+        230,
+        120
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 493
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            634
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            611
+          ]
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "links": [
+            612
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "GetVideoComponents",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 247,
+      "type": "LoadVideo",
+      "pos": [
+        850.0000133514404,
+        499.9999828338623
+      ],
+      "size": [
+        640,
+        490
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            501
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "animated_man_framing.mp4",
+        "image"
+      ]
+    },
+    {
+      "id": 254,
+      "type": "Video Slice",
+      "pos": [
+        1539.9998931884766,
+        509.99999618530273
+      ],
+      "size": [
+        270,
+        170
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 501
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            493
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Video Slice",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        0,
+        0,
+        false
+      ]
+    },
+    {
+      "id": 252,
+      "type": "7594b5c0-2b90-4aeb-846b-e3eb8fa89f33",
+      "pos": [
+        2490.000045776367,
+        640.000020980835
+      ],
+      "size": [
+        400,
+        150
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 639
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            494
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "233",
+            "$$canvas-image-preview"
+          ],
+          [
+            "232",
+            "$$canvas-image-preview"
+          ],
+          [
+            "234",
+            "$$canvas-image-preview"
+          ],
+          [
+            "285",
+            "aspect_ratio"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 249,
+      "type": "CreateVideo",
+      "pos": [
+        2920.000099182129,
+        509.99999618530273
+      ],
+      "size": [
+        230,
+        130
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 494
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": 611
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": 612
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            491
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "CreateVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.18.1",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        30
+      ]
+    },
+    {
+      "id": 245,
+      "type": "KlingOmniProEditVideoNode",
+      "pos": [
+        3250.0001678466797,
+        499.9999828338623
+      ],
+      "size": [
+        430,
+        360
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 491
+        },
+        {
+          "name": "reference_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            640
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "KlingOmniProEditVideoNode",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "kling-v3-omni",
+        "remove and outpaint the white borders of the video",
+        true,
+        "1080p",
+        1652002455,
+        "randomize"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 270,
+      "type": "SaveVideo",
+      "pos": [
+        3750.0000915527344,
+        439.9999771118164
+      ],
+      "size": [
+        590,
+        1230
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 640
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveVideo",
+        "cnr_id": "comfy-core",
+        "ver": "0.12.3",
+        "widget_ue_connectable": {}
+      },
+      "widgets_values": [
+        "video/9x16",
+        "auto",
+        "auto"
+      ]
+    },
+    {
+      "id": 295,
+      "type": "Note",
+      "pos": [
+        2119.9999237060547,
+        1029.9999465942383
+      ],
+      "size": [
+        580,
+        230
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "Adjust the offsets to reframe the video vertically or horizontally before extension\n\nThis workflow is only designed for horizontal to vertical and vice versa. If you want to adjust the aspect ratio only slightly or to 1x1 square format, Kling Video Edit node is not recommended."
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 302,
+      "type": "JWImageResizeByShorterSide",
+      "pos": [
+        2140.000099182129,
+        640.000020980835
+      ],
+      "size": [
+        300,
+        140
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 634
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            639
+          ]
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "JWImageResizeByShorterSide"
+      },
+      "widgets_values": [
+        1080,
+        "bicubic"
+      ]
+    }
+  ],
+  "links": [
+    [
+      491,
+      249,
+      0,
+      245,
+      0,
+      "VIDEO"
+    ],
+    [
+      493,
+      254,
+      0,
+      248,
+      0,
+      "VIDEO"
+    ],
+    [
+      494,
+      252,
+      0,
+      249,
+      0,
+      "IMAGE"
+    ],
+    [
+      501,
+      247,
+      0,
+      254,
+      0,
+      "VIDEO"
+    ],
+    [
+      611,
+      248,
+      1,
+      249,
+      1,
+      "AUDIO"
+    ],
+    [
+      612,
+      248,
+      2,
+      249,
+      2,
+      "FLOAT"
+    ],
+    [
+      634,
+      248,
+      0,
+      302,
+      0,
+      "IMAGE"
+    ],
+    [
+      639,
+      302,
+      0,
+      252,
+      0,
+      "IMAGE"
+    ],
+    [
+      640,
+      245,
+      0,
+      270,
+      0,
+      "VIDEO"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 5,
+      "title": "Video Resize and Extend",
+      "bounding": [
+        2120,
+        410,
+        1060,
+        560
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "Input Video",
+      "bounding": [
+        830,
+        420,
+        690,
+        620
+      ],
+      "color": "#8A8",
+      "font_size": 24,
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "Video Outpaint",
+      "bounding": [
+        3210,
+        410,
+        500,
+        560
+      ],
+      "color": "#3f789e",
+      "font_size": 24,
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "7594b5c0-2b90-4aeb-846b-e3eb8fa89f33",
+        "version": 1,
+        "state": {
+          "lastGroupId": 8,
+          "lastNodeId": 304,
+          "lastLinkId": 641,
+          "lastRerouteId": 2
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Video Extend",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -2390,
+            610,
+            120,
+            60
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            110.99131176844274,
+            366.6738400794415,
+            120,
+            80
+          ]
+        },
+        "inputs": [
+          {
+            "id": "190e929c-5f4a-4ae7-8294-b948fcc0806d",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              429,
+              430
+            ],
+            "localized_name": "image",
+            "pos": [
+              -2290,
+              630
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "df58d266-37ca-4c0a-a9bb-db0887941c34",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              275,
+              275
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              130.99131176844276,
+              386.6738400794415
+            ]
+          },
+          {
+            "id": "844db080-9f93-4ca2-ab10-bb75acec9f2c",
+            "name": "MASK",
+            "type": "MASK",
+            "linkIds": [
+              533
+            ],
+            "pos": [
+              130.99131176844276,
+              406.6738400794415
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 229,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1260,
+              20
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 460
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 461
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  447,
+                  448
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#ffffff"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 230,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1260,
+              270
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 607
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 609
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  451
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#000000"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 233,
+            "type": "PreviewImage",
+            "pos": [
+              240,
+              0
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 12,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 462
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 232,
+            "type": "PreviewImage",
+            "pos": [
+              250,
+              520
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 459
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 163,
+            "type": "Get Image Size",
+            "pos": [
+              -1590,
+              70
+            ],
+            "size": [
+              230,
+              100
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 429
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "slot_index": 0,
+                "links": [
+                  460
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "slot_index": 1,
+                "links": [
+                  461
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Get Image Size",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 234,
+            "type": "PreviewImage",
+            "pos": [
+              -810,
+              780
+            ],
+            "size": [
+              380,
+              420
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 4,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 466
+              }
+            ],
+            "outputs": [],
+            "properties": {
+              "Node name for S&R": "PreviewImage",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 162,
+            "type": "ImageRemoveAlpha+",
+            "pos": [
+              -350,
+              530
+            ],
+            "size": [
+              300,
+              80
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 263
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  275,
+                  459
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ImageRemoveAlpha+",
+              "cnr_id": "comfyui_essentials",
+              "ver": "1.1.0",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 153,
+            "type": "ImageToMask",
+            "pos": [
+              -810,
+              280
+            ],
+            "size": [
+              350,
+              110
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 249
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MASK",
+                "name": "MASK",
+                "type": "MASK",
+                "slot_index": 0,
+                "links": [
+                  533
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ImageToMask",
+              "cnr_id": "comfy-core",
+              "ver": "0.3.39",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "red"
+            ]
+          },
+          {
+            "id": 152,
+            "type": "Paste By Mask",
+            "pos": [
+              -820,
+              10
+            ],
+            "size": [
+              350,
+              180
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image_base",
+                "name": "image_base",
+                "type": "IMAGE",
+                "link": 451
+              },
+              {
+                "localized_name": "image_to_paste",
+                "name": "image_to_paste",
+                "type": "IMAGE",
+                "link": 447
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "IMAGE",
+                "link": 448
+              },
+              {
+                "localized_name": "mask_mapping_optional",
+                "name": "mask_mapping_optional",
+                "shape": 7,
+                "type": "MASK_MAPPING",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  249,
+                  267,
+                  462
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Paste By Mask",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "keep_ratio_fit"
+            ]
+          },
+          {
+            "id": 165,
+            "type": "Paste By Mask",
+            "pos": [
+              -810,
+              530
+            ],
+            "size": [
+              350,
+              180
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image_base",
+                "name": "image_base",
+                "type": "IMAGE",
+                "link": 454
+              },
+              {
+                "localized_name": "image_to_paste",
+                "name": "image_to_paste",
+                "type": "IMAGE",
+                "link": 430
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "IMAGE",
+                "link": 267
+              },
+              {
+                "localized_name": "mask_mapping_optional",
+                "name": "mask_mapping_optional",
+                "shape": 7,
+                "type": "MASK_MAPPING",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  263
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "Paste By Mask",
+              "cnr_id": "masquerade-nodes-comfyui",
+              "ver": "432cb4d146a391b387a0cd25ace824328b5b61cf",
+              "enableTabs": false,
+              "hasSecondTab": false,
+              "secondTabOffset": 80,
+              "secondTabText": "Send Back",
+              "secondTabWidth": 65,
+              "tabWidth": 65,
+              "tabXOffset": 10,
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "keep_ratio_fit"
+            ]
+          },
+          {
+            "id": 231,
+            "type": "LayerUtility: ColorImage V2",
+            "pos": [
+              -1250,
+              530
+            ],
+            "size": [
+              330,
+              210
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "size_as",
+                "name": "size_as",
+                "shape": 7,
+                "type": "*",
+                "link": null
+              },
+              {
+                "localized_name": "custom_width",
+                "name": "custom_width",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_width"
+                },
+                "link": 608
+              },
+              {
+                "localized_name": "custom_height",
+                "name": "custom_height",
+                "type": "INT",
+                "widget": {
+                  "name": "custom_height"
+                },
+                "link": 610
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  454,
+                  466
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "LayerUtility: ColorImage V2",
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "1.0.90",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "custom",
+              512,
+              512,
+              "#ffffff"
+            ],
+            "color": "rgba(38, 73, 116, 0.7)"
+          },
+          {
+            "id": 228,
+            "type": "MarkdownNote",
+            "pos": [
+              -1580,
+              530
+            ],
+            "size": [
+              260,
+              200
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [],
+            "title": "Change Fill Color",
+            "properties": {
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "## Tips\n\n- If your image doesn't have enough contrast to the empty area, change the background color here 👉"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 285,
+            "type": "ResolutionSelector",
+            "pos": [
+              -1590,
+              250
+            ],
+            "size": [
+              270,
+              170
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  607,
+                  608
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  609,
+                  610
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ResolutionSelector",
+              "cnr_id": "comfy-core",
+              "ver": "0.18.1",
+              "widget_ue_connectable": {}
+            },
+            "widgets_values": [
+              "9:16 (Portrait Widescreen)",
+              2
+            ]
+          }
+        ],
+        "groups": [
+          {
+            "id": 4,
+            "title": "autoExtend",
+            "bounding": [
+              -1620,
+              -60,
+              1670,
+              1310
+            ],
+            "color": "#3f789e",
+            "font_size": 22,
+            "flags": {}
+          }
+        ],
+        "links": [
+          {
+            "id": 249,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 153,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 267,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 263,
+            "origin_id": 165,
+            "origin_slot": 0,
+            "target_id": 162,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 429,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 163,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 430,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 275,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 447,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 448,
+            "origin_id": 229,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 2,
+            "type": "IMAGE"
+          },
+          {
+            "id": 451,
+            "origin_id": 230,
+            "origin_slot": 0,
+            "target_id": 152,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 454,
+            "origin_id": 231,
+            "origin_slot": 0,
+            "target_id": 165,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 459,
+            "origin_id": 162,
+            "origin_slot": 0,
+            "target_id": 232,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 460,
+            "origin_id": 163,
+            "origin_slot": 0,
+            "target_id": 229,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 461,
+            "origin_id": 163,
+            "origin_slot": 1,
+            "target_id": 229,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 462,
+            "origin_id": 152,
+            "origin_slot": 0,
+            "target_id": 233,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 466,
+            "origin_id": 231,
+            "origin_slot": 0,
+            "target_id": 234,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 533,
+            "origin_id": 153,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "MASK"
+          },
+          {
+            "id": 607,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 230,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 608,
+            "origin_id": 285,
+            "origin_slot": 0,
+            "target_id": 231,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 609,
+            "origin_id": 285,
+            "origin_slot": 1,
+            "target_id": 230,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 610,
+            "origin_id": 285,
+            "origin_slot": 1,
+            "target_id": 231,
+            "target_slot": 2,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.41.13",
+    "linearData": {
+      "inputs": [
+        [
+          "247",
+          "file"
+        ],
+        [
+          254,
+          "start_time"
+        ],
+        [
+          254,
+          "duration"
+        ],
+        [
+          "285",
+          "aspect_ratio"
+        ],
+        [
+          245,
+          "resolution"
+        ]
+      ],
+      "outputs": [
+        "270"
+      ]
+    },
+    "VHS_KeepIntermediate": true,
+    "VHS_MetadataImage": true,
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "linearMode": false,
+    "links_added_by_ue": [],
+    "ue_links": [],
+    "ds": {
+      "scale": 0.20512820512820512,
+      "offset": [
+        1163.83447265625,
+        879.85498046875
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/gallery/templates_graphic_design_recomposer.json
+++ b/tests/comfy_cli/fixtures/gallery/templates_graphic_design_recomposer.json
@@ -1,0 +1,821 @@
+{
+  "id": "73b6b198-be12-4114-9363-c1dcd74bf81c",
+  "revision": 0,
+  "last_node_id": 157,
+  "last_link_id": 248,
+  "nodes": [
+    {
+      "id": 125,
+      "type": "LoadImage",
+      "pos": [
+        2860,
+        4920
+      ],
+      "size": [
+        380,
+        480
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            233
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "latent_space_clud.png",
+        "image"
+      ]
+    },
+    {
+      "id": 131,
+      "type": "SaveImage",
+      "pos": [
+        3670,
+        4920
+      ],
+      "size": [
+        580,
+        480
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 234
+        }
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": [
+        "graphic_design_recompose"
+      ]
+    },
+    {
+      "id": 143,
+      "type": "172f1008-9337-4d2f-9212-ee081cb4faf5",
+      "pos": [
+        3280,
+        4920
+      ],
+      "size": [
+        340,
+        180
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 233
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "IMAGE",
+          "links": [
+            234
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "135",
+            "choice"
+          ],
+          [
+            "156",
+            "value"
+          ],
+          [
+            "142",
+            "value"
+          ]
+        ]
+      },
+      "widgets_values": []
+    }
+  ],
+  "links": [
+    [
+      233,
+      125,
+      0,
+      143,
+      0,
+      "IMAGE"
+    ],
+    [
+      234,
+      143,
+      0,
+      131,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "172f1008-9337-4d2f-9212-ee081cb4faf5",
+        "version": 1,
+        "state": {
+          "lastGroupId": 15,
+          "lastNodeId": 157,
+          "lastLinkId": 248,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Recompose Image",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            4690,
+            7430,
+            128,
+            68
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            7680,
+            7470,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "7cbedb18-b324-4f1b-96d7-4517996bc432",
+            "name": "images",
+            "type": "IMAGE",
+            "linkIds": [
+              212,
+              244
+            ],
+            "localized_name": "images",
+            "shape": 7,
+            "pos": [
+              4794,
+              7454
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "cde817df-cc4a-4726-9aca-fb1e9200a1e6",
+            "name": "output",
+            "type": "IMAGE",
+            "linkIds": [
+              230
+            ],
+            "localized_name": "output",
+            "pos": [
+              7704,
+              7494
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 2,
+            "type": "PrimitiveStringMultiline",
+            "pos": [
+              5190,
+              7570
+            ],
+            "size": [
+              560,
+              580
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  211,
+                  247
+                ]
+              }
+            ],
+            "title": "Prompt",
+            "properties": {
+              "Node name for S&R": "PrimitiveStringMultiline"
+            },
+            "widgets_values": [
+              "Role: Act as an expert art director and compositing specialist. Your objective is to adapt the provided image to a new aspect ratio by expanding the background and rearranging its core elements. Never stretch, squish, or letterbox the image.\n\n1. Canvas Expansion & Outpainting\n\nSeamless Extension: Expand the canvas to the target dimensions using generative outpainting. Seamlessly continue the existing environment (sky, textures, walls, floors) while perfectly matching the original lighting, grain, and perspective.\n\nStrict Limitations: Do not shrink the original image onto a blurred or colored background. Do not introduce new focal objects, characters, or decorative borders. Only continue existing environmental elements.\n\n2. Element Redistribution\n\nTreat as Layers: Separate the main components (typography, logos, hero imagery, credits) into distinct, movable elements.\n\nSmart Rearrangement: Reposition these elements to suit the new aspect ratio using professional layout principles (e.g., shifting a vertical stack into a horizontal, side-by-side composition). Use the newly generated space intentionally to avoid awkward negative space.\n\nPreserve Proportions: Maintain the exact original aspect ratio of every individual element. Keep all font styles, weights, and text styling identical. Scale elements uniformly only if required for layout balance.\n\n3. Visual Integrity & Polish\n\nMaintain Hierarchy: Preserve the original visual dominance of the headline, hero image, and logo placement.\n\nNative Feel: The final composition must look cohesive, breathable, and deliberately designed from scratch for this specific format."
+            ]
+          },
+          {
+            "id": 130,
+            "type": "GeminiImage2Node",
+            "pos": [
+              6020,
+              6910
+            ],
+            "size": [
+              470,
+              350
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 212
+              },
+              {
+                "localized_name": "files",
+                "name": "files",
+                "shape": 7,
+                "type": "GEMINI_INPUT_FILES",
+                "link": null
+              },
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 211
+              },
+              {
+                "localized_name": "aspect_ratio",
+                "name": "aspect_ratio",
+                "type": "COMBO",
+                "widget": {
+                  "name": "aspect_ratio"
+                },
+                "link": 229
+              },
+              {
+                "localized_name": "resolution",
+                "name": "resolution",
+                "type": "COMBO",
+                "widget": {
+                  "name": "resolution"
+                },
+                "link": 243
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  232
+                ]
+              },
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GeminiImage2Node"
+            },
+            "widgets_values": [
+              "",
+              "gemini-3-pro-image-preview",
+              314507571392615,
+              "randomize",
+              "16:9",
+              "2K",
+              "IMAGE+TEXT",
+              "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input—regardless of format, intent, or abstraction—as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 134,
+            "type": "ComfySwitchNode",
+            "pos": [
+              7280,
+              7470
+            ],
+            "size": [
+              280,
+              130
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "on_false",
+                "name": "on_false",
+                "type": "IMAGE",
+                "link": 232
+              },
+              {
+                "localized_name": "on_true",
+                "name": "on_true",
+                "type": "IMAGE",
+                "link": 248
+              },
+              {
+                "localized_name": "switch",
+                "name": "switch",
+                "type": "BOOLEAN",
+                "widget": {
+                  "name": "switch"
+                },
+                "link": 222
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "IMAGE",
+                "links": [
+                  230
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "ComfySwitchNode"
+            },
+            "widgets_values": [
+              true
+            ]
+          },
+          {
+            "id": 135,
+            "type": "CustomCombo",
+            "pos": [
+              6030,
+              8030
+            ],
+            "size": [
+              280,
+              250
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "model",
+                "localized_name": "choice",
+                "name": "choice",
+                "type": "COMBO",
+                "widget": {
+                  "name": "choice"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": [
+                  217
+                ]
+              },
+              {
+                "localized_name": "INDEX",
+                "name": "INDEX",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "CustomCombo"
+            },
+            "widgets_values": [
+              "Nano Banana 2",
+              0,
+              "Nano Banana 2",
+              "Nano Banana Pro",
+              ""
+            ]
+          },
+          {
+            "id": 157,
+            "type": "GeminiNanoBanana2V2",
+            "pos": [
+              6020,
+              7540
+            ],
+            "size": [
+              400,
+              350
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "prompt",
+                "name": "prompt",
+                "type": "STRING",
+                "widget": {
+                  "name": "prompt"
+                },
+                "link": 247
+              },
+              {
+                "localized_name": "model.aspect_ratio",
+                "name": "model.aspect_ratio",
+                "type": "COMBO",
+                "widget": {
+                  "name": "model.aspect_ratio"
+                },
+                "link": 245
+              },
+              {
+                "localized_name": "model.resolution",
+                "name": "model.resolution",
+                "type": "COMBO",
+                "widget": {
+                  "name": "model.resolution"
+                },
+                "link": 246
+              },
+              {
+                "label": "image_1",
+                "localized_name": "model.images.image_1",
+                "name": "model.images.image_1",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 244
+              },
+              {
+                "label": "image_2",
+                "localized_name": "model.images.image_2",
+                "name": "model.images.image_2",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": null
+              },
+              {
+                "label": "files",
+                "localized_name": "model.files",
+                "name": "model.files",
+                "shape": 7,
+                "type": "GEMINI_INPUT_FILES",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  248
+                ]
+              },
+              {
+                "localized_name": "STRING",
+                "name": "STRING",
+                "type": "STRING",
+                "links": null
+              },
+              {
+                "localized_name": "thought_image",
+                "name": "thought_image",
+                "type": "IMAGE",
+                "links": null
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "GeminiNanoBanana2V2"
+            },
+            "widgets_values": [
+              "",
+              "Nano Banana 2 (Gemini 3.1 Flash Image)",
+              "16:9",
+              "2K",
+              "MINIMAL",
+              42,
+              "randomize",
+              "IMAGE",
+              "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input—regardless of format, intent, or abstraction—as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests."
+            ],
+            "color": "#432",
+            "bgcolor": "#653"
+          },
+          {
+            "id": 156,
+            "type": "PrimitiveNode",
+            "pos": [
+              5280,
+              7090
+            ],
+            "size": [
+              450,
+              150
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "COMBO",
+                "type": "COMBO",
+                "widget": {
+                  "name": "resolution"
+                },
+                "links": [
+                  243,
+                  246
+                ]
+              }
+            ],
+            "title": "resolution",
+            "properties": {
+              "Run widget replace on values": false
+            },
+            "widgets_values": [
+              "2K",
+              "fixed",
+              ""
+            ]
+          },
+          {
+            "id": 142,
+            "type": "PrimitiveNode",
+            "pos": [
+              5280,
+              7310
+            ],
+            "size": [
+              450,
+              150
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "name": "COMBO",
+                "type": "COMBO",
+                "widget": {
+                  "name": "aspect_ratio"
+                },
+                "links": [
+                  229,
+                  245
+                ]
+              }
+            ],
+            "title": "aspect_ratio",
+            "properties": {
+              "Run widget replace on values": false
+            },
+            "widgets_values": [
+              "16:9",
+              "fixed",
+              ""
+            ]
+          },
+          {
+            "id": 136,
+            "type": "StringCompare",
+            "pos": [
+              6430,
+              8020
+            ],
+            "size": [
+              300,
+              280
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "showAdvanced": true,
+            "inputs": [
+              {
+                "localized_name": "string_a",
+                "name": "string_a",
+                "type": "STRING",
+                "widget": {
+                  "name": "string_a"
+                },
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "BOOLEAN",
+                "name": "BOOLEAN",
+                "type": "BOOLEAN",
+                "links": [
+                  222
+                ]
+              }
+            ],
+            "properties": {
+              "Node name for S&R": "StringCompare"
+            },
+            "widgets_values": [
+              "Nano Banana 2",
+              "nano banana 2",
+              "Starts With",
+              false
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 211,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 2,
+            "type": "STRING"
+          },
+          {
+            "id": 229,
+            "origin_id": 142,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 3,
+            "type": "COMBO"
+          },
+          {
+            "id": 232,
+            "origin_id": 130,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 222,
+            "origin_id": 136,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 2,
+            "type": "BOOLEAN"
+          },
+          {
+            "id": 217,
+            "origin_id": 135,
+            "origin_slot": 0,
+            "target_id": 136,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 212,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 230,
+            "origin_id": 134,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 243,
+            "origin_id": 156,
+            "origin_slot": 0,
+            "target_id": 130,
+            "target_slot": 4,
+            "type": "COMBO"
+          },
+          {
+            "id": 244,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 3,
+            "type": "IMAGE"
+          },
+          {
+            "id": 245,
+            "origin_id": 142,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 1,
+            "type": "COMBO"
+          },
+          {
+            "id": 246,
+            "origin_id": 156,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 2,
+            "type": "COMBO"
+          },
+          {
+            "id": 247,
+            "origin_id": 2,
+            "origin_slot": 0,
+            "target_id": 157,
+            "target_slot": 0,
+            "type": "STRING"
+          },
+          {
+            "id": 248,
+            "origin_id": 157,
+            "origin_slot": 0,
+            "target_id": 134,
+            "target_slot": 1,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "Vue-corrected"
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.44.15",
+    "workflowRendererVersion": "Vue-corrected",
+    "linearMode": false,
+    "linearData": {
+      "inputs": [
+        [
+          "125",
+          "image"
+        ],
+        [
+          "135",
+          "choice"
+        ],
+        [
+          "156",
+          "value"
+        ],
+        [
+          "142",
+          "value"
+        ]
+      ],
+      "outputs": [
+        "131"
+      ]
+    },
+    "VHS_KeepIntermediate": true,
+    "VHS_MetadataImage": true,
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "ds": {
+      "scale": 0.4022323830016147,
+      "offset": [
+        -4682.813818294955,
+        -5898.263907601024
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/tests/comfy_cli/fixtures/object_info_legacy_proxy.json
+++ b/tests/comfy_cli/fixtures/object_info_legacy_proxy.json
@@ -1,0 +1,2790 @@
+{
+ "CLIPTextEncode": {
+  "input": {
+   "required": {
+    "text": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "clip": [
+     "CLIP",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "text",
+    "clip"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "CLIPTextEncode",
+  "display_name": "CLIP Text Encode (Prompt)",
+  "description": "Encodes a text prompt using a CLIP model into an embedding that can be used to guide the diffusion model towards generating specific images.",
+  "python_module": "nodes",
+  "category": "model/conditioning",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "A conditioning containing the embedded text used to guide the diffusion model."
+  ],
+  "search_aliases": [
+   "text",
+   "prompt",
+   "text prompt",
+   "positive prompt",
+   "negative prompt",
+   "encode text",
+   "text encoder",
+   "encode prompt"
+  ]
+ },
+ "ComfySwitchNode": {
+  "input": {
+   "required": {
+    "switch": [
+     "BOOLEAN",
+     {}
+    ],
+    "on_false": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ],
+    "on_true": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "switch",
+    "on_false",
+    "on_true"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "COMFY_MATCHTYPE_V3"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "output"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": [
+   "switch"
+  ],
+  "name": "ComfySwitchNode",
+  "display_name": "If/Else Switch",
+  "description": "",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities/logic",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "if",
+   "then",
+   "switch",
+   "conditional",
+   "branch"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "ConditioningZeroOut": {
+  "input": {
+   "required": {
+    "conditioning": [
+     "CONDITIONING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "conditioning"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "ConditioningZeroOut",
+  "display_name": "Conditioning Zero Out",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/conditioning/transform",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "null conditioning",
+   "clear conditioning"
+  ]
+ },
+ "CreateVideo": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "fps": [
+     "FLOAT",
+     {
+      "default": 30.0,
+      "min": 1.0,
+      "max": 120.0,
+      "step": 1.0
+     }
+    ]
+   },
+   "optional": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "bit_depth": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       8,
+       10
+      ]
+     }
+    ],
+    "color_space": [
+     "COMBO",
+     {
+      "default": "sRGB",
+      "multiselect": false,
+      "options": [
+       "sRGB",
+       "HDR",
+       "HDR PQ"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "fps"
+   ],
+   "optional": [
+    "audio",
+    "bit_depth",
+    "color_space"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CreateVideo",
+  "display_name": "Create Video",
+  "description": "Create a video from images.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "images to video"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false
+ },
+ "CustomCombo": {
+  "input": {
+   "required": {
+    "choice": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": []
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "choice"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "STRING",
+   "INDEX"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CustomCombo",
+  "display_name": "Custom Combo",
+  "description": "",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "DualCLIPLoader": {
+  "input": {
+   "required": {
+    "clip_name1": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "clip_name2": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "type": [
+     [
+      "sdxl",
+      "sd3",
+      "flux",
+      "hunyuan_video",
+      "hidream",
+      "hunyuan_image",
+      "hunyuan_video_15",
+      "kandinsky5",
+      "kandinsky5_image",
+      "ltxv",
+      "newbie",
+      "ace"
+     ]
+    ]
+   },
+   "optional": {
+    "device": [
+     [
+      "default",
+      "cpu"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip_name1",
+    "clip_name2",
+    "type"
+   ],
+   "optional": [
+    "device"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CLIP"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CLIP"
+  ],
+  "name": "DualCLIPLoader",
+  "display_name": "Load CLIP (Dual)",
+  "description": "Recipes:\nsdxl: clip-l, clip-g\nsd3: clip-l, clip-g / clip-l, t5 / clip-g, t5\nflux: clip-l, t5\nhidream: at least one of t5 or llama, recommended t5 and llama\nhunyuan_image: qwen2.5vl 7b and byt5 small\nnewbie: gemma-3-4b-it, jina clip v2",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "EmptySD3LatentImage": {
+  "input": {
+   "required": {
+    "width": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "height": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "width",
+    "height",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptySD3LatentImage",
+  "display_name": null,
+  "description": "",
+  "python_module": "comfy_extras.nodes_sd3",
+  "category": "model/latent/stable diffusion",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "GeminiImage2Node": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "gemini-3-pro-image-preview",
+       "Nano Banana 2 (Gemini 3.1 Flash Image)"
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       "1:1",
+       "2:3",
+       "3:2",
+       "3:4",
+       "4:3",
+       "4:5",
+       "5:4",
+       "9:16",
+       "16:9",
+       "21:9"
+      ]
+     }
+    ],
+    "resolution": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "1K",
+       "2K",
+       "4K"
+      ]
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE+TEXT",
+       "IMAGE"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "files": [
+     "GEMINI_INPUT_FILES",
+     {}
+    ],
+    "system_prompt": [
+     "STRING",
+     {
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "aspect_ratio",
+    "resolution",
+    "response_modalities"
+   ],
+   "optional": [
+    "images",
+    "files",
+    "system_prompt"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiImage2Node",
+  "display_name": "Nano Banana Pro (Google Gemini Image)",
+  "description": "Generate or edit images synchronously via Google Vertex API.",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMBO"
+     },
+     {
+      "name": "resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n    (\n      $m := widgets.model;\n      $r := widgets.resolution;\n      $isFlash := $contains($m, \"nano banana 2\");\n      $flashPrices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n      $proPrices := {\"1k\": 0.1608, \"2k\": 0.1608, \"4k\": 0.288};\n      $prices := $isFlash ? $flashPrices : $proPrices;\n      {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n    )\n    "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "GeminiNanoBanana2V2": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K",
+             "2K",
+             "4K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       },
+       {
+        "key": "Nano Banana 2 Lite",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE",
+       "IMAGE+TEXT"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "system_prompt": [
+     "STRING",
+     {
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ],
+    "temperature": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 1.0,
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.01
+     }
+    ],
+    "top_p": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 0.95,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "response_modalities"
+   ],
+   "optional": [
+    "system_prompt",
+    "temperature",
+    "top_p"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING",
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING",
+   "thought_image"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   "First image from the model's thinking process. Only available with thinking_level HIGH and IMAGE+TEXT modality."
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiNanoBanana2V2",
+  "display_name": "Nano Banana 2",
+  "description": "Generate or edit images synchronously via Google Vertex API.",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $contains(widgets.model, \"lite\")\n                    ? {\"type\":\"usd\",\"usd\": 0.0408, \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                    : (\n                        $r := $lookup(widgets, \"model.resolution\");\n                        $prices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n                        {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                      )\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "Get Image Size": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "name": "Get Image Size",
+  "display_name": "Get Image Size",
+  "description": "",
+  "python_module": "custom_nodes.masquerade-nodes-comfyui",
+  "category": "Masquerade Nodes",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "GetVideoComponents": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "AUDIO",
+   "FLOAT",
+   "COMBO",
+   "COMBO"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "images",
+   "audio",
+   "fps",
+   "bit_depth",
+   "color_space"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetVideoComponents",
+  "display_name": "Get Video Components",
+  "description": "Extracts video frames, audio, frame rate, bit depth, and color space.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract frames",
+   "split video",
+   "video to images",
+   "demux"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "ImageRemoveAlpha+": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "ImageRemoveAlpha+",
+  "display_name": "\ud83d\udd27 Image Remove Alpha",
+  "description": "",
+  "python_module": "custom_nodes.comfyui_essentials",
+  "category": "essentials/image utils",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "ImageToMask": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ],
+    "channel": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "red",
+       "green",
+       "blue",
+       "alpha"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "channel"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MASK"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MASK"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ImageToMask",
+  "display_name": "Convert Image to Mask",
+  "description": "",
+  "python_module": "comfy_extras.nodes_mask",
+  "category": "image/mask",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract channel",
+   "channel to mask"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "JWImageResizeByShorterSide": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE"
+    ],
+    "size": [
+     "INT",
+     {
+      "default": 512,
+      "min": 0,
+      "step": 1,
+      "max": 99999
+     }
+    ],
+    "interpolation_mode": [
+     [
+      "bicubic",
+      "bilinear",
+      "nearest",
+      "nearest exact"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "size",
+    "interpolation_mode"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "JWImageResizeByShorterSide",
+  "display_name": "Image Resize by Shorter Side",
+  "description": "",
+  "python_module": "custom_nodes.comfyui-various",
+  "category": "jamesWalker55",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "KSampler": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL",
+     {}
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "steps": [
+     "INT",
+     {
+      "default": 20,
+      "min": 1,
+      "max": 10000
+     }
+    ],
+    "cfg": [
+     "FLOAT",
+     {
+      "default": 8.0,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "sampler_name": [
+     [
+      "euler",
+      "euler_cfg_pp",
+      "euler_ancestral",
+      "euler_ancestral_cfg_pp",
+      "heun",
+      "heunpp2",
+      "exp_heun_2_x0",
+      "exp_heun_2_x0_sde",
+      "dpm_2",
+      "dpm_2_ancestral",
+      "lms",
+      "dpm_fast",
+      "dpm_adaptive",
+      "dpmpp_2s_ancestral",
+      "dpmpp_2s_ancestral_cfg_pp",
+      "dpmpp_sde",
+      "dpmpp_sde_gpu",
+      "dpmpp_2m",
+      "dpmpp_2m_cfg_pp",
+      "dpmpp_2m_sde",
+      "dpmpp_2m_sde_gpu",
+      "dpmpp_2m_sde_heun",
+      "dpmpp_2m_sde_heun_gpu",
+      "dpmpp_3m_sde",
+      "dpmpp_3m_sde_gpu",
+      "ddpm",
+      "lcm",
+      "ipndm",
+      "ipndm_v",
+      "deis",
+      "res_multistep",
+      "res_multistep_cfg_pp",
+      "res_multistep_ancestral",
+      "res_multistep_ancestral_cfg_pp",
+      "gradient_estimation",
+      "gradient_estimation_cfg_pp",
+      "er_sde",
+      "seeds_2",
+      "seeds_3",
+      "sa_solver",
+      "sa_solver_pece",
+      "ddim",
+      "uni_pc",
+      "uni_pc_bh2",
+      "legacy_rk",
+      "rk",
+      "rk_beta",
+      "deis_3m_ode",
+      "deis_2m_ode",
+      "deis_3m",
+      "deis_2m",
+      "res_6s_ode",
+      "res_5s_ode",
+      "res_3s_ode",
+      "res_2s_ode",
+      "res_3m_ode",
+      "res_2m_ode",
+      "res_6s",
+      "res_5s",
+      "res_3s",
+      "res_2s",
+      "res_3m",
+      "res_2m"
+     ],
+     {}
+    ],
+    "scheduler": [
+     [
+      "simple",
+      "sgm_uniform",
+      "karras",
+      "exponential",
+      "ddim_uniform",
+      "beta",
+      "normal",
+      "linear_quadratic",
+      "kl_optimal",
+      "bong_tangent",
+      "beta57"
+     ],
+     {}
+    ],
+    "positive": [
+     "CONDITIONING",
+     {}
+    ],
+    "negative": [
+     "CONDITIONING",
+     {}
+    ],
+    "latent_image": [
+     "LATENT",
+     {}
+    ],
+    "denoise": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "steps",
+    "cfg",
+    "sampler_name",
+    "scheduler",
+    "positive",
+    "negative",
+    "latent_image",
+    "denoise"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "name": "KSampler",
+  "display_name": "KSampler",
+  "description": "Uses the provided model, positive and negative conditioning to denoise the latent image.",
+  "python_module": "nodes",
+  "category": "model/sampling",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The denoised latent."
+  ],
+  "search_aliases": [
+   "sampler",
+   "sample",
+   "generate",
+   "denoise",
+   "diffuse",
+   "txt2img",
+   "img2img"
+  ]
+ },
+ "KlingOmniProEditVideoNode": {
+  "input": {
+   "required": {
+    "model_name": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "kling-v3-omni",
+       "kling-video-o1"
+      ]
+     }
+    ],
+    "prompt": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "keep_original_sound": [
+     "BOOLEAN",
+     {
+      "default": true
+     }
+    ]
+   },
+   "optional": {
+    "reference_images": [
+     "IMAGE",
+     {}
+    ],
+    "resolution": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "1080p",
+       "720p"
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model_name",
+    "prompt",
+    "video",
+    "keep_original_sound"
+   ],
+   "optional": [
+    "reference_images",
+    "resolution",
+    "seed"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "KlingOmniProEditVideoNode",
+  "display_name": "Kling 3.0 Omni Edit Video",
+  "description": "Edit an existing video with the latest model from Kling.",
+  "python_module": "comfy_api_nodes.nodes_kling",
+  "category": "partner/video/Kling",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $mode := (widgets.resolution = \"720p\") ? \"std\" : \"pro\";\n                  $rates := {\"std\": 0.126, \"pro\": 0.168};\n                  {\"type\":\"usd\",\"usd\": $lookup($rates, $mode), \"format\":{\"suffix\":\"/second\"}}\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": "Video Generation",
+  "has_intermediate_output": false
+ },
+ "LayerUtility: ColorImage V2": {
+  "input": {
+   "required": {
+    "size": [
+     [
+      "custom",
+      "1024 x 1024",
+      "768 x 512",
+      "512 x 768",
+      "1280 x 720",
+      "720 x 1280",
+      "1344 x 768",
+      "768 x 1344",
+      "1536 x 640",
+      "640 x 1536"
+     ]
+    ],
+    "custom_width": [
+     "INT",
+     {
+      "default": 512,
+      "min": 4,
+      "max": 99999,
+      "step": 1
+     }
+    ],
+    "custom_height": [
+     "INT",
+     {
+      "default": 512,
+      "min": 4,
+      "max": 99999,
+      "step": 1
+     }
+    ],
+    "color": [
+     "STRING",
+     {
+      "default": "#000000"
+     }
+    ]
+   },
+   "optional": {
+    "size_as": [
+     "*",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "size",
+    "custom_width",
+    "custom_height",
+    "color"
+   ],
+   "optional": [
+    "size_as"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "image"
+  ],
+  "name": "LayerUtility: ColorImage V2",
+  "display_name": "LayerUtility: ColorImage V2",
+  "description": "",
+  "python_module": "custom_nodes.comfyui_layerstyle",
+  "category": "\ud83d\ude3adzNodes/LayerUtility",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "LoadImage": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "MASK"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "MASK"
+  ],
+  "name": "LoadImage",
+  "display_name": "Load Image",
+  "description": "",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "load image",
+   "open image",
+   "import image",
+   "image input",
+   "upload image",
+   "read image",
+   "image loader"
+  ],
+  "essentials_category": "Basics"
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "description": "",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "Paste By Mask": {
+  "input": {
+   "required": {
+    "image_base": [
+     "IMAGE"
+    ],
+    "image_to_paste": [
+     "IMAGE"
+    ],
+    "mask": [
+     "IMAGE"
+    ],
+    "resize_behavior": [
+     [
+      "resize",
+      "keep_ratio_fill",
+      "keep_ratio_fit",
+      "source_size",
+      "source_size_unmasked"
+     ]
+    ]
+   },
+   "optional": {
+    "mask_mapping_optional": [
+     "MASK_MAPPING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image_base",
+    "image_to_paste",
+    "mask",
+    "resize_behavior"
+   ],
+   "optional": [
+    "mask_mapping_optional"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "Paste By Mask",
+  "display_name": "Paste By Mask",
+  "description": "",
+  "python_module": "custom_nodes.masquerade-nodes-comfyui",
+  "category": "Masquerade Nodes",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "PreviewImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE"
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "PreviewImage",
+  "display_name": "Preview Image",
+  "description": "Preview the images without saving them to the ComfyUI output directory.",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "preview",
+   "preview image",
+   "show image",
+   "view image",
+   "display image",
+   "image viewer"
+  ],
+  "essentials_category": "Basics"
+ },
+ "PrimitiveStringMultiline": {
+  "input": {
+   "required": {
+    "value": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "STRING"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveStringMultiline",
+  "display_name": "Text (Multiline)",
+  "description": "",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "text",
+   "string",
+   "text multiline",
+   "string multiline",
+   "text box",
+   "prompt"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "ResolutionSelector": {
+  "input": {
+   "required": {
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "1:1 (Square)",
+      "multiselect": false,
+      "options": [
+       "1:1 (Square)",
+       "2:3 (Portrait Photo)",
+       "3:2 (Photo)",
+       "3:4 (Portrait Standard)",
+       "4:3 (Standard)",
+       "9:16 (Portrait Widescreen)",
+       "16:9 (Widescreen)",
+       "21:9 (Ultrawide)"
+      ]
+     }
+    ],
+    "megapixels": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.1,
+      "max": 16.0,
+      "step": 0.1
+     }
+    ],
+    "multiple": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 8,
+      "min": 8,
+      "max": 128,
+      "step": 4
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "aspect_ratio",
+    "megapixels",
+    "multiple"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "output_tooltips": [
+   "Calculated width in pixels multiplied by the selected multiple.",
+   "Calculated height in pixels multiplied by the selected multiple."
+  ],
+  "output_matchtypes": null,
+  "name": "ResolutionSelector",
+  "display_name": "Resolution Selector",
+  "description": "Calculate width and height from aspect ratio and megapixel target. Useful for setting up Empty Latent Image dimensions.",
+  "python_module": "comfy_extras.nodes_resolution",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "description": "Saves the input images to your ComfyUI output directory.",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "save",
+   "save image",
+   "export image",
+   "output image",
+   "write image",
+   "download"
+  ],
+  "essentials_category": "Basics"
+ },
+ "SaveVideo": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "video/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mp4",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mkv",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "webm",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "codec": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "hidden": true,
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "h264",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 23.0,
+                  "min": 0.0,
+                  "max": 51.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "av1",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 30.0,
+                  "min": 0.0,
+                  "max": 63.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "filename_prefix",
+    "format"
+   ],
+   "optional": [
+    "codec"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "video"
+  ],
+  "output_tooltips": [
+   "The input video, unchanged."
+  ],
+  "output_matchtypes": null,
+  "name": "SaveVideo",
+  "display_name": "Save Video",
+  "description": "Saves the input videos to your ComfyUI output directory.",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "export video"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "StringCompare": {
+  "input": {
+   "required": {
+    "string_a": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "string_b": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ],
+    "mode": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "Starts With",
+       "Ends With",
+       "Equal"
+      ]
+     }
+    ],
+    "case_sensitive": [
+     "BOOLEAN",
+     {
+      "advanced": true,
+      "default": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "string_a",
+    "string_b",
+    "mode",
+    "case_sensitive"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "BOOLEAN"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "BOOLEAN"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "StringCompare",
+  "display_name": "Compare Text",
+  "description": "",
+  "python_module": "comfy_extras.nodes_string",
+  "category": "text",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "compare",
+   "text match",
+   "string equals",
+   "starts with",
+   "ends with"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false
+ },
+ "UNETLoader": {
+  "input": {
+   "required": {
+    "unet_name": [
+     [
+      "put_diffusion_models.safetensors"
+     ]
+    ],
+    "weight_dtype": [
+     [
+      "default",
+      "fp8_e4m3fn",
+      "fp8_e4m3fn_fast",
+      "fp8_e5m2"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "unet_name",
+    "weight_dtype"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "UNETLoader",
+  "display_name": "Load Diffusion Model",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "VAEDecode": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "VAEDecode",
+  "display_name": "VAE Decode",
+  "description": "Decodes latent images back into pixel space images.",
+  "python_module": "nodes",
+  "category": "model/latent",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The decoded image."
+  ],
+  "search_aliases": [
+   "decode",
+   "decode latent",
+   "latent to image",
+   "render latent"
+  ]
+ },
+ "VAELoader": {
+  "input": {
+   "required": {
+    "vae_name": [
+     [
+      "put_vae.safetensors",
+      "pixel_space"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "vae_name"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VAE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VAE"
+  ],
+  "name": "VAELoader",
+  "display_name": "Load VAE",
+  "description": "",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": []
+ },
+ "Video Slice": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "start_time": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": -100000.0,
+      "max": 100000.0,
+      "step": 0.001
+     }
+    ],
+    "duration": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": 0.0,
+      "step": 0.001
+     }
+    ],
+    "strict_duration": [
+     "BOOLEAN",
+     {
+      "default": false
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "start_time",
+    "duration",
+    "strict_duration"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "Video Slice",
+  "display_name": "Trim Video",
+  "description": "",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "trim video duration",
+   "skip first frames",
+   "frame load cap",
+   "start time"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false
+ }
+}

--- a/tests/comfy_cli/fixtures/object_info_subgraph_promoted.json
+++ b/tests/comfy_cli/fixtures/object_info_subgraph_promoted.json
@@ -1,0 +1,3479 @@
+{
+ "AudioConcat": {
+  "input": {
+   "required": {
+    "audio1": [
+     "AUDIO",
+     {}
+    ],
+    "audio2": [
+     "AUDIO",
+     {}
+    ],
+    "direction": [
+     "COMBO",
+     {
+      "default": "after",
+      "multiselect": false,
+      "options": [
+       "after",
+       "before"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "audio1",
+    "audio2",
+    "direction"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "AudioConcat",
+  "display_name": "Concatenate Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "join audio",
+   "combine audio",
+   "append audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "BatchImagesNode": {
+  "input": {
+   "required": {
+    "images": [
+     "COMFY_AUTOGROW_V3",
+     {
+      "template": {
+       "input": {
+        "required": {
+         "image": [
+          "IMAGE",
+          {}
+         ]
+        }
+       },
+       "prefix": "image",
+       "min": 1,
+       "max": 50
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "BatchImagesNode",
+  "display_name": "Batch Images",
+  "python_module": "comfy_extras.nodes_post_processing",
+  "category": "image/batch",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "batch",
+   "image batch",
+   "batch images",
+   "combine images",
+   "merge images",
+   "stack images"
+  ],
+  "essentials_category": "Image Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ByteDance2ReferenceNodeV2": {
+  "input": {
+   "required": {
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Seedance 2.5",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "default": "720p",
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "16:9",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 5,
+            "min": 4,
+            "max": 30,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "task_type": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "reference",
+             "edit",
+             "extend"
+            ]
+           }
+          ],
+          "output_format": [
+           "COMBO",
+           {
+            "default": "mp4",
+            "multiselect": false,
+            "options": [
+             "mp4"
+            ]
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14",
+              "image_15",
+              "image_16",
+              "image_17",
+              "image_18",
+              "image_19",
+              "image_20",
+              "image_21",
+              "image_22",
+              "image_23",
+              "image_24",
+              "image_25",
+              "image_26",
+              "image_27",
+              "image_28",
+              "image_29",
+              "image_30"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3",
+              "video_4",
+              "video_5",
+              "video_6",
+              "video_7",
+              "video_8",
+              "video_9",
+              "video_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3",
+              "audio_4",
+              "audio_5",
+              "audio_6",
+              "audio_7",
+              "audio_8",
+              "audio_9",
+              "audio_10"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9",
+              "asset_10",
+              "asset_11",
+              "asset_12",
+              "asset_13",
+              "asset_14",
+              "asset_15",
+              "asset_16",
+              "asset_17",
+              "asset_18",
+              "asset_19",
+              "asset_20",
+              "asset_21",
+              "asset_22",
+              "asset_23",
+              "asset_24",
+              "asset_25",
+              "asset_26",
+              "asset_27",
+              "asset_28",
+              "asset_29",
+              "asset_30"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p",
+             "1080p",
+             "4k"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Fast",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "Seedance 2.0 Mini",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "480p",
+             "720p"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9",
+             "adaptive"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 7,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "generate_audio": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_assets": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_asset": [
+                "STRING",
+                {
+                 "forceInput": true,
+                 "multiline": false
+                }
+               ]
+              }
+             },
+             "names": [
+              "asset_1",
+              "asset_2",
+              "asset_3",
+              "asset_4",
+              "asset_5",
+              "asset_6",
+              "asset_7",
+              "asset_8",
+              "asset_9"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "auto_downscale": [
+           "BOOLEAN",
+           {
+            "default": true
+           }
+          ],
+          "auto_upscale": [
+           "BOOLEAN",
+           {
+            "advanced": true,
+            "default": false
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ],
+    "watermark": [
+     "BOOLEAN",
+     {
+      "advanced": true,
+      "default": false
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "watermark"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ByteDance2ReferenceNodeV2",
+  "display_name": "ByteDance Seedance 2.5 Reference to Video",
+  "python_module": "comfy_api_nodes.nodes_bytedance",
+  "category": "partner/video/ByteDance",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.ratio",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.duration",
+      "type": "INT"
+     },
+     {
+      "name": "model.task_type",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": [
+     "model.reference_videos"
+    ]
+   },
+   "expr": "\n(\n  $m := widgets.model;\n  $res := $lookup(widgets, \"model.resolution\");\n  $ratio := $lookup(widgets, \"model.ratio\");\n  $dur := $lookup(widgets, \"model.duration\");\n  $auto := $lookup(widgets, \"model.task_type\") = \"edit\";\n  $hasVideo := $exists(inputGroups) and $lookup(inputGroups, \"model.reference_videos\") > 0;\n  $ready := $type($m) = \"string\" and $type($res) = \"string\" and ($auto or $type($dur) = \"number\");\n  $ready ? (\n    $contains($m, \"2.5\") ? (\n      $is480 := $res = \"480p\";\n      $is1080 := $res = \"1080p\";\n      $perFrame := $ratio = \"1:1\"  ? ($is480 ? 400      : $is1080 ? 2025      : 900) :\n                   $ratio = \"4:3\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"3:4\"  ? ($is480 ? 411.25   : $is1080 ? 2028      : 905.6719) :\n                   $ratio = \"21:9\" ? ($is480 ? 418.5    : $is1080 ? 2037.9648 : 904.3945) :\n                                     ($is480 ? 400.3125 : $is1080 ? 2025      : 900);\n      $price := $is1080\n        ? ($hasVideo ? 0.01001 : 0.016731)\n        : ($hasVideo ? 0.009152 : 0.015301);\n      $costFor := function($d) { $floor($perFrame * (24 * $d + 1)) / 1000 * $price };\n      $lo := $costFor($auto ? 4 : $dur);\n      $hi := $costFor(($auto ? 30 : $dur) + ($hasVideo ? 30 : 0));\n      $lo = $hi\n        ? {\"type\": \"usd\", \"usd\": $lo, \"format\": {\"approximate\": true}}\n        : {\"type\": \"range_usd\", \"min_usd\": $lo, \"max_usd\": $hi, \"format\": {\"approximate\": true}}\n    ) : (\n      $rate := $res = \"4k\"    ? 195200 :\n               $res = \"1080p\" ? 48800 :\n               $res = \"720p\"  ? 21600 : 10044;\n      $noVideoPrice := $res = \"4k\"    ? 0.00572 :\n                       $res = \"1080p\" ? 0.011011 :\n                       $contains($m, \"mini\") ? 0.005005 :\n                       $contains($m, \"fast\") ? 0.008008 : 0.01001;\n      $videoPrice := $res = \"4k\"    ? 0.003432 :\n                     $res = \"1080p\" ? 0.006721 :\n                     $contains($m, \"mini\") ? 0.003003 :\n                     $contains($m, \"fast\") ? 0.004719 : 0.006149;\n      $hasVideo\n        ? {\"type\": \"range_usd\",\n           \"min_usd\": $ceil($dur * 5 / 3) * $rate * $videoPrice / 1000,\n           \"max_usd\": (15 + $dur) * $rate * $videoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n        : {\"type\": \"usd\", \"usd\": $dur * $rate * $noVideoPrice / 1000,\n           \"format\": {\"approximate\": true}}\n    )\n  ) : undefined\n)\n"
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "CLIPLoader": {
+  "input": {
+   "required": {
+    "clip_name": [
+     [
+      "clip-vit-large-patch14/put_clip__clip-vit-large-patch14.safetensors",
+      "gemma_3_12b_it_hf/put_text_encoders__gemma_3_12b_it_hf.safetensors",
+      "put_text_encoders.safetensors",
+      "siglip-so400m-patch14-384/put_clip__siglip-so400m-patch14-384.safetensors"
+     ]
+    ],
+    "type": [
+     [
+      "stable_diffusion",
+      "stable_cascade",
+      "sd3",
+      "stable_audio",
+      "mochi",
+      "ltxv",
+      "pixart",
+      "cosmos",
+      "lumina2",
+      "wan",
+      "hidream",
+      "chroma",
+      "ace",
+      "omnigen2",
+      "qwen_image",
+      "hunyuan_image",
+      "flux2",
+      "ovis",
+      "longcat_image",
+      "cogvideox",
+      "lens",
+      "pixeldit",
+      "ideogram4",
+      "boogu",
+      "krea2",
+      "joyimage",
+      "mage",
+      "minimax"
+     ]
+    ]
+   },
+   "optional": {
+    "device": [
+     [
+      "default",
+      "cpu"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip_name",
+    "type"
+   ],
+   "optional": [
+    "device"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CLIP"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CLIP"
+  ],
+  "name": "CLIPLoader",
+  "display_name": "Load CLIP",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "CLIPTextEncode": {
+  "input": {
+   "required": {
+    "text": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "clip": [
+     "CLIP",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "text",
+    "clip"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "CLIPTextEncode",
+  "display_name": "CLIP Text Encode (Prompt)",
+  "python_module": "nodes",
+  "category": "model/conditioning",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "A conditioning containing the embedded text used to guide the diffusion model."
+  ],
+  "search_aliases": [
+   "text",
+   "prompt",
+   "text prompt",
+   "positive prompt",
+   "negative prompt",
+   "encode text",
+   "text encoder",
+   "encode prompt"
+  ],
+  "description": ""
+ },
+ "ComfySwitchNode": {
+  "input": {
+   "required": {
+    "switch": [
+     "BOOLEAN",
+     {}
+    ],
+    "on_false": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ],
+    "on_true": [
+     "COMFY_MATCHTYPE_V3",
+     {
+      "lazy": true,
+      "template": {
+       "template_id": "switch",
+       "allowed_types": "*"
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "switch",
+    "on_false",
+    "on_true"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "COMFY_MATCHTYPE_V3"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "output"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": [
+   "switch"
+  ],
+  "name": "ComfySwitchNode",
+  "display_name": "If/Else Switch",
+  "python_module": "comfy_extras.nodes_logic",
+  "category": "utilities/logic",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": true,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "if",
+   "then",
+   "switch",
+   "conditional",
+   "branch"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ConditioningZeroOut": {
+  "input": {
+   "required": {
+    "conditioning": [
+     "CONDITIONING"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "conditioning"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "CONDITIONING"
+  ],
+  "name": "ConditioningZeroOut",
+  "display_name": "Conditioning Zero Out",
+  "python_module": "nodes",
+  "category": "model/conditioning/transform",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "null conditioning",
+   "clear conditioning"
+  ],
+  "description": ""
+ },
+ "CreateVideo": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "fps": [
+     "FLOAT",
+     {
+      "default": 30.0,
+      "min": 1.0,
+      "max": 120.0,
+      "step": 1.0
+     }
+    ]
+   },
+   "optional": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "bit_depth": [
+     "COMBO",
+     {
+      "default": "auto",
+      "multiselect": false,
+      "options": [
+       "auto",
+       8,
+       10
+      ]
+     }
+    ],
+    "color_space": [
+     "COMBO",
+     {
+      "default": "sRGB",
+      "multiselect": false,
+      "options": [
+       "sRGB",
+       "HDR",
+       "HDR PQ"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "fps"
+   ],
+   "optional": [
+    "audio",
+    "bit_depth",
+    "color_space"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "CreateVideo",
+  "display_name": "Create Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "images to video"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptyAudio": {
+  "input": {
+   "required": {
+    "duration": [
+     "FLOAT",
+     {
+      "default": 60.0,
+      "min": 0.0,
+      "max": 18446744073709551615,
+      "step": 0.01
+     }
+    ],
+    "sample_rate": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 44100,
+      "min": 1,
+      "max": 192000
+     }
+    ],
+    "channels": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 2,
+      "min": 1,
+      "max": 2
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "duration",
+    "sample_rate",
+    "channels"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptyAudio",
+  "display_name": "Empty Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "blank audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptyMiniMaxMusic3LatentAudio": {
+  "input": {
+   "required": {
+    "seconds": [
+     "FLOAT",
+     {
+      "default": 120.0,
+      "min": 0.04,
+      "max": 360.0,
+      "step": 0.04
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "seconds",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptyMiniMaxMusic3LatentAudio",
+  "display_name": "Empty MiniMax Music3 Latent Audio",
+  "python_module": "comfy_extras.nodes_minimax_music",
+  "category": "model/latent/minimax music",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "EmptySD3LatentImage": {
+  "input": {
+   "required": {
+    "width": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "height": [
+     "INT",
+     {
+      "default": 1024,
+      "min": 16,
+      "max": 16384,
+      "step": 16
+     }
+    ],
+    "batch_size": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 4096
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "width",
+    "height",
+    "batch_size"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "EmptySD3LatentImage",
+  "display_name": null,
+  "python_module": "comfy_extras.nodes_sd3",
+  "category": "model/latent/stable diffusion",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GetImageSize": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ]
+   },
+   "hidden": {
+    "unique_id": [
+     "UNIQUE_ID"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ],
+   "hidden": [
+    "unique_id"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height",
+   "batch_size"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetImageSize",
+  "display_name": "Get Image Size",
+  "python_module": "comfy_extras.nodes_images",
+  "category": "image",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "dimensions",
+   "resolution",
+   "image info"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GetVideoComponents": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "AUDIO",
+   "FLOAT",
+   "COMBO",
+   "COMBO"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "images",
+   "audio",
+   "fps",
+   "bit_depth",
+   "color_space"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   null,
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GetVideoComponents",
+  "display_name": "Get Video Components",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "extract frames",
+   "split video",
+   "video to images",
+   "demux"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "KSampler": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL",
+     {}
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "steps": [
+     "INT",
+     {
+      "default": 20,
+      "min": 1,
+      "max": 10000
+     }
+    ],
+    "cfg": [
+     "FLOAT",
+     {
+      "default": 8.0,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "sampler_name": [
+     [
+      "euler",
+      "euler_cfg_pp",
+      "euler_ancestral",
+      "euler_ancestral_cfg_pp",
+      "heun",
+      "heunpp2",
+      "exp_heun_2_x0",
+      "exp_heun_2_x0_sde",
+      "dpm_2",
+      "dpm_2_ancestral",
+      "lms",
+      "dpm_fast",
+      "dpm_adaptive",
+      "dpmpp_2s_ancestral",
+      "dpmpp_2s_ancestral_cfg_pp",
+      "dpmpp_sde",
+      "dpmpp_sde_gpu",
+      "dpmpp_2m",
+      "dpmpp_2m_cfg_pp",
+      "dpmpp_2m_sde",
+      "dpmpp_2m_sde_gpu",
+      "dpmpp_2m_sde_heun",
+      "dpmpp_2m_sde_heun_gpu",
+      "dpmpp_3m_sde",
+      "dpmpp_3m_sde_gpu",
+      "ddpm",
+      "lcm",
+      "ipndm",
+      "ipndm_v",
+      "deis",
+      "res_multistep",
+      "res_multistep_cfg_pp",
+      "res_multistep_ancestral",
+      "res_multistep_ancestral_cfg_pp",
+      "gradient_estimation",
+      "gradient_estimation_cfg_pp",
+      "er_sde",
+      "seeds_2",
+      "seeds_3",
+      "sa_solver",
+      "sa_solver_pece",
+      "ddim",
+      "uni_pc",
+      "uni_pc_bh2",
+      "legacy_rk",
+      "rk",
+      "rk_beta",
+      "deis_3m_ode",
+      "deis_2m_ode",
+      "deis_3m",
+      "deis_2m",
+      "res_6s_ode",
+      "res_5s_ode",
+      "res_3s_ode",
+      "res_2s_ode",
+      "res_3m_ode",
+      "res_2m_ode",
+      "res_6s",
+      "res_5s",
+      "res_3s",
+      "res_2s",
+      "res_3m",
+      "res_2m"
+     ],
+     {}
+    ],
+    "scheduler": [
+     [
+      "simple",
+      "sgm_uniform",
+      "karras",
+      "exponential",
+      "ddim_uniform",
+      "beta",
+      "normal",
+      "linear_quadratic",
+      "kl_optimal",
+      "bong_tangent",
+      "beta57"
+     ],
+     {}
+    ],
+    "positive": [
+     "CONDITIONING",
+     {}
+    ],
+    "negative": [
+     "CONDITIONING",
+     {}
+    ],
+    "latent_image": [
+     "LATENT",
+     {}
+    ],
+    "denoise": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "steps",
+    "cfg",
+    "sampler_name",
+    "scheduler",
+    "positive",
+    "negative",
+    "latent_image",
+    "denoise"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "LATENT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "LATENT"
+  ],
+  "name": "KSampler",
+  "display_name": "KSampler",
+  "python_module": "nodes",
+  "category": "model/sampling",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The denoised latent."
+  ],
+  "search_aliases": [
+   "sampler",
+   "sample",
+   "generate",
+   "denoise",
+   "diffuse",
+   "txt2img",
+   "img2img"
+  ],
+  "description": ""
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "MiniMaxMusic3TextEncode": {
+  "input": {
+   "required": {
+    "clip": [
+     "CLIP",
+     {}
+    ],
+    "caption": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "lyrics": [
+     "STRING",
+     {
+      "multiline": true,
+      "dynamicPrompts": true
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "max_duration": [
+     "FLOAT",
+     {
+      "default": 120.0,
+      "min": 0.04,
+      "max": 360.0,
+      "step": 0.04
+     }
+    ],
+    "cfg_scale": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 1.5,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.1,
+      "round": 0.01
+     }
+    ],
+    "top_k": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 50,
+      "min": 1,
+      "max": 16384
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "clip",
+    "caption",
+    "lyrics",
+    "seed",
+    "max_duration",
+    "cfg_scale",
+    "top_k"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "CONDITIONING",
+   "FLOAT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "CONDITIONING",
+   "seconds"
+  ],
+  "output_tooltips": [
+   null,
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "MiniMaxMusic3TextEncode",
+  "display_name": "MiniMax Music3 Text Encode",
+  "python_module": "comfy_extras.nodes_minimax_music",
+  "category": "model/conditioning/minimax music",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ModelSamplingAuraFlow": {
+  "input": {
+   "required": {
+    "model": [
+     "MODEL"
+    ],
+    "shift": [
+     "FLOAT",
+     {
+      "default": 1.73,
+      "min": 0.0,
+      "max": 100.0,
+      "step": 0.01
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "shift"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "ModelSamplingAuraFlow",
+  "display_name": "ModelSamplingAuraFlow",
+  "python_module": "comfy_extras.nodes_model_advanced",
+  "category": "model/patch",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "PrimitiveBoolean": {
+  "input": {
+   "required": {
+    "value": [
+     "BOOLEAN",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "BOOLEAN"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "BOOLEAN"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveBoolean",
+  "display_name": "Boolean",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveFloat": {
+  "input": {
+   "required": {
+    "value": [
+     "FLOAT",
+     {
+      "min": -9223372036854775807,
+      "max": 9223372036854775807,
+      "step": 0.1
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "FLOAT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "FLOAT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveFloat",
+  "display_name": "Float",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveInt": {
+  "input": {
+   "required": {
+    "value": [
+     "INT",
+     {
+      "min": -9223372036854775807,
+      "max": 9223372036854775807,
+      "control_after_generate": "fixed"
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "INT"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveInt",
+  "display_name": "Int",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "PrimitiveStringMultiline": {
+  "input": {
+   "required": {
+    "value": [
+     "STRING",
+     {
+      "multiline": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "value"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "STRING"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "STRING"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "PrimitiveStringMultiline",
+  "display_name": "Text (Multiline)",
+  "python_module": "comfy_extras.nodes_primitive",
+  "category": "utilities/primitive",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "text",
+   "string",
+   "text multiline",
+   "string multiline",
+   "text box",
+   "prompt"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ResizeAndPadImage": {
+  "input": {
+   "required": {
+    "image": [
+     "IMAGE",
+     {}
+    ],
+    "target_width": [
+     "INT",
+     {
+      "default": 512,
+      "min": 1,
+      "max": 16384,
+      "step": 1
+     }
+    ],
+    "target_height": [
+     "INT",
+     {
+      "default": 512,
+      "min": 1,
+      "max": 16384,
+      "step": 1
+     }
+    ],
+    "padding_color": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "white",
+       "black"
+      ]
+     }
+    ],
+    "interpolation": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "area",
+       "bicubic",
+       "nearest-exact",
+       "bilinear",
+       "lanczos"
+      ]
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "target_width",
+    "target_height",
+    "padding_color",
+    "interpolation"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "ResizeAndPadImage",
+  "display_name": "Resize And Pad Image",
+  "python_module": "comfy_extras.nodes_images",
+  "category": "image/transform",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "fit to size"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "ResolutionSelector": {
+  "input": {
+   "required": {
+    "aspect_ratio": [
+     "COMBO",
+     {
+      "default": "1:1 (Square)",
+      "multiselect": false,
+      "options": [
+       "1:1 (Square)",
+       "2:3 (Portrait Photo)",
+       "3:2 (Photo)",
+       "3:4 (Portrait Standard)",
+       "4:3 (Standard)",
+       "9:16 (Portrait Widescreen)",
+       "16:9 (Widescreen)",
+       "21:9 (Ultrawide)"
+      ]
+     }
+    ],
+    "megapixels": [
+     "FLOAT",
+     {
+      "default": 1.0,
+      "min": 0.1,
+      "max": 16.0,
+      "step": 0.1
+     }
+    ],
+    "multiple": [
+     "INT",
+     {
+      "advanced": true,
+      "default": 8,
+      "min": 8,
+      "max": 128,
+      "step": 4
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "aspect_ratio",
+    "megapixels",
+    "multiple"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT",
+   "INT"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "width",
+   "height"
+  ],
+  "output_tooltips": [
+   "Calculated width in pixels multiplied by the selected multiple.",
+   "Calculated height in pixels multiplied by the selected multiple."
+  ],
+  "output_matchtypes": null,
+  "name": "ResolutionSelector",
+  "display_name": "Resolution Selector",
+  "python_module": "comfy_extras.nodes_resolution",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SaveAudioAdvanced": {
+  "input": {
+   "required": {
+    "audio": [
+     "AUDIO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "audio/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "flac",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "mp3",
+        "inputs": {
+         "required": {
+          "quality": [
+           "COMBO",
+           {
+            "default": "V0",
+            "multiselect": false,
+            "options": [
+             "V0",
+             "128k",
+             "320k"
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "opus",
+        "inputs": {
+         "required": {
+          "quality": [
+           "COMBO",
+           {
+            "default": "128k",
+            "multiselect": false,
+            "options": [
+             "64k",
+             "96k",
+             "128k",
+             "192k",
+             "320k"
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "audio",
+    "filename_prefix",
+    "format"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "audio"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "SaveAudioAdvanced",
+  "display_name": "Save Audio (Advanced)",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "save audio",
+   "export audio",
+   "output audio",
+   "write audio",
+   "flac",
+   "mp3",
+   "opus"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "save",
+   "save image",
+   "export image",
+   "output image",
+   "write image",
+   "download"
+  ],
+  "essentials_category": "Basics",
+  "description": ""
+ },
+ "SaveVideo": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "video/ComfyUI",
+      "multiline": false
+     }
+    ],
+    "format": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mp4",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "mkv",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "h264",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 23.0,
+                        "min": 0.0,
+                        "max": 51.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "webm",
+        "inputs": {
+         "required": {
+          "codec": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "av1",
+              "inputs": {
+               "required": {},
+               "optional": {
+                "encoding": [
+                 "COMFY_DYNAMICCOMBO_V3",
+                 {
+                  "display_name": "encoding mode",
+                  "options": [
+                   {
+                    "key": "auto",
+                    "inputs": {
+                     "required": {}
+                    }
+                   },
+                   {
+                    "key": "re-encode",
+                    "inputs": {
+                     "required": {
+                      "crf": [
+                       "FLOAT",
+                       {
+                        "default": 30.0,
+                        "min": 0.0,
+                        "max": 63.0,
+                        "step": 1.0
+                       }
+                      ]
+                     }
+                    }
+                   }
+                  ]
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "codec": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "hidden": true,
+      "options": [
+       {
+        "key": "auto",
+        "inputs": {
+         "required": {}
+        }
+       },
+       {
+        "key": "h264",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 23.0,
+                  "min": 0.0,
+                  "max": 51.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       },
+       {
+        "key": "av1",
+        "inputs": {
+         "required": {},
+         "optional": {
+          "encoding": [
+           "COMFY_DYNAMICCOMBO_V3",
+           {
+            "display_name": "encoding mode",
+            "options": [
+             {
+              "key": "auto",
+              "inputs": {
+               "required": {}
+              }
+             },
+             {
+              "key": "re-encode",
+              "inputs": {
+               "required": {
+                "crf": [
+                 "FLOAT",
+                 {
+                  "default": 30.0,
+                  "min": 0.0,
+                  "max": 63.0,
+                  "step": 1.0
+                 }
+                ]
+               }
+              }
+             }
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": [
+     "PROMPT"
+    ],
+    "extra_pnginfo": [
+     "EXTRA_PNGINFO"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "filename_prefix",
+    "format"
+   ],
+   "optional": [
+    "codec"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "video"
+  ],
+  "output_tooltips": [
+   "The input video, unchanged."
+  ],
+  "output_matchtypes": null,
+  "name": "SaveVideo",
+  "display_name": "Save Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": true,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "export video"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SeedNode": {
+  "input": {
+   "required": {
+    "seed": [
+     "INT",
+     {
+      "min": 0,
+      "max": 9223372036854775807,
+      "control_after_generate": "fixed"
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "seed"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "INT"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "seed"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "SeedNode",
+  "display_name": "Seed",
+  "python_module": "comfy_extras.nodes_seed",
+  "category": "utilities",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "seed",
+   "random"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "UNETLoader": {
+  "input": {
+   "required": {
+    "unet_name": [
+     [
+      "put_diffusion_models.safetensors"
+     ]
+    ],
+    "weight_dtype": [
+     [
+      "default",
+      "fp8_e4m3fn",
+      "fp8_e4m3fn_fast",
+      "fp8_e5m2"
+     ],
+     {
+      "advanced": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "unet_name",
+    "weight_dtype"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MODEL"
+  ],
+  "name": "UNETLoader",
+  "display_name": "Load Diffusion Model",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "VAEDecode": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "name": "VAEDecode",
+  "display_name": "VAE Decode",
+  "python_module": "nodes",
+  "category": "model/latent",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "output_tooltips": [
+   "The decoded image."
+  ],
+  "search_aliases": [
+   "decode",
+   "decode latent",
+   "latent to image",
+   "render latent"
+  ],
+  "description": ""
+ },
+ "VAEDecodeAudio": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "VAEDecodeAudio",
+  "display_name": "VAE Decode Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "model/latent",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "latent to audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "VAEDecodeAudioTiled": {
+  "input": {
+   "required": {
+    "samples": [
+     "LATENT",
+     {}
+    ],
+    "vae": [
+     "VAE",
+     {}
+    ],
+    "tile_size": [
+     "INT",
+     {
+      "default": 512,
+      "min": 32,
+      "max": 8192,
+      "step": 8
+     }
+    ],
+    "overlap": [
+     "INT",
+     {
+      "default": 64,
+      "min": 0,
+      "max": 1024,
+      "step": 8
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "samples",
+    "vae",
+    "tile_size",
+    "overlap"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "VAEDecodeAudioTiled",
+  "display_name": "VAE Decode Audio (Tiled)",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "model/latent",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "latent to audio"
+  ],
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "VAELoader": {
+  "input": {
+   "required": {
+    "vae_name": [
+     [
+      "put_vae.safetensors",
+      "pixel_space"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "vae_name"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VAE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VAE"
+  ],
+  "name": "VAELoader",
+  "display_name": "Load VAE",
+  "python_module": "nodes",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [],
+  "description": ""
+ },
+ "Video Slice": {
+  "input": {
+   "required": {
+    "video": [
+     "VIDEO",
+     {}
+    ],
+    "start_time": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": -100000.0,
+      "max": 100000.0,
+      "step": 0.001
+     }
+    ],
+    "duration": [
+     "FLOAT",
+     {
+      "default": 0.0,
+      "min": 0.0,
+      "step": 0.001
+     }
+    ],
+    "strict_duration": [
+     "BOOLEAN",
+     {
+      "default": false
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "start_time",
+    "duration",
+    "strict_duration"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "Video Slice",
+  "display_name": "Trim Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "trim video duration",
+   "skip first frames",
+   "frame load cap",
+   "start time"
+  ],
+  "essentials_category": "Video Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ }
+}

--- a/tests/comfy_cli/fixtures/object_info_vhs_loadvideo.json
+++ b/tests/comfy_cli/fixtures/object_info_vhs_loadvideo.json
@@ -1,0 +1,447 @@
+{
+ "VHS_LoadVideo": {
+  "input": {
+   "required": {
+    "video": [
+     [
+      "bedroom.mp4"
+     ]
+    ],
+    "force_rate": [
+     "FLOAT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "disable": 0
+     }
+    ],
+    "custom_width": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 8192,
+      "disable": 0
+     }
+    ],
+    "custom_height": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 8192,
+      "disable": 0
+     }
+    ],
+    "frame_load_cap": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 9007199254740991,
+      "step": 1,
+      "disable": 0
+     }
+    ],
+    "skip_first_frames": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 9007199254740991,
+      "step": 1
+     }
+    ],
+    "select_every_nth": [
+     "INT",
+     {
+      "default": 1,
+      "min": 1,
+      "max": 9007199254740991,
+      "step": 1
+     }
+    ]
+   },
+   "optional": {
+    "meta_batch": [
+     "VHS_BatchManager"
+    ],
+    "vae": [
+     "VAE"
+    ],
+    "format": [
+     [
+      "None",
+      "AnimateDiff",
+      "Mochi",
+      "LTXV",
+      "Hunyuan",
+      "Cosmos",
+      "Wan"
+     ],
+     {
+      "default": "AnimateDiff",
+      "formats": {
+       "None": {},
+       "AnimateDiff": {
+        "target_rate": 8,
+        "dim": [
+         8,
+         0,
+         512,
+         512
+        ]
+       },
+       "Mochi": {
+        "target_rate": 24,
+        "dim": [
+         16,
+         0,
+         848,
+         480
+        ],
+        "frames": [
+         6,
+         1
+        ]
+       },
+       "LTXV": {
+        "target_rate": 24,
+        "dim": [
+         32,
+         0,
+         768,
+         512
+        ],
+        "frames": [
+         8,
+         1
+        ]
+       },
+       "Hunyuan": {
+        "target_rate": 24,
+        "dim": [
+         16,
+         0,
+         848,
+         480
+        ],
+        "frames": [
+         4,
+         1
+        ]
+       },
+       "Cosmos": {
+        "target_rate": 24,
+        "dim": [
+         16,
+         0,
+         1280,
+         704
+        ],
+        "frames": [
+         8,
+         1
+        ]
+       },
+       "Wan": {
+        "target_rate": 16,
+        "dim": [
+         8,
+         0,
+         832,
+         480
+        ],
+        "frames": [
+         4,
+         1
+        ]
+       }
+      }
+     }
+    ]
+   },
+   "hidden": {
+    "force_size": "STRING",
+    "unique_id": "UNIQUE_ID"
+   }
+  },
+  "input_order": {
+   "required": [
+    "video",
+    "force_rate",
+    "custom_width",
+    "custom_height",
+    "frame_load_cap",
+    "skip_first_frames",
+    "select_every_nth"
+   ],
+   "optional": [
+    "meta_batch",
+    "vae",
+    "format"
+   ],
+   "hidden": [
+    "force_size",
+    "unique_id"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "INT",
+   "AUDIO",
+   "VHS_VIDEOINFO"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "frame_count",
+   "audio",
+   "video_info"
+  ],
+  "name": "VHS_LoadVideo",
+  "display_name": "Load Video (Upload) \ud83c\udfa5\ud83c\udd65\ud83c\udd57\ud83c\udd62",
+  "python_module": "custom_nodes.comfyui-videohelpersuite",
+  "category": "Video Helper Suite \ud83c\udfa5\ud83c\udd65\ud83c\udd57\ud83c\udd62",
+  "output_node": false,
+  "has_intermediate_output": false
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "essentials_category": "Basics",
+  "has_intermediate_output": false
+ },
+ "LoadImage": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "MASK"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "MASK"
+  ],
+  "name": "LoadImage",
+  "display_name": "Load Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "essentials_category": "Basics"
+ },
+ "LoadImageMask": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ],
+    "channel": [
+     [
+      "alpha",
+      "red",
+      "green",
+      "blue"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image",
+    "channel"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MASK"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "MASK"
+  ],
+  "name": "LoadImageMask",
+  "display_name": "Load Image (as Mask)",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "essentials_category": "Image Tools"
+ },
+ "ImageOnlyCheckpointLoader": {
+  "input": {
+   "required": {
+    "ckpt_name": [
+     [
+      "dynamicrafter/controlnet/put_checkpoints__dynamicrafter__controlnet.safetensors",
+      "dynamicrafter/put_checkpoints__dynamicrafter.safetensors",
+      "put_checkpoints.safetensors"
+     ]
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "ckpt_name"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "MODEL",
+   "CLIP_VISION",
+   "VAE"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "MODEL",
+   "CLIP_VISION",
+   "VAE"
+  ],
+  "name": "ImageOnlyCheckpointLoader",
+  "display_name": "Load Checkpoint Image Only (img2vid model)",
+  "python_module": "comfy_extras.nodes_video_model",
+  "category": "model/loaders",
+  "output_node": false,
+  "has_intermediate_output": false
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "essentials_category": "Basics"
+ }
+}

--- a/tests/comfy_cli/output/test_error_code_registry.py
+++ b/tests/comfy_cli/output/test_error_code_registry.py
@@ -49,8 +49,10 @@ def _iter_python_files(root: Path):
 #: that helper deliberately hardcodes none, so each command names its own code
 #: at its own call site (the register-with-first-call-site rule). A command
 #: whose only refusal goes through those helpers would otherwise look like it
-#: registered an orphan.
-_CODE_KWARGS = frozenset({"code", "error_code"})
+#: registered an orphan. ``not_found_code=`` is the same channel in
+#: ``comfy_cli.command._cloud_errors.handle_cloud_http_error``: each caller
+#: names the 404 code for its own resource (``asset_not_found``, …).
+_CODE_KWARGS = frozenset({"code", "error_code", "not_found_code"})
 
 
 def _extract_codes_from_call(call: ast.Call) -> list[str]:

--- a/tests/comfy_cli/test_subgraph_gallery_templates.py
+++ b/tests/comfy_cli/test_subgraph_gallery_templates.py
@@ -102,13 +102,20 @@ class TestGalleryTemplateSlots:
         interior = [s for s in qwen_schema["slots"] if "/" in s["address"]]
         assert interior, f"no subgraph-interior slots surfaced; got {[s['address'] for s in qwen_schema['slots']]}"
 
-    def test_interior_prompt_and_seed_are_addressable(self, qwen_schema):
-        """The slots an agent actually edits: the prompt + seed inside the
-        opaque 'Qwen Image Edit 2509' subgraph instance (node 141)."""
+    def test_promoted_prompt_and_seed_are_addressed_at_the_host(self, qwen_schema):
+        """The slots an agent actually edits: the prompt + seed of the opaque
+        'Qwen Image Edit 2509' subgraph instance (node 141). Both are promoted
+        widgets, so they live at the instance address with the HOST value —
+        the interior KSampler still carries a stale seed (1118877715456453)
+        the frontend never runs (ADR 0009)."""
         by_addr = {s["address"]: s for s in qwen_schema["slots"]}
-        assert "141/132.prompt" in by_addr, f"missing interior prompt slot; got {sorted(by_addr)}"
-        assert by_addr["141/132.prompt"]["current_value"].startswith("Change the style")
-        assert by_addr["141/137.seed"]["current_value"] == 1118877715456453
+        assert "141.prompt" in by_addr, f"missing promoted prompt slot; got {sorted(by_addr)}"
+        assert by_addr["141.prompt"]["current_value"].startswith("Change the style")
+        assert by_addr["141.seed"]["current_value"] == 392667428726572
+        assert "141/132.prompt" not in by_addr
+        assert "141/137.seed" not in by_addr
+        # unpromoted interior widgets stay reachable
+        assert by_addr["141/137.steps"]["current_value"] == 4
 
     def test_top_level_slots_still_present(self, qwen_schema):
         by_addr = {s["address"]: s for s in qwen_schema["slots"]}

--- a/tests/comfy_cli/test_workflow_print.py
+++ b/tests/comfy_cli/test_workflow_print.py
@@ -635,7 +635,7 @@ SEEDREAM_GOLDEN_LINE = (
     'creating depth. The overall mood is high-tech, dystopian, and avant-garde.", model="seedream 5.0 pro", '
     'seed=0, control_after_generate="randomize", watermark=False, thinking=True, '
     '**{"model.images.image_1": None, "model.size_preset": "(1K) 1024x1024 (1:1)", "model.width": 2048, '
-    '"model.height": 2048})  # 1'
+    '"model.height": 2048})  # 1 model.images grows IMAGE'
 )
 
 
@@ -650,7 +650,9 @@ def test_seedream_dynamic_combo_golden():
     res = render_py(wf, graph)
     ast.parse(res.source)  # the whole render is syntactically valid Python
 
-    line = next(ln for ln in res.source.splitlines() if ln.endswith("  # 1"))
+    line = next(ln for ln in res.source.splitlines() if "  # 1 " in ln)
+    # The auto-grow group `model.images` owns no widget slot; it is named in
+    # the comment (with its element type) so the reader knows it exists.
     assert line == SEEDREAM_GOLDEN_LINE
     kwargs = line.split("**{", 1)[1]
     for frag in (

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -65,9 +65,10 @@ def _add(wf: dict, graph: Graph, class_type: str) -> tuple[dict, int]:
 
 
 def _line(source: str, node_id: Any) -> str:
-    """The printed line whose trailing comment names ``node_id``."""
-    marker = f"  # {node_id}"
-    return next(ln for ln in source.splitlines() if marker in ln)
+    """The printed line whose trailing comment names ``node_id`` — the whole
+    id, so ``# 4`` never matches a minted id that merely starts with 4."""
+    pattern = re.compile(rf"  # {re.escape(str(node_id))}(?!\d)")
+    return next(ln for ln in source.splitlines() if pattern.search(ln))
 
 
 def _kwargs(line: str) -> str:
@@ -518,3 +519,18 @@ def test_existing_workflow_is_not_mutated_by_printing(promoted_graph, autogrow_g
     before2 = copy.deepcopy(wf2)
     render_py(wf2, autogrow_graph)
     assert wf2 == before2
+
+
+def test_frontend_injected_slots_are_not_printed_as_control_after_generate(autogrow_graph):
+    """An older frontend serialized LoadImage as ``["a.png", "image"]`` — the
+    second value is the injected ``upload`` button slot (``serialize:false``
+    now). It owns no schema port, but it is NOT ``control_after_generate``,
+    and it is not an editable value either: it must not print at all."""
+    wf, nid = _add(_empty(), autogrow_graph, "LoadImage")
+    node = next(n for n in wf["nodes"] if n["id"] == nid)
+    node["widgets_values"] = ["a.png", "image"]
+    source = render_py(wf, autogrow_graph).source
+    line = _line(source, nid)
+    assert 'image="a.png"' in line
+    assert "control_after_generate" not in line
+    assert "upload" not in line

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -534,3 +534,44 @@ def test_frontend_injected_slots_are_not_printed_as_control_after_generate(autog
     assert 'image="a.png"' in line
     assert "control_after_generate" not in line
     assert "upload" not in line
+
+
+def test_promoted_values_resolve_once_per_instance_not_per_widget(promoted_graph, monkeypatch):
+    """Review (PR #816): the instance line used to call the public
+    ``promoted.effective_value`` per promoted widget, which re-derived the
+    definition index and re-located the ``PromotedInput`` the loop already
+    held — 451 ``promoted_inputs`` calls for 51 needed on 50 instances. The
+    loop's own ``pi`` and ``_State.promoted_defs`` are the whole answer."""
+    from comfy_cli.cql import promoted as promoted_mod
+
+    base = _gallery("image_z_image_turbo.json")
+    template = next(n for n in base["nodes"] if n["id"] == 57)
+    n_instances = 40
+    wf = {**base, "nodes": [n for n in base["nodes"] if n["id"] != 57], "links": []}
+    for k in range(n_instances):
+        inst = copy.deepcopy(template)
+        inst["id"] = 1000 + k
+        inst["outputs"] = [{**o, "links": []} for o in inst.get("outputs") or []]
+        wf["nodes"].append(inst)
+    wf["nodes"] = [n for n in wf["nodes"] if n["id"] != 9]  # drop the SaveImage that consumed 57
+
+    calls = {"promoted_inputs": 0, "defs_by_id": 0}
+    real_pi, real_defs = promoted_mod.promoted_inputs, promoted_mod.defs_by_id
+
+    def counting_pi(*a, **k):
+        calls["promoted_inputs"] += 1
+        return real_pi(*a, **k)
+
+    def counting_defs(*a, **k):
+        calls["defs_by_id"] += 1
+        return real_defs(*a, **k)
+
+    monkeypatch.setattr(promoted_mod, "promoted_inputs", counting_pi)
+    monkeypatch.setattr(promoted_mod, "defs_by_id", counting_defs)
+    res = render_py(wf, promoted_graph)
+    assert res.warnings == []
+    assert sum("width=1024" in ln for ln in res.source.splitlines()) == n_instances
+    # one walk per instance line, one for the definition's promoted header —
+    # never one per promoted widget (8 per instance here)
+    assert calls["promoted_inputs"] <= n_instances + 2, calls
+    assert calls["defs_by_id"] <= 2, calls

--- a/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
+++ b/tests/comfy_cli/test_workflow_print_promoted_autogrow.py
@@ -1,0 +1,520 @@
+"""``comfy workflow print`` on dynamic-combo / auto-grow nodes and on subgraph
+instances with promoted widgets.
+
+Two things the printer has to get right, both of which the slot surface
+(``comfy workflow slots``) and the editors (``set-widget`` / ``connect``)
+already model:
+
+* **Dynamic combos and auto-grow groups.** Widgets print by their value-aware
+  names (``model``, ``model.aspect_ratio``, …) at the frontend's positions —
+  never shifted, never a phantom widget slot for a link-only sub-input such as
+  a ``COMFY_AUTOGROW_V3`` group. The group itself is a *link* surface: its
+  grown slots print as links, and when nothing is wired the group is still
+  visible with its element type so a reader knows the address exists.
+
+* **Subgraph instances with promoted widgets.** A promoted widget's value
+  lives on the HOST instance (``cql.promoted``) — the instance line prints
+  the EFFECTIVE value (host value, else interior default) under the name the
+  agent edits (``57.width``), an outside link into it prints as a link, and
+  the interior line keeps ``IN.<name>`` so nobody edits ``57/13.width``.
+
+Fixtures: ``object_info_nested_autogrow.json`` (dynamic combos + auto-grow)
+and the verbatim gallery templates under ``fixtures/gallery`` with
+``object_info_subgraph_promoted.json``.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+from comfy_cli.workflow_print import render_py
+
+FIXTURES = Path(__file__).parent / "fixtures"
+GALLERY = FIXTURES / "gallery"
+
+
+@pytest.fixture(scope="module")
+def autogrow_graph() -> Graph:
+    return Graph.from_object_info(json.loads((FIXTURES / "object_info_nested_autogrow.json").read_text()))
+
+
+@pytest.fixture(scope="module")
+def promoted_graph() -> Graph:
+    return Graph.from_object_info(json.loads((FIXTURES / "object_info_subgraph_promoted.json").read_text()))
+
+
+def _empty() -> dict[str, Any]:
+    return {"last_node_id": 0, "last_link_id": 0, "nodes": [], "links": [], "groups": [], "version": 0.4}
+
+
+def _add(wf: dict, graph: Graph, class_type: str) -> tuple[dict, int]:
+    wf, op = workflow_ops.add_node(wf, graph, class_type)
+    return wf, op["node_id"]
+
+
+def _line(source: str, node_id: Any) -> str:
+    """The printed line whose trailing comment names ``node_id``."""
+    marker = f"  # {node_id}"
+    return next(ln for ln in source.splitlines() if marker in ln)
+
+
+def _kwargs(line: str) -> str:
+    """The trailing ``**{...}`` dict of a printed line (dotted names live there)."""
+    return line.split("**{", 1)[1] if "**{" in line else ""
+
+
+def _gallery(name: str) -> dict:
+    return json.loads((GALLERY / name).read_text())
+
+
+def _parses(source: str) -> None:
+    """Every printed statement is valid Python on its own. (A definition
+    block is indented under its ``# subgraph`` header, so the source as a
+    whole is deliberately not one parseable module — the lines are.)"""
+    for ln in source.splitlines():
+        stripped = ln.strip()
+        if stripped and not stripped.startswith("#"):
+            ast.parse(stripped)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Dynamic combos + auto-grow groups
+# --------------------------------------------------------------------------- #
+
+
+def test_dynamic_combo_widgets_print_by_value_aware_names(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    assert 'model="Nano Banana 2 (Gemini 3.1 Flash Image)"' in line
+    assert "seed=42" in line and 'control_after_generate="fixed"' in line
+    assert "temperature=1.0" in line and "top_p=0.95" in line
+    kwargs = _kwargs(line)
+    for frag in ('"model.aspect_ratio": "auto"', '"model.resolution": "1K"', '"model.thinking_level": "MINIMAL"'):
+        assert frag in kwargs
+    # the link-only sub-input owns no widget slot: never printed as a value
+    assert '"model.images":' not in line
+    assert res.warnings == []
+
+
+def test_switching_the_selector_reexpands_the_sub_widgets_without_shifting(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.set_widget(wf, autogrow_graph, b, "model", "Nano Banana 2 Lite")
+    wf, _ = workflow_ops.set_widget(wf, autogrow_graph, b, "seed", 7)
+    line = _line(render_py(wf, autogrow_graph).source, b)
+    assert 'model="Nano Banana 2 Lite"' in line
+    assert "seed=7" in line
+    assert '"model.resolution": "1K"' in _kwargs(line)
+
+
+def test_unwired_autogrow_group_is_visible_with_its_element_type(autogrow_graph):
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    # the group's first slot is shown open, under the name `connect` accepts
+    assert '"model.images.image_1": None' in _kwargs(line)
+    # ...and the comment names the group, its element type and its capacity
+    assert "model.images grows IMAGE (max 14)" in line.split("  # ", 1)[1]
+
+
+def test_wired_autogrow_slots_print_as_links_then_the_next_free_slot(autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, c = _add(wf, autogrow_graph, "LoadImage")
+    wf, b = _add(wf, autogrow_graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", b, "model.images.image_1")
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, c, "IMAGE", b, "model.images")
+    res = render_py(wf, autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, b)
+    kwargs = _kwargs(line)
+    # each grown slot references the loader wired into it (binding names are
+    # assigned in print order, so resolve them through `bindings`)
+    refs = dict(re.findall(r'"(model\.images\.image_\d+)": (\w+)\.IMAGE', kwargs))
+    assert res.bindings[refs["model.images.image_1"]] == str(a)
+    assert res.bindings[refs["model.images.image_2"]] == str(c)
+    assert '"model.images.image_3": None' in kwargs
+    assert '"model.images.image_4"' not in kwargs
+    # the wired group shifted nothing: the widgets still read at their names
+    assert "seed=42" in line and '"model.resolution": "1K"' in kwargs
+    assert "model.images grows IMAGE (max 14)" in line
+    assert res.warnings == []
+
+
+def test_top_level_autogrow_base_entry_is_the_group_not_a_phantom_link_input(autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, d = _add(wf, autogrow_graph, "BatchImagesNode")
+    line = _line(render_py(wf, autogrow_graph).source, d)
+    assert "images=None" not in line
+    assert '"images.image0": None' in _kwargs(line)
+    assert "images grows IMAGE (max 50)" in line
+    wf, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", d, "images")
+    line = _line(render_py(wf, autogrow_graph).source, d)
+    assert "images=None" not in line
+    assert '"images.image0": load_image' in _kwargs(line)
+    assert '"images.image1": None' in _kwargs(line)
+
+
+def _minimax_ui_workflow() -> dict[str, Any]:
+    """A UI-built ``MinimaxHailuo03ReferenceNode``: ``image_1`` wired, one free
+    trailing slot per group (the frontend's shape), 8 widget values."""
+    return {
+        "last_node_id": 4,
+        "last_link_id": 4,
+        "version": 0.4,
+        "groups": [],
+        "nodes": [
+            {
+                "id": 2,
+                "type": "LoadImage",
+                "pos": [0, 0],
+                "size": [300, 300],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [
+                    {"name": "IMAGE", "type": "IMAGE", "links": [4]},
+                    {"name": "MASK", "type": "MASK", "links": []},
+                ],
+                "properties": {},
+                "widgets_values": ["storyboard.png", "image"],
+            },
+            {
+                "id": 4,
+                "type": "MinimaxHailuo03ReferenceNode",
+                "pos": [400, 0],
+                "size": [400, 300],
+                "flags": {},
+                "order": 1,
+                "mode": 0,
+                "inputs": [
+                    {
+                        "label": "image_1",
+                        "name": "model.reference_images.image_1",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": 4,
+                    },
+                    {
+                        "label": "image_2",
+                        "name": "model.reference_images.image_2",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": None,
+                    },
+                    {
+                        "label": "video_1",
+                        "name": "model.reference_videos.video_1",
+                        "shape": 7,
+                        "type": "VIDEO",
+                        "link": None,
+                    },
+                    {
+                        "label": "audio_1",
+                        "name": "model.reference_audios.audio_1",
+                        "shape": 7,
+                        "type": "AUDIO",
+                        "link": None,
+                    },
+                ],
+                "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": []}],
+                "properties": {},
+                "widgets_values": ["MiniMax H3", "storyboard prompt", "768P", "adaptive", 5, 42, "randomize", False],
+            },
+        ],
+        "links": [[4, 2, 0, 4, 0, "IMAGE"]],
+    }
+
+
+def test_ui_built_free_slots_are_reused_not_duplicated(autogrow_graph):
+    res = render_py(_minimax_ui_workflow(), autogrow_graph)
+    _parses(res.source)
+    line = _line(res.source, 4)
+    kwargs = _kwargs(line)
+    assert '"model.reference_images.image_1": load_image.IMAGE' in kwargs
+    assert '"model.reference_images.image_2": None' in kwargs
+    assert '"model.reference_images.image_3"' not in kwargs  # a free slot already exists
+    assert '"model.reference_videos.video_1": None' in kwargs
+    assert '"model.reference_audios.audio_1": None' in kwargs
+    comment = line.split("  # ", 1)[1]
+    assert "model.reference_images grows IMAGE (max 9)" in comment
+    assert "model.reference_videos grows VIDEO (max 3)" in comment
+    assert "model.reference_audios grows AUDIO (max 3)" in comment
+    # widgets at their frontend positions, unshifted by the groups
+    assert 'model="MiniMax H3"' in line and "seed=42" in line and "watermark=False" in line
+    assert '"model.prompt": "storyboard prompt"' in kwargs and '"model.resolution": "768P"' in kwargs
+
+
+def test_full_group_prints_no_free_slot(autogrow_graph):
+    wf = _minimax_ui_workflow()
+    wf, v = _add(wf, autogrow_graph, "LoadVideo")
+    for _ in range(3):
+        wf, _ = workflow_ops.connect(wf, autogrow_graph, v, "VIDEO", 4, "model.reference_videos")
+    line = _line(render_py(wf, autogrow_graph).source, 4)
+    kwargs = _kwargs(line)
+    assert '"model.reference_videos.video_3": load_video' in kwargs
+    assert '"model.reference_videos.video_4"' not in kwargs
+    assert "model.reference_videos grows VIDEO (max 3)" in line
+
+
+def test_autogrow_group_follows_the_current_selection(autogrow_graph):
+    """A node switched to an option without the group stops advertising it."""
+    wf, b = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    node = next(n for n in wf["nodes"] if n["id"] == b)
+    node["widgets_values"][1] = "not an option"  # no option → no sub-inputs, no group
+    line = _line(render_py(wf, autogrow_graph).source, b)
+    assert "model.images" not in line
+
+
+# --------------------------------------------------------------------------- #
+# 2. Subgraph instances with promoted widgets
+# --------------------------------------------------------------------------- #
+
+
+def test_pre_migration_instance_prints_interior_defaults_at_the_host_address(promoted_graph):
+    """``image_z_image_turbo``: the host has no values yet, so the instance
+    line shows the interior defaults — under the names ``set-widget 57.<name>``
+    takes, not buried in the interior block."""
+    wf = _gallery("image_z_image_turbo.json")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "57 subgraph")
+    assert line.startswith('text_to_image_z_image_turbo = Subgraph["Text to Image (Z-Image-Turbo)"](')
+    assert 'text="Latina female with thick wavy hair' in line
+    for frag in (
+        "width=1024",
+        "height=1024",
+        "seed=0",
+        "steps=8",
+        'unet_name="z_image_turbo_bf16.safetensors"',
+        'clip_name="qwen_3_4b.safetensors"',
+        'vae_name="ae.safetensors"',
+    ):
+        assert frag in line
+    assert "text=None" not in line
+    assert res.bindings["text_to_image_z_image_turbo"] == "57"
+    assert res.warnings == []
+
+
+def test_post_migration_host_values_win_over_the_interior(promoted_graph):
+    """``audio_minimax_music_3``: the host materialized every promoted value;
+    the interior caption is ``''`` but the host's is the real prompt. The
+    values must land under the RIGHT names — not the instance's serialized
+    ``inputs[]`` order, which only lists the one input the UI showed."""
+    wf = _gallery("audio_minimax_music_3.json")
+    line = _line(render_py(wf, promoted_graph).source, "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    assert 'lyrics="[Intro]' in line
+    assert "max_duration=60" in line
+    assert "seed=197122968890040" in line
+    assert 'unet_name="minimax_music3_dit_fp16.safetensors"' in line
+    assert "switch=True" in line
+    assert 'switch="Global Metadata' not in line
+    assert 'caption=""' not in line
+
+
+def test_promoted_values_are_never_positionally_shifted(promoted_graph):
+    """``api_seedance2_5_video_extend``: two VIDEO sockets precede the widget
+    inputs, and the host's ``widgets_values`` cover ONLY the widget-backed ones
+    (in declaration order). The old positional read printed
+    ``drop_audio="lanczos"``."""
+    wf = _gallery("api_seedance2_5_video_extend.json")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "39 subgraph")
+    assert "clip_to_resize=load_video" in line
+    assert "base_video=byte_dance2_reference_node_v2" in line
+    for frag in ("pad_second_video=False", 'interpolation="lanczos"', 'padding_color="white"', "drop_audio=False"):
+        assert frag in line
+    assert 'drop_audio="lanczos"' not in line
+
+
+def test_interior_promoted_widgets_point_at_the_host_not_at_a_value(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    src = render_py(wf, promoted_graph).source
+    interior = _line(src, "13")
+    assert interior.strip().startswith("empty_sd3_latent_image = EmptySD3LatentImage(")
+    # the promoted widget is a reference to the instance's value, not a literal
+    assert "width=IN.width" in interior and "height=IN.height" in interior
+    assert "width=1024" not in interior
+    # the unpromoted widget still prints as a plain, editable value
+    assert "batch_size=1" in interior
+    # the definition block says where those IN.* values live and how to edit them
+    header_idx = next(i for i, ln in enumerate(src.splitlines()) if ln.startswith("# subgraph f2fdebf6"))
+    promoted_line = src.splitlines()[header_idx + 1]
+    assert promoted_line.startswith("#")
+    assert "promoted" in promoted_line
+    for name in ("text", "width", "height", "seed", "steps", "unet_name", "clip_name", "vae_name"):
+        assert f"IN.{name}" in promoted_line
+    assert "57.<name>" in promoted_line
+    assert "57/<id>.<name>" in promoted_line
+
+
+def test_socket_only_subgraph_inputs_are_not_listed_as_promoted_widgets(promoted_graph):
+    wf = _gallery("api_seedance2_5_video_extend.json")
+    src = render_py(wf, promoted_graph).source
+    header_idx = next(i for i, ln in enumerate(src.splitlines()) if ln.startswith("# subgraph d9aa59a4"))
+    promoted_line = src.splitlines()[header_idx + 1]
+    assert "IN.interpolation" in promoted_line and "IN.drop_audio" in promoted_line
+    assert "IN.clip_to_resize" not in promoted_line and "IN.base_video" not in promoted_line
+
+
+def test_outside_link_into_a_promoted_input_prints_as_a_link(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    wf, prim = _add(wf, promoted_graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, promoted_graph, prim, "value", 640)
+    wf, _ = workflow_ops.connect(wf, promoted_graph, prim, "INT", 57, "width")
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    line = _line(res.source, "57 subgraph")
+    assert "width=primitive_int" in line
+    assert "width=1024" not in line
+    assert "height=1024" in line  # the sibling is still the host/interior value
+    # the primitive prints before the instance that consumes it
+    assert res.source.index("primitive_int = PrimitiveInt(") < res.source.index("text_to_image_z_image_turbo = ")
+
+
+def test_host_value_edited_by_set_widget_is_what_prints(promoted_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, promoted_graph, 57, "width", 768)
+    line = _line(render_py(wf, promoted_graph).source, "57 subgraph")
+    assert "width=768" in line
+    assert "height=1024" in line
+
+
+def test_nested_promotion_prints_the_effective_value_and_legacy_proxies(promoted_graph):
+    """``subgraph_template_ui``: instance 10's ``value`` is promoted THROUGH a
+    nested instance (10/3) — it shows on the instance line with the value the
+    frontend runs; the nested instance's line inside the definition keeps
+    referencing the outer proxy. Its legacy ``proxyWidgets`` route for
+    ``seed`` (interior node 9, never declared as an input) is not a surface
+    slot — ``slots`` does not advertise it, so neither does ``print``."""
+    wf = json.loads((FIXTURES / "subgraph_template_ui.json").read_text())
+    graph = Graph.from_object_info(json.loads((FIXTURES / "subgraph_object_info.json").read_text()))
+    res = render_py(wf, graph)
+    _parses(res.source)
+    inst = _line(res.source, "10 subgraph")
+    assert 'value=""' in inst
+    assert 'aspect_ratio="16:9"' in inst
+    assert "seed=" not in inst
+    assert '**{"images.image0": None}' in inst
+    nested = _line(res.source, "3 subgraph da09b826")
+    assert "value=IN.value" in nested
+
+
+def test_self_referential_definition_is_bounded(promoted_graph):
+    """A definition that instantiates itself and promotes through itself must
+    print (with the nested value unresolved), not recurse forever."""
+    uuid = "aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa"
+    sg = {
+        "id": uuid,
+        "name": "Ouroboros",
+        "inputs": [{"name": "value", "type": "INT", "linkIds": [1]}],
+        "outputs": [],
+        "nodes": [
+            {
+                "id": 2,
+                "type": uuid,
+                "inputs": [{"name": "value", "type": "INT", "link": 1, "widget": {"name": "value"}}],
+                "outputs": [],
+                "widgets_values": [],
+            }
+        ],
+        "links": [{"id": 1, "origin_id": -10, "origin_slot": 0, "target_id": 2, "target_slot": 0}],
+    }
+    wf = {
+        "nodes": [
+            {
+                "id": 1,
+                "type": uuid,
+                "inputs": [{"name": "value", "type": "INT", "link": None, "widget": {"name": "value"}}],
+                "outputs": [],
+                "widgets_values": [3],
+            }
+        ],
+        "links": [],
+        "definitions": {"subgraphs": [sg]},
+        "version": 0.4,
+    }
+    res = render_py(wf, promoted_graph)
+    _parses(res.source)
+    assert res.source.count("# subgraph aaaaaaaa-0000") == 1
+    assert "value=IN.value" in _line(res.source, "2 subgraph")
+
+
+# --------------------------------------------------------------------------- #
+# 3. Through the CLI: the printed addresses are the ones the editors take
+# --------------------------------------------------------------------------- #
+
+
+def _run_print(path: Path, object_info: Path) -> dict:
+    set_renderer(Renderer(OutputMode.JSON))
+    try:
+        result = CliRunner().invoke(workflow_cmd.app, ["print", str(path), "--input", str(object_info)])
+    finally:
+        set_renderer(Renderer(OutputMode.PRETTY))
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)["data"]
+
+
+def test_cli_print_addresses_match_the_editors(tmp_path, promoted_graph):
+    wf = _gallery("audio_minimax_music_3.json")
+    path = tmp_path / "wf.json"
+    path.write_text(json.dumps(wf))
+    data = _run_print(path, FIXTURES / "object_info_subgraph_promoted.json")
+    line = _line(data["source"], "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    # the binding resolves to the address `set-widget` takes: 37.caption
+    assert data["bindings"]["text_to_music_mini_max_music_3"] == "37"
+    wf2, op = workflow_ops.set_widget(wf, promoted_graph, 37, "caption", "new caption")
+    assert op["node_id"] == 37 and op["widget"] == "caption"
+    assert 'caption="new caption"' in _line(render_py(wf2, promoted_graph).source, "37 subgraph")
+
+
+def test_cli_print_autogrow_addresses_match_connect(tmp_path, autogrow_graph):
+    wf, a = _add(_empty(), autogrow_graph, "LoadImage")
+    wf, b = _add(wf, autogrow_graph, "GeminiNanoBanana2V2")
+    path = tmp_path / "wf.json"
+    path.write_text(json.dumps(wf))
+    data = _run_print(path, FIXTURES / "object_info_nested_autogrow.json")
+    line = _line(data["source"], b)
+    assert '"model.images.image_1": None' in line
+    # that printed slot name is exactly what connect grows
+    wf2, _ = workflow_ops.connect(wf, autogrow_graph, a, "IMAGE", b, "model.images.image_1")
+    node = next(n for n in wf2["nodes"] if n["id"] == b)
+    assert [i["name"] for i in node["inputs"]] == ["model.images.image_1"]
+
+
+def test_no_catalog_still_prints_the_instance_values(promoted_graph):
+    """Without object_info nothing is value-aware — but promoted values that
+    the host materialized are still the host's, by name."""
+    wf = _gallery("audio_minimax_music_3.json")
+    res = render_py(wf, None)
+    line = _line(res.source, "37 subgraph")
+    assert 'caption="Global Metadata: Lo-fi hip-hop' in line
+    assert "switch=True" in line
+
+
+def test_existing_workflow_is_not_mutated_by_printing(promoted_graph, autogrow_graph):
+    wf = _gallery("image_z_image_turbo.json")
+    before = copy.deepcopy(wf)
+    render_py(wf, promoted_graph)
+    assert wf == before
+    wf2, _ = _add(_empty(), autogrow_graph, "GeminiNanoBanana2V2")
+    before2 = copy.deepcopy(wf2)
+    render_py(wf2, autogrow_graph)
+    assert wf2 == before2

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -1,0 +1,97 @@
+"""UI→API conversion honors host-owned promoted widget values (BE-10305).
+
+``convert_ui_to_api`` expanded subgraph instances by reattaching *external*
+links to interior inputs and otherwise reading the interior node's own
+``widgets_values``. That is the pre-ADR-0009 world. A post-migration save
+keeps the promoted value on the HOST instance (``widgets_values`` positional
+over the widget-backed subgraph inputs), so the interior widget can be stale
+or empty — ``audio_minimax_music_3`` ships an interior ``caption`` of ``''``
+while the host carries the whole prompt — and the prompt the CLI submitted
+(``comfy run`` / ``validate``) was not the prompt the frontend runs.
+
+Precedence, exactly as the frontend serializes it: an external link into the
+instance input wins over everything; else the host value when materialized;
+else the interior widget.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli import workflow_ops
+from comfy_cli.cql.engine import Graph
+from comfy_cli.workflow_to_api import convert_ui_to_api
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+_GALLERY = _FIXTURES / "gallery"
+
+
+@pytest.fixture(scope="module")
+def object_info() -> dict:
+    return json.loads((_FIXTURES / "object_info_subgraph_promoted.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def graph(object_info) -> Graph:
+    return Graph.from_object_info(object_info)
+
+
+def _load(name: str) -> dict:
+    return json.loads((_GALLERY / name).read_text(encoding="utf-8"))
+
+
+def _api_node(api: dict, class_type: str, api_id: str | None = None) -> dict:
+    if api_id is not None:
+        return api[api_id]
+    return next(v for v in api.values() if v["class_type"] == class_type)
+
+
+def test_post_migration_host_values_reach_the_prompt(object_info):
+    api = convert_ui_to_api(_load("audio_minimax_music_3.json"), object_info)
+    enc = _api_node(api, "MiniMaxMusic3TextEncode", "37:13")["inputs"]
+    assert enc["caption"].startswith("Global Metadata: Lo-fi hip-hop")
+    assert enc["lyrics"].startswith("[Intro]")
+    assert enc["max_duration"] == 60
+    assert _api_node(api, "UNETLoader", "37:6")["inputs"]["unet_name"] == "minimax_music3_dit_fp16.safetensors"
+    assert _api_node(api, "ComfySwitchNode", "37:43")["inputs"]["switch"] is True
+
+
+def test_host_value_written_by_set_widget_reaches_the_prompt(object_info, graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    api = convert_ui_to_api(wf, object_info)
+    latent = _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]
+    assert latent["width"] == 768
+    assert latent["height"] == 1024
+
+
+def test_interior_value_still_used_when_no_host_value_exists(object_info):
+    api = convert_ui_to_api(_load("image_z_image_turbo.json"), object_info)
+    assert _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]["width"] == 1024
+    assert _api_node(api, "KSampler", "57:3")["inputs"]["steps"] == 8
+
+
+def test_external_link_into_a_promoted_input_wins_over_the_host_value(object_info, graph):
+    wf = _load("image_z_image_turbo.json")
+    wf, _ = workflow_ops.set_widget(wf, graph, 57, "width", 768)
+    wf, prim = workflow_ops.add_node(wf, graph, "PrimitiveInt")
+    wf, _ = workflow_ops.set_widget(wf, graph, prim["node_id"], "value", 640)
+    wf, _ = workflow_ops.connect(wf, graph, prim["node_id"], "INT", 57, "width")
+    api = convert_ui_to_api(wf, object_info)
+    assert _api_node(api, "EmptySD3LatentImage", "57:13")["inputs"]["width"] == [str(prim["node_id"]), 0]
+    assert api[str(prim["node_id"])]["inputs"]["value"] == 640
+
+
+def test_socket_links_and_host_values_coexist(object_info):
+    api = convert_ui_to_api(_load("api_seedance2_5_video_extend.json"), object_info)
+    pad = _api_node(api, "PrimitiveBoolean", "39:28")["inputs"]
+    assert pad["value"] is False
+    resize = _api_node(api, "ResizeAndPadImage", "39:6")["inputs"]
+    assert resize["interpolation"] == "lanczos"
+    assert resize["padding_color"] == "white"
+    # the two VIDEO socket inputs are external links, reattached as before
+    comps = _api_node(api, "GetVideoComponents", "39:1")["inputs"]
+    assert isinstance(comps["video"], list) and len(comps["video"]) == 2

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -112,3 +112,16 @@ def test_list_valued_host_values_are_wrapped_not_read_as_links(object_info, grap
     assert isinstance(plain, str)
     assert text != ["a", "b"] or not (isinstance(text, list) and len(text) == 2 and isinstance(text[0], str))
     assert text == workflow_to_api._wrap_widget_value(["a", "b"])
+
+
+def test_dangling_link_on_a_promoted_input_does_not_drop_the_host_value(object_info):
+    """A promoted input whose serialized ``link`` id no longer exists in
+    ``links`` is unlinked as far as the frontend is concerned (it drops the
+    link on load): the host value must reach the prompt, exactly as
+    ``resolve_write`` already treats that shape."""
+    wf = _load("audio_minimax_music_3.json")
+    inst = next(n for n in wf["nodes"] if n["id"] == 37)
+    inst["inputs"].append({"name": "caption", "type": "STRING", "widget": {"name": "caption"}, "link": 999999})
+    assert all(link[0] != 999999 for link in wf["links"])
+    api = convert_ui_to_api(wf, object_info)
+    assert _api_node(api, "MiniMaxMusic3TextEncode", "37:13")["inputs"]["caption"].startswith("Global Metadata")

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from comfy_cli import workflow_ops
+from comfy_cli import workflow_ops, workflow_to_api
 from comfy_cli.cql.engine import Graph
 from comfy_cli.workflow_to_api import convert_ui_to_api
 
@@ -95,3 +95,20 @@ def test_socket_links_and_host_values_coexist(object_info):
     # the two VIDEO socket inputs are external links, reattached as before
     comps = _api_node(api, "GetVideoComponents", "39:1")["inputs"]
     assert isinstance(comps["video"], list) and len(comps["video"]) == 2
+
+
+def test_list_valued_host_values_are_wrapped_not_read_as_links(object_info, graph):
+    """A two-item list host value must not be mistaken for a ``[node, slot]``
+    link when overlaid onto the interior node."""
+    wf = _load("image_z_image_turbo.json")
+    from comfy_cli.cql import promoted
+
+    promoted.set_host_value(wf, next(n for n in wf["nodes"] if n["id"] == 57), "text", ["a", "b"], graph)
+    api = convert_ui_to_api(wf, object_info)
+    text = _api_node(api, "CLIPTextEncode", "57:27")["inputs"]["text"]
+    plain = _api_node(convert_ui_to_api(_load("image_z_image_turbo.json"), object_info), "CLIPTextEncode", "57:27")[
+        "inputs"
+    ]["text"]
+    assert isinstance(plain, str)
+    assert text != ["a", "b"] or not (isinstance(text, list) and len(text) == 2 and isinstance(text[0], str))
+    assert text == workflow_to_api._wrap_widget_value(["a", "b"])

--- a/tests/comfy_cli/test_workflow_to_api_promoted.py
+++ b/tests/comfy_cli/test_workflow_to_api_promoted.py
@@ -1,8 +1,8 @@
-"""UI→API conversion honors host-owned promoted widget values (BE-10305).
+"""UI→API conversion honors host-owned promoted widget values.
 
 ``convert_ui_to_api`` expanded subgraph instances by reattaching *external*
 links to interior inputs and otherwise reading the interior node's own
-``widgets_values``. That is the pre-ADR-0009 world. A post-migration save
+``widgets_values``. That is the pre-ADR 0009 world. A post-migration save
 keeps the promoted value on the HOST instance (``widgets_values`` positional
 over the widget-backed subgraph inputs), so the interior widget can be stale
 or empty — ``audio_minimax_music_3`` ships an interior ``caption`` of ``''``


### PR DESCRIPTION
> **Consolidated stack head.** After #809 and #825 (ex-#812) merged, the remaining reviewed PRs were folded into this one to run CI once: #815 (promoted widgets on the host), #816 (`workflow print`), #818 (op shapes, amendment v1.5), #819 (legacy proxyWidgets repair) and the five Langfuse fixes below — 19 commits, every one individually approved by @annehe9 on its own PR (all closed pointing here). Merged with a **rebase merge** so each commit lands on `main` with its own message.


## Why

A Langfuse sweep of every comfy-agent tool call from 2026-08-25 to 08-28 (1,764 observations, all on comfy-cli pin `8b9c8b01`) found 57 failing tool observations in 23 clusters. Most are cleared by #809/#812/#815 or belong to the doc host / agent service (report: `langfuse_tool_errors.md`, attached to the Linear thread). These five were new and fixable in the CLI, each with the production payload pinned as a red→green test:

### fix(cql): accept uploaded files on unmarked input-folder COMBOs (VHS_LoadVideo) (`0f2cd990`)

`comfy run` refused every content hash an agent uploaded to Comfy Cloud and
wired into `VHS_LoadVideo.video` (`unknown_enum_value '<64hex>.mp4' not in 1
known options for video`) — an eight-shot assembly never rendered. The port
exemption for upload-backed COMBOs only honoured the core loaders'
`<kind>_upload` marker; VideoHelperSuite lists the input folder itself and
attaches its own upload button by class name, so its catalog entry is a bare
`[["bedroom.mp4"]]`.

When the catalog declares nothing, the listing decides: a COMBO whose every
option is a media file name is a folder listing, not an install-time
vocabulary. An explicit `<kind>_upload: false` still wins. Model folders
(`.safetensors`) and plain enums stay constrained. Pinned with the real
cloud catalog entry.



### fix(cql): no edge_type_mismatch when the produced type is in a comma-separated accept list (`ac701283`)

ComfyUI types a multi-type socket as a comma-separated union (`INT,FLOAT`
on a math operand, `MESH,FILE_3D_GLB,…` on a 3D importer). The validate edge
check compared raw strings, so a `FLOAT` output feeding an `INT,FLOAT` input
warned `edge_type_mismatch` — 12 of the 23 such warnings in the 08-25..28
prod window were this shape, on edges the frontend draws and the server runs.

Route the check (and the "use X[i] instead" hint) through the converter's
`_is_valid_connection`, the mirror of the frontend's `isValidConnection`,
which expands the union on both ends. Wildcards (`*`, `COMFY_MATCHTYPE_V3`)
keep short-circuiting first; the report's other four warnings were that
wildcard, which the pin already honours (TestMatchTypeWildcard).



### fix(assets): `assets library ensure` 404 is asset_not_found, not workflow_not_found (`016d28c6`)

An agent passed a file name (`comfyorg_logo.png`) where the content hash
belongs; the API answered 404 and the CLI said `workflow_not_found` /
"workflow not found (ensure)" with a hint to `workflow list` — the
`cloud_http` helper's 404 branch hardcodes the saved-workflow vocabulary.

Route `ensure` through the parameterized `_cloud_errors` helper with a new
registered `asset_not_found` code: the message names the hash, `details.hash`
carries it, and the hint says how to get a real one (`assets library ls`,
or upload first). The registry test now recognises `not_found_code=` as a
code kwarg so callers of the parameterized helper register like any other.



### fix(workflow): let `clear` and `reset-doc` accept an API-format draft (`cec8eadb`)

`generate --emit-workflow` leaves an API-format draft in the tab's scratch
file; every edit then fails `workflow_not_frontend_format` — including
`clear`, so nothing could replace the draft and the agent abandoned the tab
(Langfuse 2026-08-26).

Clearing discards the content, so the format of what is thrown away is no
reason to refuse. `clear` and `reset-doc` now load through a loader that
accepts either format, substituting the empty frontend baseline for an
API-format document so the op applies to a frontend document and the file is
editable afterwards. A JSON value that is a workflow in neither format still
fails as before; the slot-editing commands keep their frontend-only gate.



### feat(generate): flag --emit-workflow support per model in `generate list` (`2d63b325`)

`generate list` advertises the whole proxy catalog while `--emit-workflow`
can render five of them as partner nodes; an agent asked for a workflow for
`flux-pro` and got the umbrella `emit_workflow_failed` with the supported
set buried in prose (Langfuse 2026-08-27). It had no way to know beforehand.

Every `generate list` row now carries `emit_supported: bool` (schema-required,
`generate_list.json`), computed by the same lookup `build_workflow` uses so
the two cannot drift. Asking for `--emit-workflow` on an unsupported model
raises a typed `UnsupportedModelError` and surfaces as its own registered
code, `emit_workflow_unsupported_model`, with `details.model` and
`details.supported` as data; `emit_workflow_failed` is left for bad inputs
and unwritable paths.



## Verification

Full suite on this head (the stack head, `7b892b0f`): **6379 passed, 38 skipped**; public-repo-hygiene green across the stack. ruff 0.15.15 check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
