### PR TITLE
ci(gpu): gate the PR leg of the GPU workflow behind a maintainer-applied gpu-ci label

### DIFF
--- a/.github/workflows/run-on-gpu.yml
+++ b/.github/workflows/run-on-gpu.yml
@@ -12,6 +12,9 @@ on:
       - "!.coveragerc"
       - "!.gitignore"
   pull_request:
+    # `labeled` is required on top of the default trigger set: without it a
+    # freshly applied `gpu-ci` label would do nothing until the next push.
+    types: [opened, synchronize, reopened, labeled]
     branches:
       - main
     paths:
@@ -27,6 +30,12 @@ permissions:
 
 jobs:
   test-cli-gpu:
+    # PR runs are opt-in via the maintainer-applied `gpu-ci` label, because this
+    # job checks out and executes PR code on self-hosted GPU runners. Push-to-main
+    # runs stay automatic. The label persists across later pushes to the same PR,
+    # so apply it only after reading the diff and remove it to re-gate the PR.
+    # Prerequisite for the review-gated auto-builder in #786.
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'gpu-ci')
     name: "Run Tests on GPU Runners"
     runs-on:
       group: gpu-runners

--- a/.github/workflows/run-on-gpu.yml
+++ b/.github/workflows/run-on-gpu.yml
@@ -12,30 +12,44 @@ on:
       - "!.coveragerc"
       - "!.gitignore"
   pull_request:
-    # `labeled` is required on top of the default trigger set: without it a
-    # freshly applied `gpu-ci` label would do nothing until the next push.
-    types: [opened, synchronize, reopened, labeled]
+    # Label events *only*, so a PR run exists one-to-one with a maintainer
+    # applying `gpu-ci`: a later push cannot inherit that approval, because
+    # `synchronize` no longer triggers this workflow at all. Re-label (remove,
+    # re-add) to re-run against new commits. `unlabeled` never runs the job --
+    # it is here so removing the label lands in the same concurrency group and
+    # cancels an in-flight run. Same shape as ci-cursor-review.yml.
+    types: [labeled, unlabeled]
     branches:
       - main
-    paths:
-      - "comfy_cli/**"
-      - "!comfy_cli/test_**"
-      - "!.github/**"
-      - "!tests/**"
-      - "!.coveragerc"
-      - "!.gitignore"
+    # Deliberately no `paths` filter on this leg. Applying the label *is* the
+    # intent signal, so filtering here would only produce the surprise of a
+    # labeled PR that never runs -- e.g. one touching just tests/ or .github/.
+    # The push-to-main leg above keeps its filter, since those runs are
+    # automatic and do need narrowing.
 
 permissions:
   contents: read
+
+concurrency:
+  # Keyed on the label name as well as the PR, so an unrelated label applied to
+  # an already-labeled PR cannot cancel an in-flight GPU run; removing `gpu-ci`
+  # shares the group and *does* cancel it, which is how a maintainer stops a run
+  # they no longer want. Push-to-main runs key on the SHA, so they queue.
+  group: run-on-gpu-${{ github.event.pull_request.number || github.sha }}-${{ github.event.label.name }}
+  cancel-in-progress: true
 
 jobs:
   test-cli-gpu:
     # PR runs are opt-in via the maintainer-applied `gpu-ci` label, because this
     # job checks out and executes PR code on self-hosted GPU runners. Push-to-main
-    # runs stay automatic. The label persists across later pushes to the same PR,
-    # so apply it only after reading the diff and remove it to re-gate the PR.
+    # runs stay automatic. Gate on the labeling *event* rather than on the label
+    # being present in the set: `labeled` fires for every label, so a membership
+    # test would re-queue a full GPU run whenever any unrelated label (`bug`, an
+    # automation-applied area label) was added to an already-labeled PR.
     # Prerequisite for the review-gated auto-builder in #786.
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'gpu-ci')
+    if: >-
+      github.event_name == 'push'
+      || (github.event.action == 'labeled' && github.event.label.name == 'gpu-ci')
     name: "Run Tests on GPU Runners"
     runs-on:
       group: gpu-runners
@@ -48,6 +62,15 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          # Pin to the commit that carried the label, not the merge ref resolved
+          # whenever a runner frees up. The `gpu-runners` pool is small, so a
+          # labeled run can sit queued for minutes -- long enough for the author
+          # to push after a maintainer read the diff. This makes the code that
+          # executes on the self-hosted runner exactly the code that was
+          # approved. It tests the PR head rather than the merged result; the
+          # push-to-main leg covers the merged state.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check Nvidia
         run: |

