### PR TITLE
perf(workspace): resolve the workspace on first read (BE-10535)

### DIFF
--- a/comfy_cli/workspace_manager.py
+++ b/comfy_cli/workspace_manager.py
@@ -161,9 +161,9 @@ class WorkspaceManager:
         self.specified_workspace = None
         self.use_here = None
         self.use_recent = None
-        self.workspace_path = None
-        self.workspace_type = None
         self.skip_prompting = None
+        self._flags_set = False
+        self._resolved: tuple[str | None, WorkspaceType | None] | None = None
 
     def setup_workspace_manager(
         self,
@@ -175,8 +175,48 @@ class WorkspaceManager:
         self.specified_workspace = specified_workspace
         self.use_here = use_here
         self.use_recent = use_recent
-        self.workspace_path, self.workspace_type = self.get_workspace_path()
         self.skip_prompting = skip_prompting
+        self._flags_set = True
+        self._resolved = None
+
+    def _resolve(self) -> tuple[str | None, WorkspaceType | None]:
+        """Resolve the workspace on first read and cache it.
+
+        Deferred because ``get_workspace_path`` runs ``check_comfy_repo``, which
+        imports GitPython and opens the repo — 40 ms warm, more on a cold cache,
+        that every workspace-free command (``knowledge``, ``cloud``, ``skills``,
+        ...) would otherwise pay in the Typer callback before dispatch.
+        """
+        if self._resolved is None:
+            self._resolved = self.get_workspace_path() if self._flags_set else (None, None)
+        return self._resolved
+
+    # The setters and deleters are what keep ``patch.object(manager,
+    # "workspace_path", ...)`` working across the test suite: patching a property
+    # needs both, and unpatching goes through the deleter.
+    @property
+    def workspace_path(self) -> str | None:
+        return self._resolve()[0]
+
+    @workspace_path.setter
+    def workspace_path(self, value: str | None):
+        self._resolved = (value, (self._resolved or (None, None))[1])
+
+    @workspace_path.deleter
+    def workspace_path(self):
+        self._resolved = None
+
+    @property
+    def workspace_type(self) -> WorkspaceType | None:
+        return self._resolve()[1]
+
+    @workspace_type.setter
+    def workspace_type(self, value: WorkspaceType | None):
+        self._resolved = ((self._resolved or (None, None))[0], value)
+
+    @workspace_type.deleter
+    def workspace_type(self):
+        self._resolved = None
 
     def set_recent_workspace(self, path: str):
         """

--- a/tests/comfy_cli/test_workspace_manager.py
+++ b/tests/comfy_cli/test_workspace_manager.py
@@ -663,3 +663,85 @@ class TestFullIntegration:
 
         assert ws_type == WorkspaceType.DEFAULT
         assert path == str(comfy_dir)
+
+
+class TestLazyResolution:
+    """``workspace_path``/``workspace_type`` resolve on first read, not in ``entry()``."""
+
+    def test_path_is_none_before_setup(self):
+        """``_make_manager`` cannot reset the singleton, so ask for a genuinely fresh one."""
+        from comfy_cli.utils import reset_singleton_for_testing
+        from comfy_cli.workspace_manager import WorkspaceManager
+
+        reset_singleton_for_testing(WorkspaceManager)
+        mgr = WorkspaceManager()
+        assert mgr.workspace_path is None
+        assert mgr.workspace_type is None
+
+    def test_setup_does_not_probe(self):
+        mgr = _make_manager()
+        with patch("comfy_cli.workspace_manager.check_comfy_repo", side_effect=AssertionError("probed")):
+            mgr.setup_workspace_manager()
+
+    def test_first_read_resolves_once(self):
+        mgr = _make_manager()
+        mgr.setup_workspace_manager()
+        with patch.object(mgr, "get_workspace_path", return_value=("/ws", WorkspaceType.DEFAULT)) as resolve:
+            assert mgr.workspace_path == "/ws"
+            assert mgr.workspace_type == WorkspaceType.DEFAULT
+            assert mgr.workspace_path == "/ws"
+        assert resolve.call_count == 1
+
+    def test_second_setup_discards_the_cached_path(self):
+        """``comfy install`` re-runs setup with the freshly created repo dir."""
+        mgr = _make_manager()
+        mgr.setup_workspace_manager(specified_workspace="/first")
+        assert mgr.workspace_path == "/first"
+        mgr.setup_workspace_manager(specified_workspace="/second")
+        assert mgr.workspace_path == "/second"
+
+
+class TestWorkspaceFreeCommands:
+    """Commands that never read the workspace must not pay for the git probe."""
+
+    @staticmethod
+    def _invoke(args):
+        from typer.testing import CliRunner
+
+        import comfy_cli.workspace_manager as workspace_manager_module
+        from comfy_cli.cmdline import app
+
+        with patch.object(
+            workspace_manager_module, "check_comfy_repo", side_effect=AssertionError("workspace was probed")
+        ):
+            return CliRunner().invoke(app, args)
+
+    @pytest.mark.parametrize("command", [["knowledge", "status"], ["cloud", "status"]])
+    def test_no_workspace_probe(self, command):
+        result = self._invoke(["--json", *command])
+        assert not isinstance(result.exception, AssertionError), result.exception
+
+    def test_which_still_resolves_the_workspace(self):
+        from typer.testing import CliRunner
+
+        import comfy_cli.workspace_manager as workspace_manager_module
+        from comfy_cli.cmdline import app
+
+        with patch.object(workspace_manager_module, "check_comfy_repo", return_value=(True, "/sentinel/ComfyUI")):
+            result = CliRunner().invoke(app, ["--json", "which"])
+
+        assert result.exit_code == 0, result.output
+        assert "/sentinel/ComfyUI" in result.output
+
+    def test_gitpython_is_not_imported(self):
+        import subprocess
+        import sys
+
+        source = (
+            "import sys\n"
+            "from typer.testing import CliRunner\n"
+            "from comfy_cli.cmdline import app\n"
+            "CliRunner().invoke(app, ['--json', 'knowledge', 'status'])\n"
+            "assert 'git' not in sys.modules, 'GitPython was imported'\n"
+        )
+        subprocess.run([sys.executable, "-c", source], check=True, capture_output=True, timeout=120)


### PR DESCRIPTION
Linear: [BE-10535](https://linear.app/comfyorg/issue/BE-10535). Follow-up to BE-9907.

## Problem

`entry()` in `comfy_cli/cmdline.py:301` calls `setup_workspace_manager` for every subcommand before dispatch. That eagerly ran `get_workspace_path()`, which calls `check_comfy_repo(os.getcwd())`, which imports GitPython and opens the repo. Only `--version` and `--help-json` short-circuit before it. Every command that never reads the workspace (`knowledge`, `cloud`, `skills`, ...) paid for a value it discards.

## Change

Option 2 from the ticket. `setup_workspace_manager` now only stores the flags. `workspace_path` and `workspace_type` are properties that resolve on first read and cache the pair.

Confirmed nothing reads the path eagerly, so no fallback to option 1 was needed. Every reader is inside a command handler: `cmdline.py:749/816/1687/1697`, `command/build.py:933+`, `command/launch.py:415/432/848`, `command/custom_nodes/*`, `command/models/models.py:55`. `_maybe_nudge_setup` and `tracking.prompt_tracking_consent` do not touch it. `command/install.py:273` calls `setup_workspace_manager` a second time after creating the repo; that discards the cached pair.

The property setters and deleters exist because roughly 100 test call sites do `patch.object(manager, "workspace_path", ...)`. Patching a property needs a setter, and unpatching goes through the deleter.

## Measurements

Median of runs on a quiet machine, dependencies from `uv sync --locked`, two alternating rounds against `origin/main`.

| | main | branch |
|---|---|---|
| `comfy --json` (bare), min of 20 | 0.13 s / 0.17 s | 0.09 s / 0.09 s |
| `git` in `-X importtime` | 58 ms | absent |

`comfy --json knowledge status` shows no measurable change (0.86-0.94 s either way). The two sequential authed GETs dominate that command; BE-10534 is the ticket for those.

## Tests

`uv run --locked --extra dev pytest`, matching the CI workflow:

- `origin/main`: 7281 passed, 39 skipped
- this branch: 7289 passed, 39 skipped

The 8 new tests are in `tests/comfy_cli/test_workspace_manager.py`. Five of them fail against `origin/main`, so they pin the change rather than restating it:

- `setup_workspace_manager` does not probe (`check_comfy_repo` patched to raise)
- first read resolves exactly once, and caches
- a second `setup_workspace_manager` discards the cached path
- `knowledge status` and `cloud status` run with `check_comfy_repo` patched to raise
- a subprocess asserts GitPython never reaches `sys.modules`
- `which` still resolves the workspace, and the path is None before setup

`uvx ruff@0.15.15 check` and `format --diff` both clean, matching `.github/workflows/ruff_check.yml`.

## Behaviour note

`get_workspace_path` can raise `typer.Exit(1)` when `--recent` is passed with no recent workspace set. That now fires on first read rather than in the callback, so `comfy --recent knowledge status` succeeds instead of aborting. That is the point of the change: a workspace-free command should not be gated on workspace resolution. Every workspace-consuming command still aborts exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)