### PR TITLE
fix(workflow): reshape dynamic combo values on set-widget

### DIFF
--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -777,6 +777,15 @@ def _set_widget_impl(
     value, norm_note = _normalize_combo(graph, class_type, widget, value)
     old = widgets[idx] if idx < len(widgets) else None
     warnings = _validate_widget(graph, class_type, widget, value)  # raises on shape mismatch
+    morphism = graph.node(class_type)
+    port = next((p for p in morphism.inputs if p.name == widget), None) if morphism is not None else None
+    if port is not None and port.dynamic_options:
+        # Preview through the same value-aware writer apply/replay uses. A
+        # selector change owns a variable-width positional span, so its roster
+        # rebuild warning cannot be derived by scalar validation alone.
+        for warning in _engine._write_widget(copy.deepcopy(node), widget, value, graph, extend=True):
+            if warning not in warnings:
+                warnings.append(warning)
     if norm_note:
         warnings = [norm_note, *warnings]
     op = _new_op(
@@ -1901,12 +1910,10 @@ def _apply_set_widget(workflow: dict, op: dict, graph) -> None:
         return  # target concurrently deleted => no-op (delete wins).
     from comfy_cli.cql import engine as _engine
 
-    widgets = _engine._widgets_as_positional(node.get("widgets_values"), graph, node.get("type", ""))
-    node["widgets_values"] = widgets
-    idx = _widget_index(graph, node.get("type", ""), op["widget"], widgets)
-    if idx >= len(widgets):
-        widgets.extend([None] * (idx + 1 - len(widgets)))
-    widgets[idx] = op["value"]
+    # The CQL writer is the schema-aware positional owner. In particular, a
+    # dynamic-combo selector change must replace the old option's variable-width
+    # sub-widget span before preserving trailing values such as seed/watermark.
+    _engine._write_widget(node, op["widget"], op["value"], graph, extend=True)
     _lww_commit(workflow, op)
 
 
@@ -2260,7 +2267,16 @@ def detect_conflict(a: dict, b: dict) -> bool:
     the same base conflict here (their batch order is undecidable leaderlessly)
     even though :func:`apply_op` keeps both connections and ``canonical`` treats
     their order as immaterial."""
-    if _write_target(a) != _write_target(b):
+    target_a = _write_target(a)
+    target_b = _write_target(b)
+    if a["op"] == "set_widget" and b["op"] == "set_widget" and target_a[:-1] == target_b[:-1]:
+        widget_a, widget_b = str(target_a[-1]), str(target_b[-1])
+        # A dynamic-combo selector owns the dotted sub-widget roster below it.
+        # A concurrent selector/sub-widget pair can therefore be order-dependent
+        # even though their leaf names differ; route it through ask-to-merge.
+        if widget_a.startswith(f"{widget_b}.") or widget_b.startswith(f"{widget_a}."):
+            return True
+    if target_a != target_b:
         return False
     if a["op"] == "set_widget" and b["op"] == "set_widget":
         return a.get("value") != b.get("value")

--- a/tests/comfy_cli/command/test_workflow_edit_dynamic_combo.py
+++ b/tests/comfy_cli/command/test_workflow_edit_dynamic_combo.py
@@ -1,0 +1,139 @@
+"""Regression coverage for name-keyed edits that change a dynamic-combo schema."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from comfy_cli import workflow_ops, workflow_to_api
+from comfy_cli.cql.engine import Graph
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_OBJECT_INFO = _FIXTURES / "object_info_subgraph_promoted.json"
+_SEEDANCE_WORKFLOW = _FIXTURES / "gallery" / "api_seedance2_5_video_extend.json"
+_SEEDANCE_NODE_ID = 38
+
+_TRAILING_VALUES = [1672978219, "fixed", False]
+_SEEDANCE_20_DEFAULTS = [
+    "Seedance 2.0",
+    "",
+    "480p",
+    "adaptive",
+    7,
+    True,
+    True,
+    False,
+    *_TRAILING_VALUES,
+]
+_SEEDANCE_25_DEFAULTS = [
+    "Seedance 2.5",
+    "",
+    "720p",
+    "16:9",
+    5,
+    True,
+    "auto",
+    "mp4",
+    True,
+    False,
+    *_TRAILING_VALUES,
+]
+
+
+@pytest.fixture(scope="module")
+def object_info() -> dict[str, Any]:
+    return json.loads(_OBJECT_INFO.read_text())
+
+
+@pytest.fixture(scope="module")
+def graph(object_info) -> Graph:
+    return Graph.from_object_info(object_info)
+
+
+def _seedance_workflow() -> dict[str, Any]:
+    return json.loads(_SEEDANCE_WORKFLOW.read_text())
+
+
+def _seedance_values(workflow: dict[str, Any]) -> list[Any]:
+    return next(node["widgets_values"] for node in workflow["nodes"] if node["id"] == _SEEDANCE_NODE_ID)
+
+
+def test_set_widget_reshapes_seedance_roster_in_both_directions(graph):
+    base = _seedance_workflow()
+    changed, op_20 = workflow_ops.set_widget(copy.deepcopy(base), graph, _SEEDANCE_NODE_ID, "model", "Seedance 2.0")
+
+    assert _seedance_values(changed) == _SEEDANCE_20_DEFAULTS
+    assert [warning["code"] for warning in op_20["warnings"]] == ["dynamic_combo_roster_rebuilt"]
+    replayed = workflow_ops.apply_op(copy.deepcopy(base), op_20, graph)
+    assert workflow_ops.canonical(replayed) == workflow_ops.canonical(changed)
+
+    restored, op_25 = workflow_ops.set_widget(
+        changed, graph, _SEEDANCE_NODE_ID, "model", "Seedance 2.5", base_version=1
+    )
+    assert _seedance_values(restored) == _SEEDANCE_25_DEFAULTS
+    assert [warning["code"] for warning in op_25["warnings"]] == ["dynamic_combo_roster_rebuilt"]
+
+
+def test_agent_add_and_name_keyed_writes_copy_seedance_20_values(graph, object_info):
+    source_values = [
+        "Seedance 2.0",
+        "copied prompt",
+        "4k",
+        "9:16",
+        11,
+        False,
+        False,
+        True,
+        42,
+        "fixed",
+        True,
+    ]
+    workflow, add_op = workflow_ops.add_node(
+        {"nodes": [], "links": [], "groups": [], "last_node_id": 0, "last_link_id": 0},
+        graph,
+        "ByteDance2ReferenceNodeV2",
+    )
+    node_id = add_op["node_id"]
+    copied = {
+        "model": source_values[0],
+        "model.prompt": source_values[1],
+        "model.resolution": source_values[2],
+        "model.ratio": source_values[3],
+        "model.duration": source_values[4],
+        "model.generate_audio": source_values[5],
+        "model.auto_downscale": source_values[6],
+        "model.auto_upscale": source_values[7],
+        "seed": source_values[8],
+        "watermark": source_values[10],
+    }
+    for widget, value in copied.items():
+        workflow, _ = workflow_ops.set_widget(workflow, graph, node_id, widget, value)
+
+    target = next(node for node in workflow["nodes"] if node["id"] == node_id)
+    assert target["widgets_values"] == source_values
+    api_inputs = workflow_to_api.convert_ui_to_api(workflow, object_info)[str(node_id)]["inputs"]
+    assert api_inputs["seed"] == 42
+    assert "model.task_type" not in api_inputs
+    assert "model.output_format" not in api_inputs
+
+
+def test_selector_conflicts_with_owned_sub_widget_but_not_trailing_seed(graph):
+    base = _seedance_workflow()
+    _, selector = workflow_ops.set_widget(
+        copy.deepcopy(base), graph, _SEEDANCE_NODE_ID, "model", "Seedance 2.0", actor="selector"
+    )
+    _, prompt = workflow_ops.set_widget(
+        copy.deepcopy(base), graph, _SEEDANCE_NODE_ID, "model.prompt", "concurrent", actor="prompt"
+    )
+    _, seed = workflow_ops.set_widget(copy.deepcopy(base), graph, _SEEDANCE_NODE_ID, "seed", 42, actor="seed")
+
+    assert workflow_ops.detect_conflict(selector, prompt) is True
+    assert workflow_ops.detect_conflict(selector, seed) is False
+    selector_seed = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), selector, graph), seed, graph)
+    seed_selector = workflow_ops.apply_op(workflow_ops.apply_op(copy.deepcopy(base), seed, graph), selector, graph)
+    assert workflow_ops.canonical(selector_seed) == workflow_ops.canonical(seed_selector)
+    assert _seedance_values(selector_seed)[-3:] == [42, "fixed", False]


