### PR TITLE
fix(cql): shape-check the definitions/subgraphs containers before reading them

### DIFF
--- a/comfy_cli/command/templates.py
+++ b/comfy_cli/command/templates.py
@@ -1621,10 +1621,12 @@ def _workflow_node_types(workflow: Any) -> set[str]:
         return types
     if isinstance(workflow.get("nodes"), list):
         node_lists = [workflow.get("nodes") or []]
-        subgraphs = (workflow.get("definitions") or {}).get("subgraphs") or []
-        for sg in subgraphs:
-            if isinstance(sg, dict):
-                node_lists.append(sg.get("nodes") or [])
+        definitions = workflow.get("definitions")
+        subgraphs = definitions.get("subgraphs") if isinstance(definitions, dict) else None
+        if isinstance(subgraphs, list):
+            for sg in subgraphs:
+                if isinstance(sg, dict):
+                    node_lists.append(sg.get("nodes") or [])
         for nodes in node_lists:
             for node in nodes:
                 if isinstance(node, dict) and isinstance(node.get("type"), str):

--- a/comfy_cli/cql/engine.py
+++ b/comfy_cli/cql/engine.py
@@ -2794,8 +2794,18 @@ def _subgraph_defs_by_id(workflow: dict) -> dict[str, dict]:
     always wins. We still register ``name`` as a *fallback* key (only when it
     doesn't shadow an id and isn't ambiguous across defs) to support older
     name-typed templates that predate UUID ids.
