### PR TITLE
chore(hygiene): drop the internal ticket id from test_deprecated_nodes

### DIFF
--- a/tests/comfy_cli/command/test_deprecated_nodes.py
+++ b/tests/comfy_cli/command/test_deprecated_nodes.py
@@ -4,7 +4,7 @@ ComfyUI marks a retired class with ``deprecated: true`` in object_info and
 suffixes its display name with "(DEPRECATED)" / "(Legacy)"; the successor is
 registered under the bare display name (``ImageBatch`` -> ``BatchImagesNode``).
 The frontend hides such classes from its node library by default. The agent
-kept building on ``ImageBatch`` (BE-7684) because ``nodes search`` ranked it
+kept building on ``ImageBatch`` because ``nodes search`` ranked it
 like any live class and ``add-node`` accepted it, so:
 
   * ``nodes search`` / ``nodes ls`` drop deprecated rows unless


### PR DESCRIPTION
The public-repo-hygiene check flags ticket-shaped ids. This one arrived in #808 and has kept `main` (and every open PR, whose merge ref includes it) red since. The sentence loses nothing without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)