--- a/.github/workflows/run-on-gpu.yml
+++ b/.github/workflows/run-on-gpu.yml
@@ -17,7 +17,14 @@ on:
     # `synchronize` no longer triggers this workflow at all. Re-label (remove,
     # re-add) to re-run against new commits. `unlabeled` never runs the job --
     # it is here so removing the label lands in the same concurrency group and
-    # cancels an in-flight run. Same shape as ci-cursor-review.yml.
+    # usually cancels an in-flight run (see the caveat on `concurrency` below).
+    # Same shape as ci-cursor-review.yml.
+    #
+    # Trap worth knowing: GitHub creates no `pull_request` runs at all while a
+    # PR has merge conflicts, so applying the label to a conflicted PR is
+    # silently lost -- and resolving the conflict emits only `synchronize`,
+    # which is not a trigger here. Recovery is the same remove/re-add, and it
+    # does need the removal first, since the label is already applied.
     types: [labeled, unlabeled]
     branches:
       - main
@@ -33,8 +40,15 @@ permissions:
 concurrency:
   # Keyed on the label name as well as the PR, so an unrelated label applied to
   # an already-labeled PR cannot cancel an in-flight GPU run; removing `gpu-ci`
-  # shares the group and *does* cancel it, which is how a maintainer stops a run
-  # they no longer want. Push-to-main runs key on the SHA, so they queue.
+  # shares the group and so usually cancels it, which is how a maintainer stops
+  # a run they no longer want. Treat that as a convenience rather than a stop
+  # button: the cancelling run is created from the *merge ref's* copy of this
+  # file, so a push landed after labeling can edit this key or drop the
+  # `unlabeled` trigger and the removal then cancels nothing.
+  #
+  # Push-to-main runs fall back to `github.sha`, which is distinct per push, so
+  # each sits alone in its own group: they are simply unaffected here, neither
+  # cancelled nor serialized.
   group: run-on-gpu-${{ github.event.pull_request.number || github.sha }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
@@ -51,6 +65,13 @@ jobs:
       github.event_name == 'push'
       || (github.event.action == 'labeled' && github.event.label.name == 'gpu-ci')
     name: "Run Tests on GPU Runners"
+    # Bound a hung or hostile run on the shared self-hosted pool, which the
+    # 6-hour default does not: this job executes PR-supplied code (`pip install
+    # -e .` runs the PR's build backend, pytest loads its conftest), and with
+    # the concurrency group above a stuck run also blocks that PR's next one.
+    # The last 20 successful runs all finished within ~11.5 min end to end, so
+    # 30 leaves roughly 2.5x headroom.
+    timeout-minutes: 30
     runs-on:
       group: gpu-runners
       labels: ${{ matrix.os }}-x64-gpu #
@@ -63,14 +84,28 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          # Pin to the commit that carried the label, not the merge ref resolved
-          # whenever a runner frees up. The `gpu-runners` pool is small, so a
-          # labeled run can sit queued for minutes -- long enough for the author
-          # to push after a maintainer read the diff. This makes the code that
-          # executes on the self-hosted runner exactly the code that was
-          # approved. It tests the PR head rather than the merged result; the
-          # push-to-main leg covers the merged state.
+          # Pin to the head SHA carried by the `labeled` webhook rather than the
+          # merge ref, which would otherwise be resolved whenever a runner frees
+          # up. The `gpu-runners` pool is small, so a labeled run can sit queued
+          # for minutes -- long enough for the author to push first. This closes
+          # that queue window, but it is not proof the maintainer read this
+          # commit: labels are PR-level, so a push between reading the diff and
+          # clicking the label is still what gets captured. Check the head SHA
+          # when you label.
+          #
+          # Two consequences of testing the head rather than the merge result.
+          # A branch that predates a file main added can fail on a step the
+          # merged YAML still references (the workflow definition comes from the
+          # merge ref even though the tree no longer does) -- rebase to clear
+          # it. And for a PR outside the push leg's `paths` filter (tests/,
+          # .github/, pyproject.toml) the merged tree is never GPU-tested at
+          # all, since that leg will not run for it post-merge either.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Keep the job's GITHUB_TOKEN out of .git/config, where it would sit
+          # as an http.extraheader that the PR code running next could read and
+          # reuse for the job's lifetime on a persistent self-hosted runner.
+          # Nothing here pushes, and the build backend needs no git metadata.
+          persist-credentials: false
 
       - name: Check Nvidia
         run: |


### PR DESCRIPTION
## ELI-5

The GPU test job runs on our own physical machines, and until now any pull request that touched `comfy_cli/**` got to run its own code on that hardware automatically, before a human had read the diff. This makes the PR half of that job **opt-in**: it runs only when a maintainer applies the `gpu-ci` label, and it runs the exact commit that was labeled. Pushes to `main` still run it automatically, exactly as before.

## What changed

Single file, `.github/workflows/run-on-gpu.yml`.

1. `pull_request.types: [labeled, unlabeled]` — label events *only*. A PR run is one-to-one with a maintainer applying `gpu-ci`; because `synchronize` is not a trigger, a later push cannot inherit that approval. `unlabeled` never runs the job — it exists so removing the label lands in the same concurrency group and cancels an in-flight run.
2. A job-level `if:` gating on the labeling **event**, not on membership in the label set: `github.event_name == 'push' || (github.event.action == 'labeled' && github.event.label.name == 'gpu-ci')`. `labeled` fires for *every* label, so a membership test re-queued a full GPU run whenever any unrelated label was added to an already-labeled PR.
3. `actions/checkout` pinned to `github.event.pull_request.head.sha` (falling back to `github.sha` on push). The `gpu-runners` pool is small, so a labeled run can otherwise sit queued for minutes while the merge ref is resolved at checkout time.
4. `persist-credentials: false` on that checkout, so the job's `GITHUB_TOKEN` is not left in `.git/config` as an `http.extraheader` for the PR code that runs next to read on a persistent self-hosted runner. Nothing here pushes, and the build backend is plain `setuptools.build_meta` with a static version, so it needs no git metadata.
5. `timeout-minutes: 30` on the job. It executes PR-supplied code under what was otherwise a 6-hour ceiling, and with the new concurrency group a stuck run also blocks that PR's next one. Sized from history: the last 20 successful runs all finished within ~11.5 min end to end.
6. A `concurrency` group keyed on PR number **and** label name, `cancel-in-progress: true`. Removing `gpu-ci` cancels an in-flight run; an unrelated label cannot. Push-to-main runs key on the SHA, so each sits alone in its own group and is unaffected.
7. The `paths` filter is dropped from the `pull_request` leg. With PR runs opt-in, applying the label *is* the intent signal, and filtering here only produced the surprise of a labeled PR that never runs (e.g. one touching just `tests/` or `.github/`). The push-to-main leg keeps its filter, since those runs are automatic and do need narrowing.

This mirrors the pattern `ci-cursor-review.yml` already uses in this repo: label-event trigger, `action == 'labeled'` guard, concurrency keyed on PR + label.

The `push` trigger and every job step other than the checkout `with:` block are untouched.

I also created the label itself, since it has to exist before a maintainer can apply it: `gpu-ci`, colour `D93F0B`, description "Maintainer opt-in: run the self-hosted GPU CI leg on this PR". Verified present via `gh api repos/Comfy-Org/comfy-cli/labels/gpu-ci` — no operator step needed.

## What maintainers need to know

- **A push to a labeled PR does not re-run the GPU leg.** Remove and re-apply `gpu-ci` to test new commits. This is what makes the label authorize a *commit* rather than a *pull request*, and it matches how `cursor-review` already behaves here.
- **Check the head SHA when you label.** The pin closes the queue window (label click → runner pickup), but labels are PR-level and carry no SHA, so a push landed between reading the diff and clicking the label is still what executes.
- **Conflicted PRs are a trap.** GitHub creates no `pull_request` runs at all while a PR has merge conflicts, so labeling one is silently lost — and resolving the conflict emits only `synchronize`, which is no longer a trigger. Recovery is remove the label, then re-add.
- **The job tests the PR head, not the merge result.** Two consequences: a branch that predates a file `main` added can fail on a step the merged YAML still references (rebase clears it), and for PRs outside the push leg's `paths` filter (`tests/`, `.github/`, `pyproject.toml`) the merged tree is never GPU-tested, since that leg will not run for them post-merge either.

## Why the gate holds

`test-cli-gpu` is **not** a required status check. The only active ruleset on `main` (`cla`, id 18051499) requires exactly one context, `cla-assistant` — I read the ruleset directly rather than assuming, and branch protection is disabled on the repo. With the trigger narrowed to label events, unlabeled PRs produce no run at all, so there is no "skipped counts as passed" question either way.

Applying a label to a PR requires triage/write permission, which is precisely the "a maintainer looked at this" signal the gate wants. Outside contributors cannot self-authorize.

The `if:` covers both of the workflow's triggers exhaustively (`push` and `pull_request`). Note for a future editor: if a `workflow_dispatch` trigger is ever added, that arm has to be added to the `if:` too, or manual runs would skip.

## Known limit: this is a convenience gate, not an authorization boundary

For `pull_request` events the workflow definition comes from the PR's merge ref, so a PR can edit this `if:` and have its own version execute. The repo's Actions fork-approval policy is currently `first_time_contributors` (`gh api repos/Comfy-Org/comfy-cli/actions/permissions/fork-pr-contributor-approval`), so a *returning* outside contributor's fork PR runs without approval. The same root cause means the unlabel-cancels-in-flight behaviour is a convenience rather than a guaranteed stop button.

Closing this requires enforcement outside PR-controlled YAML — a protected Environment with required reviewers, or moving the policy to "all outside collaborators" — which is a repo-settings change, not a workflow change, and so is not in this PR. Filed as a follow-up. This is pre-existing and strictly improved here: before this PR, such a PR ran on the GPU runners with no label at all.

## Verification

- `python -c "import yaml; yaml.safe_load(...)"` — parses; I dumped the parsed `on:`, `concurrency`, job `if:`, `timeout-minutes` and checkout step and confirmed each is what is intended, and that the `push` trigger and its `paths` list are byte-identical to `main`.
- `ruff check .` and `ruff format --check .` at the pinned `ruff==0.15.15` (the version in `[dev]`, and what CI runs) — all checks passed, 446 files already formatted. A stray local `ruff` 0.16.0 flags one file as reformattable; that is version drift in a file this PR does not touch, not a real failure.
- `pytest` (full suite, `uv run --python 3.12 --extra dev`) — 7380 passed, 38 skipped, 1 failed in 291s. The one failure, `test_an_unloadable_supplement_falls_through_to_the_platform_roots`, asserts the platform trust store's CA count and is an artifact of this macOS box (182 vs certifi's 145). This diff contains no Python, and CI's `build` job passes on the branch.
- `timeout-minutes: 30` sized against real data, not guessed: `gh api .../actions/workflows/105477158/runs` for the last 20 successful runs gives a maximum of ~11.5 min end to end.
- `persist-credentials: false` checked safe: no step after checkout uses git, and `pyproject.toml` uses `setuptools.build_meta` with `version = "0.0.0"` (no setuptools-scm), so the editable install needs no git metadata.
- Premise check, since this change removes an automatic run: the last 100 runs of this workflow are 78 `pull_request` + 22 `push`, all `completed` with conclusions only in `{success, failure}` — **zero** `action_required`, i.e. no same-repo PR run has ever been held for approval. That is the hole this closes.
- Two full review-panel rounds (17 findings) are addressed and all threads resolved.

