### PR TITLE
feat(assets): forward has_more/total through the `assets library ls` envelope

### DIFF
--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -15,6 +15,7 @@ import typer
 
 from comfy_cli import tracking
 from comfy_cli.command.cloud_http import (
+    ResponseUnparseable,
     cloud_target_or_local_error,
     handle_cloud_http_error,
     http_request,
@@ -56,9 +57,22 @@ def ls_cmd(
     url = target.url("assets") + "?" + urllib.parse.urlencode(params)
 
     try:
-        _, body = http_request(url, target)
+        # `strict_json` so a 200 carrying a proxy/captive-portal error page is
+        # reported as malformed rather than collapsed to `None`, which is
+        # indistinguishable here from a genuinely empty body — and would render
+        # a broken response as a successful EMPTY library, the same masquerade
+        # the shape guards below refuse to make.
+        _, body = http_request(url, target, strict_json=True)
     except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
         raise handle_cloud_http_error(renderer, e, operation="list") from e
+    except ResponseUnparseable as e:
+        renderer.error(
+            code="cloud_http_error",
+            message="unexpected response from /api/assets (body was not valid JSON)",
+            hint="check whether a proxy or captive portal is intercepting the request",
+            details={"operation": "list"},
+        )
+        raise typer.Exit(code=1) from e
 
     # A non-empty body decodes here only if it was valid JSON, but valid JSON is
     # not necessarily the shape we asked for: a proxy or error page can answer 200
@@ -87,23 +101,32 @@ def ls_cmd(
             details={"got_type": type(rows).__name__},
         )
         raise typer.Exit(code=1)
+    assets = [
+        {
+            "id": r.get("id"),
+            "name": r.get("name"),
+            "hash": r.get("hash"),
+            "mime_type": r.get("mime_type"),
+            "size": r.get("size"),
+            "tags": r.get("tags"),
+            "preview_url": r.get("preview_url"),
+            "job_id": r.get("job_id"),
+            "created_at": r.get("created_at"),
+        }
+        for r in rows
+        if isinstance(r, dict)
+    ]
     payload = {
-        "count": len(rows),
-        "assets": [
-            {
-                "id": r.get("id"),
-                "name": r.get("name"),
-                "hash": r.get("hash"),
-                "mime_type": r.get("mime_type"),
-                "size": r.get("size"),
-                "tags": r.get("tags"),
-                "preview_url": r.get("preview_url"),
-                "job_id": r.get("job_id"),
-                "created_at": r.get("created_at"),
-            }
-            for r in rows
-            if isinstance(r, dict)
-        ],
+        # `count` describes the array actually emitted, not the raw server rows.
+        # A non-dict row is dropped from `assets` above, so counting raw rows
+        # reported more items than the payload carries — and a knowingly-skewed
+        # `count` sitting next to a forwarded `total` undercuts the point of
+        # forwarding an authoritative count at all. Identical to the old value
+        # for every well-formed response; it differs only where the old value
+        # was simply wrong. Matches the repo convention in
+        # `comfy_cli/command/nodes.py`, where `count` is over the emitted rows.
+        "count": len(assets),
+        "assets": assets,
     }
     # Forward the server's own truncation signal instead of making callers infer
     # it from an exactly-full page: `has_more`/`total` are both `required` on the

--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -60,7 +60,8 @@ def ls_cmd(
     except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
         raise handle_cloud_http_error(renderer, e, operation="list") from e
 
-    rows = (body or {}).get("assets") or []
+    b = body or {}
+    rows = b.get("assets") or []
     payload = {
         "count": len(rows),
         "assets": [
@@ -79,6 +80,17 @@ def ls_cmd(
             if isinstance(r, dict)
         ],
     }
+    # Forward the server's own truncation signal instead of making callers infer
+    # it from an exactly-full page: `has_more`/`total` are both `required` on the
+    # cloud API's `ListAssetsResponse`, and `has_more` comes off a limit+1
+    # sentinel row rather than off the returned row count, so it stays correct
+    # on a page that comes back short. Only forward what the server actually
+    # sent — an older or local server may omit them, and a JSON `null` in the
+    # envelope would poison a consumer's type assertion, so omit the key rather
+    # than emitting None.
+    for k in ("has_more", "total"):
+        if isinstance(b.get(k), (bool, int)):
+            payload[k] = b[k]
     renderer.emit(payload, command="assets library ls", where="cloud")
 
 

--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -60,8 +60,33 @@ def ls_cmd(
     except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
         raise handle_cloud_http_error(renderer, e, operation="list") from e
 
+    # A non-empty body decodes here only if it was valid JSON, but valid JSON is
+    # not necessarily the shape we asked for: a proxy or error page can answer 200
+    # with an array or a scalar, and `b.get(...)` would then raise a raw
+    # `AttributeError` past the `except` above — a traceback instead of an error
+    # envelope. Guard it the way `workflow list` guards the same failure on the
+    # sibling endpoint. An empty body stays a legitimate `None` (→ no rows).
+    if body is not None and not isinstance(body, dict):
+        renderer.error(
+            code="cloud_http_error",
+            message="unexpected response shape from /api/assets (expected a JSON object)",
+            details={"got_type": type(body).__name__},
+        )
+        raise typer.Exit(code=1)
+
     b = body or {}
-    rows = b.get("assets") or []
+    # A missing/empty `assets` is a legitimately-empty listing; a present non-list
+    # `assets` is malformed the same way, and `len(rows)` would raise `TypeError`.
+    rows = b.get("assets")
+    if rows is None:
+        rows = []
+    elif not isinstance(rows, list):
+        renderer.error(
+            code="cloud_http_error",
+            message="unexpected response shape from /api/assets (assets must be a JSON array)",
+            details={"got_type": type(rows).__name__},
+        )
+        raise typer.Exit(code=1)
     payload = {
         "count": len(rows),
         "assets": [
@@ -96,7 +121,10 @@ def ls_cmd(
     if isinstance(b.get("has_more"), bool):
         payload["has_more"] = b["has_more"]
     total = b.get("total")
-    if isinstance(total, int) and not isinstance(total, bool):
+    # `>= 0` because the schema publishes `total` as a non-negative integer, and a
+    # guard looser than the declared contract is how the envelope ends up violating
+    # its own schema.
+    if isinstance(total, int) and not isinstance(total, bool) and total >= 0:
         payload["total"] = total
     renderer.emit(payload, command="assets library ls", where="cloud")
 

--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -88,9 +88,16 @@ def ls_cmd(
     # sent — an older or local server may omit them, and a JSON `null` in the
     # envelope would poison a consumer's type assertion, so omit the key rather
     # than emitting None.
-    for k in ("has_more", "total"):
-        if isinstance(b.get(k), (bool, int)):
-            payload[k] = b[k]
+    #
+    # Each field is checked against its OWN type, not a shared bool-or-int test:
+    # `bool` is a subclass of `int` in Python, so one shared check would forward
+    # `has_more: 0` and `total: false` and emit an envelope that violates
+    # schemas/assets_library.json — the very contract this command publishes.
+    if isinstance(b.get("has_more"), bool):
+        payload["has_more"] = b["has_more"]
+    total = b.get("total")
+    if isinstance(total, int) and not isinstance(total, bool):
+        payload["total"] = total
     renderer.emit(payload, command="assets library ls", where="cloud")
 
 

--- a/comfy_cli/command/cloud_http.py
+++ b/comfy_cli/command/cloud_http.py
@@ -88,7 +88,18 @@ def http_request(
         return status, None
     try:
         return status, json.loads(raw)
-    except json.JSONDecodeError as e:
+    except (ValueError, RecursionError) as e:
+        # Catch the ``ValueError`` BASE, not ``JSONDecodeError``: handed raw bytes,
+        # ``json.loads`` rejects a malformed body with three different exceptions and
+        # only one of them is a ``JSONDecodeError``. Non-UTF-8 bytes (``b"\xff"``, a
+        # binary error page) raise ``UnicodeDecodeError``; a JSON integer past
+        # CPython's 4300-digit int/str limit raises a bare ``ValueError``; both
+        # subclass ``ValueError``. Pathologically nested input raises
+        # ``RecursionError``, which does not — the 64 MiB read permits deep nesting.
+        # Narrowing to ``JSONDecodeError`` let those escape past ``strict_json`` and
+        # past every call site's ``except``, crashing the CLI with a raw traceback
+        # for exactly the malformed response this helper exists to classify. Same
+        # reasoning, and the same catch, as the sibling helper in ``workflow.py``.
         if strict_json:
             raise ResponseUnparseable(f"non-JSON response body from {url}") from e
         return status, None

--- a/comfy_cli/command/cloud_http.py
+++ b/comfy_cli/command/cloud_http.py
@@ -46,11 +46,32 @@ def _authed_request(
     return req
 
 
+class ResponseUnparseable(Exception):
+    """A non-empty response body that was not valid JSON.
+
+    Only raised when a caller opts in via ``http_request(..., strict_json=True)``;
+    otherwise a decode failure keeps collapsing to ``None`` as it always has.
+    """
+
+
 def http_request(
-    url: str, target, *, method: str = "GET", body: dict | None = None, timeout: float = 30.0
+    url: str,
+    target,
+    *,
+    method: str = "GET",
+    body: dict | None = None,
+    timeout: float = 30.0,
+    strict_json: bool = False,
 ) -> tuple[int, dict | None]:
     """Authed HTTP call returning (status, parsed_json_or_none). Raises
-    urllib errors verbatim so callers can surface the right error code."""
+    urllib errors verbatim so callers can surface the right error code.
+
+    An *empty* body is reported as ``None``. A *non-empty* body that fails to
+    decode is reported as ``None`` too, unless ``strict_json`` is set — then it
+    raises ``ResponseUnparseable``. The two are different answers ("nothing to
+    say" vs. "a malformed answer"), and a listing caller that conflates them
+    reports a proxy or captive-portal error page as a successful empty listing.
+    """
     import urllib.request
 
     data = json.dumps(body).encode("utf-8") if body is not None else None
@@ -59,11 +80,17 @@ def http_request(
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         status = resp.status
         raw = resp.read(64 * 1024 * 1024)  # 64 MiB cap
-    if not raw:
+    # `.strip()` so a whitespace-only body counts as empty rather than as a
+    # decode failure: identical to the old behaviour on the default path (it
+    # collapsed to `None` either way), but it keeps `strict_json` from calling a
+    # server that answers `b"\n"` malformed.
+    if not raw.strip():
         return status, None
     try:
         return status, json.loads(raw)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        if strict_json:
+            raise ResponseUnparseable(f"non-JSON response body from {url}") from e
         return status, None
 
 

--- a/comfy_cli/schemas/assets_library.json
+++ b/comfy_cli/schemas/assets_library.json
@@ -25,6 +25,8 @@
     }
    }
   },
+  "has_more": { "type": "boolean" },
+  "total": { "type": "integer" },
   "id": { "type": ["string", "null"] },
   "hash": { "type": ["string", "null"] },
   "created_new": { "type": ["boolean", "null"] }

--- a/comfy_cli/schemas/assets_library.json
+++ b/comfy_cli/schemas/assets_library.json
@@ -26,7 +26,7 @@
    }
   },
   "has_more": { "type": "boolean" },
-  "total": { "type": "integer" },
+  "total": { "type": "integer", "minimum": 0 },
   "id": { "type": ["string", "null"] },
   "hash": { "type": ["string", "null"] },
   "created_new": { "type": ["boolean", "null"] }

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -142,6 +142,21 @@ class TestLsPagination:
         assert "has_more" not in data
         assert "total" not in data
 
+    def test_omits_cross_typed_values(self, cloud_target, monkeypatch, capsys):
+        # `bool` is a subclass of `int` in Python, so a shared bool-or-int check
+        # would let `has_more: 0` / `total: false` through and emit an envelope
+        # that violates this command's own published schema. Each field is
+        # validated against its own type instead, and a mistyped value is
+        # dropped exactly like an absent one.
+        data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": 0, "total": False})
+        assert "has_more" not in data
+        assert "total" not in data
+
+    def test_omits_values_of_the_wrong_json_type(self, cloud_target, monkeypatch, capsys):
+        data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": "true", "total": "1234"})
+        assert "has_more" not in data
+        assert "total" not in data
+
     def test_existing_count_and_assets_shape_unchanged(self, cloud_target, monkeypatch, capsys):
         rows = [
             {

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -238,6 +238,25 @@ class TestLsPagination:
         assert env["error"]["code"] == "cloud_http_error"
         assert error_codes.is_registered(env["error"]["code"])
 
+    def test_invalid_utf8_body_is_an_error_envelope_not_a_traceback(self, cloud_target, monkeypatch, capsys):
+        # Handed raw bytes, `json.loads` rejects a NON-UTF-8 body with
+        # `UnicodeDecodeError`, not `JSONDecodeError` — so a binary error page (or
+        # a gzip/TLS fragment from a misbehaving proxy) escaped the `strict_json`
+        # catch entirely and crashed the CLI with a traceback, past the very
+        # handler added to stop invalid JSON from masquerading as an empty
+        # library. Same malformed answer as the test above, different bytes.
+        #
+        # These bytes are chosen to be invalid UTF-8 that is ALSO not a BOM:
+        # `json.loads` sniffs raw bytes for UTF-16/32 (RFC 4627), so a body
+        # starting `\xff\x00` is guessed as UTF-16-LE, decodes to garbage text and
+        # fails as an ordinary `JSONDecodeError` — which the narrow catch already
+        # handled, making it a test that passes with or without the fix.
+        _patch_urlopen_raw(monkeypatch, b"\x80\x81\x82 binary garbage")
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+
     def test_count_matches_the_emitted_assets_and_projection_is_unchanged(self, cloud_target, monkeypatch, capsys):
         rows = [
             {
@@ -313,3 +332,69 @@ class TestEnsure:
         assert env["ok"] is True
         assert env["data"] == {"id": "asset-1", "hash": "a" * 64, "created_new": True}
         assert calls[0]["url"].endswith("/api/assets/from-hash") and calls[0]["method"] == "POST"
+
+
+class TestHttpRequestRejectsEveryUnparseableBody:
+    """`http_request`'s decode guard is keyed on the malformed body, not on which
+    exception the parser happened to pick.
+
+    `json.loads` rejects a malformed body with three different exceptions and only
+    one is a `JSONDecodeError`; the other two are exercised here through a patched
+    `json.loads` rather than through pathological input, because the thresholds
+    that produce them (CPython's 4300-digit int limit, the recursion limit) move
+    between interpreter versions and would make the test a platform coin-flip.
+    The invalid-UTF-8 case is deterministic everywhere and is pinned end-to-end
+    in `TestLsPagination` above.
+    """
+
+    @staticmethod
+    def _request(monkeypatch, target, exc: BaseException, *, strict_json: bool):
+        from comfy_cli.command import cloud_http
+
+        class _Resp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self, n=None):
+                return b'{"assets": []}'
+
+        monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=None: _Resp())
+
+        def _boom(_raw):
+            raise exc
+
+        monkeypatch.setattr(cloud_http.json, "loads", _boom)
+        return cloud_http.http_request(target.url("assets"), target, strict_json=strict_json)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            pytest.param(ValueError("Exceeds the limit for integer string conversion"), id="bare-ValueError"),
+            pytest.param(RecursionError("maximum recursion depth exceeded"), id="RecursionError"),
+        ],
+    )
+    def test_strict_json_raises_response_unparseable(self, cloud_target, monkeypatch, exc):
+        from comfy_cli.command.cloud_http import ResponseUnparseable
+
+        # Not `pytest.raises(type(exc))`: the point is that the raw exception is
+        # translated, so a call site's `except ResponseUnparseable` sees it.
+        with pytest.raises(ResponseUnparseable):
+            self._request(monkeypatch, cloud_target, exc, strict_json=True)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            pytest.param(ValueError("Exceeds the limit for integer string conversion"), id="bare-ValueError"),
+            pytest.param(RecursionError("maximum recursion depth exceeded"), id="RecursionError"),
+        ],
+    )
+    def test_default_path_still_collapses_to_none(self, cloud_target, monkeypatch, exc):
+        # The default path's documented contract is that an undecodable body
+        # collapses to `None`; broadening the catch makes that true for these two
+        # as well, instead of letting them escape as a traceback.
+        assert self._request(monkeypatch, cloud_target, exc, strict_json=False) == (200, None)

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -1,6 +1,17 @@
-"""``comfy assets library`` error envelopes.
+"""``comfy assets library`` envelopes.
 
-Pins the 404 mapping for ``assets library ensure``. Found in prod (Langfuse
+Pins two things: the ``assets library ls`` pagination passthrough, and the 404
+mapping for ``assets library ensure``.
+
+``ls`` forwards the server's ``has_more``/``total`` so a downstream consumer
+(the cloud agent's asset gate) reads an authoritative truncation signal instead
+of inferring one from a page that came back exactly full — which both misses a
+short truncated page and misreads a library of exactly ``--limit`` assets. Both
+fields are ``required`` on the cloud API's ``ListAssetsResponse``, but a server
+that omits them must leave the keys ABSENT rather than emit ``null``, because
+the consumer type-asserts them out of the decoded envelope.
+
+The 404 mapping was found in prod (Langfuse
 2026-08-25, ``use_asset_as_input``): an agent passed a FILE NAME
 (``comfyorg_logo.png``) where the content hash belongs, the API answered 404,
 and the CLI reported ``workflow_not_found`` / "workflow not found (ensure)"
@@ -87,6 +98,91 @@ def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, outcome):
 
     monkeypatch.setattr("urllib.request.urlopen", _fake)
     return calls
+
+
+class TestLsPagination:
+    """`ls` forwards the server's truncation signal, and only when it sent one."""
+
+    def _ls(self, monkeypatch, capsys, body: dict) -> dict[str, Any]:
+        _patch_urlopen(monkeypatch, body)
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is True, env
+        return env["data"]
+
+    def test_forwards_has_more_and_total(self, cloud_target, monkeypatch, capsys):
+        data = self._ls(
+            monkeypatch,
+            capsys,
+            {"assets": [{"id": "a1", "name": "cat.png", "hash": "h1"}], "has_more": True, "total": 1234},
+        )
+        assert data["has_more"] is True
+        assert data["total"] == 1234
+        # Alongside, not instead of, the existing shape.
+        assert data["count"] == 1
+        assert data["assets"][0]["id"] == "a1"
+
+    def test_forwards_has_more_false(self, cloud_target, monkeypatch, capsys):
+        # `false` is a real answer, not a missing one — the falsy value must
+        # survive, otherwise the consumer cannot distinguish "not truncated"
+        # from "server did not say".
+        data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": False, "total": 0})
+        assert data["has_more"] is False
+        assert data["total"] == 0
+
+    def test_omits_keys_when_server_does_not_send_them(self, cloud_target, monkeypatch, capsys):
+        data = self._ls(monkeypatch, capsys, {"assets": [{"id": "a1"}]})
+        assert "has_more" not in data
+        assert "total" not in data
+        assert data["count"] == 1
+
+    def test_omits_keys_when_server_sends_nulls(self, cloud_target, monkeypatch, capsys):
+        # A forwarded `null` would poison the consumer's type assertion, so a
+        # null is treated exactly like an absent key.
+        data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": None, "total": None})
+        assert "has_more" not in data
+        assert "total" not in data
+
+    def test_existing_count_and_assets_shape_unchanged(self, cloud_target, monkeypatch, capsys):
+        rows = [
+            {
+                "id": "a1",
+                "name": "cat.png",
+                "hash": "h1",
+                "mime_type": "image/png",
+                "size": 12,
+                "tags": ["input"],
+                "preview_url": "https://example.com/p.png",
+                "job_id": "j1",
+                "created_at": "2026-01-01T00:00:00Z",
+                "extra_server_field": "dropped",
+            },
+            "not-a-dict",
+        ]
+        data = self._ls(monkeypatch, capsys, {"assets": rows, "has_more": False, "total": 1})
+        assert data["count"] == 2  # counts raw rows, as before
+        assert data["assets"] == [
+            {
+                "id": "a1",
+                "name": "cat.png",
+                "hash": "h1",
+                "mime_type": "image/png",
+                "size": 12,
+                "tags": ["input"],
+                "preview_url": "https://example.com/p.png",
+                "job_id": "j1",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+
+    def test_envelope_validates_against_the_published_schema(self, cloud_target, monkeypatch, capsys):
+        import json as _json
+        from pathlib import Path
+
+        import jsonschema
+
+        data = self._ls(monkeypatch, capsys, {"assets": [{"id": "a1"}], "has_more": True, "total": 7})
+        schema_path = Path(assets_library.__file__).resolve().parents[1] / "schemas" / "assets_library.json"
+        jsonschema.Draft202012Validator(_json.loads(schema_path.read_text())).validate(data)
 
 
 class TestEnsure:

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -152,10 +152,43 @@ class TestLsPagination:
         assert "has_more" not in data
         assert "total" not in data
 
+    def test_omits_a_negative_total(self, cloud_target, monkeypatch, capsys):
+        # The schema publishes `total` as `minimum: 0`, so forwarding a negative
+        # server value would emit an envelope violating this command's own
+        # contract — the same class of bug as the cross-typed case above.
+        data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": False, "total": -1})
+        assert "total" not in data
+        assert data["has_more"] is False
+
     def test_omits_values_of_the_wrong_json_type(self, cloud_target, monkeypatch, capsys):
         data = self._ls(monkeypatch, capsys, {"assets": [], "has_more": "true", "total": "1234"})
         assert "has_more" not in data
         assert "total" not in data
+
+    def test_non_object_body_is_an_error_envelope_not_a_traceback(self, cloud_target, monkeypatch, capsys):
+        # A proxy or error page can answer 200 with valid JSON that is not an
+        # object. `b.get(...)` would raise a bare AttributeError past the
+        # HTTPError/URLError/OSError handler, so the user would see a traceback
+        # rather than an envelope.
+        _patch_urlopen(monkeypatch, [1, 2, 3])
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+        assert env["error"]["details"]["got_type"] == "list"
+
+    def test_non_list_assets_is_an_error_envelope_not_a_traceback(self, cloud_target, monkeypatch, capsys):
+        # Same failure one level down: `len(rows)` on a scalar raises TypeError.
+        _patch_urlopen(monkeypatch, {"assets": 42})
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert env["error"]["details"]["got_type"] == "int"
+
+    def test_empty_body_is_an_empty_listing_not_an_error(self, cloud_target, monkeypatch, capsys):
+        data = self._ls(monkeypatch, capsys, None)
+        assert data["count"] == 0
+        assert data["assets"] == []
 
     def test_existing_count_and_assets_shape_unchanged(self, cloud_target, monkeypatch, capsys):
         rows = [

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -100,6 +100,26 @@ def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, outcome):
     return calls
 
 
+def _patch_urlopen_raw(monkeypatch: pytest.MonkeyPatch, raw: bytes):
+    """Like ``_patch_urlopen`` but serves ``raw`` verbatim, so a test can send a
+    body that is not valid JSON at all (or is genuinely empty) rather than one
+    that round-trips through ``json.dumps``."""
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, n=None):
+            return raw
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=None: _Resp())
+
+
 class TestLsPagination:
     """`ls` forwards the server's truncation signal, and only when it sent one."""
 
@@ -185,12 +205,40 @@ class TestLsPagination:
         assert env["error"]["code"] == "cloud_http_error"
         assert env["error"]["details"]["got_type"] == "int"
 
-    def test_empty_body_is_an_empty_listing_not_an_error(self, cloud_target, monkeypatch, capsys):
+    def test_json_null_body_is_an_empty_listing_not_an_error(self, cloud_target, monkeypatch, capsys):
         data = self._ls(monkeypatch, capsys, None)
         assert data["count"] == 0
         assert data["assets"] == []
 
-    def test_existing_count_and_assets_shape_unchanged(self, cloud_target, monkeypatch, capsys):
+    def test_truly_empty_body_is_an_empty_listing_not_an_error(self, cloud_target, monkeypatch, capsys):
+        # Zero bytes: the server had nothing to say, which is a legitimate
+        # empty library and must stay a success envelope.
+        _patch_urlopen_raw(monkeypatch, b"")
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["count"] == 0
+        assert env["data"]["assets"] == []
+
+    def test_whitespace_only_body_is_an_empty_listing_not_an_error(self, cloud_target, monkeypatch, capsys):
+        # A body of just a newline is "nothing to say", not a malformed answer;
+        # `strict_json` must not turn it into an error envelope.
+        _patch_urlopen_raw(monkeypatch, b"\n")
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is True, env
+        assert env["data"]["count"] == 0
+
+    def test_invalid_json_body_is_an_error_envelope_not_an_empty_listing(self, cloud_target, monkeypatch, capsys):
+        # `http_request` collapses a JSONDecodeError to `None` by default, which
+        # is indistinguishable from the empty body above — so a proxy or
+        # captive-portal error page answering 200 rendered as a successful EMPTY
+        # library. `ls` opts into `strict_json` so the two stay distinct.
+        _patch_urlopen_raw(monkeypatch, b"<html><body>502 Bad Gateway</body></html>")
+        env = _run(["ls", "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+
+    def test_count_matches_the_emitted_assets_and_projection_is_unchanged(self, cloud_target, monkeypatch, capsys):
         rows = [
             {
                 "id": "a1",
@@ -207,7 +255,12 @@ class TestLsPagination:
             "not-a-dict",
         ]
         data = self._ls(monkeypatch, capsys, {"assets": rows, "has_more": False, "total": 1})
-        assert data["count"] == 2  # counts raw rows, as before
+        # `count` describes the array actually emitted: the non-dict row is
+        # dropped from `assets`, so counting it too would report more items than
+        # the payload carries — misleading in general, and self-defeating beside
+        # a forwarded `total` whose whole purpose is an authoritative count.
+        assert data["count"] == 1
+        assert data["total"] == 1
         assert data["assets"] == [
             {
                 "id": "a1",


### PR DESCRIPTION
## ELI-5

`comfy assets library ls` asks the cloud for a page of your assets. The server answers with the rows *and* with two honest facts about the page — `has_more` ("there are more beyond this one") and `total` ("how many match altogether"). The CLI was throwing those two away and handing callers only `{count, assets[]}`, so anything downstream had to guess at truncation by checking whether the page came back exactly full. This forwards the server's own answer instead of making callers guess.

## What changed

`ls_cmd` now copies `has_more` and `total` from the `GET /api/assets` response into the JSON envelope's `data`, alongside the existing `count`/`assets` — and only when the server actually sent them.

- **Absent, not `null`.** An older or self-hosted server may not send these. A forwarded JSON `null` is worse than a missing key for a consumer that type-asserts the value out of the decoded envelope, so a missing-or-null field leaves the key off entirely.
- **Each field is validated against its own type.** `has_more` must be a `bool` and `total` an `int`; a cross-typed value is dropped exactly like an absent one. This is deliberately not a shared `isinstance(v, (bool, int))` test — `bool` is a subclass of `int` in Python, so one shared check forwards `has_more: 0` and `total: false`, emitting an envelope that violates the schema this command publishes. Caught in review on the first revision of this PR and fixed in the second commit, with regression cases for both malformed values.
- **`false`/`0` still survive.** The guard is a type check, not a truthiness check, so `has_more: false` and `total: 0` are forwarded as real answers — a consumer can distinguish "not truncated" from "server didn't say", which is the whole point.
- **`comfy_cli/schemas/assets_library.json`** declares both fields. That schema is how an agent resolves this command's output shape through `comfy discover`, so a field that ships undeclared is a field nobody downstream knows to read. The schema is `additionalProperties: true`, so this is documentation rather than a validation change.

### Also in this PR — malformed-response hardening

Review surfaced that `ls_cmd` never checked `body` was actually a dict. `http_request` returns whatever `json.loads` produced (its `dict | None` annotation is not enforced), so a proxy or error page answering 200 with a JSON array or scalar made `b.get(...)` raise a bare `AttributeError`, and a present-but-non-list `assets` made `len(rows)` raise `TypeError`. Both escape the `except (HTTPError, URLError, OSError)` above, so the user got a traceback where every other cloud failure on this command produces an envelope. This is pre-existing, but the passthrough adds two more `.get` calls on the same unvalidated value, so it is fixed here rather than left next to new code that depends on it — using the `cloud_http_error` envelope that `workflow list` already uses for the identical failure on the sibling endpoint. Coercing a malformed shape to `[]` is deliberately not the fallback, since that masquerades as a genuinely-empty library; an empty body remains a legitimate empty listing.

A later review pass found the same masquerade one level lower, on the path *into* that guard. `cloud_http.http_request` collapses **both** an empty body and a `JSONDecodeError` to `None`, so `ls` could not tell them apart: a 200 carrying a proxy or captive-portal error page emitted a successful, **empty** asset library — the exact failure the shape guards above refuse to make, arriving through the one door they do not cover. `http_request` now takes an opt-in `strict_json` that raises a new `ResponseUnparseable` on a non-empty undecodable body. `ls` opts in and emits the same `cloud_http_error` envelope as its sibling guards. `ensure_cmd` is the only other caller of that helper, and `assets_library.py` is the only module that imports `cloud_http` at all.

"Nothing to say" deliberately stays a success. The empty check became `not raw.strip()`, so zero bytes, a whitespace-only body and a JSON `null` all remain a legitimate empty listing — that is identical to the old behaviour on the default path, where they collapsed to `None` either way. Only genuinely undecodable content errors, so the change tightens a malformed case without closing off an empty library.

### Also in this PR — every unparseable body, not just `JSONDecodeError`

A final review pass (CodeRabbit) found that the `strict_json` guard above caught the wrong *set*. It caught `json.JSONDecodeError`, but handed raw bytes `json.loads` rejects a malformed body with **three** different exceptions and only one of them is a `JSONDecodeError`:

| body | raises | is a `JSONDecodeError`? |
|---|---|---|
| non-UTF-8 bytes (a binary error page, a gzip/TLS fragment from a proxy) | `UnicodeDecodeError` | no |
| a JSON integer past CPython's 4300-digit int/str limit | bare `ValueError` | no |
| pathologically nested input (the 64 MiB read permits it) | `RecursionError` | no — not even a `ValueError` |

All three escaped `strict_json` **and** every call site's `except`, so `ls` crashed with a raw traceback for exactly the malformed response the `ResponseUnparseable` handler exists to convert into an envelope — the reported defect reappearing one layer up, in the handler meant to close it. Verified by probe before the fix: each of the three escaped unhandled on both the strict and default paths.

The catch is now `except (ValueError, RecursionError)` — the same catch, for the same reasons, as the sibling helper in `workflow.py:975-989` that `cloud_http` was extracted from and that already got this right. Reviewer suggested adding `UnicodeDecodeError` alone; that would have left the other two escaping.

**One deliberate departure from that sibling.** `workflow.py` also decodes UTF-8 *explicitly* before parsing, to reject a UTF-16/32 body that `json.loads` would otherwise sniff and accept. That is **not** copied here: it would newly reject a body that parses fine today, no reviewer asked for it, and it would break a server that currently works. Confirmed by control probe — a UTF-16 body still parses on both paths, as do well-formed, empty and whitespace-only bodies.

**The default path does change for these three classes**, which is why the byte-for-byte claim above is now corrected rather than repeated. They previously escaped as a traceback and now collapse to `None`, which is what the helper's docstring already promised for an undecodable body. That makes `ensure_cmd` consistent with its *existing* behaviour for ordinary invalid JSON instead of branching on which exotic bytes arrived; the fake-success this exposes there is pre-existing for every other malformed body, is not widened in kind (only in which byte sequences reach it), and is tracked separately.

## Why the old signal was wrong

Inferring truncation from `len(rows) >= limit` is wrong in both directions. It reads any *short* truncated page as a complete library — the dangerous direction, since a consumer gating on "is this asset in the library?" would then report assets it simply never saw. And it fires spuriously on a library of exactly `--limit` assets, needlessly disabling the gate. The server's `has_more` has neither failure: it is computed from a limit+1 sentinel row rather than from the returned row count, so it stays correct on a short page.

Consistency note: `models search` / `models show` already read `has_more` and `total` off this same `/api/assets` endpoint (`comfy_cli/command/models/search.py`). This brings `assets library ls` in line with them.

## Sizing the half not fixed

Swept every `/api/assets` call site in `comfy_cli/` so the scope claim is a number rather than an impression: **4 call sites, 3 of which are list GETs.** One is the upload POST (`deploy_assets.py`, no pagination to forward). Of the three list GETs: this PR fixes `assets_library.ls_cmd`; `models/search.py`'s exact-name paging loop already terminates on the server's `has_more` and is correct as-is; and `models/search.py`'s `_cloud_search` already surfaces `total` in its own envelope (rendered as "(of N total)") but not `has_more` — a caller there can still compare `len(rows) < total`, so it is a weaker signal rather than an absent one, and it is left alone as out of scope.

Rebase note: the test file this PR extends was introduced by #820, which merged on 2026-08-29. This branch is cut from `main` at a commit that already contains it, so there is no rebase pending and no overlap — #820 touched the `ensure` error path, this touches `ls`.

## Verification

Verified the premise against the API contract rather than assuming it, and confirmed red→green rather than shipping tests that only assert their own premise:

- Read the cloud API's `ListAssetsResponse` schema: `assets`, `total` and `has_more` are all listed `required`; `total` is an integer and `has_more` a boolean.
- Read the server handler: it fetches `limit + 1` rows and derives `has_more` from whether the sentinel row came back, explicitly *not* from a count — so the flag is accurate on a short page.
- Read the downstream consumer that motivated this. It still keys truncation off `len(rows) >= 500`, and its own comment names this CLI file as the reason ("the flag does not survive the CLI").
- Reverted the product change and re-ran the new tests: 2 failed / 7 passed. With the change: 9 passed.
- Ran the whole suite: 1 failed, 7386 passed, 38 skipped. The one failure is `tests/comfy_cli/test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots`, which is **pre-existing and unrelated** — it fails identically on a clean checkout of `main` with none of this diff applied (verified in a separate detached worktree at `origin/main`: 1 failed, 72 passed). It concerns TLS CA-bundle fallback and touches nothing this PR changes. Not fixed here, and not this PR's to fix.

## Tests

`tests/comfy_cli/command/test_assets_library.py::TestLsPagination` — both fields forwarded; `has_more: false` / `total: 0` forwarded rather than dropped as falsy; keys absent when the server omits them; keys absent when the server sends nulls; keys absent when the server sends cross-typed values (`has_more: 0`, `total: false`) or wrong-JSON-type values (strings); the existing `count`/`assets[]` projection byte-for-byte unchanged; the emitted payload validated against the published schema; an invalid-JSON 200 body producing an error envelope rather than an empty listing, while a raw-empty and a whitespace-only body each stay an empty listing; and `count` matching the emitted array on a response containing a malformed row. Plus an invalid-**UTF-8** 200 body producing an error envelope rather than a traceback, end-to-end through `ls`.

`tests/comfy_cli/command/test_assets_library.py::TestHttpRequestRejectsEveryUnparseableBody` — the bare-`ValueError` and `RecursionError` classes pinned directly on `http_request`, on both the strict and default paths. These two are driven through a patched `json.loads` rather than through pathological input, because the thresholds that produce them naturally (CPython's int-digit limit, the recursion limit) move between interpreter versions and would make the test a platform coin-flip across the three CI OSes on 3.10; the invalid-UTF-8 case is deterministic everywhere and is exercised for real.

### Also in this PR — `count` now describes the array it sits next to

`count` was `len(rows)` over the raw server rows while `assets[]` filters out any non-dict row, so a single malformed row reported more items than the payload actually carried. Two reviewers raised it independently, with the fair point that a knowingly-skewed `count` sitting beside a forwarded `total` undercuts the whole purpose of this change, and that the repo convention (`comfy_cli/command/nodes.py:284`) is for `count` to describe the emitted array.

An earlier revision of this PR declined the fix on the grounds that redefining published output is a contract decision. On a second look that reasoning does not hold: for **every well-formed response** the two expressions are equal, so no consumer of a valid response can observe the change at all. It differs only on a malformed row — precisely where the old value was simply wrong. `count` is now `len(assets)`, and `test_count_matches_the_emitted_assets_and_projection_is_unchanged` pins both the corrected count and the byte-for-byte unchanged field projection.

## Residual

Not fixed here, and each item is written to stand on its own:

- **The consumer still infers truncation from a full page.** The cloud-side asset gate that motivated this change is in a different repository and is not touched by this PR — it continues to treat `len(rows) >= 500` as the truncation signal, so the improved signal is available but not yet consumed. Its source comment asserting that the flag "does not survive the CLI" is stale as of this PR and should be updated when that side is changed. That is the separately-tracked follow-up phase, not a gap in this diff.
- **`next_cursor` is not forwarded.** The same response also carries an optional `next_cursor` string for keyset pagination. It is deliberately out of scope here: forwarding it only helps once `ls` grows a way to *use* a cursor (there is no `--after`/`--cursor` option today), and shipping a cursor a caller cannot pass back invites a consumer to build paging on a half-present contract. Worth its own change alongside a paging flag.
- **`total` is not meaningful in the server's cursor mode.** The server skips the COUNT query when paginating by cursor, so `total` there is not an authoritative count. `ls` never sends a cursor (offset mode only), so this is unreachable from this command today — but it becomes live the moment the `next_cursor` item above is done, and a consumer that trusts `total` unconditionally would be reading a value nobody computed.

Artifacts named by the task that I could **not** exercise, and why:

- **No call against a live `/api/assets`.** Every test stubs `urllib.request.urlopen`; this sandbox has no authorized cloud target or API key, so the passthrough is proven against the published response contract and the server's own handler source, not against a live server. If the deployed server ever diverged from its spec on these two fields, nothing here would catch it.
- **The originating tracker issue and its investigation notes were not readable** from this environment. The implementation plan was reconstructed from, and checked against, the API contract and the server/consumer source directly; any acceptance detail recorded only in that tracker is unverified by me.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** on the final commit (`ec5fc4f6`, the review-resolution commit) — `ruff check .` / `ruff format --diff .` under the pinned CI ruff 0.15.15: clean, 446 files already formatted. `pytest tests/comfy_cli/command/test_assets_library.py`: 23 passed, 0 failed. Red→green confirmed by reverting only the product change: 5 failed / 18 passed, restored 23 passed. That red run is also what caught a bad first attempt at the regression test — `b"\xff\x00\x8f ..."` passes with *and* without the fix, because `json.loads` sniffs the leading `\xff\x00` as a UTF-16-LE BOM and fails as an ordinary `JSONDecodeError`; the committed test uses non-BOM invalid UTF-8 (`b"\x80\x81\x82 ..."`). The premise and the fix were each checked by direct probe of `http_request` rather than inferred: before, all three of `UnicodeDecodeError` / bare `ValueError` / `RecursionError` escaped unhandled on both the strict and default paths; after, all three are classified, while control bodies that parse today (well-formed, UTF-16, empty, whitespace-only) still parse identically on both paths. Full-suite regression check done as a **before/after diff on the same machine** rather than as an absolute number, because this checkout's local venv is missing `blake3` and runs a typer/click combination that breaks a set of tests unrelated to this diff: the failing-id set with the diff applied is **identical** to the set with it stashed (101 both ways, zero added, zero removed), so this commit introduces no regression. CI on the PR was green on all 18 checks before this commit, which is the authoritative signal for those locally-broken tests. Blast radius re-verified by grep: `cloud_http` is imported by exactly one module (`assets_library.py`), and `http_request` has exactly two call sites, only one of which opts into `strict_json`. Earlier commits — `f14ebb72`: 18 passed; reverting the per-field guard to the shared bool-or-int check makes the regression case fail (1 failed, 10 passed); on the first commit, full `pytest` was 7386 passed / 38 skipped / 1 failed, that one failure (`test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots`) reproducing on a clean `origin/main` checkout
- **Deviations:** four departures from the requested change, all deliberate and all driven by review. First, the ticket prescribed a shared `isinstance(b.get(k), (bool, int))` guard; that is unsafe once the fields are declared in the schema, because Python's `bool`-is-an-`int` makes it forward `has_more: 0` / `total: false` and emit a schema-violating envelope. The guard is per-field instead, and rejects a negative `total` for the same reason. Second, the PR also fixes the malformed-response traceback described above — pre-existing, but sitting directly under the new `.get` calls, and the repo already had a settled pattern to copy; a follow-up review pass extended that fix to the invalid-JSON body, which reached the same masquerade through the one door the shape guards did not cover, and which required an opt-in `strict_json` flag on the shared `cloud_http.http_request` helper. Third, `count` is now derived from the emitted `assets` array rather than the raw server rows; an earlier revision deferred this as a contract change, but the two values are equal for every well-formed response, so the correction is unobservable except where the old value was wrong. Fourth, and newest, that `strict_json` guard caught only `json.JSONDecodeError` while `json.loads` rejects a malformed body with three different exceptions; the catch is broadened to `(ValueError, RecursionError)` following the sibling helper in `workflow.py`. That fourth item **narrows an earlier claim in this body**: the `strict_json` default path is no longer byte-for-byte unchanged — for those three exception classes it now collapses to `None` (as the helper's docstring already promised) instead of escaping as a traceback. The sibling's explicit UTF-8 pre-decode is deliberately *not* copied, since it would newly reject UTF-16/32 bodies that parse today. Beyond the literal request: the two fields are also declared in `comfy_cli/schemas/assets_library.json` (that schema is the published output contract for this command, so an undeclared field is invisible to the agents that read it), and the test set adds a `has_more: false` / `total: 0` case, a schema-validation case, and the malformed-body cases above.

  One item is **not** fixed here and was proposed as a follow-up instead: `ensure_cmd` in the same file has the identical unvalidated-body defect (a non-dict 200 raises a bare `AttributeError`; an unparseable one emits `created_new: false` with a null `id`, a fake success for a borrow that may not have happened). It is a different command on a different endpoint (`/api/assets/from-hash`) and out of scope for a PR about `ls` pagination, so it is tracked separately rather than folded in.
