### PR TITLE
fix(build): correct billing error code in error-report docstring

### DIFF
--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -2330,7 +2330,7 @@ def _builder_client(renderer, builder_url: str | None):
 def _report_builder_error(renderer, e) -> None:
     """Emit one error envelope for a builder failure. Prefers the limited-beta 403,
     then the builder's own error body (e.g. `INVALID_DEFINITION: …` or
-    `SUBSCRIPTION_REQUIRED: …`) over urllib's opaque "HTTP Error 400", then the
+    `PAYMENT_REQUIRED: …`) over urllib's opaque "HTTP Error 400", then the
     generic transport error.
 
     It carries no Build id, because the old `create` verb's orphan case is gone:


### PR DESCRIPTION
## What

\`_report_builder_error\`'s docstring cited \`SUBSCRIPTION_REQUIRED\` as an example builder error code. comfy-builder never emits that code — it only emits \`PAYMENT_REQUIRED\` for billing refusals (\`services/comfy-builder/apiserver/httpkit/billing_gate.go:44\`, confirmed against current cloud \`main\`).

## Why this matters

Agent-facing guidance (docstrings/comments agents read to decide how to react to a builder error) told them to match a code the server never sends, risking a permanent billing refusal being treated as an unmatched/retryable error by any caller trying to special-case it.

## Verification

- \`_builder_msg\` (the actual error-body parser) has no hardcoded code matching — it passes the body's \`error\` field through verbatim, so runtime behavior already surfaced the real \`PAYMENT_REQUIRED\` string correctly. This is a documentation-only fix; no behavior change.
- Cross-checked against comfy-builder source: \`PAYMENT_REQUIRED\` is the only billing error code emitted (billing_gate.go, api.gen.go, releases/builds billing_gate_test.go).
- Full build test suite: 574 passed, 1 skipped.
- ruff clean.

Source: [Linear BE-11190](https://linear.app/comfyorg/issue/BE-11190/comfy-cli-tells-agents-to-look-for-an-error-code-the-builder-never)