### PR TITLE
feat(knowledge): carry the bundle's compile date in every envelope (BE-9893)

### DIFF
--- a/comfy_cli/command/knowledge.py
+++ b/comfy_cli/command/knowledge.py
@@ -84,6 +84,7 @@ def status_cmd(
             "stale": bundle.stale,
             "version": bundle.version,
             "schema_version": knowledge.SCHEMA_VERSION,
+            "compiled_at": bundle.compiled_at,
             "as_of": bundle.as_of,
             "path": bundle.path,
             **_env_context(),
@@ -137,6 +138,7 @@ def resolve_cmd(
         "model": row,
         "deprecation": bundle.deprecations.get(model_id),
         "bundle_version": bundle.version,
+        "compiled_at": bundle.compiled_at,
         "stale": bundle.stale,
     }
     if renderer.is_pretty():
@@ -164,6 +166,7 @@ def _emit_capabilities(renderer, bundle: knowledge.Bundle, *, query: str | None 
         "capabilities": caps,
         "zero_hit": query is not None,
         "bundle_version": bundle.version,
+        "compiled_at": bundle.compiled_at,
         "stale": bundle.stale,
     }
     if query is not None:
@@ -212,6 +215,7 @@ def pick_cmd(
         "as_of": _text(cap.get("as_of")),
         "picks": picks,
         "bundle_version": bundle.version,
+        "compiled_at": bundle.compiled_at,
         "stale": bundle.stale,
     }
     if renderer.is_pretty():

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -590,7 +590,7 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
         source=source,
         stale=stale,
         as_of=datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        compiled_at=compiled_at[:MAX_VERSION_CHARS] if isinstance(compiled_at, str) else None,
+        compiled_at=(compiled_at if isinstance(compiled_at, str) and len(compiled_at) <= MAX_VERSION_CHARS else None),
         path=path,
         models=models,
         capabilities=capabilities,
@@ -899,6 +899,7 @@ def log_query(
             "hit_ids": hit_ids,
             "zero_hit": zero_hit,
             "bundle_version": bundle.version,
+            "compiled_at": bundle.compiled_at,
         }
         if uncurated is not None:
             props["uncurated_queries"] = uncurated

--- a/comfy_cli/knowledge.py
+++ b/comfy_cli/knowledge.py
@@ -89,8 +89,18 @@ REASON_FETCH_FAILED = "fetch from COMFY_KNOWLEDGE_URL failed and no cached bundl
 class Bundle:
     version: str
     source: str  # "env" | "cache" | "fetch" | "stale-cache"
+    # Not an age signal. True only on the "stale-cache" path: the TTL expired
+    # and no fetch replaced it. A caller that passes COMFY_KNOWLEDGE_FILE takes
+    # the "env" branch, where this is always False no matter how old the file
+    # is, so a consumer reading it as freshness learns nothing.
     stale: bool
-    as_of: str  # ISO-8601 UTC, from the loaded file's mtime
+    # When this machine got the file, from its mtime. Says nothing about how
+    # old the content is: a bundle fetched at pod start reads as new whatever
+    # it holds. Read compiled_at for the content's date.
+    as_of: str
+    # The content's date, from the manifest's compiled_at. None for a bundle
+    # compiled before the key existed, or one built outside a git checkout.
+    compiled_at: str | None
     path: str
     models: dict[str, dict]
     capabilities: dict[str, dict]
@@ -574,11 +584,13 @@ def _index(data: dict, manifest: dict | None, *, source: str, stale: bool, path:
     }
 
     version = manifest.get("version") if manifest is not None else None
+    compiled_at = manifest.get("compiled_at") if manifest is not None else None
     return Bundle(
         version=version[:MAX_VERSION_CHARS] if isinstance(version, str) else "unknown",
         source=source,
         stale=stale,
         as_of=datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        compiled_at=compiled_at[:MAX_VERSION_CHARS] if isinstance(compiled_at, str) else None,
         path=path,
         models=models,
         capabilities=capabilities,
@@ -1020,6 +1032,7 @@ def attach(
             "bundle_version": bundle.version,
             "stale": bundle.stale,
             "as_of": bundle.as_of,
+            "compiled_at": bundle.compiled_at,
             "models": entries,
             "picks": picks,
             "capabilities_available": sorted(bundle.capabilities),
@@ -1059,6 +1072,7 @@ def attach(
                 "bundle_version": bundle.version,
                 "stale": bundle.stale,
                 "as_of": bundle.as_of,
+                "compiled_at": bundle.compiled_at,
                 # What matched before _fit, not what survived it. Rows shed to
                 # make the ceiling are curated knowledge that exists, and filing
                 # them as a gap would put a covered term in the curation inbox.

--- a/comfy_cli/schemas/knowledge.json
+++ b/comfy_cli/schemas/knowledge.json
@@ -28,6 +28,7 @@
     "model": { "type": "object", "description": "The full model row as shipped in the bundle (resolve)." },
     "deprecation": { "type": ["object", "null"], "description": "Matching deprecations entry, if any (resolve)." },
     "bundle_version": { "type": "string", "description": "Bundle version the answer came from (resolve, pick)." },
+    "compiled_at": { "type": ["string", "null"], "description": "Committer date of the commit the bundle was compiled from, ISO-8601 UTC. The content's date, unlike `as_of` (when this machine got the file) and `stale` (a fetch-failure flag). Null for a bundle compiled before the manifest carried the key. Treat as an opaque string; it is not validated." },
     "capability": { "type": "string", "description": "Capability id (pick)." },
     "capabilities": {
       "type": "array",

--- a/comfy_cli/schemas/knowledge_block.json
+++ b/comfy_cli/schemas/knowledge_block.json
@@ -2,10 +2,11 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://comfy.org/schemas/knowledge_block.json",
   "title": "knowledge block",
-  "description": "Curated model knowledge attached as `data.knowledge` by discovery commands (generate schema|list, templates ls|show|get, nodes search|ls, models search). Absent when no bundle is loaded, or when the call named no subject at all (an unfiltered listing). A query term nothing curated answers attaches a rowless block: `bundle_version`, `stale`, `as_of`, `hit_ids: []`, `zero_hit` and `uncurated_queries`, with no models and no picks. That block is itself dropped in the one case where the terms alone overrun the byte ceiling. Every field is optional; readers must ignore unknown fields.",
+  "description": "Curated model knowledge attached as `data.knowledge` by discovery commands (generate schema|list, templates ls|show|get, nodes search|ls, models search). Absent when no bundle is loaded, or when the call named no subject at all (an unfiltered listing). A query term nothing curated answers attaches a rowless block: `bundle_version`, `compiled_at`, `stale`, `as_of`, `hit_ids: []`, `zero_hit` and `uncurated_queries`, with no models and no picks. That block is itself dropped in the one case where the terms alone overrun the byte ceiling. Every field is optional; readers must ignore unknown fields.",
   "type": "object",
   "properties": {
     "bundle_version": { "type": "string", "description": "Version of the comfy-knowledge bundle the block came from." },
+    "compiled_at": { "type": ["string", "null"], "description": "Committer date of the commit the bundle was compiled from, ISO-8601 UTC. The content's date, unlike `as_of` (when this machine got the file) and `stale` (a fetch-failure flag). Null for a bundle compiled before the manifest carried the key. Treat as an opaque string; it is not validated." },
     "stale": { "type": "boolean", "description": "True when the bundle was served from an expired cache." },
     "as_of": { "type": "string", "description": "ISO-8601 UTC timestamp of the loaded bundle file." },
     "models": {

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -651,6 +651,23 @@ class TestIndex:
         assert [p["model"] for p in knowledge.pick(b, "c")["picks"]] == ["z", "y", "x"]
         assert b.as_of == "1970-01-01T00:00:00Z"
 
+    def test_compiled_at_comes_from_the_manifest_not_the_file(self, tmp_path, monkeypatch):
+        manifest = json.loads(FIXTURE_MANIFEST.read_text())
+        manifest["compiled_at"] = "2026-08-28T02:44:27Z"
+        _env_bundle(tmp_path, monkeypatch, manifest=manifest)
+
+        b = knowledge.load_bundle()
+
+        assert b.compiled_at == "2026-08-28T02:44:27Z"
+        # as_of is when this machine got the file, so the two must not agree
+        # just because one was copied from the other.
+        assert b.as_of != b.compiled_at
+
+    def test_compiled_at_is_none_for_a_bundle_predating_the_key(self, tmp_path, monkeypatch):
+        _env_bundle(tmp_path, monkeypatch)
+
+        assert knowledge.load_bundle().compiled_at is None
+
     def test_pick_attaches_the_model_fits(self):
         fits = {"vram_gb": {"fp8": 12, "bf16": 24}, "credits_per_image": 0.5, "max_refs": 3, "source": "measured"}
         data = {

--- a/tests/comfy_cli/test_knowledge.py
+++ b/tests/comfy_cli/test_knowledge.py
@@ -668,6 +668,15 @@ class TestIndex:
 
         assert knowledge.load_bundle().compiled_at is None
 
+    def test_an_over_long_compiled_at_is_dropped_not_truncated(self, tmp_path, monkeypatch):
+        manifest = json.loads(FIXTURE_MANIFEST.read_text())
+        manifest["compiled_at"] = "2026-08-31T12:00:00" + "0" * knowledge.MAX_VERSION_CHARS + "+00:00"
+        _env_bundle(tmp_path, monkeypatch, manifest=manifest)
+
+        # Cutting a timestamp to length yields a date that parses to the wrong
+        # instant, which is worse than reporting none.
+        assert knowledge.load_bundle().compiled_at is None
+
     def test_pick_attaches_the_model_fits(self):
         fits = {"vram_gb": {"fp8": 12, "bf16": 24}, "credits_per_image": 0.5, "max_refs": 3, "source": "measured"}
         data = {
@@ -740,6 +749,39 @@ def _run(args: list[str], capsys) -> tuple[int, dict[str, Any]]:
 
 def _validate(data: dict) -> None:
     jsonschema.Draft202012Validator(SCHEMA).validate(data)
+
+
+class TestCompiledAtReachesEveryPayload:
+    """One test per emit site, so removing any single one fails."""
+
+    STAMPED = "2026-08-28T02:44:27Z"
+
+    @pytest.fixture(autouse=True)
+    def _stamped_bundle(self, tmp_path, monkeypatch):
+        manifest = json.loads(FIXTURE_MANIFEST.read_text())
+        manifest["compiled_at"] = self.STAMPED
+        _env_bundle(tmp_path, monkeypatch, manifest=manifest)
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["status"],
+            ["resolve", "acme-h3"],
+            ["pick", "lipsync"],
+            ["pick", "no-such-capability"],
+        ],
+        ids=["status", "resolve", "pick", "pick-miss"],
+    )
+    def test_command_payload_dates_its_bundle(self, args, capsys):
+        _, envelope = _run(args, capsys)
+
+        assert envelope["data"]["compiled_at"] == self.STAMPED
+
+    def test_the_attach_block_dates_its_bundle(self):
+        payload: dict = {}
+        knowledge.attach(payload, command="generate list", queries=["acme-h3"])
+
+        assert payload["knowledge"]["compiled_at"] == self.STAMPED
 
 
 class TestCli:

--- a/tests/comfy_cli/test_knowledge_attach.py
+++ b/tests/comfy_cli/test_knowledge_attach.py
@@ -705,6 +705,7 @@ class TestMissMarker:
             "bundle_version": "0.1.0-fixture",
             "stale": False,
             "as_of": k["as_of"],
+            "compiled_at": None,
             "hit_ids": [],
             "zero_hit": False,
             "uncurated_queries": ["faceswap"],


### PR DESCRIPTION
## What changed

Every knowledge payload now carries `compiled_at`, the bundle's content date, read from `manifest.json`.

**Merge after Comfy-Org/comfy-knowledge#33**, which is what writes the key. Until a bundle carrying it is published, this ships `compiled_at: null` everywhere and looks inert.

## Why

A consumer reading an enrichment envelope had no way to tell how old the advice was. Two fields look like the answer and neither is one.

`stale` is true only on the `stale-cache` path: the TTL expired and no fetch replaced it. A caller that sets `COMFY_KNOWLEDGE_FILE` takes the `env` branch, where it is hardcoded `False` no matter how old the file is. The cloud agent always sets that variable, so `stale` is structurally always `False` there.

`as_of` is the loaded file's mtime. On the cloud agent that file is written by a GCS warm fetch at pod start, so it reports how long the pod has been up and says nothing about the content. Before the warm fetch shipped it was at least the image build time.

Found triaging eval run `run_3e91922d97784821be2c96bf9a0debcf`: every response carried `stale: false` on canon that was 21 days behind, and nothing in the envelope contradicted it.

## What this does not change

Additive, per the bundle schemas' additive-only rule. `as_of` and `stale` keep their meanings and gain comments saying what those meanings are, so nothing that reads them today changes behaviour. A rename would also have put the code out of step with the design doc, which uses `stale` with exactly this meaning in two places.

`compiled_at` is `None` for a bundle compiled before the key existed, including the 0.1.4 bundle vendored into the cloud agent images, so old bundles keep loading.

## Where it ships

`status`, `resolve`, `pick`, the pick-capabilities miss, the `attach()` block and its miss marker, and the `knowledge_query` telemetry event. The miss log is the curation inbox, so a gap found against an old bundle should not rank beside one found against a current bundle.

Declared in `comfy_cli/schemas/knowledge.json` and `knowledge_block.json` as `["string", "null"]` and documented as opaque. The producer validates the date; a consumer must not, which is the tolerant-reader rule the bundle schemas already state.

An over-long value from a hostile manifest is dropped rather than truncated. Cutting a timestamp to length yields a date that parses to the wrong instant, and no date beats a wrong one. The `version` field beside it tolerates truncation because nothing parses it.

## Testing

`7289 passed, 39 skipped`. ruff check and format clean on every file touched.

`TestCompiledAtReachesEveryPayload` covers each emit site. Confirmed by deleting each `"compiled_at": bundle.compiled_at,` line and checking a test fails: without these, all six sites could be removed with the suite still green.

End to end against a bundle compiled from comfy-knowledge#33:

```
manifest: {'version': '0.1.4', 'compiled_at': '2026-08-31T17:28:37Z'}
envelope: {'bundle_version': '0.1.4', 'compiled_at': '2026-08-31T17:28:37Z',
           'stale': False, 'as_of': '2026-08-27'}
```

`as_of` there is the capability row's curator date, a different field from `Bundle.as_of`. The point of the change is that these are now distinguishable.

## Follow-ups, both blocked on a pin bump

Cloud can stamp `compiled_at` as a Langfuse span attribute beside `bundle_version` in `services/agent/internal/loop/knowledge_span.go`, and contract `data.compiled_at` in `services/agent/internal/loop/cli_fields.json`. Neither can land until this merges and the agent's comfy-cli pin moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