+
+    Containers that are not a ``dict``/``list`` read as "no definitions", so a
+    corrupt file degrades to an empty index rather than raising (a truthy
+    non-dict ``definitions`` or non-list ``subgraphs``) or walking a string
+    per-character.
     """
-    defs = (workflow.get("definitions") or {}).get("subgraphs") or []
+    definitions = workflow.get("definitions")
+    if not isinstance(definitions, dict):
+        return {}
+    defs = definitions.get("subgraphs")
+    if not isinstance(defs, list):
+        return {}
     by_id: dict[str, dict] = {}
     name_counts: dict[str, int] = {}
     name_first: dict[str, dict] = {}
@@ -3493,11 +3503,14 @@ def _count_instances(workflow: dict, def_id: str) -> int:
     for n in workflow.get("nodes") or []:
         if isinstance(n, dict) and str(n.get("type", "")) == def_id:
             count += 1
-    for sg in (workflow.get("definitions") or {}).get("subgraphs") or []:
-        if isinstance(sg, dict):
-            for n in sg.get("nodes") or []:
-                if isinstance(n, dict) and str(n.get("type", "")) == def_id:
-                    count += 1
+    definitions = workflow.get("definitions")
+    subgraphs = definitions.get("subgraphs") if isinstance(definitions, dict) else None
+    if isinstance(subgraphs, list):
+        for sg in subgraphs:
+            if isinstance(sg, dict):
+                for n in sg.get("nodes") or []:
+                    if isinstance(n, dict) and str(n.get("type", "")) == def_id:
+                        count += 1
     return count
 
 

--- a/tests/comfy_cli/command/test_templates.py
+++ b/tests/comfy_cli/command/test_templates.py
@@ -1517,3 +1517,32 @@ def test_ls_self_heals_from_a_cache_poisoned_by_an_older_build(cache_file, monke
     assert result.exit_code == 0, result.output
     assert _envelope(result.output)["data"]["total_in_gallery"] > 0
     assert json.loads(cache_file.read_bytes()) == FIXTURE  # healed on disk too
+
+
+# ---------------------------------------------------------------------------
+# _workflow_node_types — corrupt definitions containers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "definitions",
+    [5, "definitions", ["x"], {"subgraphs": 5}, {"subgraphs": "abc"}],
+    ids=["int", "str", "list", "non-list-subgraphs", "str-subgraphs"],
+)
+def test_workflow_node_types_tolerates_corrupt_definitions(definitions):
+    """A wrong-typed ``definitions``/``subgraphs`` reads as "no definitions".
+
+    ``or`` only replaced falsy values, so a truthy wrong-typed one reached
+    ``.get``/the loop and raised. Top-level nodes are still collected.
+    """
+    wf = {"nodes": [{"id": 1, "type": "KSampler"}], "definitions": definitions}
+    assert templates_cmd._workflow_node_types(wf) == {"KSampler"}
+
+
+def test_workflow_node_types_still_reads_well_formed_subgraph_nodes():
+    """Positive control: the shape checks must not cost the happy path."""
+    wf = {
+        "nodes": [{"id": 1, "type": "KSampler"}],
+        "definitions": {"subgraphs": [{"id": "u1", "nodes": [{"id": 9, "type": "CLIPTextEncode"}]}]},
+    }
+    assert templates_cmd._workflow_node_types(wf) == {"KSampler", "CLIPTextEncode"}

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -1040,3 +1040,39 @@ class TestRoutingErrorEnvelope:
         path = _write_workflow(tmp_path, _direct_workflow())
         env = _run(["slots", str(path), "--input", str(oi)], capsys)
         assert env["ok"] is True, env
+
+
+class TestSlotsCorruptDefinitions:
+    """End-to-end: a corrupt ``definitions`` block must still yield an envelope.
+
+    Before the shape checks in ``_subgraph_defs_by_id`` these two shapes exited
+    ``comfy workflow slots`` on a rich traceback (``AttributeError`` /
+    ``TypeError``) with NOTHING on stdout — the JSON caller saw a hard crash
+    instead of a parseable result. ``slots_cmd``'s ``except (ValueError,
+    KeyError)`` does not catch either, and there is no catch-all above it.
+    """
+
+    @pytest.mark.parametrize(
+        "definitions",
+        [5, {"subgraphs": 5}, {"subgraphs": "abc"}, ["x"]],
+        ids=["non-dict-definitions", "non-list-subgraphs", "str-subgraphs", "list-definitions"],
+    )
+    def test_slots_degrades_to_an_empty_index(self, patched_graph, tmp_path, capsys, definitions):
+        path = _write_workflow(tmp_path, {"nodes": [], "links": [], "definitions": definitions})
+        captured, _err, result = _invoke(["slots", str(path)], capsys)
+        assert result.exception is None, f"crashed instead of degrading: {result.exception!r}"
+        assert result.exit_code == 0, captured
+        env = json.loads([ln for ln in captured.strip().splitlines() if ln.strip()][-1])
+        assert env["ok"] is True
+        assert env["data"]["count"] == 0
+        assert env["data"]["slots"] == []
+
+    def test_top_level_nodes_are_still_read_past_a_corrupt_definitions_block(self, patched_graph, tmp_path, capsys):
+        """Degrading is not the same as giving up: only the definitions block is
+        unreadable, so the top-level graph's slots must still come back."""
+        wf = dict(_direct_workflow(), definitions=5)
+        path = _write_workflow(tmp_path, wf)
+        env = _run(["slots", str(path)], capsys)
+        assert env["ok"] is True
+        assert env["data"]["count"] > 0
+        assert "6.text" in {s["address"] for s in env["data"]["slots"]}

