### PR TITLE
perf(file_utils): import httpx lazily (BE-10537)

### DIFF
--- a/comfy_cli/file_utils.py
+++ b/comfy_cli/file_utils.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -10,7 +11,6 @@ import zipfile
 from collections.abc import Callable
 from http import HTTPStatus
 
-import httpx
 from pathspec import PathSpec
 
 from comfy_cli import constants, ui
@@ -471,13 +471,6 @@ _VALID_DOWNLOADERS = {"httpx", "aria2"}
 
 _DOWNLOAD_MAX_RETRIES = 3
 _DOWNLOAD_RETRY_BACKOFF = 2  # seconds multiplier
-_DOWNLOAD_TIMEOUT = httpx.Timeout(10.0, read=300.0)
-_TRANSIENT_EXCEPTIONS = (
-    httpx.TimeoutException,
-    httpx.NetworkError,
-    httpx.ProtocolError,
-    httpx.ProxyError,
-)
 # HTTP statuses that typically indicate a transient server-side or rate-limit
 # problem worth retrying with backoff. Auth/not-found/redirect statuses stay
 # out of this set so they fail fast.
@@ -493,7 +486,25 @@ class _TransientHTTPStatusError(Exception):
         super().__init__(f"HTTP {status_code}: {reason}")
 
 
-_RETRIABLE_EXCEPTIONS = _TRANSIENT_EXCEPTIONS + (_TransientHTTPStatusError,)
+# Built on first use, not at import: httpx costs 11 ms warm to import, more on
+# a cold cache, and most importers of this module only want ``atomic_write_*``.
+@functools.cache
+def _download_timeout():
+    import httpx
+
+    return httpx.Timeout(10.0, read=300.0)
+
+
+@functools.cache
+def _transient_exceptions() -> tuple[type[BaseException], ...]:
+    import httpx
+
+    return (httpx.TimeoutException, httpx.NetworkError, httpx.ProtocolError, httpx.ProxyError)
+
+
+@functools.cache
+def _retriable_exceptions() -> tuple[type[BaseException], ...]:
+    return (*_transient_exceptions(), _TransientHTTPStatusError)
 
 
 def _cleanup_partial(filepath: pathlib.Path) -> None:
@@ -687,6 +698,8 @@ def cleanup_stale_tmp_files(
 
 def _friendly_network_error(exc: Exception) -> str:
     """Return a user-friendly description of a network error."""
+    import httpx
+
     if isinstance(exc, _TransientHTTPStatusError):
         try:
             phrase = HTTPStatus(exc.status_code).phrase
@@ -744,11 +757,13 @@ def _download_file_httpx(
     deliberate exception: a :class:`KeyboardInterrupt` leaves it in place so
     :func:`download_file` can ask the user whether to keep the partial.
     """
-    with httpx.stream("GET", url, follow_redirects=True, headers=headers, timeout=_DOWNLOAD_TIMEOUT) as response:
+    import httpx
+
+    with httpx.stream("GET", url, follow_redirects=True, headers=headers, timeout=_download_timeout()) as response:
         if response.status_code != 200:
             try:
                 error_body = response.read()
-            except _TRANSIENT_EXCEPTIONS:
+            except _transient_exceptions():
                 error_body = ""
             status_reason = guess_status_code_reason(response.status_code, error_body)
             if response.status_code in _RETRIABLE_STATUSES:
@@ -859,6 +874,8 @@ def download_file(
     if downloader == "aria2":
         return _download_file_aria2(url, local_filepath, headers, progress_callback)
 
+    import httpx
+
     last_exc: Exception | None = None
     state: dict = {"file_opened": False, "part_path": None}
 
@@ -868,7 +885,7 @@ def download_file(
         try:
             _download_file_httpx(url, local_filepath, headers, state=state, progress_callback=progress_callback)
             return
-        except _RETRIABLE_EXCEPTIONS as exc:
+        except _retriable_exceptions() as exc:
             last_exc = exc
             # The temp file this attempt was writing is already gone (the helper
             # unlinks it on the way out) and the destination was never touched, so

--- a/tests/test_file_utils_network.py
+++ b/tests/test_file_utils_network.py
@@ -1285,3 +1285,22 @@ class TestDownloadNonRetriableHTTPError:
             download_file("http://example.com/model.bin", dest)
 
         assert not dest.exists()
+
+
+def test_knowledge_import_does_not_pull_httpx():
+    """``comfy_cli.knowledge`` wants only ``atomic_write_bytes`` from ``file_utils``.
+
+    httpx costs 11 ms warm to import, so it stays out of every command that never
+    downloads. ``-X importtime`` names each module that was actually imported.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, "-X", "importtime", "-c", "import comfy_cli.knowledge"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    imported = {line.rsplit("|", 1)[-1].strip() for line in proc.stderr.splitlines()}
+    assert "httpx" not in imported


### PR DESCRIPTION
Linear: [BE-10537](https://linear.app/comfyorg/issue/BE-10537). Follow-up to BE-9907.

## Problem

`comfy_cli/file_utils.py` imported httpx at module top, and two module-level constants built httpx objects at import time (`_DOWNLOAD_TIMEOUT = httpx.Timeout(...)` and the transient/retriable exception tuples). Only `_download_file_httpx`, `download_file` and `_friendly_network_error` need httpx. Everything else that imports this module wants `atomic_write_text` or `atomic_write_bytes` alone: `knowledge.py`, `build.py`, `build_spec.py`, `outdated.py`, `project.py`, `workflow.py`, `cql/loader.py`, `jobs_state.py`, `skills/__init__.py`.

## Change

`import httpx` moved into those three functions. In `download_file` it sits after the aria2 early return, so the aria2 path never imports it.

The two constants became three `functools.cache` helpers built on first download: `_download_timeout`, `_transient_exceptions`, `_retriable_exceptions`. Same classes in the same order, and the cache means `except _retriable_exceptions() as exc:` compares against the same tuple object every time, so timeout and retry behaviour is unchanged. Nothing outside the module referenced the removed names.

`atomic_write_text` / `atomic_write_bytes` were not split into a new module, per the ticket.

## Measurements

`python -X importtime -c "import comfy_cli.knowledge"` on a quiet machine, dependencies from `uv sync --locked`, min of 11, two alternating rounds against `origin/main`.

| | main | branch |
|---|---|---|
| `comfy_cli.knowledge` | 79.0 ms / 79.5 ms | 70.0 ms / 70.9 ms |
| `httpx` line | 11.3 ms | absent |

The ticket estimated 0.13 s. The real figure on a warm machine is 11 ms, because `rich` is already loaded by the time httpx pulls `httpx._main`.

## Tests

`uv run --locked --extra dev pytest`, matching the CI workflow:

- `origin/main`: 7281 passed, 39 skipped
- this branch: 7282 passed, 39 skipped

The new test is `test_knowledge_import_does_not_pull_httpx` in `tests/test_file_utils_network.py`. It runs `-X importtime` in a subprocess and asserts httpx is absent from the import list. Verified it fails against `origin/main`.

Download behaviour is covered by the existing suites, which pass unchanged: `tests/test_file_utils_network.py` and `tests/comfy_cli/command/test_model_download_background.py`, 301 tests including the timeout and retry paths.

`uvx ruff@0.15.15 check` and `format --diff` both clean, matching `.github/workflows/ruff_check.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)