### PR TITLE
fix(install): stop the GPU override from unpinning torch from torchvision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ history.
 
 ### Fixed
 
+- `comfy install --fast-deps --nvidia` no longer installs a torch that its
+  torchvision was not built against, which made ComfyUI fail to import with
+  `RuntimeError: operator torchvision::nms does not exist`. The GPU override
+  named `torch` outright, and a uv `--override` replaces every requirement for
+  the package it names, so torchvision's `torch==<x.y.z>` pin was discarded and
+  a same-day torch release resolved ahead of its matching torchvision.
 - Promoted subgraph widgets are edited where the frontend reads them. The
   frontend (ADR 0009) keeps a promoted widget's value on the HOST instance
   (`widgets_values` positional over the widget-backed subgraph inputs) and

--- a/comfy_cli/uv.py
+++ b/comfy_cli/uv.py
@@ -129,10 +129,15 @@ class DependencyCompiler:
     rocmTorchBackend = "rocm7.2"
     nvidiaTorchBackend = "cu126"
 
+    # `torch` is deliberately absent: a uv --override replaces every requirement
+    # for a package, so listing it here discards torchvision's `torch==<x.y.z>`
+    # pin and lets a torch release land before its matching torchvision exists
+    # (`RuntimeError: operator torchvision::nms does not exist` at import). The
+    # GPU flavor comes from --torch-backend, not from this file, and the core
+    # pass re-pins torch as an override for the extension pass.
     overrideGpu = dedent(
         """
         # ensure usage of {gpu} version of pytorch
-        torch
         torchaudio
         torchsde
         torchvision

--- a/tests/uv/test_uv.py
+++ b/tests/uv/test_uv.py
@@ -164,6 +164,18 @@ def test_override_file_has_no_extra_index_url():
     assert "torch" in content
 
 
+def test_gpu_override_does_not_pin_torch_itself():
+    """A uv --override replaces every requirement for the package it names, so a
+    bare `torch` line discards torchvision's `torch==<x.y.z>` pin. A torch release
+    then resolves ahead of its matching torchvision, and ComfyUI fails to import
+    with `RuntimeError: operator torchvision::nms does not exist`. The GPU flavor
+    comes from --torch-backend, not from this override.
+    """
+    lines = {line.strip() for line in DependencyCompiler.overrideGpu.splitlines()}
+    assert "torch" not in lines
+    assert {"torchvision", "torchaudio"} <= lines
+
+
 def test_make_override_does_not_strip_cuda_toolkit_extras():
     """Regression test for #412: override must not pin cuda-toolkit without extras.
 


### PR DESCRIPTION
`comfy install --fast-deps --nvidia` currently installs a torch its torchvision
was not built against, and ComfyUI then fails to import:

```
RuntimeError: operator torchvision::nms does not exist
```

This started when PyTorch published torch 2.14.0 to the cu126 index. It also
fails the `Windows Specific Commands` job on every PR that touches
`comfy_cli/**` or `pyproject.toml`.

## Cause

`DependencyCompiler.overrideGpu` listed `torch` outright:

```
# ensure usage of {gpu} version of pytorch
torch
torchaudio
torchsde
torchvision
```

A uv `--override` **replaces every requirement for the package it names**,
anywhere in the graph. `torchvision==0.28.0+cu126` declares
`Requires-Dist: torch (==2.13.0)`, and the override discarded that, so uv was
free to take the newest torch on the index.

PyTorch publishes torch ahead of its matching torchvision, so this breaks on
every torch release day and stays broken until torchvision catches up. The
cu126 index today has torch through 2.14.0 but no torchvision past 0.28.0.

The same file already carries a comment about this exact hazard, from #412,
where the override stripped `cuda-toolkit`'s extras and dropped the CUDA
runtime packages.

## Fix

Drop `torch` from the override and let torchvision's pin decide. Nothing else
needs it:

- the GPU flavor comes from `--torch-backend=cu126`, not from this file;
- `compile_core_plus_ext` writes the resolved core versions back as overrides
  for the extension pass, so a third-party extension still cannot move torch.

## Verification

Resolving for windows/cp312 against the live cu126 index, with the override
file this code actually writes:

| override | torch | torchvision |
|---|---|---|
| before (`torch` listed) | 2.14.0+cu126 | 0.28.0+cu126 → import fails |
| after (`torch` removed) | 2.13.0+cu126 | 0.28.0+cu126 → matched |

torchaudio resolves to 2.11.0+cu126 either way; it declares no torch
requirement. The "after" row is the exact set the Windows job last passed on.

`tests/uv/test_uv.py::test_gpu_override_does_not_pin_torch_itself` guards the
override list so `torch` cannot be added back without the reason surfacing.

Full suite: 7308 passed, 39 skipped. `ruff check` and `ruff format --diff`
clean at 0.15.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
