### PR TITLE
fix(assets): error on a non-object 2xx body from `assets library ensure`

### DIFF
--- a/comfy_cli/command/assets_library.py
+++ b/comfy_cli/command/assets_library.py
@@ -123,10 +123,24 @@ def ensure_cmd(
             resource_id=hash,
         ) from e
 
-    b = body or {}
+    # Unlike `ls`, an EMPTY body is an error here, not an empty result: a POST
+    # cannot confirm the borrow without one, and the server contract
+    # (`AssetCreated`) always returns an object. `http_request` also collapses
+    # an unparseable body (an HTML error page from a proxy, say) to `None`, so
+    # `NoneType` covers both — otherwise they emit `{"ok": true}` with a null id
+    # and the caller's own hash echoed back as if the borrow had happened.
+    if not isinstance(body, dict):
+        renderer.error(
+            code="cloud_http_error",
+            message="unexpected response from /api/assets/from-hash (expected a JSON object describing the asset)",
+            hint="the borrow could not be confirmed; retry, and check whether a proxy is intercepting the request",
+            details={"operation": "ensure", "hash": hash, "got_type": type(body).__name__},
+        )
+        raise typer.Exit(code=1)
+
     payload = {
-        "id": b.get("id"),
-        "hash": b.get("hash", hash),
+        "id": body.get("id"),
+        "hash": body.get("hash", hash),
         "created_new": status == 201,
     }
     renderer.emit(payload, command="assets library ensure", where="cloud")

--- a/tests/comfy_cli/command/test_assets_library.py
+++ b/tests/comfy_cli/command/test_assets_library.py
@@ -89,6 +89,35 @@ def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, outcome):
     return calls
 
 
+def _patch_urlopen_raw(monkeypatch: pytest.MonkeyPatch, raw: bytes, status: int = 201):
+    """Serve ``raw`` verbatim, unlike ``_patch_urlopen`` which JSON-encodes it.
+
+    Needed for the bodies a real proxy/gateway returns — an HTML error page,
+    nothing at all — which never survive a ``json.dumps`` round trip.
+    """
+    calls: list[dict] = []
+
+    class _Resp:
+        def __init__(self):
+            self.status = status
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, n=None):
+            return raw
+
+    def _fake(req, timeout=None):
+        calls.append({"url": req.full_url, "method": req.get_method(), "body": req.data})
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake)
+    return calls
+
+
 class TestEnsure:
     def test_404_is_asset_not_found_not_workflow_not_found(self, cloud_target, monkeypatch, capsys):
         _patch_urlopen(monkeypatch, _http_error(404))
@@ -104,6 +133,44 @@ class TestEnsure:
         assert "workflow list" not in err["hint"]
         assert err["details"]["hash"] == "comfyorg_logo.png"
         assert err["details"]["operation"] == "ensure"
+
+    def test_non_object_body_is_cloud_http_error(self, cloud_target, monkeypatch, capsys):
+        # Pre-fix: `AttributeError: 'list' object has no attribute 'get'` and no envelope at all.
+        _patch_urlopen(monkeypatch, [1, 2, 3])
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+        assert env["error"]["details"]["got_type"] == "list"
+        assert env["error"]["details"]["operation"] == "ensure"
+        assert "created_new" not in json.dumps(env)
+
+    def test_unparseable_body_is_cloud_http_error_not_fake_success(self, cloud_target, monkeypatch, capsys):
+        # Pre-fix: `{"ok": true, "data": {"id": null, "hash": <the caller's own hash>, "created_new": true}}`
+        # — a borrow the server never confirmed, reported as done.
+        _patch_urlopen_raw(monkeypatch, b"<html><body>502 Bad Gateway</body></html>")
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+        assert "created_new" not in json.dumps(env)
+
+    def test_empty_body_is_cloud_http_error(self, cloud_target, monkeypatch, capsys):
+        # A POST with no body cannot confirm the borrow: unlike `ls`, empty is an error here.
+        _patch_urlopen_raw(monkeypatch, b"", status=200)
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+        assert "created_new" not in json.dumps(env)
+
+    def test_whitespace_body_is_cloud_http_error(self, cloud_target, monkeypatch, capsys):
+        _patch_urlopen_raw(monkeypatch, b"\n")
+        env = _run(["ensure", "--hash", "a" * 64, "--where", "cloud"], capsys)
+        assert env["ok"] is False
+        assert env["error"]["code"] == "cloud_http_error"
+        assert error_codes.is_registered(env["error"]["code"])
+        assert "created_new" not in json.dumps(env)
 
     def test_401_is_still_cloud_unauthorized(self, cloud_target, monkeypatch, capsys):
         _patch_urlopen(monkeypatch, _http_error(401))