### PR DESCRIPTION
Seedance copies now keep the selected model schema.

- Dynamic-combo edits rebuild their positional widget roster.
- Seed and watermark stay aligned; copied 2.0 values survive API lowering.
- Selector/sub-widget races are surfaced as merge conflicts.

<details><summary>Full context for agent readers</summary>

## Root cause

The cloud agent already emits name-keyed `set_widget` operations and the frontend materializes the resulting positional array. The top-level comfy-cli `set_widget` apply path duplicated a scalar index write instead of using comfy-cli's existing schema-aware CQL writer. Changing `model` therefore changed only the selector while leaving the previous option's variable-width sub-widget span in place.

The apply path now delegates to that schema-aware writer, which replaces the old dynamic option roster with the new option's defaults and preserves values after the roster. The edit receipt also carries the existing `dynamic_combo_roster_rebuilt` warning. Conflict detection now treats a selector and one of its dotted sub-widgets as overlapping writes while leaving trailing fields such as `seed` independent.

## Regression coverage

The production `ByteDance2ReferenceNodeV2` object-info fixture and Seedance 2.5 gallery workflow cover:

- Seedance 2.5 → 2.0 roster shrink.
- Seedance 2.0 → 2.5 roster growth.
- operation replay fidelity.
- agent-style `add_node` plus name-keyed writes copying customized Seedance 2.0 values.
- API lowering with numeric `seed=42` and no stale 2.5-only `task_type`/`output_format` fields.
- selector/sub-widget conflict detection and selector/seed commutativity.

## Evidence

- `.venv/bin/pytest -q tests/comfy_cli/command/test_workflow_edit_dynamic_combo.py tests/comfy_cli/cql/test_engine.py tests/comfy_cli/command/test_workflow_slots.py tests/comfy_cli/command/test_workflow_edit.py` — 389 passed.
- `.venv/bin/pytest -q tests/comfy_cli/command/test_workflow_edit_dynamic_combo.py` — 3 passed after formatting.
- `.venv/bin/ruff check .` — passed.
- `.venv/bin/ruff format --check .` — 447 files formatted.
- `.venv/bin/pytest -q` — 7,379 passed, 38 skipped, 5 failed. All five failures are in untouched environment-sensitive tests (`test_node_deps`, rich ANSI rendering, two file-mode/default-ACL assertions, platform CA roots); the same five fail when invoked from the unmodified `origin/main` test tree on this worker.

## Sources

- [Linear BE-10306](https://linear.app/comfyorg/issue/BE-10306/agent-cant-wire-asset-load-nodes-load-image-video-audio-into-nodes)
- [Jo's Seedance reproduction](https://comfy-organization.slack.com/archives/C0BGH348Z0C/p1788460446804899)

</details>

<!-- authored-by:agent lane-qa-2027-1850 -->