## Residual

The acceptance checks are **post-merge** and could not be exercised from this branch, because a `pull_request` gate only takes effect once the workflow file is on `main`. Someone should confirm each after merge:

1. **Unlabeled PR produces no run.** On the next unlabeled PR touching `comfy_cli/**`, `gh run list --workflow=run-on-gpu.yml` shows no new run for it.
2. **Labeled PR runs on GPU, against the labeled commit.** Apply `gpu-ci` to a trusted PR and confirm the job lands on the `gpu-runners` group and the checked-out SHA equals the PR head at label time.
3. **Removing the label cancels an in-flight run**, via the concurrency group.
4. **Push-to-main is unaffected.** Confirm the next push to `main` touching `comfy_cli/**` still runs automatically.

Two knowingly-accepted items, neither fixable at this layer:

- GitHub expression string comparison is **case-insensitive**, so a label named `GPU-CI` would also satisfy `github.event.label.name == 'gpu-ci'`. Benign — either label needs the same write permission to create or apply.
- Every label add/remove on a PR targeting `main` creates a run whose job is skipped, publishing a `skipped` check under this name. GitHub offers no label-name filter on the trigger itself, so any label-gated workflow has this property (`ci-cursor-review.yml` included). Cosmetic here, since no check is required.

One documented deviation from the plan I was given: the comment block was asked to cite an internal tracker id alongside #786. This repo is public, so the comment cites only #786 and omits the internal id. Same reason there is no tracker reference anywhere in this PR's title or body.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** YAML parse of the changed workflow with `on:`/`concurrency`/`if:`/`timeout-minutes`/checkout dumped and inspected; `ruff check .` and `ruff format --check .` at the pinned `ruff==0.15.15`: both clean; `pytest`: 7380 passed, 38 skipped, 1 failed — the single failure asserts this machine's platform CA count and is unrelated to a workflow-only diff; `timeout-minutes` and `persist-credentials` each checked against repo/run evidence before being added; 17 review findings across two panel rounds addressed, all threads resolved
- **Deviations:** the in-file comment omits the internal tracker id the plan quoted (public repo); acceptance checks are post-merge and are listed under `## Residual` instead of being run; the fork-approval hardening raised in review is a repo-settings change and was deferred to a follow-up rather than attempted here; SHA-pinning `actions/checkout`/`actions/setup-python` was declined as a repo-wide convention decision, since first-party actions are tag-pinned in all thirteen workflows