### PR DESCRIPTION
## ELI-5

`comfy assets library ensure --hash <h>` asks the cloud to hand you a copy of an asset it already stores, and then prints a JSON envelope saying whether you now own it. It read the server's reply as a dictionary without ever checking that it *was* one. So when the reply was a JSON array, an HTML error page from a proxy, or nothing at all, the command either crashed with a raw `AttributeError` and printed no envelope, or — worse — printed `{"ok": true, ...}` with a null id and the caller's own input hash echoed back, claiming a borrow the server never confirmed. This adds a shape check before the read, so those replies now produce a proper `cloud_http_error` envelope and exit 1.

## What changed

`comfy_cli/command/assets_library.py`, `ensure_cmd` only. Replaced `b = body or {}` with an unconditional `isinstance(body, dict)` guard that emits the already-registered `cloud_http_error` (`comfy_cli/error_codes.py`) with `details.got_type`, then `raise typer.Exit(code=1)`. The success path reads `body` directly afterwards. `created_new` is still `status == 201`, untouched. No schema change (`id` is already nullable, and the error envelope has its own schema).

Unlike `ls`, an EMPTY body is an error here rather than an empty result — a POST cannot confirm the borrow without one, and the server contract (`AssetCreated`) always returns an object. `http_request` collapses both an empty body and an unparseable one to `None`, so the single `NoneType` case covers both rows; there is a comment in the code saying so.

`tests/comfy_cli/command/test_assets_library.py`: added `_patch_urlopen_raw` (serves bytes verbatim, unlike `_patch_urlopen` which JSON-encodes) and four `TestEnsure` cases — non-object, unparseable HTML, empty, whitespace-only. `test_success_reports_id_hash_and_created_new` is unchanged and still green.

## Reproduction, before and after

Driven through the real CLI entrypoint (`assets_library.app` under `CliRunner`, JSON mode) against a stubbed `urllib.request.urlopen`, on `origin/main` at `0343f505` and again on this branch:

| body served (2xx) | before | after |
| --- | --- | --- |
| `[1, 2, 3]` | `AttributeError: 'list' object has no attribute 'get'`, no envelope on stdout | `ok: false`, `cloud_http_error`, `got_type: "list"` |
| `<html><body>502 Bad Gateway</body></html>` | `{"ok": true, "data": {"id": null, "hash": <caller's own hash>, "created_new": true}}` | `ok: false`, `cloud_http_error`, `got_type: "NoneType"` |
| `` (empty, status 200) | `{"ok": true, "data": {"id": null, ..., "created_new": false}}` | `ok: false`, `cloud_http_error`, `got_type: "NoneType"` |
| `\n` | `{"ok": true, "data": {"id": null, ..., "created_new": true}}` | `ok: false`, `cloud_http_error`, `got_type: "NoneType"` |

The first three rows match the reported evidence exactly.

## On the deny path this adds

This PR's user-facing outcome denies a previously-"working" outcome, so it gets the falsification check rather than an assertion that the old behaviour was wrong. The denied capability is "report `ensure` as succeeded from a non-object 2xx body", and it was empirically attempted through the only path the product offers — the CLI command itself, all four body shapes, above. Every pre-fix "success" carries `id: null` and a `hash` that is just the caller's own `--hash` argument reflected back; `body.get("id")` is the sole source of the asset id in this command and it is `None` in all four rows, so nothing in the codebase derives a confirmed borrow from those bodies. The pre-fix output was fabricated, not a capability this removes. A well-formed JSON object body is completely unaffected — `test_success_reports_id_hash_and_created_new` pins that.

## Adjacent code swept and NOT changed

