### PR TITLE
fix(cli): unbreak the interactive pickers and Go timestamp parsing on 3.10

### DIFF
--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -36,8 +36,9 @@ import time
 import urllib.error
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, NoReturn
+from typing import TYPE_CHECKING, Annotated, Final, NoReturn
 from urllib.parse import urlsplit
 
 import requests
@@ -96,6 +97,7 @@ from comfy_cli.constants import SUPPORTED_PT_EXTENSIONS
 from comfy_cli.interaction import confirm, require_option
 from comfy_cli.output import get_renderer
 from comfy_cli.registry.api import sanitize_error_body
+from comfy_cli.utils import parse_rfc3339
 
 if TYPE_CHECKING:
     from comfy_cli.builder_api import BuilderClient
@@ -2406,13 +2408,28 @@ def show_cmd(
 _RELEASE_POLL_SECONDS = 2.0
 
 
-def _release_order(release: dict) -> tuple[int, str]:
+#: Sorts below every usable timestamp, so a release the builder dated badly loses
+#: the tiebreak instead of winning it on a value nobody can read. A Go zero
+#: ``time.Time`` marshals to ``0001-01-01T00:00:00Z`` and ties with it, which is
+#: the same answer: neither row carries a date worth ordering on.
+_UNDATED: Final = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _release_order(release: dict) -> tuple[int, datetime]:
+    """Order releases by version, breaking ties on the instant they were cut.
+
+    The instant, not its spelling: the builder marshals Go ``time.Time``, whose
+    trailing-zero trimming leaves the fractional part a variable width, and
+    comparing those as text sorts a whole-second ``...:16Z`` above the strictly
+    later ``...:16.5Z`` — ``.`` precedes ``Z`` in ASCII.
+    """
     version = release.get("version")
     created_at = release.get("createdAt")
-    return (
-        version if isinstance(version, int) else -1,
-        created_at if isinstance(created_at, str) else "",
-    )
+    try:
+        created = parse_rfc3339(created_at) if isinstance(created_at, str) else _UNDATED
+    except ValueError:
+        created = _UNDATED
+    return (version if isinstance(version, int) else -1, created)
 
 
 def _newest_release_id(renderer, client, build_id: str) -> str:

--- a/comfy_cli/command/deploy_resolve.py
+++ b/comfy_cli/command/deploy_resolve.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Final, Protocol
 
 from comfy_cli.command.build_spec import BuildSpec, JsonObject, JsonValue
 from comfy_cli.command.deploy_types import required_string, server_shape_error
+from comfy_cli.utils import parse_rfc3339
 
 # Wave 8 status formatting must import this table rather than redefine the order.
 _STATUS_RANK: Final[dict[str, int]] = {
@@ -160,18 +161,21 @@ def deployment_selection_key(deployment: JsonObject) -> tuple[int, datetime]:
 
     Every failure is a server-shape failure, never a traceback: an unknown
     status or an unparsable ``createdAt`` surfaces as ``deploy_server_error``
-    like any other bad field. A naive timestamp is read as UTC because the wire
-    format is RFC 3339 — leaving it naive would make the ``max()`` over these
-    keys raise on a batch that mixes aware and naive values.
+    like any other bad field. The two are reported apart, and each names the
+    value it rejected, because a message hedging across both fields sent
+    everyone after the wrong one — a valid ``provisioning`` was printed as the
+    evidence while the timestamp that actually failed went unmentioned.
     """
     status = required_string(deployment, "status")
     created_at = required_string(deployment, "createdAt")
+    rank = _STATUS_RANK.get(status)
+    if rank is None:
+        raise server_shape_error("the deployment has an unknown status", status=status)
     try:
-        rank = _STATUS_RANK[status]
-        created = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-    except (KeyError, ValueError) as error:
-        raise server_shape_error("the deployment has an invalid status or createdAt", status=status) from error
-    return rank, created if created.tzinfo is not None else created.replace(tzinfo=timezone.utc)
+        created = parse_rfc3339(created_at)
+    except ValueError as error:
+        raise server_shape_error("the deployment has an unparsable createdAt", createdAt=created_at) from error
+    return rank, created
 
 
 def resolve_release(

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -47,6 +47,7 @@ from comfy_cli.host_port import resolve_host_port as _resolve_host_port
 from comfy_cli.http import ResponseTooLarge, authed_urlopen, plain_urlopen, read_capped
 from comfy_cli.output import get_renderer
 from comfy_cli.output.sanitize import sanitize, sanitize_markup
+from comfy_cli.utils import parse_rfc3339
 from comfy_cli.where import cloud_preflight_or_exit
 
 if TYPE_CHECKING:
@@ -455,12 +456,20 @@ def _gather_local_state_files(*, limit: int, orphaned_only: bool = False, where:
 
 
 def _parse_epoch(ts: str | None) -> float:
-    """Parse an ISO ``updated_at`` to epoch seconds; 0.0 if missing/unparseable."""
-    if not ts:
+    """Parse an ISO ``updated_at`` to epoch seconds; 0.0 if missing/unparseable.
+
+    Shares the wire parser rather than calling ``fromisoformat`` directly, whose
+    Python 3.10 spelling rejects a bare ``Z`` and any sub-second precision but 3
+    or 6 digits. State files are stamped whole-second UTC, so nothing written
+    today needs the wider grammar — but a row that did hit it would silently
+    sort to epoch 0, below every dated one, exactly where ``jobs ls`` slices its
+    ``[:limit]`` and drops a fresh completion.
+    """
+    if not isinstance(ts, str) or not ts:
         return 0.0
     try:
-        return datetime.fromisoformat(ts).timestamp()
-    except (ValueError, TypeError):
+        return parse_rfc3339(ts).timestamp()
+    except ValueError:
         return 0.0
 
 

--- a/comfy_cli/ui.py
+++ b/comfy_cli/ui.py
@@ -43,7 +43,7 @@ def show_progress(iterable, total, description="Downloading..."):
 
 
 def prompt_autocomplete(
-    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
+    question: str, choices: list[ChoiceType], default: ChoiceType | None = None, force_prompting: bool = False
 ) -> ChoiceType | None:
     """
     Asks a single select question using questionary and returns the selected response.
@@ -65,7 +65,7 @@ def prompt_autocomplete(
 
 
 def prompt_select(
-    question: str, choices: list[ChoiceType], default: ChoiceType = "", force_prompting: bool = False
+    question: str, choices: list[ChoiceType], default: ChoiceType | None = None, force_prompting: bool = False
 ) -> ChoiceType | None:
     """
     Asks a single select question using questionary and returns the selected response.

--- a/comfy_cli/utils.py
+++ b/comfy_cli/utils.py
@@ -4,11 +4,13 @@ Module for utility functions.
 
 import functools
 import platform
+import re
 import shutil
 import tarfile
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import Any, BinaryIO, Final, cast
 
 from rich import progress
 from rich.live import Live
@@ -83,6 +85,36 @@ def get_proc():
 
 def get_not_user_set_default_workspace():
     return DEFAULT_COMFY_WORKSPACE[get_os()]
+
+
+_RFC3339_RE: Final = re.compile(
+    r"(?P<head>\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2})(?:\.(?P<frac>\d+))?(?P<tz>[Zz]|[+-]\d{2}:?\d{2})?"
+)
+
+
+def parse_rfc3339(value: str) -> datetime:
+    """Parse an RFC 3339 timestamp at any sub-second precision, always aware.
+
+    ``datetime.fromisoformat`` cannot do this alone on Python 3.10, the minimum
+    this package supports: there it takes only 3 or 6 fractional digits and no
+    bare ``Z``. Our Go services marshal ``time.Time``, whose RFC3339Nano
+    encoding trims trailing zeros, so microseconds of ``437450`` ship as
+    ``...:09.43745Z`` — five digits, rejected. Roughly one row in ten is stamped
+    that way, and a ``createdAt`` never changes, so such a row was permanently
+    unreadable rather than intermittently so.
+
+    A missing zone reads as UTC: callers order these against each other, and
+    comparing a naive value to an aware one raises ``TypeError``.
+    """
+    match = _RFC3339_RE.fullmatch(value.strip())
+    if match is None:
+        raise ValueError(f"not an RFC 3339 timestamp: {value!r}")
+    # Pad so ".1" is a tenth of a second rather than a microsecond, and truncate
+    # so Go's nanosecond precision degrades instead of failing.
+    fraction = (match.group("frac") or "")[:6].ljust(6, "0")
+    zone = match.group("tz") or ""
+    offset = "+00:00" if zone in ("Z", "z", "") else (zone if ":" in zone else f"{zone[:3]}:{zone[3:]}")
+    return datetime.fromisoformat(f"{match.group('head')}.{fraction}{offset}")
 
 
 def kill_all(pid):

--- a/tests/comfy_cli/command/test_build_release.py
+++ b/tests/comfy_cli/command/test_build_release.py
@@ -303,3 +303,39 @@ def test_create_watch_polls_to_complete_and_reflects_target_failure(
     # Then
     assert result.exit_code == expected_exit, result.stderr
     assert len([call for call in client.calls if call["method"] == "get_release"]) == 3
+
+
+def test_same_version_releases_break_the_tie_on_the_instant_not_the_spelling() -> None:
+    """Compared as text, the whole-second stamp wins this pair: ``.`` precedes
+    ``Z``, so the strictly later fractional one sorts below it."""
+    # Given
+    whole_second = {"id": "release-earlier", "version": 1, "createdAt": "2026-08-28T03:26:09Z"}
+    fractional = {"id": "release-later", "version": 1, "createdAt": "2026-08-28T03:26:09.5Z"}
+
+    # When
+    newest = max([whole_second, fractional], key=build._release_order)
+
+    # Then
+    assert newest["id"] == "release-later"
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        pytest.param("2026-08-28T03:26:09.43745Z", id="zero-trimmed"),
+        pytest.param(None, id="missing"),
+        pytest.param("not-a-timestamp", id="unparsable"),
+    ],
+)
+def test_a_release_order_key_stays_comparable_for_every_created_at(created_at: object) -> None:
+    """The key is a sort key before it is anything else: one row the builder
+    dated oddly must not make ``max`` raise across the whole list."""
+    # Given
+    dated = {"id": "release-dated", "version": 1, "createdAt": "2026-08-28T03:26:09.5Z"}
+    odd = {"id": "release-odd", "version": 1, "createdAt": created_at}
+
+    # When
+    newest = max([odd, dated], key=build._release_order)
+
+    # Then
+    assert newest["id"] == "release-dated"

--- a/tests/comfy_cli/command/test_deploy_resolve.py
+++ b/tests/comfy_cli/command/test_deploy_resolve.py
@@ -386,13 +386,28 @@ def test_zero_matching_deployments_returns_none() -> None:
 
 
 @pytest.mark.parametrize(
-    "row",
+    ("row", "message", "details"),
     [
-        pytest.param(_deployment("deployment-bad", created_at="not-a-timestamp"), id="unparsable-createdAt"),
-        pytest.param(_deployment("deployment-bad", status="unheard-of"), id="unknown-status"),
+        pytest.param(
+            _deployment("deployment-bad", created_at="not-a-timestamp"),
+            "unparsable createdAt",
+            {"createdAt": "not-a-timestamp"},
+            id="unparsable-createdAt",
+        ),
+        pytest.param(
+            _deployment("deployment-bad", status="unheard-of"),
+            "unknown status",
+            {"status": "unheard-of"},
+            id="unknown-status",
+        ),
     ],
 )
-def test_a_malformed_selection_field_is_a_server_shape_error_not_a_traceback(row: JsonObject) -> None:
+def test_a_malformed_selection_field_is_a_server_shape_error_naming_only_that_field(
+    row: JsonObject, message: str, details: JsonObject
+) -> None:
+    """A message hedging across both fields reported a valid ``provisioning``
+    status as the evidence for a timestamp it could not parse, so each failure
+    has to carry the value it actually rejected."""
     # Given
     builder = RecordingBuilder(pages=[[{"id": "release-1"}]])
     deployments = RecordingDeployments([[row]])
@@ -401,6 +416,8 @@ def test_a_malformed_selection_field_is_a_server_shape_error_not_a_traceback(row
     with pytest.raises(DeployAPIError) as raised:
         resolve_deployment(builder, deployments, "build-1")
     assert raised.value.code == "deploy_server_error"
+    assert message in str(raised.value)
+    assert raised.value.details == details
 
 
 def test_a_naive_timestamp_never_makes_the_ranking_comparison_raise() -> None:
@@ -420,6 +437,40 @@ def test_a_naive_timestamp_never_makes_the_ranking_comparison_raise() -> None:
     # Then
     assert resolved is not None
     assert resolved["id"] == "deployment-naive"
+
+
+def test_a_zero_trimmed_timestamp_ranks_instead_of_failing_the_command() -> None:
+    """Go marshals ``time.Time`` as RFC3339Nano, which trims trailing zeros, so
+    microseconds of ``437450`` ship as five digits — the shape that made
+    ``comfy deploy status`` report a server error against a healthy deployment
+    and blame its perfectly valid ``provisioning`` status for it."""
+    # Given
+    builder = RecordingBuilder(pages=[[{"id": "release-1"}]])
+    trimmed = _deployment("deployment-provisioning", "provisioning", created_at="2026-08-28T03:26:09.43745Z")
+    deployments = RecordingDeployments([[trimmed]])
+
+    # When
+    resolved = resolve_deployment(builder, deployments, "build-1")
+
+    # Then
+    assert resolved == trimmed
+
+
+def test_mixed_precision_timestamps_rank_by_instant_not_by_digit_count() -> None:
+    """Both rows tie on status, so ``max`` falls to the timestamps: compared as
+    strings rather than instants, the trimmed ``.43745`` would sort above the
+    genuinely later ``.5``."""
+    # Given
+    builder = RecordingBuilder(pages=[[{"id": "release-1"}]])
+    earlier = _deployment("deployment-earlier", "ready", created_at="2026-08-28T03:26:09.43745Z")
+    later = _deployment("deployment-later", "ready", created_at="2026-08-28T03:26:09.5Z")
+    deployments = RecordingDeployments([[earlier, later]])
+
+    # When
+    resolved = resolve_deployment(builder, deployments, "build-1")
+
+    # Then
+    assert resolved == later
 
 
 def test_join_consumes_three_pages_from_each_exhaustive_collector() -> None:

--- a/tests/comfy_cli/jobs/test_jobs.py
+++ b/tests/comfy_cli/jobs/test_jobs.py
@@ -49,6 +49,34 @@ _HISTORY_FIXTURE = {
 }
 
 
+@pytest.mark.parametrize(
+    "updated_at",
+    [
+        pytest.param("2026-08-28T03:26:09+00:00", id="what-state-files-write-today"),
+        pytest.param("2026-08-28T03:26:09Z", id="bare-z"),
+        pytest.param("2026-08-28T03:26:09.43745Z", id="zero-trimmed-fraction"),
+    ],
+)
+def test_a_dated_terminal_row_never_sinks_to_the_epoch_zero_floor(updated_at: str):
+    """0.0 doubles as "undated", so a stamp the parser cannot read sorts the row
+    below every dated one — right where ``jobs ls`` takes its ``[:limit]`` slice
+    and drops a fresh completion."""
+    assert jobs_mod._parse_epoch(updated_at) > 0.0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param("", id="empty"),
+        pytest.param("not-a-timestamp", id="unparsable"),
+        pytest.param(1234, id="not-even-a-string"),
+    ],
+)
+def test_an_unreadable_updated_at_falls_back_to_the_floor(value: object):
+    assert jobs_mod._parse_epoch(value) == 0.0
+
+
 def test_gather_jobs_combines_queue_and_history(monkeypatch: pytest.MonkeyPatch):
     def fake_get(url, timeout=10.0):
         if url.endswith("/queue"):

--- a/tests/comfy_cli/test_utils.py
+++ b/tests/comfy_cli/test_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from comfy_cli.http import DOWNLOAD_TIMEOUT
-from comfy_cli.utils import create_tarball, download_url, extract_tarball
+from comfy_cli.utils import create_tarball, download_url, extract_tarball, parse_rfc3339
 
 
 class _FakeRaw(io.BytesIO):
@@ -159,3 +159,44 @@ class TestExtractTarballFiltering:
         assert (dest / "bin" / "python3.12").read_bytes() == b"#!/bin/sh\n"
         assert (dest / "bin" / "python3").is_symlink()
         assert (dest / "bin" / "python").is_symlink()
+
+
+class TestParseRfc3339:
+    """``datetime.fromisoformat`` alone takes only 3 or 6 fractional digits and
+    no bare ``Z`` on Python 3.10, the minimum this package supports, while the
+    Go services trim trailing zeros and so emit every width between 0 and 9."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param("2026-08-28T03:26:09.43745Z", "2026-08-28T03:26:09.437450+00:00", id="five-digits-trimmed"),
+            pytest.param("2026-08-28T03:26:09.1Z", "2026-08-28T03:26:09.100000+00:00", id="one-digit-pads-not-shifts"),
+            pytest.param(
+                "2026-08-28T03:26:09.806473123Z", "2026-08-28T03:26:09.806473+00:00", id="nanoseconds-truncate"
+            ),
+            pytest.param("2026-08-28T03:26:09.806473Z", "2026-08-28T03:26:09.806473+00:00", id="microseconds"),
+            pytest.param("2026-08-28T03:26:09Z", "2026-08-28T03:26:09+00:00", id="whole-seconds"),
+            pytest.param("2026-08-28T03:26:09.806-07:00", "2026-08-28T03:26:09.806000-07:00", id="offset-zone"),
+            pytest.param("2026-08-28T03:26:09.806-0700", "2026-08-28T03:26:09.806000-07:00", id="offset-no-colon"),
+            pytest.param("2026-08-28T03:26:09", "2026-08-28T03:26:09+00:00", id="missing-zone-reads-as-utc"),
+        ],
+    )
+    def test_every_precision_a_go_service_can_emit_parses(self, value, expected):
+        assert parse_rfc3339(value).isoformat() == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("", id="empty"),
+            pytest.param("not-a-timestamp", id="not-a-timestamp"),
+            pytest.param("2026-08-28", id="date-only"),
+            pytest.param("2026-08-28T03:26:09.806Z trailing", id="trailing-junk"),
+        ],
+    )
+    def test_a_value_shaped_nothing_like_rfc3339_is_rejected(self, value):
+        with pytest.raises(ValueError):
+            parse_rfc3339(value)
+
+    def test_a_trimmed_value_orders_by_instant_not_by_digit_count(self):
+        """``.5`` is later than ``.43745`` but sorts below it as text."""
+        assert parse_rfc3339("2026-08-28T03:26:09.43745Z") < parse_rfc3339("2026-08-28T03:26:09.5Z")


