### PR TITLE
fix(cql): grow nested auto-grow slots under dynamic combos; stop counting link-only subs as widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ history.
 
 ### Fixed
 
+- `comfy workflow connect` can wire a Load Image / Load Video / Load Audio
+  into an auto-grow group nested under a dynamic combo (`GeminiNanoBanana2V2`
+  `model.images`, `MinimaxHailuo03ReferenceNode` / `ByteDance2ReferenceNodeV2`
+  `model.reference_images` / `reference_videos` / `reference_audios`, and the
+  other 27 partner nodes shaped that way). Slots are resolved from the node's
+  schema for its current selection — not from a pre-existing input — so an
+  agent-built node grows `model.images.image_1`, `image_2`, … by name or by
+  addressing the group base, a UI-built node reuses its free pre-created slot
+  and then keeps growing, a UI-built top-level group (`BatchImagesNode`) can
+  be base-addressed and grown past its free slot, a wrong element type is
+  refused (`type mismatch`), and a group never grows past the schema's
+  `names` length / `max`. `comfy nodes show` now lists every dynamic-combo
+  option's sub-inputs and names each auto-grow group's element type, slot
+  vocabulary and first keys to wire.
+- The widget order no longer counts a dynamic combo's link-only sub-inputs
+  (auto-grow groups, `GEMINI_INPUT_FILES`, …) as `widgets_values` slots.
+  `add-node` wrote them as phantom `null` values and the published widget
+  catalog named them, so every widget after the groups was one or more slots
+  off: an agent-built Nano Banana 2 converted with `seed` in
+  `response_modalities`, and through the CRDT doc host a UI-built MiniMax H3
+  node's `seed` position mapped onto `model.reference_images`. `add-node`,
+  the catalog and `set-widget` now share one walk, so a fresh node's layout
+  is exactly what `set-widget` indexes and what the frontend serializes (41
+  classes in the cloud catalog change width).
 - The widget order (`comfy nodes widget-catalog`, `set-widget` indexing, the
   UI→API converter) now names every slot the frontend serializes: the
   `upload` button frontend extensions inject on media loaders (`LoadImage`,

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -154,11 +154,60 @@ class Port:
         return self.type.startswith("COMFY_") and "COMBO" in self.type
 
     def autogrow_slot_example(self) -> str:
-        """Best-effort slot-key example for hints. The element name comes from
-        the node's V3 definition and isn't in object_info; the observed server
-        convention is the singular of the input name (images → image0)."""
-        stem = self.name[:-1] if self.name.endswith("s") else self.name
-        return f"{self.name}.{stem}0, {self.name}.{stem}1, …"
+        """Slot-key example for hints: the first two slot names this group
+        grows, from the schema template when the catalog carries one
+        (``model.images.image_1, model.images.image_2, …``), else the
+        historical singular-of-the-input-name guess (``images.image0, …``)."""
+        template = self.autogrow_element_template or {}
+        names = template.get("names")
+        if names:
+            first = [f"{self.name}.{n}" for n in names[:2]]
+        else:
+            prefix = template.get("prefix") or (self.name[:-1] if self.name.endswith("s") else self.name)
+            first = [f"{self.name}.{prefix}0", f"{self.name}.{prefix}1"]
+        return ", ".join(first) + ", …"
+
+    @property
+    def autogrow_element_type(self) -> str | None:
+        """The socket type every grown slot of this autogrow input carries —
+        the single input the schema ``template`` declares (``IMAGE`` for
+        ``model.images``, ``VIDEO`` for ``model.reference_videos``). Every
+        group in the production catalog declares exactly one template input;
+        a template with none (or a non-autogrow port) reads as ``None``, which
+        callers treat as "accept the source type".
+        """
+        t = self.options.template
+        if not self.is_autogrow or not isinstance(t, dict):
+            return None
+        inputs = t.get("input")
+        if not isinstance(inputs, dict):
+            return None
+        for section in ("required", "optional"):
+            section_def = inputs.get(section)
+            if not isinstance(section_def, dict):
+                continue
+            for spec in section_def.values():
+                type_id = spec[0] if isinstance(spec, (list, tuple)) and spec else spec
+                if isinstance(type_id, str) and type_id:
+                    return type_id
+        return None
+
+    @property
+    def autogrow_limits(self) -> tuple[int, int | None]:
+        """``(min, max)`` slots for this autogrow input, exactly as the frontend
+        derives them (``applyAutogrow``): ``min`` defaults to 1, ``max`` is the
+        length of ``names`` when the template enumerates them, else the
+        template's ``max`` (``None`` when the schema leaves it open — the
+        frontend's own default there is 100, but that is a UI choice, not a
+        server limit, so it is not asserted here)."""
+        t = self.options.template if isinstance(self.options.template, dict) else {}
+        lo = t.get("min")
+        lo = int(lo) if isinstance(lo, (int, float)) and not isinstance(lo, bool) else 1
+        names = t.get("names")
+        if isinstance(names, list) and names:
+            return lo, len(names)
+        hi = t.get("max")
+        return lo, (int(hi) if isinstance(hi, (int, float)) and not isinstance(hi, bool) else None)
 
     @property
     def autogrow_template(self) -> dict | None:
@@ -704,49 +753,6 @@ def _parse_input_spec(spec: Any) -> tuple[str, bool, list[Any], PortOptions, boo
         return "COMBO", True, list(first), port_opts, True, []
 
     return "UNKNOWN", False, [], port_opts, False, []
-
-
-_FIRST_KEY = object()  # sentinel: expand the first/default dynamic-combo key
-
-
-def _dynamic_sub_widget_names(base: str, options: list, selected: Any = _FIRST_KEY) -> list[str]:
-    """Sub-widget names a dynamic combo expands to for the ``selected`` key
-    (default: the first/default key) — e.g. ``model`` → ``["model.resolution"]``.
-    Static mirror of the converter's value-driven ``_dynamic_combo_sub_inputs``."""
-    return [name for name, _ in _dynamic_sub_widget_defaults(base, options, selected).items()]
-
-
-def _dynamic_sub_widget_defaults(base: str, options: list, selected: Any = _FIRST_KEY) -> dict[str, Any]:
-    """``{f"{base}.{sub}": default}`` for the ``selected`` key's sub-inputs.
-
-    Defaults to the first key (fresh nodes select it). Passing the node's actual
-    selected key — as ``widget_order_for_node`` does — keeps the widget order
-    aligned to ``widgets_values`` when a node picks an option whose sub-widget
-    count differs from the default. An unknown key expands to nothing, matching
-    the converter's ``_dynamic_combo_sub_inputs``."""
-    if not options:
-        return {}
-    if selected is _FIRST_KEY:
-        option = options[0] if isinstance(options[0], dict) else None
-    else:
-        option = next((o for o in options if isinstance(o, dict) and o.get("key") == selected), None)
-    if option is None:
-        return {}
-    sub_def = option.get("inputs")
-    if not isinstance(sub_def, dict):
-        return {}
-    out: dict[str, Any] = {}
-    for section in ("required", "optional"):
-        section_def = sub_def.get(section) or {}
-        if not isinstance(section_def, dict):
-            continue
-        for sub_name, spec in section_def.items():
-            _t, _e, enum_values, opts, _declared, _dyn = _parse_input_spec(spec)
-            default = opts.default
-            if default is None and enum_values:
-                default = enum_values[0]
-            out[f"{base}.{sub_name}"] = default
-    return out
 
 
 def _is_scalar_choice(v: Any) -> bool:
@@ -1309,17 +1315,7 @@ class Graph:
         m = self._nodes.get(class_name)
         if m is None:
             return []
-        order: list[str] = []
-        for p in m.inputs:
-            if p.is_link:
-                continue
-            order.append(p.name)
-            if p.dynamic_options:
-                order.extend(_dynamic_sub_widget_names(p.name, p.dynamic_options))
-            if _has_control_after_generate_slot(p):
-                order.append("control_after_generate")
-        order.extend(frontend_extra_widget_names(m))
-        return order
+        return [e.name for e in _expand_widget_entries(m, [], first_key=True)]
 
     def widget_order_for_node(self, class_name: str, widgets_values: list[Any] | None) -> list[str]:
         """Value-aware widget order: like ``widget_order`` but at each dynamic
@@ -1357,22 +1353,18 @@ class Graph:
         if m is None:
             return {}
         out: dict[str, Any] = {}
-        for p in m.inputs:
-            if p.is_link:
+        # Same walk as ``widget_order_default`` (first key at every dynamic
+        # combo, link-only sub-inputs skipped), so the two can never disagree
+        # about which names own a slot.
+        for entry in _expand_widget_entries(m, [], first_key=True):
+            if entry.port is None:
+                if entry.name == "control_after_generate":
+                    out[entry.name] = "fixed"
+                # Frontend-injected marker slots (``upload``, ``audioUI``) are
+                # trailing and ``serialize: false`` on current frontends: no
+                # default, no value.
                 continue
-            if p.dynamic_options:
-                out[p.name] = p.enum_values[0] if p.enum_values else None  # selected key
-                out.update(_dynamic_sub_widget_defaults(p.name, p.dynamic_options))
-            elif p.options.default is not None:
-                out[p.name] = p.options.default
-            elif p.enum_values:
-                out[p.name] = p.enum_values[0]
-            elif p.type in _FRONTEND_DOM_WIDGET_TYPES:
-                out[p.name] = _FRONTEND_DOM_WIDGET_DEFAULTS.get(p.type)
-            else:
-                out[p.name] = None
-            if _has_control_after_generate_slot(p):
-                out["control_after_generate"] = "fixed"
+            out[entry.name] = _widget_default(entry.port)
         # Frontend-injected slots: the ``upload``/``audioUI`` buttons are
         # ``serialize: false`` on current frontends — no default, no value, so
         # a fresh node ends before them (``_build_node`` drops trailing names
@@ -1383,6 +1375,26 @@ class Graph:
         if m.id in _PREVIEW_3D_CLASSES and "image" not in out and "image" in frontend_extra_widget_names(m):
             out["image"] = _FRONTEND_DOM_WIDGET_DEFAULTS["PREVIEW_3D"]
         return out
+
+    def autogrow_groups(self, class_name: str, widgets_values: list[Any] | None) -> list[Port]:
+        """Every ``COMFY_AUTOGROW_V3`` group a node of ``class_name`` exposes
+        for its CURRENT selection, in declaration order: top-level groups
+        (``BatchImagesNode.images``) and those nested under the option each
+        dynamic combo currently selects, named the way the frontend names
+        them — dotted under the combo (``model.reference_images``).
+
+        ``widgets_values`` supplies the selectors (read positionally, exactly
+        as ``widget_order_for_node`` does), so a node switched to an option
+        without the group stops exposing it. Unknown class → ``[]``.
+        """
+        m = self._nodes.get(class_name)
+        if m is None:
+            return []
+        sub_links: list[Port] = []
+        _expand_widget_entries(m, widgets_values or [], sub_links=sub_links)
+        top = [p for p in m.inputs if p.is_autogrow]
+        nested = [p for p in sub_links if p.is_autogrow]
+        return top + nested
 
     # -- Validation --
 
@@ -1782,28 +1794,64 @@ class Graph:
             "pack": m.pack,
             "labels": m.labels,
             "cloud_disabled": m.cloud_disabled,
-            "inputs": [
-                {
-                    "name": p.name,
-                    "type": p.type,
-                    "required": p.required,
-                    "is_link": p.is_link,
-                    "section": "required" if p.required else "optional",
-                    "choices": p.enum_values,
-                    "options": {
-                        "min": p.options.min,
-                        "max": p.options.max,
-                        "step": p.options.step,
-                        "default": p.options.default,
-                    },
-                    # Autogrow inputs wire as one slot key per connection;
-                    # surface that here so `nodes show` is self-documenting.
-                    **({"autogrow": True, "wire_as": p.autogrow_slot_example()} if p.is_autogrow else {}),
-                }
-                for p in m.inputs
-            ],
+            "inputs": [_input_payload(p, 0) for p in m.inputs],
             "outputs": [{"name": p.name, "type": p.type} for p in m.outputs],
         }
+
+
+def _widget_default(p: Port) -> Any:
+    """The value a fresh node carries for widget port ``p`` — a dynamic
+    combo's first key, else the schema default, else the first choice, else
+    the DOM-widget placeholder, else ``None``."""
+    if p.dynamic_options:
+        return p.enum_values[0] if p.enum_values else None
+    if p.options.default is not None:
+        return p.options.default
+    if p.enum_values:
+        return p.enum_values[0]
+    if p.type in _FRONTEND_DOM_WIDGET_TYPES:
+        return _FRONTEND_DOM_WIDGET_DEFAULTS.get(p.type)
+    return None
+
+
+def _input_payload(p: Port, depth: int) -> dict[str, Any]:
+    """One ``nodes show`` input entry. A dynamic combo lists every option
+    with that option's sub-inputs (dotted, recursively); an autogrow input —
+    top-level or nested — names its element type, its slot vocabulary and the
+    first keys to wire, so an agent can address ``model.images.image_1``
+    without first failing a connect to learn the name."""
+    entry: dict[str, Any] = {
+        "name": p.name,
+        "type": p.type,
+        "required": p.required,
+        "is_link": p.is_link,
+        "section": "required" if p.required else "optional",
+        "choices": p.enum_values,
+        "options": {
+            "min": p.options.min,
+            "max": p.options.max,
+            "step": p.options.step,
+            "default": p.options.default,
+        },
+    }
+    if p.is_autogrow:
+        lo, hi = p.autogrow_limits
+        template = p.autogrow_element_template or {}
+        entry["autogrow"] = True
+        entry["element_type"] = p.autogrow_element_type
+        entry["slots"] = {**template, "min": lo, "max": hi}
+        entry["wire_as"] = p.autogrow_slot_example()
+    if p.dynamic_options and _is_dynamic_combo_type(p.type) and depth < _MAX_DYNAMIC_COMBO_DEPTH:
+        entry["dynamic_options"] = [
+            {
+                "key": key,
+                "inputs": [
+                    _input_payload(sub, depth + 1) for sub in _dynamic_combo_sub_ports(p.dynamic_options, key, p.name)
+                ],
+            }
+            for key in p.enum_values
+        ]
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -2505,7 +2553,13 @@ def _dynamic_combo_sub_ports(dynamic_options: list[dict], selector: Any, prefix:
     return ports
 
 
-def _expand_widget_entries(m: Morphism, widgets_values: list[Any]) -> list[_WidgetEntry]:
+def _expand_widget_entries(
+    m: Morphism,
+    widgets_values: list[Any],
+    *,
+    first_key: bool = False,
+    sub_links: list[Port] | None = None,
+) -> list[_WidgetEntry]:
     """Flatten a node's widget ports into one entry per ``widgets_values`` slot.
 
     Walks declared ports in order; at a dynamic combo it reads the current
@@ -2514,6 +2568,16 @@ def _expand_widget_entries(m: Morphism, widgets_values: list[Any]) -> list[_Widg
     combos; connection sub-inputs contribute no slot). A control-flagged input
     — top-level or sub — is followed by its ``control_after_generate`` marker
     slot, exactly as the frontend serializes it.
+
+    ``first_key=True`` selects every dynamic combo's first option instead of
+    reading ``widgets_values`` — the layout of a FRESH node, which is what the
+    static catalog (``widget_order_default``) and ``add_node``
+    (``widget_defaults``) publish. One walk for both keeps them from ever
+    disagreeing with the value-aware order ``set-widget`` indexes by.
+
+    ``sub_links`` collects the connection-only sub-inputs the selected options
+    contribute (``COMFY_AUTOGROW_V3`` groups, ``GEMINI_INPUT_FILES``…) — they
+    own no slot, but the wiring side needs to know they exist.
     """
     entries: list[_WidgetEntry] = []
 
@@ -2523,9 +2587,14 @@ def _expand_widget_entries(m: Morphism, widgets_values: list[Any]) -> list[_Widg
             if depth >= _MAX_DYNAMIC_COMBO_DEPTH:
                 return
             idx = len(entries) - 1
-            selector = widgets_values[idx] if idx < len(widgets_values) else port.options.default
+            if first_key:
+                selector = port.enum_values[0] if port.enum_values else None
+            else:
+                selector = widgets_values[idx] if idx < len(widgets_values) else port.options.default
             for sub in _dynamic_combo_sub_ports(port.dynamic_options, selector, name):
                 if sub.is_link:
+                    if sub_links is not None:
+                        sub_links.append(sub)
                     continue
                 emit(sub.name, sub, name, depth + 1)
         elif _has_control_after_generate_slot(port):

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -401,23 +401,35 @@ def _lww_commit(workflow: dict, op: dict) -> None:
     workflow.setdefault("_widget_stamps", {})[json.dumps(_write_target(op), default=str)] = _stamp_key(op)
 
 
-def _autogrow_template(graph, node_type: str, base: str) -> dict | None:
-    """The schema-declared element-naming template for the ``base`` autogrow
-    input on ``node_type`` — looked up from the same object_info-derived
-    ``graph`` the connect path already resolves node schemas from (see
-    ``cql.engine.Port.autogrow_template``). None when ``graph`` is unavailable,
-    ``node_type`` isn't in the catalog (offline edit), or the catalog entry
-    carries no template — callers then fall back to the historical
-    pluralization heuristic in :func:`_autogrow_elem_name`."""
+def _autogrow_group_port(graph, node: dict, base: str):
+    """The schema :class:`~comfy_cli.cql.engine.Port` for autogrow group
+    ``base`` on ``node`` — a top-level group (``BatchImagesNode.images``) or
+    one nested under the option ``node`` currently selects at a dynamic combo
+    (``MinimaxHailuo03ReferenceNode`` → ``model.reference_images``). The
+    selection is read from the node's own ``widgets_values`` the same way
+    ``set-widget`` indexes them, so a node switched to an option without the
+    group stops resolving it. None when ``graph`` is unavailable, the class
+    isn't in the catalog (offline edit), or no such group exists."""
     if graph is None:
         return None
-    m = graph.node(node_type)
-    if m is None:
-        return None
-    for p in m.inputs:
-        if p.name == base and p.is_autogrow:
-            return p.autogrow_template
+    from comfy_cli.cql import engine as _engine
+
+    node_type = node.get("type", "")
+    values = _engine._widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    for port in graph.autogrow_groups(node_type, values):
+        if port.name == base:
+            return port
     return None
+
+
+def _autogrow_template(graph, node: dict, base: str) -> dict | None:
+    """The schema-declared element-naming template for the ``base`` autogrow
+    group on ``node`` (see :func:`_autogrow_group_port` and
+    ``cql.engine.Port.autogrow_template``). None when the schema is
+    unavailable or carries no template — callers then fall back to the
+    historical pluralization heuristic in :func:`_autogrow_elem_name`."""
+    port = _autogrow_group_port(graph, node, base)
+    return None if port is None else port.autogrow_template
 
 
 def _autogrow_elem_name(base: str, n: int, template: dict | None) -> str:
@@ -467,9 +479,17 @@ def _next_autogrow_name(ins: list, requested: str, template: dict | None = None)
     taken = {i.get("name") for i in ins}
     if requested not in taken:
         return requested
-    base = requested.split(".", 1)[0]
+    base = _autogrow_base(requested)
     n = _first_free_autogrow_index(taken, base, template)
     return f"{base}.{_autogrow_elem_name(base, n, template)}"
+
+
+def _autogrow_base(slot_name: str) -> str:
+    """The group a grown slot name belongs to: everything before the LAST
+    dot. Element names never contain a dot, but a group nested under a
+    dynamic combo does (``model.images.image_1`` → ``model.images``), so
+    splitting on the first dot would name the combo, not the group."""
+    return slot_name.rsplit(".", 1)[0]
 
 
 def _next_inputcount_name(ins: list, requested: str) -> str:
@@ -1785,8 +1805,8 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
                 # base.elemN fallback — that name is meaningless for this family.
                 name = _next_inputcount_name(ins, grow["name"])
             else:
-                base = str(grow["name"]).split(".", 1)[0]
-                template = None if grow.get("widget") else _autogrow_template(graph, dst.get("type", ""), base)
+                base = _autogrow_base(str(grow["name"]))
+                template = None if grow.get("widget") else _autogrow_template(graph, dst, base)
                 name = _next_autogrow_name(ins, grow["name"], template)
             entry = {
                 "name": name,
@@ -2373,13 +2393,12 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
       the API converter reads the link and skips the widget by name.
     """
     ins = node.get("inputs") or []
-    node_type = node.get("type", "")
     # Concrete slot (index or exact name) that is NOT an autogrow base.
     try:
         idx = _resolve_input_slot(node, None, slot)
         if str(ins[idx].get("type", "")).startswith("COMFY_AUTOGROW"):
             base = ins[idx].get("name")
-            template = _autogrow_template(graph, node_type, base)
+            template = _autogrow_template(graph, node, base)
             return None, _plan_autogrow(ins, base, elem_type, template)
         return idx, None
     except ValueError:
@@ -2391,7 +2410,7 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             (i for i in ins if i.get("name") == base and str(i.get("type", "")).startswith("COMFY_AUTOGROW")), None
         )
         if ag is not None:
-            template = _autogrow_template(graph, node_type, base)
+            template = _autogrow_template(graph, node, base)
             grow = _plan_autogrow(ins, base, elem_type, template)  # canonical next sequential slot
             # Addressing the bare base auto-appends. A dotted key is accepted ONLY if
             # it names that exact next slot; an index gap (images.image4), a doubled
@@ -2406,7 +2425,16 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
                     f"or use the next free key {grow['name']!r}"
                 )
             return None, grow
+    # Schema-declared autogrow group — the slot exists in object_info even
+    # when the node's ``inputs`` carry no trace of it: a group nested under a
+    # dynamic combo (``model.images``), or a top-level group on a UI-built node
+    # (the frontend writes the grown ``images.imageN`` slots, never the base).
+    if graph is not None and isinstance(slot, str):
+        resolved = _resolve_schema_autogrow(node, graph, slot, elem_type)
+        if resolved is not None:
+            return resolved
     # Widget-backed input: convert the widget to a linked input.
+    node_type = node.get("type", "")
     if graph is not None and isinstance(slot, str) and slot in graph.widget_order(node_type):
         return None, {"name": slot, "type": elem_type or "*", "widget": slot}
     # Bare autogrow ELEMENT name (`image1` for base `images`) — the guess agents
@@ -2420,7 +2448,7 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             base = ag.get("name")
             if not base or not str(ag.get("type", "")).startswith("COMFY_AUTOGROW"):
                 continue
-            template = _autogrow_template(graph, node_type, base)
+            template = _autogrow_template(graph, node, base)
             if not _autogrow_bare_slot_pattern(base, template).fullmatch(slot):
                 continue
             grow = _plan_autogrow(ins, base, elem_type, template)
@@ -2458,6 +2486,75 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             )
     names = [i.get("name") for i in ins]
     raise ValueError(f"input {slot!r} not found on node {node.get('id')}; inputs: {names}")
+
+
+def _resolve_schema_autogrow(
+    node: dict, graph, slot: str, elem_type: str | None
+) -> tuple[int | None, dict | None] | None:
+    """Resolve ``slot`` against the autogrow groups the node's SCHEMA declares
+    for its current selection (:func:`_autogrow_group_port`), mirroring what
+    the frontend does when a noodle is dropped on the group:
+
+    * the group base (``model.reference_images``) wires the lowest free slot
+      the node already carries (the frontend pre-creates one), else appends
+      the next schema-named slot;
+    * a dotted key (``model.reference_images.image_3``) or a bare element
+      name (``image_3``) must name that exact next slot — an index gap would
+      mint a key the server can't map, so it is rejected with the next free
+      key instead;
+    * the source type must match the group's declared element type, and the
+      group never grows past the schema's ``max`` (``names`` length).
+
+    Returns ``None`` when ``slot`` addresses no schema group, so the caller
+    keeps falling through its other resolutions.
+    """
+    from comfy_cli.cql import engine as _engine
+
+    ins = node.get("inputs") or []
+    node_type = node.get("type", "")
+    values = _engine._widgets_as_positional(node.get("widgets_values"), graph, node_type)
+    for port in graph.autogrow_groups(node_type, values):
+        base = port.name
+        template = port.autogrow_element_template
+        if slot == base:
+            target = None
+        elif slot.startswith(base + "."):
+            target = slot
+        elif _autogrow_bare_slot_pattern(base, template).fullmatch(slot):
+            target = f"{base}.{slot}"
+        else:
+            continue
+        declared = port.autogrow_element_type
+        if elem_type and declared and not _types_compatible(elem_type, declared):
+            raise ValueError(
+                f"type mismatch: {elem_type} output cannot connect to autogrow input {base!r} of node "
+                f"{node.get('id')} — its slots take {declared}"
+            )
+        _lo, hi = port.autogrow_limits
+        n = 0
+        while True:
+            name = f"{base}.{_autogrow_elem_name(base, n, template)}"
+            idx = next((k for k, i in enumerate(ins) if i.get("name") == name), None)
+            if idx is None:
+                break
+            if target == name or (target is None and ins[idx].get("link") is None):
+                return idx, None
+            n += 1
+        grown = [i.get("name") for i in ins if str(i.get("name", "")).startswith(base + ".")]
+        if target is not None and target != name:
+            raise ValueError(
+                f"input {slot!r} is not a valid autogrow slot on node {node.get('id')}; "
+                f"autogrow input {base!r} appends one sequential slot per connection "
+                f"(existing: {grown}) — connect to the base {base!r} to auto-append, "
+                f"or use the next free key {name!r}"
+            )
+        if hi is not None and n >= hi:
+            raise ValueError(
+                f"autogrow input {base!r} on node {node.get('id')} is full: the schema allows at most "
+                f"{hi} slots (existing: {grown})"
+            )
+        return None, {"name": name, "type": declared or elem_type or "*"}
+    return None
 
 
 def _autogrow_bare_slot_pattern(base: str, template: dict | None) -> re.Pattern:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -2009,7 +2009,10 @@ def _write_target(op: dict) -> tuple:
             # Two autogrow connects onto the same base share a target (their
             # relative order in the batch is the sequence decision the merge
             # consumer must make); distinct bases don't collide.
-            return ("input", str(op["to_node"]), "grow", str(grow["name"]).split(".", 1)[0])
+            # The group is everything before the LAST dot: a group nested
+            # under a dynamic combo (``model.reference_images.image_1``) must
+            # not share a target with its sibling (``model.reference_videos``).
+            return ("input", str(op["to_node"]), "grow", _autogrow_base(str(grow["name"])))
         return ("input", str(op["to_node"]), op["to_slot"])
     return (kind,)
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -2401,6 +2401,12 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
         idx = _resolve_input_slot(node, None, slot)
         if str(ins[idx].get("type", "")).startswith("COMFY_AUTOGROW"):
             base = ins[idx].get("name")
+            # The CLI's own add-node writes this base entry; the schema-aware
+            # resolver applies the declared element type and ``max`` exactly
+            # as it does for a UI-built node (which carries no base entry).
+            resolved = _resolve_schema_autogrow(node, graph, str(base), elem_type) if graph is not None else None
+            if resolved is not None:
+                return resolved
             template = _autogrow_template(graph, node, base)
             return None, _plan_autogrow(ins, base, elem_type, template)
         return idx, None
@@ -2413,6 +2419,9 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
             (i for i in ins if i.get("name") == base and str(i.get("type", "")).startswith("COMFY_AUTOGROW")), None
         )
         if ag is not None:
+            resolved = _resolve_schema_autogrow(node, graph, slot, elem_type) if graph is not None else None
+            if resolved is not None:
+                return resolved
             template = _autogrow_template(graph, node, base)
             grow = _plan_autogrow(ins, base, elem_type, template)  # canonical next sequential slot
             # Addressing the bare base auto-appends. A dotted key is accepted ONLY if
@@ -2432,14 +2441,16 @@ def _resolve_input_target(node: dict, graph, slot: Any, elem_type: str | None) -
     # when the node's ``inputs`` carry no trace of it: a group nested under a
     # dynamic combo (``model.images``), or a top-level group on a UI-built node
     # (the frontend writes the grown ``images.imageN`` slots, never the base).
+    # Widget-backed input: convert the widget to a linked input. Checked before
+    # the schema group resolution so a real widget name always outranks the
+    # bare-element guess (``image0``) a group's vocabulary might also match.
+    node_type = node.get("type", "")
+    if graph is not None and isinstance(slot, str) and slot in graph.widget_order(node_type):
+        return None, {"name": slot, "type": elem_type or "*", "widget": slot}
     if graph is not None and isinstance(slot, str):
         resolved = _resolve_schema_autogrow(node, graph, slot, elem_type)
         if resolved is not None:
             return resolved
-    # Widget-backed input: convert the widget to a linked input.
-    node_type = node.get("type", "")
-    if graph is not None and isinstance(slot, str) and slot in graph.widget_order(node_type):
-        return None, {"name": slot, "type": elem_type or "*", "widget": slot}
     # Bare autogrow ELEMENT name (`image1` for base `images`) — the guess agents
     # make on classic batch nodes, and the top workflow-edit failure in alpha
     # traffic. Map it onto the dotted key it implies and hold it to the same
@@ -2544,17 +2555,19 @@ def _resolve_schema_autogrow(
                 return idx, None
             n += 1
         grown = [i.get("name") for i in ins if str(i.get("name", "")).startswith(base + ".")]
+        # A full group is reported as full FIRST: a gapped key on a full group
+        # must not be handed a "next free key" the next call would refuse.
+        if hi is not None and n >= hi:
+            raise ValueError(
+                f"autogrow input {base!r} on node {node.get('id')} is full: the schema allows at most "
+                f"{hi} slots (existing: {grown})"
+            )
         if target is not None and target != name:
             raise ValueError(
                 f"input {slot!r} is not a valid autogrow slot on node {node.get('id')}; "
                 f"autogrow input {base!r} appends one sequential slot per connection "
                 f"(existing: {grown}) — connect to the base {base!r} to auto-append, "
                 f"or use the next free key {name!r}"
-            )
-        if hi is not None and n >= hi:
-            raise ValueError(
-                f"autogrow input {base!r} on node {node.get('id')} is full: the schema allows at most "
-                f"{hi} slots (existing: {grown})"
             )
         return None, {"name": name, "type": declared or elem_type or "*"}
     return None

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1806,8 +1806,19 @@ def _apply_connect(workflow: dict, op: dict, graph) -> None:
                 name = _next_inputcount_name(ins, grow["name"])
             else:
                 base = _autogrow_base(str(grow["name"]))
-                template = None if grow.get("widget") else _autogrow_template(graph, dst, base)
+                port = None if grow.get("widget") else _autogrow_group_port(graph, dst, base)
+                template = None if port is None else port.autogrow_template
                 name = _next_autogrow_name(ins, grow["name"], template)
+                if port is not None and name != grow["name"]:
+                    # A replay collision renamed the slot: never mint one past
+                    # the schema's max. The group is full, so this op is dropped
+                    # (no-op) — which slot the concurrent race keeps is
+                    # arrival-ordered, the same accepted limitation the
+                    # inputcount family documents below; the schema bound is not.
+                    _lo, hi = port.autogrow_limits
+                    occupied = sum(1 for i in ins if str(i.get("name", "")).startswith(base + "."))
+                    if hi is not None and occupied >= hi:
+                        return
             entry = {
                 "name": name,
                 "type": grow["type"],

--- a/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
+++ b/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
@@ -388,3 +388,16 @@ def test_cli_connect_load_image_into_nano_banana_reference_group(tmp_path, capsy
     assert env["ok"] is True, env
     saved = json.loads(wf_path.read_text())
     assert _inputs(saved, b) == ["model.images.image_1", "model.images.image_2"]
+
+
+def test_grows_on_different_nested_groups_are_different_conflict_targets(graph):
+    """``model.reference_images.image_1`` and ``model.reference_videos.video_1``
+    belong to two groups; keying the grow target on the FIRST dot made both
+    ``model`` and reported a false conflict between them."""
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    _, op_img = workflow_ops.connect(copy.deepcopy(wf), graph, 2, "IMAGE", 4, "model.reference_images.image_3")
+    _, op_vid = workflow_ops.connect(copy.deepcopy(wf), graph, v, "VIDEO", 4, "model.reference_videos.video_2")
+    assert workflow_ops._write_target(op_img) == ("input", "4", "grow", "model.reference_images")
+    assert workflow_ops._write_target(op_vid) == ("input", "4", "grow", "model.reference_videos")
+    assert workflow_ops.detect_conflict(op_img, op_vid) is False

--- a/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
+++ b/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
@@ -1,0 +1,390 @@
+"""``connect`` / ``add-node`` on nodes whose auto-grow groups live under a dynamic combo.
+
+Reproduces the in-app agent defect: on an agent-built ``GeminiNanoBanana2V2``
+the reference input did not exist (``add_node`` wrote ``inputs: []``) and no
+address could create it; on a UI-built ``MinimaxHailuo03ReferenceNode`` only
+the one free slot the frontend pre-creates could be wired, so a second or
+third reference — or any Load Video / Load Audio — failed with
+``input ... not found``. The same slot-driven resolver also could not
+base-address or grow past the free slot on a UI-built *top-level* group
+(``BatchImagesNode``).
+
+The frontend contract these tests hold the CLI to
+(``ComfyUI_frontend/src/core/graph/widgets/dynamicWidgets.ts``):
+
+* slot names are ``<group>.<names[ordinal]>`` (or ``<group>.<prefix><ordinal>``),
+  with ``<group>`` dotted under its combo (``model.reference_images.image_1``);
+* a group holds at most ``names.length`` (or ``template.max``) slots;
+* a grown slot carries the group's declared element type;
+* the group owns no ``widgets_values`` slot, so wiring never shifts a widget.
+
+Fixture: ``tests/comfy_cli/fixtures/object_info_nested_autogrow.json`` — the
+production catalog's entries with tooltips stripped.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import workflow_ops, workflow_to_api
+from comfy_cli.caller import Caller
+from comfy_cli.command import workflow as workflow_cmd
+from comfy_cli.cql.engine import Graph
+from comfy_cli.output.renderer import OutputMode, Renderer, set_renderer
+
+FIXTURE = Path(__file__).resolve().parents[2] / "comfy_cli" / "fixtures" / "object_info_nested_autogrow.json"
+
+
+@pytest.fixture(scope="module")
+def object_info() -> dict[str, Any]:
+    return json.loads(FIXTURE.read_text())
+
+
+@pytest.fixture(scope="module")
+def graph(object_info) -> Graph:
+    return Graph.from_object_info(object_info)
+
+
+def _empty() -> dict[str, Any]:
+    return {"last_node_id": 0, "last_link_id": 0, "nodes": [], "links": [], "groups": [], "version": 0.4}
+
+
+def _node(wf: dict, node_id: Any) -> dict:
+    return next(n for n in wf["nodes"] if n["id"] == node_id)
+
+
+def _inputs(wf: dict, node_id: Any) -> list[str]:
+    return [i["name"] for i in _node(wf, node_id).get("inputs") or []]
+
+
+def _link_of(wf: dict, node_id: Any, name: str):
+    return next(i for i in _node(wf, node_id)["inputs"] if i["name"] == name)["link"]
+
+
+def _minimax_ui_workflow() -> dict[str, Any]:
+    """The ``api_minimax_h3_r2v`` gallery template's shape: ``image_1`` wired,
+    one free trailing slot per group (``shape: 7`` = optional), 8 widget values."""
+    return {
+        "last_node_id": 4,
+        "last_link_id": 4,
+        "version": 0.4,
+        "groups": [],
+        "nodes": [
+            {
+                "id": 2,
+                "type": "LoadImage",
+                "pos": [0, 0],
+                "size": [300, 300],
+                "flags": {},
+                "order": 0,
+                "mode": 0,
+                "inputs": [],
+                "outputs": [
+                    {"name": "IMAGE", "type": "IMAGE", "links": [4]},
+                    {"name": "MASK", "type": "MASK", "links": []},
+                ],
+                "properties": {},
+                "widgets_values": ["storyboard.png", "image"],
+            },
+            {
+                "id": 4,
+                "type": "MinimaxHailuo03ReferenceNode",
+                "pos": [400, 0],
+                "size": [400, 300],
+                "flags": {},
+                "order": 1,
+                "mode": 0,
+                "inputs": [
+                    {
+                        "label": "image_1",
+                        "name": "model.reference_images.image_1",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": 4,
+                    },
+                    {
+                        "label": "image_2",
+                        "name": "model.reference_images.image_2",
+                        "shape": 7,
+                        "type": "IMAGE",
+                        "link": None,
+                    },
+                    {
+                        "label": "video_1",
+                        "name": "model.reference_videos.video_1",
+                        "shape": 7,
+                        "type": "VIDEO",
+                        "link": None,
+                    },
+                    {
+                        "label": "audio_1",
+                        "name": "model.reference_audios.audio_1",
+                        "shape": 7,
+                        "type": "AUDIO",
+                        "link": None,
+                    },
+                ],
+                "outputs": [{"name": "VIDEO", "type": "VIDEO", "links": []}],
+                "properties": {},
+                "widgets_values": ["MiniMax H3", "storyboard prompt", "768P", "adaptive", 5, 42, "randomize", False],
+            },
+        ],
+        "links": [[4, 2, 0, 4, 0, "IMAGE"]],
+    }
+
+
+def _add_loader(wf: dict, graph: Graph, class_type: str) -> tuple[dict, int]:
+    wf, op = workflow_ops.add_node(wf, graph, class_type)
+    return wf, op["node_id"]
+
+
+# --------------------------------------------------------------------------- #
+# add-node: no phantom widget slots, no phantom input slots
+# --------------------------------------------------------------------------- #
+
+
+def test_add_node_writes_frontend_width_widgets_and_no_group_inputs(graph):
+    wf, _ = workflow_ops.add_node(_empty(), graph, "MinimaxHailuo03ReferenceNode")
+    node = wf["nodes"][0]
+    assert node["inputs"] == []
+    order = graph.widget_order_default("MinimaxHailuo03ReferenceNode")
+    assert len(node["widgets_values"]) == len(order) == 8
+    by_name = dict(zip(order, node["widgets_values"]))
+    assert by_name["model"] == "MiniMax H3"
+    assert by_name["seed"] == 42
+    assert by_name["watermark"] is False
+
+
+# --------------------------------------------------------------------------- #
+# connect on an agent-built node: grow nested slots by name, by base, in order
+# --------------------------------------------------------------------------- #
+
+
+def test_connect_grows_first_nested_slot_by_its_schema_name(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    widgets_before = list(_node(wf, b)["widgets_values"])
+    wf, op = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images.image_1")
+    grown = _node(wf, b)["inputs"]
+    assert [i["name"] for i in grown] == ["model.images.image_1"]
+    assert grown[0]["type"] == "IMAGE"
+    assert grown[0]["link"] == op["link_id"]
+    assert _node(wf, b)["widgets_values"] == widgets_before
+
+
+def test_connect_to_the_group_base_appends_the_next_slot(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images")
+    assert _inputs(wf, b) == ["model.images.image_1", "model.images.image_2"]
+
+
+def test_connect_explicit_next_key_ok_and_gap_rejected_with_the_next_free_key(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images.image_1")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images.image_2")
+    with pytest.raises(ValueError, match=r"model\.images\.image_3"):
+        workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images.image_5")
+    assert _inputs(wf, b) == ["model.images.image_1", "model.images.image_2"]
+
+
+def test_bare_element_name_maps_onto_the_nested_group(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "image_1")
+    assert _inputs(wf, b) == ["model.images.image_1"]
+
+
+def test_group_resolution_follows_the_node_selection(graph):
+    """Switching the selector to an option without the group makes the
+    group unaddressable — the resolver reads the node, not the first key."""
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.set_widget(wf, graph, b, "model", "Nano Banana 2 Lite")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images")
+    assert _inputs(wf, b) == ["model.images.image_1"]
+
+
+# --------------------------------------------------------------------------- #
+# connect on a UI-built node: reuse the free slot, then keep growing
+# --------------------------------------------------------------------------- #
+
+
+def test_ui_built_free_slot_is_reused_before_growing(graph):
+    wf = _minimax_ui_workflow()
+    wf, op = workflow_ops.connect(wf, graph, 2, "IMAGE", 4, "model.reference_images")
+    assert _inputs(wf, 4) == [
+        "model.reference_images.image_1",
+        "model.reference_images.image_2",
+        "model.reference_videos.video_1",
+        "model.reference_audios.audio_1",
+    ]
+    assert _link_of(wf, 4, "model.reference_images.image_2") == op["link_id"]
+    wf, _ = workflow_ops.connect(wf, graph, 2, "IMAGE", 4, "model.reference_images")
+    assert "model.reference_images.image_3" in _inputs(wf, 4)
+
+
+def test_ui_built_explicit_third_slot_grows(graph):
+    wf = _minimax_ui_workflow()
+    wf, _ = workflow_ops.connect(wf, graph, 2, "IMAGE", 4, "model.reference_images.image_2")
+    wf, op = workflow_ops.connect(wf, graph, 2, "IMAGE", 4, "model.reference_images.image_3")
+    grown = next(i for i in _node(wf, 4)["inputs"] if i["name"] == "model.reference_images.image_3")
+    assert grown["type"] == "IMAGE"
+    assert grown["link"] == op["link_id"]
+
+
+def test_load_video_and_load_audio_wire_into_their_reference_groups(graph):
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    wf, au = _add_loader(wf, graph, "LoadAudio")
+    wf, op_v = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+    wf, op_a = workflow_ops.connect(wf, graph, au, "AUDIO", 4, "model.reference_audios.audio_1")
+    assert _link_of(wf, 4, "model.reference_videos.video_1") == op_v["link_id"]
+    assert _link_of(wf, 4, "model.reference_audios.audio_1") == op_a["link_id"]
+    wf, _ = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos.video_2")
+    assert "model.reference_videos.video_2" in _inputs(wf, 4)
+
+
+def test_wrong_element_type_into_a_group_is_refused(graph):
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_images")
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_images.image_3")
+
+
+def test_group_max_from_the_schema_is_enforced(graph):
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    for _ in range(3):
+        wf, _ = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+    assert [n for n in _inputs(wf, 4) if n.startswith("model.reference_videos.")] == [
+        "model.reference_videos.video_1",
+        "model.reference_videos.video_2",
+        "model.reference_videos.video_3",
+    ]
+    with pytest.raises(ValueError, match=r"(?i)max(imum)? .*3|3 slots|full"):
+        workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+
+
+def test_ui_built_top_level_group_base_and_next_key(graph):
+    wf = _empty()
+    wf, a = _add_loader(wf, graph, "LoadImage")
+    wf["nodes"].append(
+        {
+            "id": 99,
+            "type": "BatchImagesNode",
+            "pos": [0, 0],
+            "size": [200, 100],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+                {"name": "images.image0", "type": "IMAGE", "link": 77},
+                {"name": "images.image1", "type": "IMAGE", "link": None, "shape": 7},
+            ],
+            "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+            "properties": {},
+            "widgets_values": [],
+        }
+    )
+    wf["last_node_id"] = 99
+    wf["last_link_id"] = 77
+    wf, op = workflow_ops.connect(wf, graph, a, "IMAGE", 99, "images")
+    assert _inputs(wf, 99) == ["images.image0", "images.image1"]
+    assert _link_of(wf, 99, "images.image1") == op["link_id"]
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", 99, "images.image2")
+    assert _inputs(wf, 99) == ["images.image0", "images.image1", "images.image2"]
+
+
+# --------------------------------------------------------------------------- #
+# widgets never shift; the converter carries every reference
+# --------------------------------------------------------------------------- #
+
+
+def test_set_widget_after_the_groups_lands_in_the_frontend_position(graph):
+    wf = _minimax_ui_workflow()
+    wf, _ = workflow_ops.set_widget(wf, graph, 4, "seed", 7)
+    values = _node(wf, 4)["widgets_values"]
+    assert values[5] == 7
+    assert values[7] is False
+    assert len(values) == 8
+
+
+def test_agent_built_node_converts_with_every_reference_and_unshifted_widgets(graph, object_info):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, c = _add_loader(wf, graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images")
+    wf, _ = workflow_ops.connect(wf, graph, c, "IMAGE", b, "model.images")
+    wf, _ = workflow_ops.set_widget(wf, graph, b, "seed", 7)
+    wf, save = _add_loader(wf, graph, "SaveImage")
+    wf, _ = workflow_ops.connect(wf, graph, b, "IMAGE", save, "images")
+    api = workflow_to_api.convert_ui_to_api(wf, object_info)
+    inputs = api[str(b)]["inputs"]
+    assert inputs["model.images.image_1"] == [str(a), 0]
+    assert inputs["model.images.image_2"] == [str(c), 0]
+    assert inputs["seed"] == 7
+    assert inputs["response_modalities"] == "IMAGE"
+    assert inputs["temperature"] == 1.0
+    assert inputs["top_p"] == 0.95
+    assert "model.images" not in inputs
+    assert "model.files" not in inputs
+    assert graph.validate_workflow(api)["errors"] == []
+
+
+def test_replaying_a_nested_grow_op_is_idempotent(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, b = _add_loader(wf, graph, "GeminiNanoBanana2V2")
+    base = copy.deepcopy(wf)
+    wf, op = workflow_ops.connect(wf, graph, a, "IMAGE", b, "model.images")
+    replayed = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), op, graph), op, graph)
+    assert _inputs(replayed, b) == ["model.images.image_1"]
+    assert _inputs(replayed, b) == _inputs(wf, b)
+
+
+# --------------------------------------------------------------------------- #
+# CLI surface
+# --------------------------------------------------------------------------- #
+
+
+def _run(args: list[str], capsys) -> dict[str, Any]:
+    r = Renderer.resolve(
+        is_stdout_tty=False, env={}, caller=Caller(kind="user", agentic=False, source_env=None), json_flag=True
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    result = CliRunner().invoke(workflow_cmd.app, args, standalone_mode=False)
+    out = capsys.readouterr().out
+    if not out.strip():
+        out = result.stdout or ""
+    for line in reversed([ln for ln in out.strip().splitlines() if ln.strip()]):
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"no JSON envelope (rc={result.exit_code}, exc={result.exception}, out={out[:600]})")
+
+
+def test_cli_connect_load_image_into_nano_banana_reference_group(tmp_path, capsys):
+    wf_path = tmp_path / "wf.json"
+    wf_path.write_text(json.dumps(_empty()))
+    env_a = _run(["add-node", str(wf_path), "LoadImage", "--input", str(FIXTURE)], capsys)
+    env_b = _run(["add-node", str(wf_path), "GeminiNanoBanana2V2", "--input", str(FIXTURE)], capsys)
+    assert env_a["ok"] and env_b["ok"], (env_a, env_b)
+    a, b = env_a["data"]["op"]["node_id"], env_b["data"]["op"]["node_id"]
+    env = _run(["connect", str(wf_path), f"{a}.IMAGE", f"{b}.model.images.image_1", "--input", str(FIXTURE)], capsys)
+    assert env["ok"] is True, env
+    env = _run(["connect", str(wf_path), f"{a}.IMAGE", f"{b}.model.images", "--input", str(FIXTURE)], capsys)
+    assert env["ok"] is True, env
+    saved = json.loads(wf_path.read_text())
+    assert _inputs(saved, b) == ["model.images.image_1", "model.images.image_2"]

--- a/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
+++ b/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
@@ -401,3 +401,57 @@ def test_grows_on_different_nested_groups_are_different_conflict_targets(graph):
     assert workflow_ops._write_target(op_img) == ("input", "4", "grow", "model.reference_images")
     assert workflow_ops._write_target(op_vid) == ("input", "4", "grow", "model.reference_videos")
     assert workflow_ops.detect_conflict(op_img, op_vid) is False
+
+
+# --------------------------------------------------------------------------- #
+# Review (annehe9) on #812: the guards must cover the CLI-built shape too
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_built_top_level_group_refuses_the_wrong_element_type(graph):
+    """``add_node`` writes a ``COMFY_AUTOGROW_V3`` base entry; connecting
+    through it must apply the same declared-element-type check as the
+    UI-built shape (no base entry) does."""
+    wf, au = _add_loader(_empty(), graph, "LoadAudio")
+    wf, batch = _add_loader(wf, graph, "BatchImagesNode")
+    assert _inputs(wf, batch) == ["images"]
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, au, "AUDIO", batch, "images")
+    with pytest.raises(ValueError, match="type mismatch"):
+        workflow_ops.connect(wf, graph, au, "AUDIO", batch, "images.image0")
+
+
+def test_cli_built_top_level_group_enforces_max(graph):
+    wf, a = _add_loader(_empty(), graph, "LoadImage")
+    wf, batch = _add_loader(wf, graph, "BatchImagesNode")
+    for _ in range(50):
+        wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", batch, "images")
+    assert "images.image49" in _inputs(wf, batch)
+    with pytest.raises(ValueError, match=r"(?i)max(imum)? .*50|50 slots|full"):
+        workflow_ops.connect(wf, graph, a, "IMAGE", batch, "images")
+
+
+def test_full_group_reports_full_before_the_next_key_hint(graph):
+    """A gapped key on a FULL group must not be told to use a next key the
+    next call would refuse."""
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    for _ in range(3):
+        wf, _ = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+    with pytest.raises(ValueError) as e:
+        workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos.video_9")
+    assert "at most 3" in str(e.value)
+    assert "next free key" not in str(e.value)
+
+
+def test_a_real_widget_name_outranks_the_bare_element_guess(graph):
+    """A node whose group's bare element vocabulary collides with a real
+    widget name keeps the widget→input conversion (the existing precedence)."""
+    oi = json.loads(FIXTURE.read_text())
+    oi["BatchImagesNode"]["input"]["required"]["image0"] = ["STRING", {"default": ""}]
+    oi["BatchImagesNode"]["input_order"]["required"].append("image0")
+    g = Graph.from_object_info(oi)
+    wf, prim = _add_loader(_empty(), g, "LoadImage")
+    wf, batch = _add_loader(wf, g, "BatchImagesNode")
+    _idx, grow = workflow_ops._resolve_input_target(_node(wf, batch), g, "image0", "STRING")
+    assert grow == {"name": "image0", "type": "STRING", "widget": "image0"}

--- a/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
+++ b/tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py
@@ -272,7 +272,7 @@ def test_group_max_from_the_schema_is_enforced(graph):
         "model.reference_videos.video_2",
         "model.reference_videos.video_3",
     ]
-    with pytest.raises(ValueError, match=r"(?i)max(imum)? .*3|3 slots|full"):
+    with pytest.raises(ValueError, match=r"at most 3 slots"):
         workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
 
 
@@ -427,7 +427,7 @@ def test_cli_built_top_level_group_enforces_max(graph):
     for _ in range(50):
         wf, _ = workflow_ops.connect(wf, graph, a, "IMAGE", batch, "images")
     assert "images.image49" in _inputs(wf, batch)
-    with pytest.raises(ValueError, match=r"(?i)max(imum)? .*50|50 slots|full"):
+    with pytest.raises(ValueError, match=r"at most 50 slots"):
         workflow_ops.connect(wf, graph, a, "IMAGE", batch, "images")
 
 
@@ -444,14 +444,36 @@ def test_full_group_reports_full_before_the_next_key_hint(graph):
     assert "next free key" not in str(e.value)
 
 
-def test_a_real_widget_name_outranks_the_bare_element_guess(graph):
+def test_a_real_widget_name_outranks_the_bare_element_guess():
     """A node whose group's bare element vocabulary collides with a real
     widget name keeps the widget→input conversion (the existing precedence)."""
     oi = json.loads(FIXTURE.read_text())
     oi["BatchImagesNode"]["input"]["required"]["image0"] = ["STRING", {"default": ""}]
     oi["BatchImagesNode"]["input_order"]["required"].append("image0")
     g = Graph.from_object_info(oi)
-    wf, prim = _add_loader(_empty(), g, "LoadImage")
-    wf, batch = _add_loader(wf, g, "BatchImagesNode")
+    wf, batch = _add_loader(_empty(), g, "BatchImagesNode")
     _idx, grow = workflow_ops._resolve_input_target(_node(wf, batch), g, "image0", "STRING")
     assert grow == {"name": "image0", "type": "STRING", "widget": "image0"}
+
+
+def test_replay_collision_never_grows_past_the_schema_max(graph):
+    """Two replicas each mint the LAST free slot of a 3-slot group. On
+    replay the second arrival collides on ``video_3``; renaming it must not
+    mint ``video_4`` past the schema max — the op is dropped instead."""
+    wf = _minimax_ui_workflow()
+    wf, v = _add_loader(wf, graph, "LoadVideo")
+    wf, _ = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+    wf, _ = workflow_ops.connect(wf, graph, v, "VIDEO", 4, "model.reference_videos")
+    _, op_a = workflow_ops.connect(copy.deepcopy(wf), graph, v, "VIDEO", 4, "model.reference_videos", actor="a")
+    _, op_b = workflow_ops.connect(copy.deepcopy(wf), graph, v, "VIDEO", 4, "model.reference_videos", actor="b")
+    assert op_a["grow"]["name"] == op_b["grow"]["name"] == "model.reference_videos.video_3"
+    for order in ((op_a, op_b), (op_b, op_a)):
+        replica = copy.deepcopy(wf)
+        for op in order:
+            replica = workflow_ops.apply_op(replica, op, graph)
+        videos = [n for n in _inputs(replica, 4) if n.startswith("model.reference_videos.")]
+        assert videos == [
+            "model.reference_videos.video_1",
+            "model.reference_videos.video_2",
+            "model.reference_videos.video_3",
+        ]

--- a/tests/comfy_cli/cql/test_nested_autogrow.py
+++ b/tests/comfy_cli/cql/test_nested_autogrow.py
@@ -1,0 +1,163 @@
+"""Nested auto-grow groups under a dynamic combo (``model.images``, ``model.reference_videos``).
+
+Partner nodes such as ``GeminiNanoBanana2V2`` and ``MinimaxHailuo03ReferenceNode``
+declare their reference-media inputs as ``COMFY_AUTOGROW_V3`` groups *inside*
+the selected option of a ``COMFY_DYNAMICCOMBO_V3`` selector. The frontend names
+the grown slots ``<combo>.<group>.<names[i]>`` (``model.images.image_1``) and
+writes **no** ``widgets_values`` entry for the group. Two engine defects made
+those nodes unbuildable from the CLI:
+
+* ``widget_order_default`` / ``widget_defaults`` counted every sub-input of the
+  selected option — link-only groups included — so a fresh node carried more
+  positional values than the frontend serializes, and every widget after the
+  groups (``seed``, ``watermark``, ``temperature``…) was read one or more slots
+  off. The published widget catalog is what the CRDT doc host uses to name
+  positions, so a UI-built node's ``seed`` was force-mapped onto
+  ``model.reference_images``.
+* Nothing in the engine could name a nested group at all: only a top-level
+  ``COMFY_AUTOGROW_V3`` port was visible, so ``connect`` had nothing to grow.
+
+Fixture: ``tests/comfy_cli/fixtures/object_info_nested_autogrow.json`` — the
+production catalog's entries with tooltips stripped (structure verbatim).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comfy_cli.cql.engine import Graph
+
+FIXTURE = Path(__file__).resolve().parents[2] / "comfy_cli" / "fixtures" / "object_info_nested_autogrow.json"
+
+# ``widgets_values`` the frontend wrote for ``api_minimax_h3_r2v`` (the gallery
+# template), captured verbatim: selector, prompt, resolution, ratio, duration,
+# seed, control_after_generate, watermark. No slot for the reference groups.
+MINIMAX_UI_WIDGETS = ["MiniMax H3", "storyboard prompt", "768P", "adaptive", 5, 42, "randomize", False]
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    return Graph.from_object_info(json.loads(FIXTURE.read_text()))
+
+
+# --------------------------------------------------------------------------- #
+# (B) link-only sub-inputs of a dynamic combo own no widgets_values slot
+# --------------------------------------------------------------------------- #
+
+
+def test_default_order_skips_link_only_dynamic_subs(graph):
+    order = graph.widget_order_default("MinimaxHailuo03ReferenceNode")
+    assert order == [
+        "model",
+        "model.prompt",
+        "model.resolution",
+        "model.ratio",
+        "model.duration",
+        "seed",
+        "control_after_generate",
+        "watermark",
+    ]
+
+
+def test_default_order_matches_captured_frontend_shape(graph):
+    order = graph.widget_order_default("MinimaxHailuo03ReferenceNode")
+    assert len(order) == len(MINIMAX_UI_WIDGETS)
+    by_name = dict(zip(order, MINIMAX_UI_WIDGETS))
+    assert by_name["seed"] == 42
+    assert by_name["watermark"] is False
+
+
+def test_nano_banana_default_order_has_no_group_or_file_slots(graph):
+    order = graph.widget_order_default("GeminiNanoBanana2V2")
+    assert "model.images" not in order
+    assert "model.files" not in order
+    assert order.index("seed") == order.index("model.thinking_level") + 1
+
+
+def test_widget_defaults_round_trip_through_value_aware_order(graph):
+    """The layout ``add_node`` writes (defaults over the default order) must
+    be exactly what ``set-widget`` indexes against on that same fresh node."""
+    for cls in ("MinimaxHailuo03ReferenceNode", "GeminiNanoBanana2V2", "GrokImageEditNodeV2"):
+        order = graph.widget_order_default(cls)
+        defaults = graph.widget_defaults(cls)
+        values = [defaults.get(name) for name in order]
+        assert graph.widget_order_for_node(cls, values) == order, cls
+        assert set(defaults) == set(order), cls
+
+
+# --------------------------------------------------------------------------- #
+# (A) the engine names every auto-grow group the selected option carries
+# --------------------------------------------------------------------------- #
+
+
+def test_autogrow_groups_lists_nested_groups_for_selected_option(graph):
+    groups = graph.autogrow_groups("MinimaxHailuo03ReferenceNode", MINIMAX_UI_WIDGETS)
+    assert [(p.name, p.autogrow_element_type) for p in groups] == [
+        ("model.reference_images", "IMAGE"),
+        ("model.reference_videos", "VIDEO"),
+        ("model.reference_audios", "AUDIO"),
+    ]
+
+
+def test_autogrow_groups_lists_top_level_group(graph):
+    groups = graph.autogrow_groups("BatchImagesNode", [])
+    assert [(p.name, p.autogrow_element_type) for p in groups] == [("images", "IMAGE")]
+
+
+def test_autogrow_groups_follow_the_node_selection(graph):
+    lite = graph.widget_defaults("GeminiNanoBanana2V2")
+    order = graph.widget_order_default("GeminiNanoBanana2V2")
+    values = [lite.get(n) for n in order]
+    values[order.index("model")] = "Nano Banana 2 Lite"
+    groups = graph.autogrow_groups("GeminiNanoBanana2V2", values)
+    assert [p.name for p in groups] == ["model.images"]
+    assert graph.autogrow_groups("GeminiNanoBanana2V2", ["", "no such option"]) == []
+
+
+def test_autogrow_template_and_limits_come_from_the_schema(graph):
+    videos = next(
+        p
+        for p in graph.autogrow_groups("MinimaxHailuo03ReferenceNode", MINIMAX_UI_WIDGETS)
+        if p.name.endswith("videos")
+    )
+    assert videos.autogrow_template == {"names": ["video_1", "video_2", "video_3"]}
+    assert videos.autogrow_limits == (0, 3)
+    images = graph.autogrow_groups("BatchImagesNode", [])[0]
+    assert images.autogrow_template == {"prefix": "image"}
+    assert images.autogrow_limits == (1, 50)
+    grok_defaults = graph.widget_defaults("GrokImageEditNodeV2")
+    grok_values = [grok_defaults.get(n) for n in graph.widget_order_default("GrokImageEditNodeV2")]
+    grok = graph.autogrow_groups("GrokImageEditNodeV2", grok_values)[0]
+    assert grok.autogrow_limits == (1, 3)
+
+
+# --------------------------------------------------------------------------- #
+# (C) `nodes show` payload names the group, its element type and next slot
+# --------------------------------------------------------------------------- #
+
+
+def test_show_payload_expands_dynamic_combo_options_with_autogrow_groups(graph):
+    payload = graph.morphism_to_dict(graph.node("MinimaxHailuo03ReferenceNode"))
+    model = next(i for i in payload["inputs"] if i["name"] == "model")
+    assert [o["key"] for o in model["dynamic_options"]] == ["MiniMax H3"]
+    subs = {s["name"]: s for s in model["dynamic_options"][0]["inputs"]}
+    images = subs["model.reference_images"]
+    assert images["is_link"] is True
+    assert images["autogrow"] is True
+    assert images["element_type"] == "IMAGE"
+    assert images["slots"]["names"][:2] == ["image_1", "image_2"]
+    assert images["slots"]["max"] == 9
+    assert images["wire_as"].startswith("model.reference_images.image_1")
+    assert subs["model.reference_videos"]["element_type"] == "VIDEO"
+    assert subs["model.prompt"]["is_link"] is False
+
+
+def test_show_payload_top_level_autogrow_uses_schema_names(graph):
+    payload = graph.morphism_to_dict(graph.node("BatchImagesNode"))
+    images = payload["inputs"][0]
+    assert images["autogrow"] is True
+    assert images["element_type"] == "IMAGE"
+    assert images["wire_as"].startswith("images.image0")

--- a/tests/comfy_cli/fixtures/object_info_nested_autogrow.json
+++ b/tests/comfy_cli/fixtures/object_info_nested_autogrow.json
@@ -1,0 +1,1033 @@
+{
+ "LoadImage": {
+  "input": {
+   "required": {
+    "image": [
+     [
+      "beach.jpg",
+      "eth3d.png",
+      "example.png",
+      "example_image.jpg",
+      "groceries.jpg",
+      "image.png",
+      "middlebury.jpg"
+     ],
+     {
+      "image_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "image"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "MASK"
+  ],
+  "output_is_list": [
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "MASK"
+  ],
+  "name": "LoadImage",
+  "display_name": "Load Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": false,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "load image",
+   "open image",
+   "import image",
+   "image input",
+   "upload image",
+   "read image",
+   "image loader"
+  ],
+  "essentials_category": "Basics",
+  "description": ""
+ },
+ "LoadVideo": {
+  "input": {
+   "required": {
+    "file": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "video_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "file"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadVideo",
+  "display_name": "Load Video",
+  "python_module": "comfy_extras.nodes_video",
+  "category": "video",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import video",
+   "open video",
+   "video file"
+  ],
+  "essentials_category": "Basics",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "LoadAudio": {
+  "input": {
+   "required": {
+    "audio": [
+     "COMBO",
+     {
+      "multiselect": false,
+      "options": [
+       "bedroom.mp4"
+      ],
+      "audio_upload": true
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "audio"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "AUDIO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "AUDIO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "LoadAudio",
+  "display_name": "Load Audio",
+  "python_module": "comfy_extras.nodes_audio",
+  "category": "audio",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "import audio",
+   "open audio",
+   "audio file"
+  ],
+  "essentials_category": "Audio",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GeminiNanoBanana2V2": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "Nano Banana 2 (Gemini 3.1 Flash Image)",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K",
+             "2K",
+             "4K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       },
+       {
+        "key": "Nano Banana 2 Lite",
+        "inputs": {
+         "required": {
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "default": "auto",
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "4:5",
+             "5:4",
+             "9:16",
+             "16:9",
+             "21:9",
+             "1:4",
+             "4:1",
+             "8:1",
+             "1:8"
+            ]
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K"
+            ]
+           }
+          ],
+          "thinking_level": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "MINIMAL",
+             "HIGH"
+            ]
+           }
+          ],
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9",
+              "image_10",
+              "image_11",
+              "image_12",
+              "image_13",
+              "image_14"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         },
+         "optional": {
+          "files": [
+           "GEMINI_INPUT_FILES",
+           {}
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 18446744073709551615,
+      "control_after_generate": true
+     }
+    ],
+    "response_modalities": [
+     "COMBO",
+     {
+      "advanced": true,
+      "multiselect": false,
+      "options": [
+       "IMAGE",
+       "IMAGE+TEXT"
+      ]
+     }
+    ]
+   },
+   "optional": {
+    "system_prompt": [
+     "STRING",
+     {
+      "advanced": true,
+      "default": "You are an expert image-generation engine. You must ALWAYS produce an image.\nInterpret all user input\u2014regardless of format, intent, or abstraction\u2014as literal visual directives for image composition.\nIf a prompt is conversational or lacks specific visual details, you must creatively invent a concrete visual scenario that depicts the concept.\nPrioritize generating the visual representation above any text, formatting, or conversational requests.",
+      "multiline": true
+     }
+    ],
+    "temperature": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 1.0,
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.01
+     }
+    ],
+    "top_p": [
+     "FLOAT",
+     {
+      "advanced": true,
+      "default": 0.95,
+      "min": 0.0,
+      "max": 1.0,
+      "step": 0.01
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed",
+    "response_modalities"
+   ],
+   "optional": [
+    "system_prompt",
+    "temperature",
+    "top_p"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE",
+   "STRING",
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false,
+   false,
+   false
+  ],
+  "output_name": [
+   "IMAGE",
+   "STRING",
+   "thought_image"
+  ],
+  "output_tooltips": [
+   null,
+   null,
+   "First image from the model's thinking process. Only available with thinking_level HIGH and IMAGE+TEXT modality."
+  ],
+  "output_matchtypes": null,
+  "name": "GeminiNanoBanana2V2",
+  "display_name": "Nano Banana 2",
+  "python_module": "comfy_api_nodes.nodes_gemini",
+  "category": "partner/image/Gemini",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $contains(widgets.model, \"lite\")\n                    ? {\"type\":\"usd\",\"usd\": 0.0408, \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                    : (\n                        $r := $lookup(widgets, \"model.resolution\");\n                        $prices := {\"1k\": 0.0835, \"2k\": 0.1217, \"4k\": 0.1848};\n                        {\"type\":\"usd\",\"usd\": $lookup($prices, $r), \"format\":{\"suffix\":\"/Image\",\"approximate\":true}}\n                      )\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "MinimaxHailuo03ReferenceNode": {
+  "input": {
+   "required": {
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "MiniMax H3",
+        "inputs": {
+         "required": {
+          "prompt": [
+           "STRING",
+           {
+            "default": "",
+            "multiline": true
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "768P",
+             "2K"
+            ]
+           }
+          ],
+          "ratio": [
+           "COMBO",
+           {
+            "default": "adaptive",
+            "multiselect": false,
+            "options": [
+             "adaptive",
+             "16:9",
+             "4:3",
+             "1:1",
+             "3:4",
+             "9:16",
+             "21:9"
+            ]
+           }
+          ],
+          "duration": [
+           "INT",
+           {
+            "default": 5,
+            "min": 4,
+            "max": 15,
+            "step": 1,
+            "display": "slider"
+           }
+          ],
+          "reference_images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3",
+              "image_4",
+              "image_5",
+              "image_6",
+              "image_7",
+              "image_8",
+              "image_9"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_videos": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_video": [
+                "VIDEO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "video_1",
+              "video_2",
+              "video_3"
+             ],
+             "min": 0
+            }
+           }
+          ],
+          "reference_audios": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "reference_audio": [
+                "AUDIO",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "audio_1",
+              "audio_2",
+              "audio_3"
+             ],
+             "min": 0
+            }
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 42,
+      "min": 0,
+      "max": 4294967295,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ],
+    "watermark": [
+     "BOOLEAN",
+     {
+      "advanced": true,
+      "default": false
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "model",
+    "seed",
+    "watermark"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "VIDEO"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "VIDEO"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "MinimaxHailuo03ReferenceNode",
+  "display_name": "MiniMax H3 Reference to Video",
+  "python_module": "comfy_api_nodes.nodes_minimax",
+  "category": "partner/video/MiniMax",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.duration",
+      "type": "INT"
+     }
+    ],
+    "inputs": [],
+    "input_groups": [
+     "model.reference_images",
+     "model.reference_videos"
+    ]
+   },
+   "expr": "\n                (\n                  $dur := $lookup(widgets, \"model.duration\");\n                  $rate := $lookup(widgets, \"model.resolution\") = \"768p\" ? 0.1287 : 0.1859;\n                  $imgsRaw := $lookup(inputGroups, \"model.reference_images\");\n                  $imgs := $imgsRaw ? $imgsRaw : 0;\n                  $vidsRaw := $lookup(inputGroups, \"model.reference_videos\");\n                  $vids := $vidsRaw ? $vidsRaw : 0;\n                  $base := $dur * $rate + ($imgs > 5 ? ($imgs - 5) * 0.0572 : 0);\n                  $vids > 0\n                    ? {\"type\": \"range_usd\", \"min_usd\": $base + $vids * 2 * $rate,\n                       \"max_usd\": $base + 15 * $rate, \"format\": {\"approximate\": true}}\n                    : {\"type\": \"usd\", \"usd\": $base}\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "BatchImagesNode": {
+  "input": {
+   "required": {
+    "images": [
+     "COMFY_AUTOGROW_V3",
+     {
+      "template": {
+       "input": {
+        "required": {
+         "image": [
+          "IMAGE",
+          {}
+         ]
+        }
+       },
+       "prefix": "image",
+       "min": 1,
+       "max": 50
+      }
+     }
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "images"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "BatchImagesNode",
+  "display_name": "Batch Images",
+  "python_module": "comfy_extras.nodes_post_processing",
+  "category": "image/batch",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": false,
+  "price_badge": null,
+  "search_aliases": [
+   "batch",
+   "image batch",
+   "batch images",
+   "combine images",
+   "merge images",
+   "stack images"
+  ],
+  "essentials_category": "Image Tools",
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "GrokImageEditNodeV2": {
+  "input": {
+   "required": {
+    "prompt": [
+     "STRING",
+     {
+      "default": "",
+      "multiline": true
+     }
+    ],
+    "model": [
+     "COMFY_DYNAMICCOMBO_V3",
+     {
+      "options": [
+       {
+        "key": "grok-imagine-image-2.0",
+        "inputs": {
+         "required": {
+          "images": [
+           "COMFY_AUTOGROW_V3",
+           {
+            "template": {
+             "input": {
+              "required": {
+               "image": [
+                "IMAGE",
+                {}
+               ]
+              }
+             },
+             "names": [
+              "image_1",
+              "image_2",
+              "image_3"
+             ],
+             "min": 1
+            }
+           }
+          ],
+          "resolution": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "1K",
+             "2K"
+            ]
+           }
+          ],
+          "number_of_images": [
+           "INT",
+           {
+            "default": 1,
+            "min": 1,
+            "max": 10,
+            "step": 1,
+            "display": "number"
+           }
+          ],
+          "quality": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "medium",
+             "low"
+            ]
+           }
+          ],
+          "aspect_ratio": [
+           "COMBO",
+           {
+            "multiselect": false,
+            "options": [
+             "auto",
+             "1:1",
+             "2:3",
+             "3:2",
+             "3:4",
+             "4:3",
+             "9:16",
+             "16:9",
+             "9:19.5",
+             "19.5:9",
+             "9:20",
+             "20:9",
+             "1:2",
+             "2:1"
+            ]
+           }
+          ]
+         }
+        }
+       }
+      ]
+     }
+    ],
+    "seed": [
+     "INT",
+     {
+      "default": 0,
+      "min": 0,
+      "max": 2147483647,
+      "step": 1,
+      "control_after_generate": true,
+      "display": "number"
+     }
+    ]
+   },
+   "hidden": {
+    "auth_token_comfy_org": [
+     "AUTH_TOKEN_COMFY_ORG"
+    ],
+    "api_key_comfy_org": [
+     "API_KEY_COMFY_ORG"
+    ],
+    "unique_id": [
+     "UNIQUE_ID"
+    ],
+    "comfy_usage_source": [
+     "COMFY_USAGE_SOURCE"
+    ]
+   }
+  },
+  "input_order": {
+   "required": [
+    "prompt",
+    "model",
+    "seed"
+   ],
+   "hidden": [
+    "auth_token_comfy_org",
+    "api_key_comfy_org",
+    "unique_id",
+    "comfy_usage_source"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "IMAGE"
+  ],
+  "output_tooltips": [
+   null
+  ],
+  "output_matchtypes": null,
+  "name": "GrokImageEditNodeV2",
+  "display_name": "Grok Image Edit",
+  "python_module": "comfy_api_nodes.nodes_grok",
+  "category": "partner/image/Grok",
+  "output_node": false,
+  "deprecated": false,
+  "experimental": false,
+  "dev_only": false,
+  "api_node": true,
+  "price_badge": {
+   "engine": "jsonata",
+   "depends_on": {
+    "widgets": [
+     {
+      "name": "model",
+      "type": "COMFY_DYNAMICCOMBO_V3"
+     },
+     {
+      "name": "model.resolution",
+      "type": "COMBO"
+     },
+     {
+      "name": "model.number_of_images",
+      "type": "INT"
+     },
+     {
+      "name": "model.quality",
+      "type": "COMBO"
+     }
+    ],
+    "inputs": [],
+    "input_groups": []
+   },
+   "expr": "\n                (\n                  $is20 := widgets.model = \"grok-imagine-image-2.0\";\n                  $isPro := $contains(widgets.model, \"pro\");\n                  $res := $lookup(widgets, \"model.resolution\");\n                  $n := $lookup(widgets, \"model.number_of_images\");\n                  $is1k := $res = \"1k\";\n                  $rate := $is20\n                    ? ($lookup(widgets, \"model.quality\") = \"low\"\n                        ? ($is1k ? 0.04 : 0.06)\n                        : ($is1k ? 0.06 : 0.08))\n                    : (widgets.model = \"grok-imagine-image-quality\"\n                        ? ($is1k ? 0.05 : 0.07)\n                        : ($isPro ? 0.07 : 0.02));\n                  $base := ($is20 or widgets.model = \"grok-imagine-image-quality\") ? 0.01 : 0.002;\n                  $output := $rate * $n;\n                  $isPro\n                    ? {\"type\":\"usd\",\"usd\": $base + $output}\n                    : {\"type\":\"range_usd\",\"min_usd\": $base + $output, \"max_usd\": 3 * $base + $output}\n                )\n                "
+  },
+  "search_aliases": null,
+  "essentials_category": null,
+  "has_intermediate_output": false,
+  "description": ""
+ },
+ "SaveImage": {
+  "input": {
+   "required": {
+    "images": [
+     "IMAGE",
+     {}
+    ],
+    "filename_prefix": [
+     "STRING",
+     {
+      "default": "ComfyUI"
+     }
+    ]
+   },
+   "hidden": {
+    "prompt": "PROMPT",
+    "extra_pnginfo": "EXTRA_PNGINFO"
+   }
+  },
+  "input_order": {
+   "required": [
+    "images",
+    "filename_prefix"
+   ],
+   "hidden": [
+    "prompt",
+    "extra_pnginfo"
+   ]
+  },
+  "is_input_list": false,
+  "output": [
+   "IMAGE"
+  ],
+  "output_is_list": [
+   false
+  ],
+  "output_name": [
+   "images"
+  ],
+  "name": "SaveImage",
+  "display_name": "Save Image",
+  "python_module": "nodes",
+  "category": "image",
+  "output_node": true,
+  "has_intermediate_output": false,
+  "search_aliases": [
+   "save",
+   "save image",
+   "export image",
+   "output image",
+   "write image",
+   "download"
+  ],
+  "essentials_category": "Basics",
+  "description": ""
+ }
+}


### PR DESCRIPTION
> Replaces #812 (approved by @annehe9 at `48ba26c4`), which GitHub closed when #809 merged and its base branch was deleted. Same commits, rebased onto `main` (now that #809 is in); the review-fix commits are unchanged.

> **Stacked on #809** (`kishore/upload-companion-widget`) — both change the same `engine.py` widget-order functions. Retarget to `main` once #809 lands.

## Why

The in-app agent cannot wire a Load Image / Load Video / Load Audio into any node whose reference inputs are `COMFY_AUTOGROW_V3` groups nested under a `COMFY_DYNAMICCOMBO_V3` option — Nano Banana 2, Seedance 2.5 r2v, MiniMax H3 r2v, and 24 other partner nodes. Reproduced on the pin the agent ships (`50fd0a43`) with the cloud `object_info.json`:

- agent-built `GeminiNanoBanana2V2`: `add_node` writes `inputs: []`; `connect A.IMAGE B.model.images.image_1` and `…B.model.images` both fail `input not found`;
- UI-built `api_minimax_h3_r2v`: only the one free slot the frontend pre-created (`image_2`) wires; `image_3`, `reference_videos.video_2` fail;
- agent-built dynamic-combo nodes carried **phantom widget slots** for the groups (`model.images`, `model.files`), shifting every later widget: converting Nano Banana 2 gave `response_modalities: null, system_prompt: 42, temperature: "fixed", top_p: "IMAGE"`. The published widget catalog named those phantom slots too, so through the CRDT doc host a UI-built MiniMax H3 node's `seed` position mapped onto `model.reference_images` ("filename in the seed widget").

## Root cause

**A.** `workflow_ops._resolve_input_target` only recognised a group when the node's `inputs` already held a `COMFY_AUTOGROW*`-typed base entry — true only for *top-level* groups on *CLI-built* nodes. Nested groups never get one; UI-built nodes never carry one (the frontend writes the grown `images.imageN` slots, never the base). So even a UI-built top-level `BatchImagesNode` couldn't be base-addressed or grown past its free slot.

**B.** `widget_order_default` / `widget_defaults` expanded a dynamic combo's sub-inputs with their own helper (`_dynamic_sub_widget_defaults`) that included link-only sub-inputs, while `widget_order_for_node` (`_expand_widget_entries`) skipped them. add-node, the catalog and set-widget disagreed with each other.

## Change

- `engine.py`: one walk. `_expand_widget_entries(m, values, first_key=…, sub_links=…)` drives `widget_order_default`, `widget_defaults` (new `_widget_default`) *and* `widget_order_for_node`; the duplicate sub-widget helpers are removed. New `Graph.autogrow_groups(class, widgets_values)` lists every group the node's **current selection** exposes, dotted as the frontend names them (`model.reference_images`). New `Port.autogrow_element_type` (the template's declared input type) and `Port.autogrow_limits` (`(min, max)` with `max = len(names)` else `template.max`, as `applyAutogrow` derives them). `autogrow_slot_example` uses the schema names. `morphism_to_dict` (`nodes show`) adds `dynamic_options: [{key, inputs:[…]}]` per option and, on any autogrow input, `element_type`, `slots {names|prefix, min, max}`, `wire_as`.
- `workflow_ops.py`: `_resolve_schema_autogrow` mirrors `dynamicWidgets.ts` — base address reuses the lowest **free** existing slot, else appends the next schema-named slot; a dotted key or bare element name must be that exact next slot (gap → rejected with the next free key); source type must match the group's element type (`type mismatch`); never grows past `max`. `_autogrow_group_port` resolves top-level *and* nested groups from the node's own `widgets_values`. Grow/apply splits a slot's group on the **last** dot (`_autogrow_base`) so `model.images.image_1` → `model.images`, not `model`.
- Fixture `tests/comfy_cli/fixtures/object_info_nested_autogrow.json`: the production catalog's entries for `LoadImage/LoadVideo/LoadAudio/SaveImage/BatchImagesNode/GeminiNanoBanana2V2/MinimaxHailuo03ReferenceNode/GrokImageEditNodeV2`, tooltips stripped, declaration order preserved.

## Red → green

26 new tests, all written and watched fail first (`11 == 8`, `AttributeError: autogrow_groups`, `input 'model.images.image_1' not found … inputs: []`):

- `tests/comfy_cli/cql/test_nested_autogrow.py` (10): default order = the captured frontend shape (MiniMax 8 values, `seed` at 5); add-node layout round-trips through set-widget indexing; `autogrow_groups` follows the node selection; template/limits from the schema; `nodes show` payload names group, element type, slots.
- `tests/comfy_cli/command/test_workflow_edit_nested_autogrow.py` (16): grow by name / by base / explicit next key; gap rejected with the next free key; bare element name; selection-dependent groups; UI-built free-slot reuse then growth; Load Video + Load Audio into their groups; type mismatch refused; `max` enforced; UI-built top-level `BatchImagesNode`; set-widget lands in the frontend position; agent-built node converts with `model.images.image_1/2` links and unshifted `seed`/`temperature`/`top_p` and validates; nested grow op replay idempotent; CLI `add-node` + `connect` envelopes.

## Verification

- Full suite: **6207 passed, 38 skipped**; ruff check + format clean.
- Cloud catalog sweep (3,699 classes): classes whose fresh add-node layout ≠ set-widget indexing **41 → 0**; 85 auto-grow groups (45 nested, 40 top-level) resolvable at the default selection.
- Report's repro commands with the real catalog: Nano Banana 2 `image_1` / base / `image_3` ✓, `image_9` → "use the next free key `model.images.image_4`"; MiniMax template `image_2` / `image_3` / base ✓, `LoadVideo → reference_videos.video_1` ✓, `LoadVideo → reference_images` → `type mismatch … its slots take IMAGE`; widgets stay `[…, 42, 'randomize', False]`; widget-catalog MiniMax = 8 names, NB2 = 11.

## Not in this PR (other children of the umbrella)

- Agent tool surface (`services/agent … digest.go`, `list_slots`, `connect` description) — the CLI half is done: `nodes show` now carries the names; the digest must keep `dynamic_options` / `element_type` / `wire_as`.
- comfy-knowledge canon rows "agent tooling cannot wire a Load Image to a slot that is not there yet" (nano-banana.yaml, seedream.yaml) — retract.
- In-repo follow-ups: nested groups with `min > 0` (Grok / Qwen / HappyHorse) aren't checked by `_check_autogrow_required`; grown slots carry no `label` / `shape` (the frontend recomputes them on load).

## Rollout note

Same as #809: the catalog hash changes (41 classes), so minted `workflow_docs` need a re-mint when the pin reaches an env with documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