--- a/tests/comfy_cli/command/test_workflow_slots.py
+++ b/tests/comfy_cli/command/test_workflow_slots.py
@@ -1045,11 +1045,12 @@ class TestRoutingErrorEnvelope:
 class TestSlotsCorruptDefinitions:
     """End-to-end: a corrupt ``definitions`` block must still yield an envelope.
 
-    Before the shape checks in ``_subgraph_defs_by_id`` these two shapes exited
-    ``comfy workflow slots`` on a rich traceback (``AttributeError`` /
-    ``TypeError``) with NOTHING on stdout — the JSON caller saw a hard crash
-    instead of a parseable result. ``slots_cmd``'s ``except (ValueError,
-    KeyError)`` does not catch either, and there is no catch-all above it.
+    Before the shape checks in ``_subgraph_defs_by_id`` a truthy wrong-typed
+    container exited ``comfy workflow slots`` on a rich traceback
+    (``AttributeError`` on ``definitions``, ``TypeError`` on ``subgraphs``)
+    with NOTHING on stdout — the JSON caller saw a hard crash instead of a
+    parseable result. ``slots_cmd``'s ``except (ValueError, KeyError)`` does
+    not catch either, and there is no catch-all above it.
     """
 
     @pytest.mark.parametrize(
@@ -1076,3 +1077,14 @@ class TestSlotsCorruptDefinitions:
         assert env["ok"] is True
         assert env["data"]["count"] > 0
         assert "6.text" in {s["address"] for s in env["data"]["slots"]}
+
+    def test_set_slot_reports_a_domain_error_instead_of_crashing(self, patched_graph, tmp_path, capsys):
+        """``set-slot`` reaches the same helper before any of its own guards, so
+        it crashed on the same input. It should now fail on the real problem —
+        the address doesn't resolve — through the normal error envelope."""
+        path = _write_workflow(tmp_path, {"nodes": [], "links": [], "definitions": {"subgraphs": 5}})
+        _captured, _err, result = _invoke(["set-slot", str(path), "3.seed=1"], capsys)
+        assert result.exception is None or isinstance(result.exception, SystemExit), repr(result.exception)
+        env = _run(["set-slot", str(path), "3.seed=1"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "workflow_slot_invalid"

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -4412,6 +4412,10 @@ class TestSubgraphDefsByIdShapeChecks:
         assert _subgraph_defs_by_id({"nodes": [], "definitions": None}) == {}
         assert _subgraph_defs_by_id({"nodes": [], "definitions": {}}) == {}
         assert _subgraph_defs_by_id({"nodes": [], "definitions": {"subgraphs": []}}) == {}
+        # A top-level ``subgraphs`` with no ``definitions`` wrapper is not the
+        # block this helper reads; it must not be picked up by accident.
+        assert _subgraph_defs_by_id({"subgraphs": {"a": 1}}) == {}
+        assert _subgraph_defs_by_id({"subgraphs": [{"id": "u1"}]}) == {}
 
     def test_well_formed_definitions_still_index_by_id_and_name(self):
         """Positive control: the shape checks must not cost the happy path."""

--- a/tests/comfy_cli/cql/test_engine.py
+++ b/tests/comfy_cli/cql/test_engine.py
@@ -17,7 +17,9 @@ from comfy_cli.cql.engine import (
     Graph,
     Port,
     _apply_one_slot,
+    _count_instances,
     _extract_frontend_slots,
+    _subgraph_defs_by_id,
     _write_widget,
 )
 
@@ -4364,3 +4366,79 @@ class TestUnreachableNodeIsVisible:
         assert any(e["code"] == "prompt_no_outputs" for e in result["errors"])
         warns = [w for w in result["warnings"] if w["code"] == "node_not_reachable_from_output"]
         assert warns == [], "prompt_no_outputs already says it; don't pile on"
+
+
+# ---------------------------------------------------------------------------
+# _subgraph_defs_by_id / _count_instances — corrupt definitions containers
+# ---------------------------------------------------------------------------
+
+
+class TestSubgraphDefsByIdShapeChecks:
+    """A hand-edited or truncated save can put anything under ``definitions``.
+
+    The old ``(workflow.get("definitions") or {}).get("subgraphs") or []`` only
+    replaced FALSY values, so a truthy wrong-typed one survived and crashed the
+    caller (``comfy workflow slots`` exited on a traceback with no envelope).
+    The agreed degradation is an empty index: a document with no readable
+    definitions has no subgraph instances to resolve, and every caller already
+    handles ``{}``.
+    """
+
+    @pytest.mark.parametrize(
+        "definitions",
+        [5, "definitions", ["x"], 0.0, True],
+        ids=["int", "str", "list", "float", "bool"],
+    )
+    def test_non_dict_definitions_reads_as_no_definitions(self, definitions):
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": definitions}) == {}
+
+    @pytest.mark.parametrize(
+        "subgraphs",
+        [5, {"a": 1}, 3.5, True],
+        ids=["int", "dict", "float", "bool"],
+    )
+    def test_non_list_subgraphs_reads_as_no_definitions(self, subgraphs):
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": {"subgraphs": subgraphs}}) == {}
+
+    def test_string_subgraphs_is_not_walked_per_character(self):
+        """A string is iterable, so a naive guard silently walks it character by
+        character. It happens to yield ``{}`` too (single chars aren't dicts),
+        so this case documents INTENT: the isinstance branch must reject the
+        string outright rather than arrive at ``{}`` by accident."""
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": {"subgraphs": "abc"}}) == {}
+
+    def test_missing_containers_still_read_as_empty(self):
+        assert _subgraph_defs_by_id({"nodes": []}) == {}
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": None}) == {}
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": {}}) == {}
+        assert _subgraph_defs_by_id({"nodes": [], "definitions": {"subgraphs": []}}) == {}
+
+    def test_well_formed_definitions_still_index_by_id_and_name(self):
+        """Positive control: the shape checks must not cost the happy path."""
+        wf = {"definitions": {"subgraphs": [{"id": "u1", "name": "A", "nodes": []}]}}
+        by_id = _subgraph_defs_by_id(wf)
+        assert by_id["u1"] is wf["definitions"]["subgraphs"][0]
+        assert by_id["A"] is wf["definitions"]["subgraphs"][0], "unambiguous name stays a fallback key"
+
+    def test_non_dict_entries_are_still_skipped(self):
+        """The per-entry guard is unchanged: junk beside a real def is dropped,
+        the real def is kept."""
+        wf = {"definitions": {"subgraphs": ["junk", None, 7, {"id": "u1", "name": "A", "nodes": []}]}}
+        assert set(_subgraph_defs_by_id(wf)) == {"u1", "A"}
+
+
+class TestCountInstancesShapeChecks:
+    def test_non_dict_definitions_counts_top_level_only(self):
+        wf = {"nodes": [{"id": 1, "type": "u1"}], "definitions": 5}
+        assert _count_instances(wf, "u1") == 1
+
+    def test_non_list_subgraphs_counts_top_level_only(self):
+        wf = {"nodes": [{"id": 1, "type": "u1"}], "definitions": {"subgraphs": "abc"}}
+        assert _count_instances(wf, "u1") == 1
+
+    def test_well_formed_definitions_still_count_interior_instances(self):
+        wf = {
+            "nodes": [{"id": 1, "type": "u1"}],
+            "definitions": {"subgraphs": [{"id": "u2", "nodes": [{"id": 9, "type": "u1"}]}]},
+        }
+        assert _count_instances(wf, "u1") == 2


### PR DESCRIPTION
## ELI-5

A workflow file can say `"definitions": 5` — nonsense, but valid JSON. The code that reads the subgraph definitions out of a workflow used `or` to supply a default, and `or` only kicks in for *falsy* values, so a garbage-but-truthy one sailed straight through into code that assumed a dict and a list. `comfy workflow slots` then died on a Python traceback with nothing on stdout, which for a `--json` caller is indistinguishable from the CLI being broken. This swaps the `or` for explicit type checks: a container that isn't the right shape now reads as "there are no definitions here", so the command returns an ordinary empty-result envelope instead of crashing.

## Description

`_subgraph_defs_by_id` (`comfy_cli/cql/engine.py`) read the block with:

```python
defs = (workflow.get("definitions") or {}).get("subgraphs") or []
```

`or` replaces only falsy values, so three wrong-typed shapes survived it:

| input | old behavior |
| --- | --- |
| `"definitions": 5` | `AttributeError: 'int' object has no attribute 'get'` |
| `"definitions": {"subgraphs": 5}` | `TypeError: 'int' object is not iterable` |
| `"definitions": {"subgraphs": "abc"}` | iterated the string per character, silently returned `{}` |

That helper is the **first statement** of `_extract_frontend_slots`, so it runs before any of the calling commands' own validation. `_load_workflow_or_fail` (`comfy_cli/command/workflow.py`) only checks that `nodes` is a list, `slots_cmd`'s `except (ValueError, KeyError)` catches neither exception, and `cmdline.main()` has no catch-all — so the CLI exited on a rich traceback with **nothing on stdout**.

The fix binds each container and `isinstance`-checks it, mirroring `_collect_subgraph_defs` in `comfy_cli/workflow_to_api.py`, which already does exactly this. A container that is not a `dict`/`list` reads as "no definitions" and the caller gets an empty index — the degradation every caller already handles, since a document with no readable definitions has no subgraph instances to resolve. The per-entry `if not isinstance(sg, dict): continue` and the id/name indexing are untouched.

The same `or` idiom appeared at two more sites reading the same block; both get the guard the repo already uses at `templates.py:1245` / `workflow.py:554`:

- `_count_instances` (`comfy_cli/cql/engine.py`)
- `_workflow_node_types` (`comfy_cli/command/templates.py`)

Deliberately **not** changed, per the ticket: `_load_workflow_or_fail` stays as-is and no new error code is added. Well-formed workflows are unaffected — the checks pass and the code proceeds exactly as before.

## How has this been tested?

**Reproduced on the base commit first**, then re-run after the fix, with the exact command from the report:

```
comfy --json workflow slots <corrupt>.json --input tests/comfy_cli/fixtures/sd15_ui_workflow.json
```

| workflow | before (base `0343f505`) | after |
| --- | --- | --- |
| `{"nodes": [], "links": [], "definitions": 5}` | traceback, `AttributeError`, no stdout | `exit 0`, `ok: true`, `count: 0`, `slots: []` |
| `{... "definitions": {"subgraphs": 5}}` | traceback, `TypeError`, no stdout | `exit 0`, `ok: true`, `count: 0`, `slots: []` |
| `{... "definitions": {"subgraphs": "abc"}}` | `{}` via a per-character walk | `{}` via the isinstance branch |

I also exercised the other reachable commands the report names, on the same corrupt inputs. `set-slot` and `vary` crashed identically on the base commit (`AttributeError` / `TypeError`) and now return a normal error envelope for the real problem (`workflow_slot_invalid: node 3 not found in workflow`). `notes` and `ls-nodes` already tolerated these shapes and still do.

New automated coverage:

- `tests/comfy_cli/cql/test_engine.py` — `TestSubgraphDefsByIdShapeChecks` / `TestCountInstancesShapeChecks`: non-dict `definitions` (int/str/list/float/bool), non-list `subgraphs` (int/dict/float/bool), the string case with its intent documented, a top-level `subgraphs` with no `definitions` wrapper, plus positive controls that a well-formed file still indexes by id **and** by unambiguous name and that non-dict entries beside a real def are still skipped.
- `tests/comfy_cli/command/test_templates.py` — `_workflow_node_types` over the same corrupt shapes, plus a positive control that interior subgraph node types are still collected.
- `tests/comfy_cli/command/test_workflow_slots.py` — `TestSlotsCorruptDefinitions`: end-to-end `workflow slots`, asserting `result.exception is None`, exit 0, and a success envelope with `count == 0` / `slots == []`; one test that a corrupt `definitions` block does **not** suppress the top-level graph's own slots; and one that `set-slot` reaches a domain error rather than a crash.

**These tests are not vacuous:** reverting only the two source files leaves 16 of them failing.

## Judgment calls

- **The degradation is silent on `slots`.** That is the behavior the report specifies, and `_load_workflow_or_fail` is explicitly out of scope, so no warning is emitted here. `comfy workflow print` already surfaces `workflow: ignoring non-object definitions block` for the same shape, so the "your definitions block is junk" signal does exist elsewhere in the CLI.
- **Where the end-to-end test lives.** The report suggested `test_workflow_edit.py` "or wherever `slots_cmd` is exercised"; `test_workflow_slots.py` is that file, and its convention is a patched graph rather than `--input`, so the test follows the file. The literal `--input` invocation is covered by the manual run above.
- **Open PR #740.** The report warned it renames the loop variable on the `_count_instances` line and that a rebase might be needed. As of writing, #740 is still open and its diff does not touch any `subgraphs` line, so there is no overlap today; it does touch the same three files, so a textual conflict on merge order is still possible.
- **`isinstance(True, dict)` is `False`,** so a bool `definitions` reads as "no definitions" rather than as a mapping. Covered by a test; it is the same answer the reference implementation in `workflow_to_api.py` gives.
- This change removes no capability: it converts an uncaught traceback into the empty result the callers already handle, and adds no denial, no new refusal string, and no new failure path.

## Residual

**Two of the ten `definitions` reads in `comfy_cli/` are still unguarded, and both still crash on the same input.** I swept every `get("definitions")` in the package: 10 sites, 5 already using the explicit `isinstance` pattern (`workflow_print.py`, `workflow_to_api.py`, `workflow_ops.py:1143`, `templates.py:1245`, `workflow.py:554`), 5 using the `or` idiom. This PR fixes the 3 the report names. The remaining 2 are outside its scope and are **not** fixed here:

- `comfy_cli/workflow_ops.py:1441` in `capture_recipe` — `if (workflow.get("definitions") or {}).get("subgraphs"):`
- `comfy_cli/workflow_ops.py:2347` in `canonical` — `defs = (w.get("definitions") or {}).get("subgraphs")`

Verified on this branch: both raise `AttributeError: 'int' object has no attribute 'get'` on `{"nodes": [], "links": [], "definitions": 5}`. Neither is reached by `slots` / `set-slot` / `vary`, which is why they are not in the reported repro; each is a one-line application of the same guard plus one test, and they would leave zero unguarded readers of the block. I did not trace which CLI surfaces reach `capture_recipe` and `canonical` with attacker- or user-supplied JSON, so the severity of those two is unassessed rather than assessed-as-low.

Also unexercised: the source investigation's full trace and its findings comment are not readable from this environment, so the crash characterization above rests on my own reproduction against `origin/main` rather than on that record. The 12 call sites in `workflow_ops.py` and the one in `cql/promoted.py` that the report lists as calling `_subgraph_defs_by_id` unguarded are fixed transitively by the helper returning `{}` instead of raising; I exercised that through `slots`/`set-slot`/`vary` and the unit tests, not through each of the 13 individually.

## Documentation

None needed — no user-facing surface, flag, or output schema changes. The behavior contract is recorded in the `_subgraph_defs_by_id` docstring.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `ruff check .` — All checks passed; `ruff format --check .` — 447 files already formatted; `pytest tests/comfy_cli/cql/test_engine.py tests/comfy_cli/command/test_workflow_slots.py tests/comfy_cli/command/test_templates.py` — 387 passed, 0 failed (and 16 failures when the two source files are reverted, confirming the tests bite); full `pytest` — 7420 passed, 38 skipped, **1 pre-existing failure unrelated to this change** (`test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots`, which fails identically on `origin/main` with this branch's source reverted); base-commit reproduction and post-fix re-run of the reported CLI command, and of `set-slot`/`vary`/`notes`/`ls-nodes`, on all three corrupt shapes
- **Deviations:** the two optional sites in the plan are included; the two additional unguarded sites found by the sweep are left unfixed and recorded under `## Residual`