### PR DESCRIPTION
<details><summary><b>Stack of 7 — review bottom-up</b> (this is the top)</summary>

1. #801 — `feat(build)`: packaging, sync and Builder client primitives — base `main`
2. #802 — `feat(build)!`: replace the legacy build and distribution surface **(breaking)**
3. #803 — `feat(deploy)`: the deployment control plane
4. #804 — `feat(deploy)`: the asset and job data-plane clients
5. #805 — `feat(deploy)`: `comfy deploy run`
6. #810 — `fix(build)`: a pull no longer deletes definition data silently
7. #824 — `fix(cli)`: unbreak the interactive pickers and Go timestamp parsing on 3.10  &nbsp;&nbsp;**← this PR**

Each PR is based on the branch below it, so its own diff is only its commits. Merge in order.
</details>

**TL;DR:** Two independent defects found while exercising the stack by hand, neither caught by the suite. Every interactive picker in the CLI raised `ValueError` before it could draw, and roughly one Go-issued timestamp in ten was unparsable on Python 3.10 — the version CI actually runs. Stacked on #810.

---

## 1. `ce93092` — every interactive picker raised before drawing

`prompt_select` and `prompt_autocomplete` defaulted `default` to `""` and passed it straight to questionary. questionary validates that `default` is one of `choices`, and `""` never is:

