### PR TITLE
fix(nodes,jobs): render a where_invalid envelope for a bad --where instead of a traceback or a silent misroute

### DIFF
--- a/comfy_cli/cmdline.py
+++ b/comfy_cli/cmdline.py
@@ -1132,7 +1132,7 @@ def run(
         try:
             decision = where_module.resolve(flag=where, config_value=config.get(where_module.CONFIG_KEY_WHERE_DEFAULT))
         except ValueError as e:
-            renderer.error(code="where_invalid", message=str(e), hint="use --where local or --where cloud")
+            renderer.error(code="where_invalid", message=str(e), hint=where_module.WHERE_INVALID_HINT)
             raise typer.Exit(code=1)
 
         # The routing target is now known, so every downstream error envelope
@@ -1362,7 +1362,7 @@ def upload(
     try:
         decision = where_module.resolve(flag=where, config_value=config.get(where_module.CONFIG_KEY_WHERE_DEFAULT))
     except ValueError as e:
-        renderer.error(code="where_invalid", message=str(e), hint="use --where local or --where cloud")
+        renderer.error(code="where_invalid", message=str(e), hint=where_module.WHERE_INVALID_HINT)
         raise typer.Exit(code=1)
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"
@@ -1428,7 +1428,7 @@ def download(
     try:
         decision = where_module.resolve(flag=where, config_value=config.get(where_module.CONFIG_KEY_WHERE_DEFAULT))
     except ValueError as e:
-        renderer.error(code="where_invalid", message=str(e), hint="use --where local or --where cloud")
+        renderer.error(code="where_invalid", message=str(e), hint=where_module.WHERE_INVALID_HINT)
         raise typer.Exit(code=1)
 
     effective_where = "cloud" if decision.target is where_module.WhereTarget.CLOUD else "local"

--- a/comfy_cli/command/jobs.py
+++ b/comfy_cli/command/jobs.py
@@ -2356,9 +2356,23 @@ def _is_cloud(where: str | None) -> bool:
     try:
         decision = where_module.resolve_default(flag=where)
     except ValueError:
-        # Invalid value — fall back to local; the validating command
-        # (cmdline.py top-level option) will surface ``where_invalid``.
-        return False
+        # An invalid persisted ``where_default`` shouldn't be fatal; fall back to
+        # the flag (if valid) or auto-detect with the bad config value dropped.
+        try:
+            decision = where_module.resolve(flag=where, config_value=None)
+        except ValueError as exc:
+            # The flag/env/project value itself is bad, so dropping the config
+            # changed nothing and no further fallback can make it valid. Emit the
+            # shared ``where_invalid`` envelope and exit, exactly as ``nodes``
+            # does — this used to `return False`, on the assumption that
+            # ``cmdline.py``'s top-level ``--where`` had already validated the
+            # value, but that only covers ``comfy --where X jobs ls``. A
+            # per-command ``comfy jobs ls --where bogus`` (or an exported
+            # ``COMFY_WHERE=bogus``) reaches no such validator, so it silently
+            # routed to local and exited 0 with ``ok: true``: a machine consumer
+            # got a successful *local* answer to a question about a target it
+            # never named.
+            raise where_module.where_invalid_exit(exc) from exc
     return decision.target is where_module.WhereTarget.CLOUD
 
 

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -59,7 +59,15 @@ def _resolved_where(where: str | None) -> str:
     except ValueError:
         # An invalid persisted where_default shouldn't be fatal; fall back to
         # the flag (if valid) or auto-detect with the bad config value dropped.
-        decision = where_module.resolve(flag=where, config_value=None)
+        try:
+            decision = where_module.resolve(flag=where, config_value=None)
+        except ValueError as exc:
+            # The flag/env/project value itself is bad, so dropping the config
+            # changed nothing and no further fallback can make it valid. Emit
+            # the shared `where_invalid` envelope and exit, exactly as
+            # `resolve_default_or_exit` does for the non-recovering verbs —
+            # a machine consumer must read `error.code`, not a stack trace.
+            where_module.emit_where_invalid_or_exit(exc)
     return decision.target.value  # "local" | "cloud"
 
 

--- a/comfy_cli/command/nodes.py
+++ b/comfy_cli/command/nodes.py
@@ -67,7 +67,7 @@ def _resolved_where(where: str | None) -> str:
             # the shared `where_invalid` envelope and exit, exactly as
             # `resolve_default_or_exit` does for the non-recovering verbs —
             # a machine consumer must read `error.code`, not a stack trace.
-            where_module.emit_where_invalid_or_exit(exc)
+            raise where_module.where_invalid_exit(exc) from exc
     return decision.target.value  # "local" | "cloud"
 
 

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -22,7 +22,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, NoReturn
 
 
 class WhereTarget(str, Enum):
@@ -33,6 +33,16 @@ class WhereTarget(str, Enum):
 CLOUD_PROVIDER = "comfy-cloud"
 ENV_DEFAULT = "COMFY_WHERE"
 CONFIG_KEY_WHERE_DEFAULT = "where_default"
+
+# The one hint every ``where_invalid`` envelope carries. A module constant
+# because two call sites emit it — :func:`resolve_default_or_exit` for the
+# commands with no fallback, and ``nodes._resolved_where`` for the recover-first
+# commands once their fallback is exhausted — and a user-facing string that lives
+# in two places drifts.
+WHERE_INVALID_HINT = (
+    "use --where local or --where cloud, and check COMFY_WHERE, "
+    "`defaults.where` in comfy.yaml, and `comfy set-default --where`"
+)
 
 
 @dataclass
@@ -115,22 +125,32 @@ def resolve_default_or_exit(
     JSON-envelope command.
 
     Commands that *can* recover (``nodes``, ``jobs``) keep their own
-    ``except ValueError`` fallback instead of calling this.
+    ``except ValueError`` fallback instead of calling this — but a fallback only
+    recovers the *config* case, so once it too fails they end on
+    :func:`emit_where_invalid_or_exit`, which is this function's tail.
+    """
+    try:
+        return resolve_default(flag=flag, env=env, project_value=project_value)
+    except ValueError as e:
+        emit_where_invalid_or_exit(e)
+
+
+def emit_where_invalid_or_exit(exc: ValueError) -> NoReturn:
+    """Render the shared ``where_invalid`` envelope for *exc* and exit 1.
+
+    Split out of :func:`resolve_default_or_exit` so a command with its own
+    recovery fallback can reuse the identical envelope (same ``code``, same
+    ``message``, same :data:`WHERE_INVALID_HINT`, same exit code) once that
+    fallback is exhausted, instead of letting the ``ValueError`` escape as a raw
+    traceback with nothing on stdout — the worst possible shape for a machine
+    consumer of a JSON-envelope command.
     """
     import typer
 
     from comfy_cli.output import get_renderer
 
-    try:
-        return resolve_default(flag=flag, env=env, project_value=project_value)
-    except ValueError as e:
-        get_renderer().error(
-            code="where_invalid",
-            message=str(e),
-            hint="use --where local or --where cloud, and check COMFY_WHERE, "
-            "`defaults.where` in comfy.yaml, and `comfy set-default --where`",
-        )
-        raise typer.Exit(code=1) from e
+    get_renderer().error(code="where_invalid", message=str(exc), hint=WHERE_INVALID_HINT)
+    raise typer.Exit(code=1) from exc
 
 
 def _project_where_default() -> str | None:

--- a/comfy_cli/where.py
+++ b/comfy_cli/where.py
@@ -22,7 +22,10 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, NoReturn
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import typer
 
 
 class WhereTarget(str, Enum):
@@ -34,11 +37,19 @@ CLOUD_PROVIDER = "comfy-cloud"
 ENV_DEFAULT = "COMFY_WHERE"
 CONFIG_KEY_WHERE_DEFAULT = "where_default"
 
-# The one hint every ``where_invalid`` envelope carries. A module constant
-# because two call sites emit it — :func:`resolve_default_or_exit` for the
-# commands with no fallback, and ``nodes._resolved_where`` for the recover-first
-# commands once their fallback is exhausted — and a user-facing string that lives
-# in two places drifts.
+# The hint carried by every ``where_invalid`` envelope raised from a *multi-source*
+# routing failure — one where the offending value could have come from the flag,
+# ``COMFY_WHERE``, ``defaults.where``, or the persisted ``where_default``, so the
+# user has to be told where to look. A module constant because several call sites
+# emit it (:func:`resolve_default_or_exit`, the recover-first ``nodes``/``jobs``
+# helpers once their fallback is exhausted, and ``cmdline``'s ``run``/``upload``/
+# ``download``) and a user-facing string that lives in six places drifts.
+#
+# Sites that validate a *single explicit* value deliberately keep a shorter hint:
+# the top-level ``--where`` flag and ``comfy set-default --where`` / ``comfy setup``
+# call :func:`_parse` on exactly the string the user just typed, and ``comfy logs``
+# is local-only, so pointing any of them at ``COMFY_WHERE``/``comfy.yaml`` would
+# send the user hunting in a file that had nothing to do with the failure.
 WHERE_INVALID_HINT = (
     "use --where local or --where cloud, and check COMFY_WHERE, "
     "`defaults.where` in comfy.yaml, and `comfy set-default --where`"
@@ -126,17 +137,18 @@ def resolve_default_or_exit(
 
     Commands that *can* recover (``nodes``, ``jobs``) keep their own
     ``except ValueError`` fallback instead of calling this — but a fallback only
-    recovers the *config* case, so once it too fails they end on
-    :func:`emit_where_invalid_or_exit`, which is this function's tail.
+    recovers the *config* case, so once it too fails they raise
+    :func:`where_invalid_exit`, which is this function's tail.
     """
     try:
         return resolve_default(flag=flag, env=env, project_value=project_value)
     except ValueError as e:
-        emit_where_invalid_or_exit(e)
+        raise where_invalid_exit(e) from e
 
 
-def emit_where_invalid_or_exit(exc: ValueError) -> NoReturn:
-    """Render the shared ``where_invalid`` envelope for *exc* and exit 1.
+def where_invalid_exit(exc: ValueError) -> typer.Exit:
+    """Render the shared ``where_invalid`` envelope for *exc* and return the
+    ``typer.Exit`` the caller must ``raise``.
 
     Split out of :func:`resolve_default_or_exit` so a command with its own
     recovery fallback can reuse the identical envelope (same ``code``, same
@@ -144,13 +156,22 @@ def emit_where_invalid_or_exit(exc: ValueError) -> NoReturn:
     fallback is exhausted, instead of letting the ``ValueError`` escape as a raw
     traceback with nothing on stdout — the worst possible shape for a machine
     consumer of a JSON-envelope command.
+
+    It *returns* the exception rather than raising it (and is deliberately not
+    annotated ``NoReturn``) so that every call site reads ``raise
+    where_invalid_exit(e) from e``. Nothing in CI enforces a ``NoReturn``
+    contract — ruff's selected rules don't and there is no type checker in the
+    pipeline — so a caller that merely *called* an exiting helper would fall
+    through to an unbound local the moment this function was stubbed, mocked, or
+    softened. Making the ``raise`` structural at each call site keeps the
+    control flow checkable by eye and by any future linter.
     """
     import typer
 
     from comfy_cli.output import get_renderer
 
     get_renderer().error(code="where_invalid", message=str(exc), hint=WHERE_INVALID_HINT)
-    raise typer.Exit(code=1) from exc
+    return typer.Exit(code=1)
 
 
 def _project_where_default() -> str | None:

--- a/tests/comfy_cli/command/test_jobs_where_invalid.py
+++ b/tests/comfy_cli/command/test_jobs_where_invalid.py
@@ -1,0 +1,206 @@
+"""``comfy jobs`` renders a ``where_invalid`` envelope for a bad routing value.
+
+The sibling of :mod:`tests.comfy_cli.command.test_nodes_where_invalid`, for the
+other recover-first command. ``jobs._is_cloud`` used to swallow the ``ValueError``
+and ``return False`` on the assumption that ``cmdline.py``'s top-level ``--where``
+had already rejected a bad value. That only holds for ``comfy --where X jobs ls``:
+a **per-command** ``comfy jobs ls --where bogus``, an exported ``COMFY_WHERE``, or a
+stale ``defaults.where`` reaches no such validator, so the verb silently routed to
+local and exited **0 with ``ok: true``** — a machine consumer got a successful
+*local* answer to a question about a target it never named, which is worse than the
+traceback the ``nodes`` half of this change fixed.
+
+These tests pin both halves: the unrecoverable sources now emit the shared
+envelope, and the config-recovery branch still recovers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import where as where_module
+from comfy_cli.caller import Caller
+from comfy_cli.command import jobs as jobs_cmd
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+# Every verb that stamps routing at entry, i.e. every verb routed through
+# ``_stamp_where`` -> ``_is_cloud``. Each calls it as its first statement, so a
+# bad value exits before any host/port resolution or network call — that is what
+# makes these safe to run offline.
+ROUTED_VERBS: list[list[str]] = [
+    ["ls"],
+    ["status", "abc123"],
+    ["wait", "abc123"],
+    ["cancel", "abc123"],
+    ["watch", "abc123"],
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def isolated_routing_sources(monkeypatch: pytest.MonkeyPatch):
+    """Pin every routing source the tests don't set themselves.
+
+    Without this the assertions would read the developer's real ``COMFY_WHERE``,
+    a ``comfy.yaml`` above the checkout, their persisted ``where_default``, and
+    their cloud credentials.
+    """
+    monkeypatch.delenv(where_module.ENV_DEFAULT, raising=False)
+    monkeypatch.setattr("comfy_cli.project.find_project", lambda *a, **kw: None)
+    monkeypatch.setattr(where_module, "_has_cloud_credentials", lambda: False)
+    _set_persisted_where_default(monkeypatch, None)
+
+
+def _set_persisted_where_default(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    """Make ``ConfigManager().get("where_default")`` answer *value*.
+
+    ``ConfigManager`` is ``@singleton``-wrapped, so the module-level name is a
+    factory, not the class — patch the real class off the instance it hands back.
+    """
+    from comfy_cli.config_manager import ConfigManager
+
+    cls = type(ConfigManager())
+    real_get = cls.get
+
+    def fake_get(self, key, *a, **kw):
+        if key == where_module.CONFIG_KEY_WHERE_DEFAULT:
+            return value
+        return real_get(self, key, *a, **kw)
+
+    monkeypatch.setattr(cls, "get", fake_get)
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _invoke(args: list[str], capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
+    """Run a ``jobs`` verb and return ``(exit_code, stdout, stderr)``.
+
+    ``standalone_mode`` is left ON: the whole claim here is about the process
+    exit code, and only click's own standalone handling turns ``typer.Exit``
+    into one.
+    """
+    _force_json_renderer()
+    result = CliRunner().invoke(jobs_cmd.app, args)
+    captured = capsys.readouterr()
+    out = captured.out or result.stdout or ""
+    return result.exit_code, out, captured.err
+
+
+def _sole_envelope(out: str) -> dict[str, Any]:
+    lines = [ln for ln in out.strip().splitlines() if ln.strip()]
+    assert len(lines) == 1, f"expected exactly one envelope on stdout, got {len(lines)} lines: {lines!r}"
+    return json.loads(lines[0])
+
+
+def _assert_where_invalid(code: int, out: str, err: str, bad_value: str):
+    assert code == 1, f"expected exit 1, got {code} (stdout={out!r})"
+    env = _sole_envelope(out)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "where_invalid"
+    assert bad_value in env["error"]["message"]
+    # The regression this file exists for: the old code exited 0 with a *local*
+    # success envelope, so a consumer keying on `ok` never learned it was
+    # answered about the wrong target.
+    for stream in (out, err):
+        assert "Traceback" not in stream
+        assert "ValueError" not in stream
+
+
+class TestBadFlag:
+    @pytest.mark.parametrize("verb", ROUTED_VERBS, ids=lambda v: "-".join(v))
+    def test_bad_where_flag_renders_envelope(self, verb, capsys):
+        """Every routed verb, not just ``ls`` — they share one resolver."""
+        code, out, err = _invoke([*verb, "--where", "bogus"], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_bad_where_flag_wins_over_a_valid_config(self, monkeypatch, capsys):
+        """A *valid* persisted default must not paper over an explicit bad flag."""
+        _set_persisted_where_default(monkeypatch, "local")
+        code, out, err = _invoke(["ls", "--where", "bogus"], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_hint_is_the_shared_constant(self, capsys):
+        """Pin the drift the module constant exists to prevent: this envelope,
+        ``nodes``', and ``resolve_default_or_exit``'s must stay byte-identical."""
+        _, out, _err = _invoke(["ls", "--where", "bogus"], capsys)
+        assert _sole_envelope(out)["error"]["hint"] == where_module.WHERE_INVALID_HINT
+
+
+class TestBadEnvAndProject:
+    def test_bad_comfy_where_env_renders_envelope(self, monkeypatch, capsys):
+        """``COMFY_WHERE`` is also how the top-level ``comfy --where`` reaches a
+        subcommand, so this is the path an exported bad value takes."""
+        monkeypatch.setenv(where_module.ENV_DEFAULT, "bogus")
+        code, out, err = _invoke(["ls"], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_bad_project_defaults_where_renders_envelope(self, monkeypatch, capsys):
+        """``defaults.where`` in the governing ``comfy.yaml`` is re-read by the
+        fallback too, so it is just as unrecoverable as the flag."""
+        from pathlib import Path
+
+        from comfy_cli.project import Project
+
+        project = Project(root=Path("/nonexistent"), config={"schema": "project/1", "defaults": {"where": "bogus"}})
+        monkeypatch.setattr("comfy_cli.project.find_project", lambda *a, **kw: project)
+        code, out, err = _invoke(["ls"], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+
+class TestConfigRecoveryStillWorks:
+    """Regression control for the branch this change must NOT break: a corrupt
+    persisted ``where_default`` is still non-fatal, exactly as before."""
+
+    def test_corrupt_config_with_valid_flag_still_succeeds(self, monkeypatch, capsys):
+        _set_persisted_where_default(monkeypatch, "garbage")
+        code, out, _err = _invoke(["ls", "--where", "local", "--local-only"], capsys)
+        assert code == 0, f"corrupt config recovery regressed (stdout={out!r})"
+        env = _sole_envelope(out)
+        assert env["ok"] is True
+        assert env["where"] == "local"
+
+    def test_corrupt_config_with_no_flag_still_falls_back(self, monkeypatch, capsys):
+        """No flag, no env, no project: dropping the bad config leaves the
+        auto-detect default, which must still resolve rather than exit."""
+        _set_persisted_where_default(monkeypatch, "garbage")
+        code, out, _err = _invoke(["ls", "--local-only"], capsys)
+        assert code == 0, f"corrupt config recovery regressed (stdout={out!r})"
+        env = _sole_envelope(out)
+        assert env["ok"] is True
+        assert env["where"] == "local"
+
+
+class TestIsCloudUnit:
+    """The resolver itself, without the CLI layer in the way."""
+
+    def test_returns_the_target_for_a_valid_flag(self):
+        assert jobs_cmd._is_cloud("cloud") is True
+        assert jobs_cmd._is_cloud("local") is False
+
+    def test_raises_typer_exit_for_a_bad_flag(self):
+        import typer
+
+        _force_json_renderer()
+        with pytest.raises(typer.Exit) as excinfo:
+            jobs_cmd._is_cloud("bogus")
+        assert excinfo.value.exit_code == 1

--- a/tests/comfy_cli/command/test_nodes_where_invalid.py
+++ b/tests/comfy_cli/command/test_nodes_where_invalid.py
@@ -1,0 +1,205 @@
+"""``comfy nodes`` renders a ``where_invalid`` envelope for a bad routing value.
+
+``_resolved_where`` is written to survive a *corrupt persisted config* by
+dropping ``where_default`` and re-resolving. That fallback cannot help when the
+**flag/env/project** value is the bad one: the retry re-parses the same value and
+``where._parse`` raises again. Uncaught, that escaped as a raw Python traceback
+with **nothing on stdout** — the worst possible shape for the machine consumers
+these verbs exist for, since every other routed command reaches
+``where.resolve_default_or_exit`` and gets an envelope.
+
+These tests pin both halves: the unrecoverable sources now emit the shared
+envelope, and the config-recovery branch still recovers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from comfy_cli import where as where_module
+from comfy_cli.caller import Caller
+from comfy_cli.command import nodes as nodes_cmd
+from comfy_cli.output.renderer import OutputMode, Renderer, reset_renderer_for_testing, set_renderer
+
+FIXTURE = "tests/comfy_cli/fixtures/nodes_path_object_info.json"
+
+# Every verb that loads a graph, i.e. every verb routed through
+# ``_get_graph`` -> ``_resolved_where``. ``refresh`` is deliberately absent: it
+# accepts ``--where`` as a legacy no-op and never resolves routing at all.
+GRAPH_VERBS: list[list[str]] = [
+    ["ls"],
+    ["show", "KSampler"],
+    ["search", "KSampler"],
+    ["upstream", "KSampler"],
+    ["downstream", "KSampler"],
+    ["path", "MODEL", "IMAGE"],
+    ["types"],
+    ["categories"],
+    ["widget-catalog"],
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_renderer_for_testing()
+    yield
+    reset_renderer_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def isolated_routing_sources(monkeypatch: pytest.MonkeyPatch):
+    """Pin every routing source the tests don't set themselves.
+
+    Without this the assertions would read the developer's real ``COMFY_WHERE``,
+    a ``comfy.yaml`` above the checkout, their persisted ``where_default``, and
+    their cloud credentials.
+    """
+    monkeypatch.delenv(where_module.ENV_DEFAULT, raising=False)
+    monkeypatch.setattr("comfy_cli.project.find_project", lambda *a, **kw: None)
+    monkeypatch.setattr(where_module, "_has_cloud_credentials", lambda: False)
+    _set_persisted_where_default(monkeypatch, None)
+
+
+def _set_persisted_where_default(monkeypatch: pytest.MonkeyPatch, value: str | None):
+    """Make ``ConfigManager().get("where_default")`` answer *value*.
+
+    ``ConfigManager`` is ``@singleton``-wrapped, so the module-level name is a
+    factory, not the class — patch the real class off the instance it hands back.
+    """
+    from comfy_cli.config_manager import ConfigManager
+
+    cls = type(ConfigManager())
+    real_get = cls.get
+
+    def fake_get(self, key, *a, **kw):
+        if key == where_module.CONFIG_KEY_WHERE_DEFAULT:
+            return value
+        return real_get(self, key, *a, **kw)
+
+    monkeypatch.setattr(cls, "get", fake_get)
+
+
+def _force_json_renderer():
+    r = Renderer.resolve(
+        is_stdout_tty=False,
+        env={},
+        caller=Caller(kind="user", agentic=False, source_env=None),
+        json_flag=True,
+    )
+    r.mode = OutputMode.JSON
+    set_renderer(r)
+    return r
+
+
+def _invoke(args: list[str], capsys: pytest.CaptureFixture[str]) -> tuple[int, str, str]:
+    """Run a ``nodes`` verb and return ``(exit_code, stdout, stderr)``.
+
+    ``standalone_mode`` is left ON — unlike the passthrough tests in
+    ``test_nodes_cli.py``, the whole claim here is about the process exit code,
+    and only click's own standalone handling turns ``typer.Exit`` into one.
+    """
+    _force_json_renderer()
+    result = CliRunner().invoke(nodes_cmd.app, args)
+    captured = capsys.readouterr()
+    out = captured.out or result.stdout or ""
+    return result.exit_code, out, captured.err
+
+
+def _sole_envelope(out: str) -> dict[str, Any]:
+    lines = [ln for ln in out.strip().splitlines() if ln.strip()]
+    assert len(lines) == 1, f"expected exactly one envelope on stdout, got {len(lines)} lines: {lines!r}"
+    return json.loads(lines[0])
+
+
+def _assert_where_invalid(code: int, out: str, err: str, bad_value: str):
+    assert code == 1, f"expected exit 1, got {code} (stdout={out!r})"
+    env = _sole_envelope(out)
+    assert env["ok"] is False
+    assert env["error"]["code"] == "where_invalid"
+    assert bad_value in env["error"]["message"]
+    # The whole point: a machine consumer reads `error.code`, not a stack trace
+    # on stderr with an empty stdout.
+    for stream in (out, err):
+        assert "Traceback" not in stream
+        assert "ValueError" not in stream
+
+
+class TestBadFlag:
+    @pytest.mark.parametrize("verb", GRAPH_VERBS, ids=lambda v: "-".join(v))
+    def test_bad_where_flag_renders_envelope(self, verb, capsys):
+        """Every graph-loading verb, not just ``show`` — they share one resolver."""
+        code, out, err = _invoke([*verb, "--where", "bogus", "--input", FIXTURE], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_bad_where_flag_wins_over_a_valid_config(self, monkeypatch, capsys):
+        """A *valid* persisted default must not paper over an explicit bad flag."""
+        _set_persisted_where_default(monkeypatch, "local")
+        code, out, err = _invoke(["show", "KSampler", "--where", "bogus", "--input", FIXTURE], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_hint_is_the_shared_constant(self, capsys):
+        """Pin the drift the module constant exists to prevent: this envelope and
+        ``resolve_default_or_exit``'s must stay byte-identical."""
+        _, out, _err = _invoke(["show", "KSampler", "--where", "bogus", "--input", FIXTURE], capsys)
+        assert _sole_envelope(out)["error"]["hint"] == where_module.WHERE_INVALID_HINT
+
+
+class TestBadEnvAndProject:
+    def test_bad_comfy_where_env_renders_envelope(self, monkeypatch, capsys):
+        monkeypatch.setenv(where_module.ENV_DEFAULT, "bogus")
+        code, out, err = _invoke(["show", "KSampler", "--input", FIXTURE], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+    def test_bad_project_defaults_where_renders_envelope(self, monkeypatch, capsys):
+        """``defaults.where`` in the governing ``comfy.yaml`` is re-read by the
+        fallback too, so it is just as unrecoverable as the flag."""
+        from pathlib import Path
+
+        from comfy_cli.project import Project
+
+        project = Project(root=Path("/nonexistent"), config={"schema": "project/1", "defaults": {"where": "bogus"}})
+        monkeypatch.setattr("comfy_cli.project.find_project", lambda *a, **kw: project)
+        code, out, err = _invoke(["show", "KSampler", "--input", FIXTURE], capsys)
+        _assert_where_invalid(code, out, err, "bogus")
+
+
+class TestConfigRecoveryStillWorks:
+    """Regression control for the branch this change must NOT break."""
+
+    def test_corrupt_config_with_valid_flag_still_succeeds(self, monkeypatch, capsys):
+        _set_persisted_where_default(monkeypatch, "garbage")
+        code, out, err = _invoke(["show", "KSampler", "--where", "local", "--input", FIXTURE], capsys)
+        assert code == 0, f"corrupt config recovery regressed (stdout={out!r})"
+        env = _sole_envelope(out)
+        assert env["ok"] is True
+        assert env["where"] == "local"
+
+    def test_corrupt_config_with_no_flag_still_falls_back(self, monkeypatch, capsys):
+        """No flag, no env, no project: dropping the bad config leaves the
+        auto-detect default, which must still resolve rather than exit."""
+        _set_persisted_where_default(monkeypatch, "garbage")
+        code, out, err = _invoke(["show", "KSampler", "--input", FIXTURE], capsys)
+        assert code == 0, f"corrupt config recovery regressed (stdout={out!r})"
+        env = _sole_envelope(out)
+        assert env["ok"] is True
+        assert env["where"] == "local"
+
+
+class TestResolvedWhereUnit:
+    """The resolver itself, without the CLI layer in the way."""
+
+    def test_returns_the_label_for_a_valid_flag(self):
+        assert nodes_cmd._resolved_where("cloud") == "cloud"
+        assert nodes_cmd._resolved_where("local") == "local"
+
+    def test_raises_typer_exit_for_a_bad_flag(self):
+        import typer
+
+        _force_json_renderer()
+        with pytest.raises(typer.Exit) as excinfo:
+            nodes_cmd._resolved_where("bogus")
+        assert excinfo.value.exit_code == 1


### PR DESCRIPTION
## ELI-5

`comfy nodes show --where bogus` used to crash with a raw Python stack trace and print nothing on stdout. `comfy jobs ls --where bogus` was worse — it printed a *successful* local listing and exited 0. Both now print the same one-line JSON error envelope (`error.code == "where_invalid"`) that every other routed command already prints, so a script or agent reading the output gets an error code instead of a traceback or a wrong answer.

## What was wrong

`nodes._resolved_where` (`comfy_cli/command/nodes.py`) is written to survive a *corrupt persisted `where_default`*: it catches the `ValueError` and retries with the config dropped. But when the **flag / `COMFY_WHERE` / project `defaults.where`** value is the bad one, that retry re-parses the exact same value, `where._parse` raises again, and nothing catches it. Reproduced on `origin/main` (`3fddc3e1`):

```
$ comfy --json nodes show KSampler --where bogus --input tests/comfy_cli/fixtures/nodes_path_object_info.json
<rich traceback: ValueError: invalid --where value 'bogus': expected one of ['local', 'cloud']>
exit 1, stdout empty
```

`jobs._is_cloud` had the same hole with a different symptom: it swallowed the `ValueError` and returned `False`, on the commented assumption that `cmdline.py`'s top-level `--where` had already rejected the value. That only covers `comfy --where X jobs ls`; a per-command flag or an exported `COMFY_WHERE` reaches no such validator:

```
$ comfy --json jobs ls --where bogus
{"ok": true, "where": "local", "data": {..., "jobs": []}, "error": null}
exit 0
```

Every other routed command reaches `where.resolve_default_or_exit`, which renders a `where_invalid` envelope. The `nodes` and `jobs` verbs were deliberately kept on their own recovery fallbacks, but those fallbacks only ever recovered the *config* case.

## What changed

- `comfy_cli/where.py`: split the emit-and-exit tail of `resolve_default_or_exit` into a reusable `where_invalid_exit(exc) -> typer.Exit`, and lifted its hint text into a `WHERE_INVALID_HINT` module constant, so the call sites that render this envelope cannot drift apart. The helper *returns* the `typer.Exit` for the caller to `raise ... from exc` rather than being annotated `NoReturn` — nothing in CI enforces a `NoReturn` contract, so the `raise` is made structural at each call site instead.
- `comfy_cli/command/nodes.py`: the config-recovery retry is now wrapped in its own `except ValueError`, which raises `where_invalid_exit`. The config-recovery branch itself is untouched — a corrupt `where_default` still drops to the next precedence source rather than failing the command.
- `comfy_cli/command/jobs.py`: `_is_cloud` now mirrors `nodes` exactly — recover from a corrupt persisted `where_default`, emit the envelope and exit 1 when the flag/env/project value is the bad one.
- `comfy_cli/cmdline.py`: `run`, `upload` and `download` fail the same *multi-source* way (they all call `resolve(flag=..., config_value=...)`), so they now use `WHERE_INVALID_HINT` instead of three copies of a shorter string. The sites that validate a *single explicit* value keep the shorter hint on purpose — the top-level `--where`, `set-default --where` and `setup` call `_parse` on exactly the string the user just typed, and `logs` is local-only, so pointing any of them at `COMFY_WHERE`/`comfy.yaml` would send the user hunting in a file that had nothing to do with the failure.
- `tests/comfy_cli/command/test_nodes_where_invalid.py` (17 tests) and `tests/comfy_cli/command/test_jobs_where_invalid.py` (13 tests).

## Verification

Reproduced both bugs first, then verified the fixes by running the real CLI (not only the test harness):

| case | before | after |
| --- | --- | --- |
| `nodes show KSampler --where bogus --input FX` | traceback, stdout empty, exit 1 | `where_invalid` envelope, exit 1 |
| `COMFY_WHERE=bogus comfy nodes show KSampler --input FX` | traceback, stdout empty | `where_invalid` envelope, exit 1 |
| `defaults.where: bogus` in a `schema: project/1` `comfy.yaml` | traceback | `where_invalid` envelope, exit 1 |
| `jobs ls --where bogus` | **`ok: true`, `where: "local"`, exit 0** | `where_invalid` envelope, exit 1 |
| `COMFY_WHERE=bogus comfy jobs ls` | **`ok: true`, `where: "local"`, exit 0** | `where_invalid` envelope, exit 1 |
| corrupt `where_default` + `--where local` | worked | still works (unchanged) |
| `jobs ls --where cloud` | routed cloud | still routes cloud (`cloud_not_configured`, `where: "cloud"`) |

All **9** graph-loading `nodes` verbs were swept live with `--where bogus` (`ls`, `show`, `search`, `upstream`, `downstream`, `path`, `types`, `categories`, `widget-catalog`) — every one now returns the envelope with exit 1. `nodes refresh` is the tenth verb; it accepts `--where` as a documented legacy no-op and never resolves routing, so it never had the defect. All **5** routed `jobs` verbs (`ls`, `status`, `wait`, `cancel`, `watch`) are covered too — each calls `_stamp_where` as its first statement, so a bad value exits before any host/port resolution or network call.

Only the genuinely invalid value is rejected: `--where local` and `--where cloud` both still resolve and route on every touched verb, confirmed live.

Red→green proof: with the source files stashed, 14 of the 17 `nodes` tests fail. The 3 that pass without the fix are exactly the regression controls (the two corrupt-config recovery cases and the valid-flag unit test) — i.e. they test pre-existing behavior rather than asserting my own premise. The `jobs` file's `TestBadFlag`/`TestBadEnvAndProject` cases all asserted exit 1 against a path that returned exit 0 before the change.

## Judgment calls

**Exit code is 1, not 2.** The plan this PR implements asked for "exit 2, exactly as `resolve_default_or_exit` does for the other verbs" — those two clauses contradict each other. `resolve_default_or_exit` exits **1**, as do `workflow.py`'s and `launch.py`'s `where_invalid` paths and the top-level `comfy --where bogus` flag (verified live: `rc=1`). I honored the "exactly as the other verbs" half, because an agent runner keying on `where_invalid` across commands would otherwise see this one verb family disagree with all the rest. Say the word if 2 was actually intended and I'll flip it — but then it should be flipped everywhere at once.

**`jobs` is now in scope.** It was originally left out because the plan's precondition ("apply the identical fix *if it re-raises the same way*") is false — `jobs` swallowed rather than re-raised. Review pointed out that this made `where.py`'s own docstring untrue, and that silently answering *local* when the user named an unparseable target is a worse failure than the traceback. Folded in rather than deferred: it is the same five-line shape as `nodes`, on a resolver this PR already had to document.

## Residual

Not fixed here; each is actionable on its own.

1. **`assets library` still emits a raw traceback for the same input, via a different resolver.** Verified live on this branch: `comfy --json assets library ls --where bogus` → rich traceback, exit 1. It routes through `target.resolve_target` / `cloud_target_or_local_error` (`comfy_cli/target.py` ~L86), which calls `where.resolve()` with no `ValueError` handling at all — a separate code path from the `resolve_default` family this PR touches. **Sizing the half not fixed:** 22 call sites across 18 modules go through `resolve_target` / `cloud_target_or_local_error`; each would need its own check to know whether a bad `--where` there tracebacks, silently misroutes, or is unreachable. I did not sweep all 22 — only the surfaces I could drive offline. Fixing that family centrally (have `resolve_target` render the shared envelope) is the natural follow-up and would subsume this.

2. **Unexercised artifacts.** The plan this PR implements was written from an upstream investigation whose write-up lives on a tracker I have no access to; I did not read it, so this PR rests entirely on the reproductions I ran myself rather than on that upstream evidence. The GitHub half of the duplicate check I could re-run: `gh pr list --repo Comfy-Org/comfy-cli --state open --search '_resolved_where OR where_invalid'` returns nothing overlapping.

3. **One pre-existing test failure, unrelated to this change.** `tests/comfy_cli/test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots` fails on this machine (a platform trust-store root count). Confirmed it fails identically on the unmodified branch head with these changes stashed, and it is green in CI, so it is environment-dependent and not introduced here. It is left untouched.

## Provenance
- **Authored by:** agent-work loop
- **Verified:** `uv run --extra dev pytest -q`: 7410 passed, 38 skipped, with the pre-existing `test_http.py` trust-store failure deselected (see Residual #3); `ruff check .`: all checks passed; `ruff format --diff .`: 447 files already formatted; the two new files alone: 30 passed; live CLI repro + fix confirmed for both `nodes` and `jobs` across the flag/env/project routing sources, plus a live check that `--where local` and `--where cloud` still route correctly
- **Deviations:** exit code 1 rather than the plan's "exit 2" (the plan's own "exactly as `resolve_default_or_exit` does" clause, and every existing `where_invalid` site in the repo, use 1 — see Judgment calls); the plan's step 2 `jobs` fix, initially skipped because its stated precondition was false, is now applied after review — `jobs` silently misrouted rather than re-raising, which is a worse shape than the one the precondition described