Sizing the fix meant sweeping every consumer of a parsed cloud response body, so here is the count for the portion this PR does not fix: `cloud_http.http_request` has **2** call sites — `ensure_cmd` (fixed here) and `ls_cmd` (line 59, still unhardened on `main`, owned by the in-flight PR #847 and out of scope per the scope guard). `comfy_cli/command/workflow.py` uses its own already-hardened `_http_request` at **4** call sites; **3** shape-guard the body, and **1** does not — `workflow save` (line ~1520) tolerates a non-dict 2xx and emits `ok: true` with `workflow_id: null`, the same fake-success shape, in a different command family. `comfy_cli/deploy_assets.py` also POSTs to `assets/from-hash` (line 209) and **already** guards with `isinstance(parsed, dict)`, so it has no equivalent defect.

## Residual

- **The `strict_json` / `ResponseUnparseable` half was deliberately not done.** The plan this PR implements makes it conditional on PR #847 having merged; it has not (still open), and `cloud_http.http_request` has no `strict_json` parameter and no `ResponseUnparseable` on `main` today. The shape guard covers the unparseable row without it, because `http_request` collapses an unparseable body to `None` and `None` is never a valid `ensure` result — but the *message* on that row says "expected a JSON object" rather than distinguishing "the body was not valid JSON". Worth a follow-up once #847 lands: add the `strict_json=True` call plus an `except ResponseUnparseable` arm so a proxy-intercepted response gets its own message and captive-portal hint.
- **`ls_cmd` still has the identical defect on `main`.** `(body or {}).get("assets")` at `comfy_cli/command/assets_library.py:63` raises `AttributeError` on a JSON-array 2xx exactly as `ensure` did. It is explicitly out of scope here (PR #847 owns it) and this PR does not touch it — but if #847 is abandoned or descoped, that line stays broken on the same endpoint family and needs the same guard.
- **An empty JSON object `{}` still emits `ok: true` with a null id.** `b"{}"` passes the `isinstance(body, dict)` check, so `ensure` reports `{"id": null, "hash": <caller's own hash>, "created_new": true}` — the same unconfirmable-borrow shape the HTML/empty rows produced, one layer in. Verified against this branch. The guard is written exactly as specified (shape only, no `id`-presence check) and step 3 of the plan says to emit `body.get("id")` as-is, so tightening it to require a non-null `id` would invent a stricter contract than either the ticket or the `AssetCreated` schema states. Left as-is deliberately; it is the natural next increment if the server can ever return a bodyless-but-well-formed object.
- **`workflow save` has the same fake-success shape and is untouched** — see the sweep above. Different command family, not part of this change's scope.
- **No live `/api/assets/from-hash` endpoint was exercised.** All verification is against a stubbed `urllib.request.urlopen` driving the real command; no Comfy Cloud credentials or live cloud calls were used, by design (calling the real endpoint would mint assets — a mutating action). The claim that the server contract always returns an object is taken from the `AssetCreated` schema as described in the plan, not confirmed against a running server.
- **One unrelated pre-existing test failure on the branch**, `tests/comfy_cli/test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots`. Confirmed identical on a stashed tree at `origin/main` `0343f505`, i.e. it fails without this diff and is not caused by it.
- **Merge-conflict warning with PR #847:** both PRs add a `_patch_urlopen_raw` helper to `tests/comfy_cli/command/test_assets_library.py`, and #847 also touches the imports in `comfy_cli/command/assets_library.py`. Whichever lands second should drop its duplicate helper rather than renaming it.

## Provenance

- **Authored by:** agent-work loop
- **Verified:** `uv run --all-extras pytest tests/comfy_cli/command/test_assets_library.py -q` → 7 passed; `uv run --all-extras pytest tests -q` → 7396 passed, 38 skipped, 1 failed (`test_http.py::test_an_unloadable_supplement_falls_through_to_the_platform_roots`, pre-existing on `origin/main`, confirmed by re-running it on a stashed tree); `uv run --all-extras ruff check comfy_cli tests` → all checks passed; `uv run --all-extras ruff format --check comfy_cli tests` → 447 files already formatted; before/after reproduction of all four body shapes through the CLI entrypoint, table above.
- **Deviations:** the `strict_json=` / `ResponseUnparseable` step was skipped because PR #847 has not merged and neither symbol exists on `main` — the plan makes that step conditional on exactly this and states the shape guard suffices without it. See `## Residual` for that and for the three adjacent defects left unfixed.