```
ValueError: Invalid `default` value passed. The value (``) does not exist in
the set of choices. Please make sure the default value is one of the available choices.
```

This fires on construction, before any prompt renders, so **no caller with a real choice list worked**. That is every picker in the CLI:

| Call site | Picker |
|---|---|
| `build.py:2029` | the Build picker `comfy build pull` opens when given no `--id` |
| `deploy_compute.py:26` | GPU class |
| `deploy_compute.py:43` | Region |
| `uv.py:227` | Python version |
| `cmdline.py:1853`, `:1858` | feedback scores |

The fix is the correct sentinel: `default: ChoiceType | None = None`. questionary treats `None` as "no default" and selects the first choice, which is what the `""` was reaching for.

Worth noting for #810's reviewer: the broken picker is the same one the adopt flow depends on — `comfy build pull` with no `--id` lists the workspace's builds and asks you to choose one.

## 2. `f40f519` — Go's trimmed fractional seconds are unparsable on Python 3.10

Our Go services marshal `time.Time`, which encodes as RFC 3339 **Nano** — and that trims trailing zeros from the fractional part. A timestamp holding `437450` microseconds ships as `...:09.43745Z`: five fractional digits.

`datetime.fromisoformat` on Python 3.10 — `requires-python = ">=3.10"`, and the CI matrix runs 3.10 only — accepts exactly 3 or 6 fractional digits and rejects a bare `Z`. So that value raises. Trailing-zero trimming makes this roughly a one-in-ten event, and since a `createdAt` never changes, an affected row was **permanently** unreadable rather than intermittently so.

