### PR TITLE
test(workflow): pin replace_ops autogrow replay fidelity; flag the apply_specs gap (BE-10726)

### DIFF
--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -2166,6 +2166,160 @@ class TestOpModel:
             assert names == {"images.first", "images.second"}, names
         assert ops.canonical(ab) == ops.canonical(ba)
 
+    # ---------------------------------------------------------------------
+    # replace_ops on autogrow canvases (BE-10726): the CLI's repeated-edit
+    # paths leave sparse numbering where the FE compacts; the bulk-writer
+    # batch must round-trip both shapes.
+    # ---------------------------------------------------------------------
+
+    @staticmethod
+    def _autogrow_replace_canvas(n_sources: int = 3) -> dict:
+        """A BatchImagesNode whose autogrow base carries ``n_sources`` wired
+        connects (the CLI's repeated-edit path), ready to feed
+        ``replace_ops`` as ``new``."""
+        from comfy_cli import workflow_ops
+
+        g = _graph()
+        wf = _autogrow_workflow()
+        wf["nodes"].append(
+            {
+                "id": 22,
+                "type": "VAEDecode",
+                "pos": [0, 200],
+                "inputs": [
+                    {"name": "samples", "type": "LATENT", "link": None},
+                    {"name": "vae", "type": "VAE", "link": None},
+                ],
+                "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+                "widgets_values": [],
+            }
+        )
+        wf["last_node_id"] = 22
+        for src in range(n_sources):
+            wf, _ = workflow_ops.connect(wf, g, 20 + src, "IMAGE", 10, "images", actor="a")
+        return wf
+
+    @staticmethod
+    def _batchimages_slots(workflow: dict) -> list[tuple[str, bool]]:
+        node = next(n for n in workflow["nodes"] if n["type"] == "BatchImagesNode")
+        return [(i["name"], i.get("link") is not None) for i in node["inputs"]]
+
+    @staticmethod
+    def _replay_ops(batch: list[dict], graph) -> dict:
+        from comfy_cli import workflow_ops
+
+        doc = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        for op in batch:
+            doc = workflow_ops.apply_op(doc, op, graph)
+        return doc
+
+    def test_replace_ops_replays_autogrow_wiring_verbatim(self):
+        """replace_ops + apply_op reproduces a contiguous autogrow canvas
+        exactly: every grown slot keeps its name and its link, no slot is
+        re-grown, and no link is dropped (the FE-compacted repeated-edit
+        shape)."""
+        from comfy_cli import workflow_ops
+
+        g = _graph()
+        new = self._autogrow_replace_canvas()
+        old = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        batch = workflow_ops.replace_ops(old, new)
+        doc = self._replay_ops(batch, g)
+        assert self._batchimages_slots(doc) == self._batchimages_slots(new)
+        assert len(doc["links"]) == len(new["links"])
+
+    def test_replace_ops_replays_a_holed_autogrow_canvas_verbatim(self):
+        """The CLI's repeated-edit numbering is sparse where the FE compacts:
+        a canvas carrying images.image0 + images.image2 with NO image1 must
+        survive a replace_ops replay byte-for-byte in its slot names — the
+        replay must neither renumber the grown slots (silent compaction the
+        CLI never performed) nor mint a gap-filled duplicate for the hole."""
+        from comfy_cli import workflow_ops
+
+        g = _graph()
+        # A faithful holed canvas: sparse NAMES, dense slot array (the FE
+        # keeps the inputs array packed; only the element numbering gaps).
+        new = {
+            "last_node_id": 22,
+            "last_link_id": 2,
+            "nodes": [
+                {
+                    "id": 10,
+                    "type": "BatchImagesNode",
+                    "pos": [200, 0],
+                    "inputs": [
+                        {"name": "images", "type": "COMFY_AUTOGROW_V3", "link": None},
+                        {"name": "images.image0", "type": "IMAGE", "link": 1},
+                        {"name": "images.image2", "type": "IMAGE", "link": 2},
+                    ],
+                    "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": []}],
+                    "widgets_values": [],
+                },
+                {
+                    "id": 20,
+                    "type": "VAEDecode",
+                    "pos": [0, 0],
+                    "inputs": [
+                        {"name": "samples", "type": "LATENT", "link": None},
+                        {"name": "vae", "type": "VAE", "link": None},
+                    ],
+                    "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": [1]}],
+                    "widgets_values": [],
+                },
+                {
+                    "id": 22,
+                    "type": "VAEDecode",
+                    "pos": [0, 200],
+                    "inputs": [
+                        {"name": "samples", "type": "LATENT", "link": None},
+                        {"name": "vae", "type": "VAE", "link": None},
+                    ],
+                    "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": [2]}],
+                    "widgets_values": [],
+                },
+            ],
+            "links": [[1, 20, 0, 10, 1, "IMAGE"], [2, 22, 0, 10, 2, "IMAGE"]],
+        }
+        old = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        batch = workflow_ops.replace_ops(old, new)
+        doc = self._replay_ops(batch, g)
+        assert self._batchimages_slots(doc) == [
+            ("images", False),
+            ("images.image0", True),
+            ("images.image2", True),
+        ]
+        assert len(doc["links"]) == len(new["links"])
+
+    @pytest.mark.xfail(
+        reason=(
+            "replace_ops mints connect spec refs as `$alias.<slot index>`, but"
+            " apply_specs re-mints each node from the live catalog, so a freshly"
+            " added BatchImagesNode has only the bare `images` input and the index"
+            " refs resolve to nothing (ValueError: input '1' not found). The spec"
+            " path of the §8.8 one-artifact/two-consumers contract cannot replay"
+            " ANY autogrow wiring — holed or contiguous. Known defect, raised for"
+            " an owner ruling; unblocks when the mint addresses grown slots in a"
+            " form the spec path can resolve."
+        ),
+        strict=True,
+    )
+    def test_replace_ops_batch_is_replayable_through_apply_specs(self):
+        """The other half of §8.8: the same array must be accepted verbatim by
+        apply_specs. The op path reproduces autogrow wiring (tests above); the
+        spec path currently discards the whole batch. Structure-only assertion:
+        every grown slot lands wired; per §8.8 the spec path reproduces the
+        STRUCTURE, so a compaction-renamed slot is acceptable there."""
+        from comfy_cli import workflow_ops
+
+        g = _graph()
+        new = self._autogrow_replace_canvas()
+        old = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+        batch = workflow_ops.replace_ops(old, new)
+        wf2, _applied, _aliases = workflow_ops.apply_specs(copy.deepcopy(old), g, batch)
+        wired = [wired for name, wired in self._batchimages_slots(wf2) if name != "images"]
+        assert wired == [True, True, True]
+        assert len(wf2["links"]) == len(new["links"])
+
     def test_p9_autogrow_grow_id_survives_api_conversion(self):
         """The ``grow_id`` bookkeeping (persisted on grown slots as their
         convergence identity) must not break API conversion — both wired sources

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -2167,7 +2167,7 @@ class TestOpModel:
         assert ops.canonical(ab) == ops.canonical(ba)
 
     # ---------------------------------------------------------------------
-    # replace_ops on autogrow canvases (BE-10726): the CLI's repeated-edit
+    # replace_ops on autogrow canvases: the CLI's repeated-edit
     # paths leave sparse numbering where the FE compacts; the bulk-writer
     # batch must round-trip both shapes.
     # ---------------------------------------------------------------------


### PR DESCRIPTION
Auto-grow repeated-edit paths: CLI holes vs FE compaction — replace_ops round-trip now pinned; found + flagged a real apply_specs gap.

<details>
<summary>Full context for agent readers</summary>

Context: [Triage BE-10726] "Auto-grow repeated-edit paths — CLI leaves holes where FE compacts; cover replace." The CLI's repeated edits on autogrow bases leave sparse slot numbering (images.image0 + images.image2, no image1) where the FE compacts naming; the row asks the replace (bulk-writer) path to be covered.

What this PR does (tests only, no runtime change):

1. Op path fidelity: replace_ops + apply_op reproduces a contiguous (FE-compacted) autogrow canvas verbatim — names, wiring, link count.
2. Holed-canvas fidelity: a faithful holed canvas (sparse NAMES, dense slot array — the FE keeps the inputs array packed, only element numbering gaps) replays verbatim. The replay neither renumbers grown slots (silent compaction the CLI never performed) nor mints a gap-filled duplicate for the hole. This pins "CLI leaves holes where FE compacts" as intentional, reproducible-through-replace behavior.
3. Found while covering: apply_specs CANNOT replay any replace_ops batch that wires an autogrow slot — holed or contiguous. replace_ops mints connect spec refs as $alias.<slot index> (_slot_ref deliberately avoids dotted names), but apply_specs re-mints each node from the live catalog, so the fresh BatchImagesNode has only the bare images input and the index refs resolve to nothing → ValueError → the whole batch discards (abort-remainder). The §8.8 "one artifact, both consumers" contract is broken for all autogrow wiring. Invisible until now: the only existing replace_ops test (test_deprecated_nodes.py::test_replace_ops_apply) used a link-less workflow. Pinned as a strict xfail rather than fixed here — changing the frozen mint semantics (e.g. base-addressed refs ordered by to_slot, which would compact holed canvases on the spec path) is an owner decision per the amendment discipline in docs/op-vocabulary-v1.md §9.

Reviewer note: assignee is christian-byrne only (quiet week through 2026-09-06 — no teammate assignees/reviewers/mentions).

</details>

## Evidence

Commands run (worker VM, comfy-cli @ origin/main 3fddc3e + this commit):

- `pytest tests/comfy_cli/command/test_workflow_edit.py -q -k "replace_ops or autogrow or p9"` → 16 passed, 1 xfailed (the strict pin, as intended)
- `pytest tests/comfy_cli/command/test_workflow_edit.py tests/comfy_cli/command/test_deprecated_nodes.py -q` → 131 passed, 1 xfailed
- `pytest tests/comfy_cli -q --ignore=tests/comfy_cli/command` → 2158 passed, 5 skipped, 1 failed — the failure is `test_file_utils.py::test_atomic_write_text_new_file_uses_umask_default`, verified failing identically on a clean origin/main worktree on this host (worker umask baseline, pre-existing, unrelated)
- `ruff check` + `ruff format --check` on the touched file → clean
- Spec-path defect reproduced directly: `apply_specs` of a replace_ops batch wiring 3 autogrow connects raises `ValueError: input '1' not found on node …; inputs: ['images']` and discards the batch; `apply_op` of the same batch wires all 3 slots with names verbatim.

<!-- authored-by:agent lane-ext-70-2224 -->