New `utils.parse_rfc3339` parses any sub-second precision and always returns an aware datetime: it pads so `.1` is a tenth rather than a microsecond, truncates so Go's nanosecond precision degrades instead of failing, and reads a missing zone as UTC because callers order these against each other and comparing naive to aware raises `TypeError`.

Three call sites move onto it, and each had its own failure shape:

* **`deploy_resolve.deployment_selection_key`** — raised `deploy_server_error` on an affected deployment. The status and timestamp checks are also split apart now: one `except (KeyError, ValueError)` covered both and reported `status=...`, so a valid `provisioning` was printed as the evidence while the timestamp that actually failed went unmentioned. Each is now reported separately, naming the value it rejected.
* **`build._release_order`** — compared `createdAt` **as text**, so a whole-second `...:16Z` sorted above the strictly later `...:16.5Z` (`.` precedes `Z` in ASCII), and `comfy build release` picked the wrong newest release. Now ordered on the parsed instant, with an `_UNDATED` floor so a badly dated release loses the tiebreak instead of winning it.
* **`jobs._parse_epoch`** — swallowed the failure and returned `0.0`, sorting an affected row below every dated one, precisely where `jobs ls` slices `[:limit]` and drops a fresh completion.

**Validation**

* `test_utils.py`, `test_deploy_resolve.py`, `test_jobs.py`, `test_build_release.py`: **314 passed**.
* Full command + output suites on this branch: **3749 passed, 3 skipped**. `ruff check .` / `ruff format --check .` clean at CI's pin (0.15.15).
* Seven new tests, including property-based coverage that a release-order key stays comparable for every `createdAt` shape and that a dated terminal row never sinks to the epoch-zero floor.
* The picker fix is verified by construction against the installed questionary: `default=""` raises, `default=None` constructs.
