### PR TITLE
feat(build): delete one release, and name the refusals an agent can clear (BE-12349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ history.
 
 ### Added
 
-- `comfy build release delete [RELEASE]` deletes one release, freeing the slot it
-  held against the workspace's release limit. It confirms first (`--yes` skips
+- `comfy build release delete RELEASE` deletes the named release, freeing the slot
+  it held against the workspace's release limit. It confirms first (`--yes` skips
   the prompt, `build_release_delete_needs_confirm` refuses a caller that cannot
-  answer one), takes the current Build's newest release when RELEASE is omitted,
-  and is idempotent.
+  answer one), and repeating the same id is safe: the builder answers success
+  again for a release already deleted.
 - Three builder refusals an agent can act on now arrive under their own error
   codes instead of the one `build_builder_error` envelope: `build_release_limit`
   (the workspace holds as many releases as its limit allows),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ history.
   (the workspace holds as many releases as its limit allows),
   `build_release_in_use` and `build_in_use` (a deployment still references the
   release, or one of the build's releases). The builder's message is carried
-  whole, so the blocking deployment ids it names are no longer lost to the
-  1000-byte cap on the raw body.
+  whole up to 8 KiB, so the blocking deployment ids it names are no longer lost
+  to the 1000-byte cap on the raw body.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ history.
 
 ## [Unreleased]
 
+### Added
+
+- `comfy build release delete [RELEASE]` deletes one release, freeing the slot it
+  held against the workspace's release limit. It confirms first (`--yes` skips
+  the prompt, `build_release_delete_needs_confirm` refuses a caller that cannot
+  answer one), takes the current Build's newest release when RELEASE is omitted,
+  and is idempotent.
+- Three builder refusals an agent can act on now arrive under their own error
+  codes instead of the one `build_builder_error` envelope: `build_release_limit`
+  (the workspace holds as many releases as its limit allows),
+  `build_release_in_use` and `build_in_use` (a deployment still references the
+  release, or one of the build's releases). The builder's message is carried
+  whole, so the blocking deployment ids it names are no longer lost to the
+  1000-byte cap on the raw body.
+
 ### Fixed
 
 - `comfy install --fast-deps --nvidia` no longer installs a torch that its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ history.
 
 ### Fixed
 
+- A failed blob upload during `comfy build push` no longer writes the presigned
+  PUT URL's query string to stdout, into the JSON envelope, or into a CI log.
+  Both a rejected upload and a dropped connection quote the URL they were talking
+  to, and for a presigned GCS PUT that query string is a live credential
+  (`X-Goog-Credential`, `X-Goog-Signature`). The host and path are kept, so the
+  failure still says what it failed to reach.
 - `comfy install --fast-deps --nvidia` no longer installs a torch that its
   torchvision was not built against, which made ComfyUI fail to import with
   `RuntimeError: operator torchvision::nms does not exist`. The GPU override

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -237,11 +237,13 @@ class BuilderClient:
         it held against the workspace's release limit. Idempotent (204 even when
         already gone); the builder returns 409 while any deployment in the
         workspace still references it, a stopped one included."""
-        # Validate + encode the id so it stays a single terminal path segment.
-        # ``Target.url`` only ``strip('/')``s each part, so an empty id would
-        # collapse this DELETE onto the collection and an id carrying ``/`` or
-        # ``..`` would aim it, through any normalizing proxy, at a resource the
-        # caller never confirmed.
+        # Encode the id so it stays a single terminal path segment: ``Target.url``
+        # only ``strip('/')``s each part, so an id carrying ``/`` or ``..`` would
+        # aim this DELETE, through any normalizing proxy, at a resource the caller
+        # never confirmed. Percent-encoding belongs here because only the client
+        # knows it is building a URL. The empty check is a defensive precondition
+        # rather than the active rule -- ``release_delete`` refuses a blank or
+        # dot-only id above its own prompt, before this is ever called.
         release_id = (release_id or "").strip()
         if not release_id:
             raise ValueError("release_id must be a non-empty string")

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -237,16 +237,22 @@ class BuilderClient:
         it held against the workspace's release limit. Idempotent (204 even when
         already gone); the builder returns 409 while any deployment in the
         workspace still references it, a stopped one included."""
-        # Encode the id so it stays a single terminal path segment: ``Target.url``
-        # only ``strip('/')``s each part, so an id carrying ``/`` or ``..`` would
-        # aim this DELETE, through any normalizing proxy, at a resource the caller
+        # Keep the id a single terminal path segment: ``Target.url`` only
+        # ``strip('/')``s each part, so an id carrying ``/`` or ``..`` would aim
+        # this DELETE, through any normalizing proxy, at a resource the caller
         # never confirmed. Percent-encoding belongs here because only the client
-        # knows it is building a URL. The empty check is a defensive precondition
-        # rather than the active rule -- ``release_delete`` refuses a blank or
-        # dot-only id above its own prompt, before this is ever called.
+        # knows it is building a URL -- but it is not enough on its own:
+        # ``quote(safe="")`` leaves ``.`` and ``..`` untouched, RFC 3986 calling
+        # both unreserved, so those two are refused rather than encoded.
+        #
+        # This is the guarantee, and it holds for whoever calls the method.
+        # ``release_delete`` refuses the same ids above its own prompt, and that
+        # check is the one a person or an agent actually reads: it names the
+        # command's argument and points at `comfy build release ls`. This one
+        # only has to keep the sentence above true.
         release_id = (release_id or "").strip()
-        if not release_id:
-            raise ValueError("release_id must be a non-empty string")
+        if not release_id or set(release_id) == {"."}:
+            raise ValueError("release_id must name one release, not an empty or dot-only path segment")
         encoded_id = urllib.parse.quote(release_id, safe="")
         request_json(self.target.url("releases", encoded_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
 

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -232,6 +232,13 @@ class BuilderClient:
         its releases."""
         request_json(self.target.url("builds", build_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
 
+    def delete_release(self, release_id: str) -> None:
+        """DELETE /v1/releases/{id} -> stamp the release deleted, freeing the slot
+        it held against the workspace's release limit. Idempotent (204 even when
+        already gone); the builder returns 409 while any deployment in the
+        workspace still references it, a stopped one included."""
+        request_json(self.target.url("releases", release_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
+
     def validate_build(self, build_id: str) -> dict:
         """POST /v1/builds/{id}/validate -> dry-run resolve the stored
         definition (no build). 200 with a ValidateResult when resolvable; the

--- a/comfy_cli/builder_api.py
+++ b/comfy_cli/builder_api.py
@@ -237,7 +237,16 @@ class BuilderClient:
         it held against the workspace's release limit. Idempotent (204 even when
         already gone); the builder returns 409 while any deployment in the
         workspace still references it, a stopped one included."""
-        request_json(self.target.url("releases", release_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
+        # Validate + encode the id so it stays a single terminal path segment.
+        # ``Target.url`` only ``strip('/')``s each part, so an empty id would
+        # collapse this DELETE onto the collection and an id carrying ``/`` or
+        # ``..`` would aim it, through any normalizing proxy, at a resource the
+        # caller never confirmed.
+        release_id = (release_id or "").strip()
+        if not release_id:
+            raise ValueError("release_id must be a non-empty string")
+        encoded_id = urllib.parse.quote(release_id, safe="")
+        request_json(self.target.url("releases", encoded_id), self.target, method="DELETE", max_bytes=_MAX_JSON)
 
     def validate_build(self, build_id: str) -> dict:
         """POST /v1/builds/{id}/validate -> dry-run resolve the stored

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -2432,9 +2432,13 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
     # Ahead of the transport clause below, whose hint ("check the builder URL and
     # your access") points away from a failure that is neither: the endpoint and
     # the credential are both fine and the CA store is the problem.
+    # Redacted like the transport branch below: a verification failure on the
+    # presigned blob PUT quotes that URL, whose query string is the credential.
     if tls_verification_failed(e):
         renderer.error(
-            code="tls_verify_failed", message=f"TLS certificate verification failed: {e}", hint=tls_trust_hint()
+            code="tls_verify_failed",
+            message=f"TLS certificate verification failed: {_without_signed_query(e)}",
+            hint=tls_trust_hint(),
         )
         return
     if isinstance(e, urllib.error.HTTPError):
@@ -2516,11 +2520,14 @@ def _builder_call(renderer, fn, subject: Mapping[str, str] | None = None):
         # beats an unhandled traceback.
         renderer.error(code="build_builder_error", message=f"builder response exceeded the client size cap ({e})")
         raise typer.Exit(code=1) from e
-    except ValueError as e:
-        renderer.error(code="build_missing_input", message=str(e))
-        raise typer.Exit(code=1) from e
+    # Transport before ValueError: ``requests.exceptions.MissingSchema``,
+    # ``InvalidURL`` and ``InvalidSchema`` subclass both, and a malformed builder-supplied upload
+    # URL is the builder's failure, reported redacted, not the caller's input.
     except (urllib.error.URLError, requests.RequestException, KeyError) as e:
         _report_builder_error(renderer, e, subject)
+        raise typer.Exit(code=1) from e
+    except ValueError as e:
+        renderer.error(code="build_missing_input", message=str(e))
         raise typer.Exit(code=1) from e
 
 

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -96,6 +96,7 @@ from comfy_cli.command.pack_scan import read_pyproject
 from comfy_cli.constants import SUPPORTED_PT_EXTENSIONS
 from comfy_cli.interaction import confirm, require_option
 from comfy_cli.output import get_renderer
+from comfy_cli.output.sanitize import sanitize
 from comfy_cli.registry.api import sanitize_error_body
 from comfy_cli.utils import parse_rfc3339
 
@@ -2351,11 +2352,12 @@ _BUILDER_REFUSALS: Final = {
 }
 
 #: A hostile endpoint can be reached through the env-configurable base URL, so
-#: nothing it sends reaches the envelope unbounded: the body is read under
-#: ``_BUILDER_ERROR_READ``, excerpted into ``details.body`` at
-#: ``_BUILDER_BODY_CAP``, and a carried refusal message is capped at
-#: ``_BUILDER_MESSAGE_CAP`` -- far above any real blocker list, since the builder
-#: names at most ten deployments before it appends "(and more)".
+#: nothing it sends reaches the envelope unbounded or able to address a terminal:
+#: the body is read under ``_BUILDER_ERROR_READ``, excerpted into ``details.body``
+#: at ``_BUILDER_BODY_CAP``, and a carried message is stripped of control
+#: characters and capped at ``_BUILDER_MESSAGE_CAP`` -- room enough for a long
+#: list of blocking deployments and their prose without letting one endpoint
+#: decide how big an envelope is.
 _BUILDER_BODY_CAP: Final = 1000
 _BUILDER_MESSAGE_CAP: Final = 8 * 1024
 _BUILDER_ERROR_READ: Final = 64 * 1024
@@ -2409,16 +2411,18 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
             # else in its contract, so the message is carried unparsed under its
             # own cap: a regex over a rewordable sentence is a contract nobody
             # wrote, and the body excerpt would lose the tail of a long one.
+            # Sanitized before the cap, not after, so a cut cannot manufacture an
+            # unterminated escape whose sanitizer then swallows the ids.
             renderer.error(
                 code=refusal["code"],
-                message=(builder_message or refusal["message"])[:_BUILDER_MESSAGE_CAP],
+                message=sanitize(builder_message or refusal["message"])[:_BUILDER_MESSAGE_CAP],
                 details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
             )
             return
         detail = _builder_msg(body) or getattr(e, "reason", None) or str(e)
         renderer.error(
             code="build_builder_error",
-            message=f"builder call failed ({e.code}): {detail}",
+            message=f"builder call failed ({e.code}): {str(detail)[:_BUILDER_MESSAGE_CAP]}",
             details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
         )
         return
@@ -2456,16 +2460,36 @@ def _builder_call(renderer, fn, subject: Mapping[str, str] | None = None):
         raise typer.Exit(code=1) from e
 
 
+def _encodable(text: str) -> str:
+    """``text`` with anything unencodable replaced, so it can reach stdout.
+
+    A lone surrogate is legal in a JSON string and legal in a Python ``str``, but
+    encoding one raises ``UnicodeEncodeError`` — a ``ValueError``, which the JSON
+    writer's own except clause swallows, so a crafted ``message`` would cost the
+    caller the whole envelope rather than one bad character. Scrubbed where the
+    strings are produced, because that writer belongs to every command.
+    """
+    return text.encode("utf-8", "replace").decode("utf-8", "replace")
+
+
 def _builder_error_fields(body: str) -> tuple[str, str]:
     """Split a builder JSON error body ({error, message}) into its two fields,
-    or ``("", "")`` when the body isn't the expected shape."""
+    or ``("", "")`` when the body isn't the expected shape.
+
+    ``RecursionError`` is a ``RuntimeError``, so a deeply nested body escapes the
+    ``ValueError`` clause and, uncaught, every clause up to the CLI — leaving the
+    caller exit 1 and no envelope on any builder HTTP error path.
+    """
     try:
         parsed = json.loads(body)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, RecursionError):
         return "", ""
     if not isinstance(parsed, dict):
         return "", ""
-    return str(parsed.get("error") or "").strip(), str(parsed.get("message") or "").strip()
+    return (
+        _encodable(str(parsed.get("error") or "").strip()),
+        _encodable(str(parsed.get("message") or "").strip()),
+    )
 
 
 def _builder_msg(body: str) -> str:
@@ -2976,6 +3000,23 @@ def release_delete(
     # first delete out of, destroying a second release nobody asked for.
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
+    # Normalized and refused once, above the prompt, so the id confirmed, the id
+    # deleted and the id reported are one string rather than three. A segment of
+    # only dots is refused rather than encoded: `quote(safe="")` leaves it alone
+    # (RFC 3986 unreserved) and nothing between here and the service resolves dot
+    # segments, so `.` would aim this DELETE at the collection and `..` a level
+    # above it -- and `.` is a plausible argument, since every other `comfy build`
+    # verb takes a path defaulting to it. What else an id may look like is the
+    # builder's to say, so nothing here spells out its grammar.
+    release = release.strip()
+    if not release or set(release) == {"."}:
+        renderer.error(
+            code="build_missing_input",
+            message="RELEASE must name one release, not an empty or dot-only path segment.",
+            hint="pass the release id shown by `comfy build release ls`",
+            details={"invalid": [release]},
+        )
+        raise typer.Exit(code=1)
     if not confirm(
         f"Delete release {release}?",
         yes=yes,

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -96,7 +96,6 @@ from comfy_cli.command.pack_scan import read_pyproject
 from comfy_cli.constants import SUPPORTED_PT_EXTENSIONS
 from comfy_cli.interaction import confirm, require_option
 from comfy_cli.output import get_renderer
-from comfy_cli.output.sanitize import sanitize
 from comfy_cli.registry.api import sanitize_error_body
 from comfy_cli.utils import parse_rfc3339
 
@@ -2352,15 +2351,64 @@ _BUILDER_REFUSALS: Final = {
 }
 
 #: A hostile endpoint can be reached through the env-configurable base URL, so
-#: nothing it sends reaches the envelope unbounded or able to address a terminal:
-#: the body is read under ``_BUILDER_ERROR_READ``, excerpted into ``details.body``
-#: at ``_BUILDER_BODY_CAP``, and a carried message is stripped of control
-#: characters and capped at ``_BUILDER_MESSAGE_CAP`` -- room enough for a long
-#: list of blocking deployments and their prose without letting one endpoint
-#: decide how big an envelope is.
+#: nothing it sends reaches the envelope unbounded: the body is read under
+#: ``_BUILDER_ERROR_READ``, excerpted into ``details.body`` at
+#: ``_BUILDER_BODY_CAP``, and a carried message is capped at
+#: ``_BUILDER_MESSAGE_CAP`` -- room enough for a long list of blocking
+#: deployments and their prose without letting one endpoint decide how big an
+#: envelope is. The message cap counts **bytes** (see ``_capped_message``),
+#: because a cap on characters is one the sender picks the multiplier for: a
+#: message of four-byte characters costs four times what it promises. The body
+#: excerpt is a debugging aid rather than the envelope's payload, so it keeps its
+#: cheaper slice and is bounded in turn by the byte-counted ``_BUILDER_ERROR_READ``.
+#:
+#: Bounded, not sanitized. What reaches a terminal is sanitized at the terminal
+#: (``error_panel``); the envelope stays byte-faithful -- see
+#: ``_report_builder_error``.
 _BUILDER_BODY_CAP: Final = 1000
 _BUILDER_MESSAGE_CAP: Final = 8 * 1024
 _BUILDER_ERROR_READ: Final = 64 * 1024
+
+
+def _capped_message(text: str) -> str:
+    """``text`` truncated to ``_BUILDER_MESSAGE_CAP`` UTF-8 bytes, whole characters only.
+
+    Slicing the ``str`` would cap Python characters instead, which bounds the
+    envelope only for ASCII. Truncation happens on the encoded form and the
+    partial character a byte cut can leave behind is dropped, so what the JSON
+    writer receives is always decodable. Text that already fits is returned
+    unchanged rather than round-tripped, so the common case stays byte-identical.
+    """
+    encoded = text.encode("utf-8", "replace")
+    if len(encoded) <= _BUILDER_MESSAGE_CAP:
+        return text
+    return encoded[:_BUILDER_MESSAGE_CAP].decode("utf-8", "ignore")
+
+
+#: Any URL in an exception's text, with its query string. Both shapes ``requests``
+#: produces quote what they were talking to: ``raise_for_status`` gives the whole
+#: URL ("... for url: https://host/o?sig=..."), while a ``ConnectionError`` gives
+#: the path alone ("Max retries exceeded with url: /o?sig=..."), so both forms are
+#: matched. The query is lazy-anchored to the FIRST ``?`` in the run, and must be
+#: non-empty, so a sentence ending in a question mark is left alone.
+_URL_QUERY_RE: Final = re.compile(r"(?:[a-z][a-z0-9+.\-]*://\S*?|/\S*?)\?\S+", re.IGNORECASE)
+
+
+def _without_signed_query(e: BaseException) -> str:
+    """``str(e)`` with the query string cut off every URL it quotes.
+
+    ``upload_assets`` runs inside ``_builder_call``, and it talks to a presigned
+    GCS PUT whose query string *is* the credential: an ordinary failed upload
+    would otherwise write a still-valid ``X-Goog-Credential`` and
+    ``X-Goog-Signature`` to stdout, into the JSON envelope, and into any CI log
+    that captured either. Only the query comes off -- the host and the path are
+    what make the failure diagnosable.
+
+    This errs toward removing too much: a path with a legitimate ``?`` in it
+    loses its tail. That is the correct bias for a redaction, and the same one
+    ``tracking._scrub_value`` takes for a URL standing alone as a value.
+    """
+    return _URL_QUERY_RE.sub(lambda m: m.group(0).partition("?")[0], str(e))
 
 
 def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None) -> None:
@@ -2411,24 +2459,40 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
             # else in its contract, so the message is carried unparsed under its
             # own cap: a regex over a rewordable sentence is a contract nobody
             # wrote, and the body excerpt would lose the tail of a long one.
-            # Sanitized before the cap, not after, so a cut cannot manufacture an
-            # unterminated escape whose sanitizer then swallows the ids.
+            #
+            # Carried BYTE-FAITHFULLY, and deliberately not sanitized. The
+            # sanitizer's module docstring rules the JSON/NDJSON paths out, and
+            # here the cost is concrete: its unterminated-introducer rule cuts
+            # from a stray introducer to the end of the string, so one byte of
+            # ordinary mojibake would silently delete every blocking id after it
+            # -- the ids being the whole reason an agent reads this refusal.
+            # Stripping buys nothing either, since `details.body` beside it
+            # carries the same bytes raw. A terminal is protected where the
+            # terminal is: `error_panel` sanitizes `message` and every details
+            # row on the pretty path.
             renderer.error(
                 code=refusal["code"],
-                message=sanitize(builder_message or refusal["message"])[:_BUILDER_MESSAGE_CAP],
+                message=_capped_message(builder_message or refusal["message"]),
                 details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
             )
             return
         detail = _builder_msg(body) or getattr(e, "reason", None) or str(e)
         renderer.error(
             code="build_builder_error",
-            message=f"builder call failed ({e.code}): {str(detail)[:_BUILDER_MESSAGE_CAP]}",
+            message=f"builder call failed ({e.code}): {_capped_message(str(detail))}",
             details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
         )
         return
     # A dropped connection, a reset or a timeout: the caller's own remediation is
-    # to retry, which needs the id the lost attempt named.
-    renderer.error(code="build_builder_error", message=f"builder call failed: {e}", details=dict(subject or {}))
+    # to retry, which needs the id the lost attempt named. The exception is
+    # redacted rather than interpolated raw -- a failed blob upload quotes its
+    # presigned PUT URL, whose query string is a live credential (see
+    # ``_without_signed_query``).
+    renderer.error(
+        code="build_builder_error",
+        message=f"builder call failed: {_without_signed_query(e)}",
+        details=dict(subject or {}),
+    )
 
 
 def _builder_call(renderer, fn, subject: Mapping[str, str] | None = None):
@@ -2999,15 +3063,22 @@ def release_delete(
     # default would re-resolve against a list the builder has already filtered the
     # first delete out of, destroying a second release nobody asked for.
     renderer = get_renderer()
-    client = _builder_client(renderer, builder_url)
-    # Normalized and refused once, above the prompt, so the id confirmed, the id
-    # deleted and the id reported are one string rather than three. A segment of
-    # only dots is refused rather than encoded: `quote(safe="")` leaves it alone
-    # (RFC 3986 unreserved) and nothing between here and the service resolves dot
-    # segments, so `.` would aim this DELETE at the collection and `..` a level
-    # above it -- and `.` is a plausible argument, since every other `comfy build`
-    # verb takes a path defaulting to it. What else an id may look like is the
-    # builder's to say, so nothing here spells out its grammar.
+    # Normalized and refused once, above both the client and the prompt, so the
+    # id confirmed, the id deleted and the id reported are one string rather than
+    # three. Above the client because `_builder_client` can exit with
+    # `build_not_signed_in` after an OAuth round trip: a signed-out caller
+    # passing a blank id would be told to sign in, do so, and only then learn the
+    # id was never usable. This check needs nothing but the argument, so the
+    # first envelope is the actionable one.
+    #
+    # A segment of only dots is refused rather than encoded: `quote(safe="")`
+    # leaves it alone (RFC 3986 unreserved) and nothing between here and the
+    # service resolves dot segments, so `.` would aim this DELETE at the
+    # collection and `..` a level above it -- and `.` is a plausible argument,
+    # since every other `comfy build` verb takes a path defaulting to it.
+    # `delete_release` refuses the same ids for any other caller; this is the
+    # copy that produces the readable refusal. What else an id may look like is
+    # the builder's to say, so nothing here spells out its grammar.
     release = release.strip()
     if not release or set(release) == {"."}:
         renderer.error(
@@ -3017,6 +3088,7 @@ def release_delete(
             details={"invalid": [release]},
         )
         raise typer.Exit(code=1)
+    client = _builder_client(renderer, builder_url)
     if not confirm(
         f"Delete release {release}?",
         yes=yes,

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -34,7 +34,7 @@ import subprocess
 import tempfile
 import time
 import urllib.error
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -2327,16 +2327,44 @@ def _builder_client(renderer, builder_url: str | None):
         raise typer.Exit(code=1) from e
 
 
-def _report_builder_error(renderer, e) -> None:
+#: comfy-builder refusals the caller can clear itself, keyed on the builder's own
+#: ``error`` field. That field is the contract and its ``message`` is explicitly
+#: rewordable, so matching the field beats matching a substring of the body --
+#: which would also break the day the body grows past the cap below. Each row's
+#: ``message`` stands in only for a builder that sent none. Everything absent
+#: from this table stays on ``build_builder_error``.
+_BUILDER_REFUSALS: Final = {
+    "RELEASE_LIMIT": {
+        "code": "build_release_limit",
+        "message": "the workspace already holds as many releases as its limit allows",
+    },
+    "RELEASE_IN_USE": {
+        "code": "build_release_in_use",
+        "message": "a deployment still references this release",
+    },
+    "BUILD_IN_USE": {
+        "code": "build_in_use",
+        "message": "a deployment still references one of this build's releases",
+    },
+}
+
+#: A hostile endpoint can be reached through the env-configurable base URL, so a
+#: body never reaches the envelope whole.
+_BUILDER_BODY_CAP: Final = 1000
+
+
+def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None) -> None:
     """Emit one error envelope for a builder failure. Prefers the limited-beta 403,
     then the builder's own error body (e.g. `INVALID_DEFINITION: …` or
     `SUBSCRIPTION_REQUIRED: …`) over urllib's opaque "HTTP Error 400", then the
     generic transport error.
 
-    It carries no Build id, because the old `create` verb's orphan case is gone:
-    `push` writes the id into the spec on disk before it cuts, so a cut that
-    fails afterwards leaves the id in the user's own file rather than only in
-    this envelope."""
+    The generic envelope carries no Build id, because the old `create` verb's
+    orphan case is gone: `push` writes the id into the spec on disk before it
+    cuts, so a cut that fails afterwards leaves the id in the user's own file
+    rather than only in this envelope. A mapped refusal is different — it is a
+    state the caller clears by deleting a named thing — so it carries *subject*,
+    the id the command was acting on."""
     import urllib.error
 
     from comfy_cli.http import tls_trust_hint, tls_verification_failed
@@ -2361,19 +2389,33 @@ def _report_builder_error(renderer, e) -> None:
                 message="The developer platform is in limited beta and your account isn't enabled yet.",
             )
             return
+        builder_error, builder_message = _builder_error_fields(body)
+        refusal = _BUILDER_REFUSALS.get(builder_error)
+        if refusal is not None:
+            # The blocking deployment ids ride in the builder's prose and nowhere
+            # else in its contract, so the message is carried whole instead of
+            # parsed for them: a regex over a rewordable sentence is a contract
+            # nobody wrote, and the capped body would lose the tail of a long one.
+            renderer.error(
+                code=refusal["code"],
+                message=builder_message or refusal["message"],
+                details={"status": e.code, "body": body[:_BUILDER_BODY_CAP], **(subject or {})},
+            )
+            return
         detail = _builder_msg(body) or getattr(e, "reason", None) or str(e)
         renderer.error(
             code="build_builder_error",
             message=f"builder call failed ({e.code}): {detail}",
-            details={"status": e.code, "body": body[:1000]},
+            details={"status": e.code, "body": body[:_BUILDER_BODY_CAP]},
         )
         return
     renderer.error(code="build_builder_error", message=f"builder call failed: {e}")
 
 
-def _builder_call(renderer, fn):
+def _builder_call(renderer, fn, subject: Mapping[str, str] | None = None):
     """Run a builder API call, mapping every failure class to one error envelope
-    + exit(1) via _report_builder_error.
+    + exit(1) via _report_builder_error. *subject* names the id the command is
+    acting on, so a refusal an agent must act on says which one.
 
     Never package inside *fn*. ``NodePackageError`` is a ``ValueError``, so the
     clause below would relabel a packaging failure as ``build_missing_input``
@@ -2395,21 +2437,26 @@ def _builder_call(renderer, fn):
         renderer.error(code="build_missing_input", message=str(e))
         raise typer.Exit(code=1) from e
     except (urllib.error.URLError, requests.RequestException, KeyError) as e:
-        _report_builder_error(renderer, e)
+        _report_builder_error(renderer, e, subject)
         raise typer.Exit(code=1) from e
+
+
+def _builder_error_fields(body: str) -> tuple[str, str]:
+    """Split a builder JSON error body ({error, message}) into its two fields,
+    or ``("", "")`` when the body isn't the expected shape."""
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return "", ""
+    if not isinstance(parsed, dict):
+        return "", ""
+    return str(parsed.get("error") or "").strip(), str(parsed.get("message") or "").strip()
 
 
 def _builder_msg(body: str) -> str:
     """Pull ``"<error>: <message>"`` out of a builder JSON error body ({error, message}),
     or ``""`` when the body isn't the expected shape."""
-    try:
-        parsed = json.loads(body)
-    except (json.JSONDecodeError, ValueError):
-        return ""
-    if not isinstance(parsed, dict):
-        return ""
-    err = str(parsed.get("error") or "").strip()
-    msg = str(parsed.get("message") or "").strip()
+    err, msg = _builder_error_fields(body)
     return f"{err}: {msg}".strip(": ").strip() if (err or msg) else ""
 
 
@@ -2592,6 +2639,7 @@ def release_create(
     release_id, status_url = _builder_call(
         renderer,
         lambda: client.create_release(selected_build_id, requested),
+        {"buildId": selected_build_id},
     )
     payload = {
         "buildId": selected_build_id,
@@ -2807,7 +2855,7 @@ def delete_cmd(
         # `build_delete_needs_confirm` rather than reaching this branch.
         renderer.info("Aborted.")
         return
-    _builder_call(renderer, lambda: client.delete_build(selected_build_id))
+    _builder_call(renderer, lambda: client.delete_build(selected_build_id), {"buildId": selected_build_id})
     if renderer.is_pretty():
         renderer.success(f"Deleted build {selected_build_id}")
     renderer.emit({"buildId": selected_build_id, "deleted": True}, command="build delete", changed=True)
@@ -2897,6 +2945,39 @@ def release_manifest(
     if renderer.is_pretty():
         renderer.console().print_json(json.dumps(manifest))
     renderer.emit(manifest, command="build release manifest")
+
+
+@release_app.command("delete", help="Delete a release, freeing its slot against the workspace release limit.")
+@tracking.track_command("build")
+def release_delete(
+    ctx: typer.Context,
+    release: Annotated[
+        str | None, typer.Argument(help="Release id. Default: the current Build's newest release.")
+    ] = None,
+    path: Annotated[str | None, typer.Argument(help="Build spec path used when RELEASE is omitted.")] = None,
+    build_id: Annotated[str | None, typer.Option("--id", help="Resolve the newest release from this Build id.")] = None,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip the confirmation prompt.")] = False,
+    builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
+):
+    renderer = get_renderer()
+    client = _builder_client(renderer, builder_url)
+    release_id = _selected_release_id(renderer, client, _BuildScope(ctx, path, build_id), release)
+    if not confirm(
+        f"Delete release {release_id}?",
+        yes=yes,
+        error_code="build_release_delete_needs_confirm",
+        details={"releaseId": release_id},
+        ctx=ctx,
+    ):
+        # Declining needs a prompt, and a prompt needs pretty mode, where `emit`
+        # is a no-op; a machine caller is refused above with
+        # `build_release_delete_needs_confirm` rather than reaching this branch.
+        renderer.info("Aborted.")
+        return
+    _builder_call(renderer, lambda: client.delete_release(release_id), {"releaseId": release_id})
+    if renderer.is_pretty():
+        renderer.success(f"Deleted release {release_id}")
+    renderer.emit({"releaseId": release_id, "deleted": True}, command="build release delete", changed=True)
 
 
 @blob_app.command("ls", help="List the workspace's private blobs.")

--- a/comfy_cli/command/build.py
+++ b/comfy_cli/command/build.py
@@ -2031,7 +2031,9 @@ def push_cmd(
     release_summary: dict[str, str] | None = None
     if release:
         requested = [item.as_wire() for item in targets]
-        release_id, status_url = _builder_call(renderer, lambda: client.create_release(target_id, requested))
+        release_id, status_url = _builder_call(
+            renderer, lambda: client.create_release(target_id, requested), {"buildId": target_id}
+        )
         release_summary = {"releaseId": release_id, "statusUrl": status_url}
         payload["targets"] = requested
         payload["release"] = release_summary
@@ -2328,11 +2330,11 @@ def _builder_client(renderer, builder_url: str | None):
 
 
 #: comfy-builder refusals the caller can clear itself, keyed on the builder's own
-#: ``error`` field. That field is the contract and its ``message`` is explicitly
-#: rewordable, so matching the field beats matching a substring of the body --
-#: which would also break the day the body grows past the cap below. Each row's
-#: ``message`` stands in only for a builder that sent none. Everything absent
-#: from this table stays on ``build_builder_error``.
+#: ``error`` field under a 409. That field is the contract and its ``message`` is
+#: explicitly rewordable, so matching the field beats matching a substring of the
+#: body -- which would also break the day the body grows past the cap below. Each
+#: row's ``message`` stands in only for a builder that sent none. Everything
+#: absent from this table stays on ``build_builder_error``.
 _BUILDER_REFUSALS: Final = {
     "RELEASE_LIMIT": {
         "code": "build_release_limit",
@@ -2348,9 +2350,15 @@ _BUILDER_REFUSALS: Final = {
     },
 }
 
-#: A hostile endpoint can be reached through the env-configurable base URL, so a
-#: body never reaches the envelope whole.
+#: A hostile endpoint can be reached through the env-configurable base URL, so
+#: nothing it sends reaches the envelope unbounded: the body is read under
+#: ``_BUILDER_ERROR_READ``, excerpted into ``details.body`` at
+#: ``_BUILDER_BODY_CAP``, and a carried refusal message is capped at
+#: ``_BUILDER_MESSAGE_CAP`` -- far above any real blocker list, since the builder
+#: names at most ten deployments before it appends "(and more)".
 _BUILDER_BODY_CAP: Final = 1000
+_BUILDER_MESSAGE_CAP: Final = 8 * 1024
+_BUILDER_ERROR_READ: Final = 64 * 1024
 
 
 def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None) -> None:
@@ -2359,12 +2367,14 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
     `SUBSCRIPTION_REQUIRED: …`) over urllib's opaque "HTTP Error 400", then the
     generic transport error.
 
-    The generic envelope carries no Build id, because the old `create` verb's
-    orphan case is gone: `push` writes the id into the spec on disk before it
-    cuts, so a cut that fails afterwards leaves the id in the user's own file
-    rather than only in this envelope. A mapped refusal is different — it is a
-    state the caller clears by deleting a named thing — so it carries *subject*,
-    the id the command was acting on."""
+    *subject* is the id the command was acting on, spread into every envelope
+    that carries details, and spread first so it can never displace `status` or
+    `body`. A mapped refusal needs it because clearing the state means deleting
+    the named thing; a lost response needs it because retrying means naming the
+    id the first attempt used. A call site that passes none invents nothing: the
+    old `create` verb's orphan case is gone, because `push` writes the id into
+    the spec on disk before it cuts, so a cut that fails afterwards leaves the id
+    in the user's own file rather than only in this envelope."""
     import urllib.error
 
     from comfy_cli.http import tls_trust_hint, tls_verification_failed
@@ -2380,7 +2390,7 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
     if isinstance(e, urllib.error.HTTPError):
         body = ""
         try:
-            body = e.read().decode("utf-8", "replace")
+            body = (e.read(_BUILDER_ERROR_READ) or b"").decode("utf-8", "replace")
         except Exception:
             pass
         if e.code == 403 and "FEATURE_NOT_ENABLED" in body:
@@ -2390,26 +2400,31 @@ def _report_builder_error(renderer, e, subject: Mapping[str, str] | None = None)
             )
             return
         builder_error, builder_message = _builder_error_fields(body)
-        refusal = _BUILDER_REFUSALS.get(builder_error)
+        # All three refusals are 409 in the builder's contract and nothing else
+        # sends them, so a mapped code under any other status came from something
+        # that is not the builder and must not be answered with its remediation.
+        refusal = _BUILDER_REFUSALS.get(builder_error) if e.code == 409 else None
         if refusal is not None:
             # The blocking deployment ids ride in the builder's prose and nowhere
-            # else in its contract, so the message is carried whole instead of
-            # parsed for them: a regex over a rewordable sentence is a contract
-            # nobody wrote, and the capped body would lose the tail of a long one.
+            # else in its contract, so the message is carried unparsed under its
+            # own cap: a regex over a rewordable sentence is a contract nobody
+            # wrote, and the body excerpt would lose the tail of a long one.
             renderer.error(
                 code=refusal["code"],
-                message=builder_message or refusal["message"],
-                details={"status": e.code, "body": body[:_BUILDER_BODY_CAP], **(subject or {})},
+                message=(builder_message or refusal["message"])[:_BUILDER_MESSAGE_CAP],
+                details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
             )
             return
         detail = _builder_msg(body) or getattr(e, "reason", None) or str(e)
         renderer.error(
             code="build_builder_error",
             message=f"builder call failed ({e.code}): {detail}",
-            details={"status": e.code, "body": body[:_BUILDER_BODY_CAP]},
+            details={**(subject or {}), "status": e.code, "body": body[:_BUILDER_BODY_CAP]},
         )
         return
-    renderer.error(code="build_builder_error", message=f"builder call failed: {e}")
+    # A dropped connection, a reset or a timeout: the caller's own remediation is
+    # to retry, which needs the id the lost attempt named.
+    renderer.error(code="build_builder_error", message=f"builder call failed: {e}", details=dict(subject or {}))
 
 
 def _builder_call(renderer, fn, subject: Mapping[str, str] | None = None):
@@ -2951,22 +2966,21 @@ def release_manifest(
 @tracking.track_command("build")
 def release_delete(
     ctx: typer.Context,
-    release: Annotated[
-        str | None, typer.Argument(help="Release id. Default: the current Build's newest release.")
-    ] = None,
-    path: Annotated[str | None, typer.Argument(help="Build spec path used when RELEASE is omitted.")] = None,
-    build_id: Annotated[str | None, typer.Option("--id", help="Resolve the newest release from this Build id.")] = None,
+    release: Annotated[str, typer.Argument(help="Release id to delete.")],
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip the confirmation prompt.")] = False,
     builder_url: Annotated[str | None, _BUILDER_URL_OPT] = None,
 ):
+    # The one release verb that destroys something names its target and takes no
+    # other selector: a caller whose connection dropped retries, and a resolved
+    # default would re-resolve against a list the builder has already filtered the
+    # first delete out of, destroying a second release nobody asked for.
     renderer = get_renderer()
     client = _builder_client(renderer, builder_url)
-    release_id = _selected_release_id(renderer, client, _BuildScope(ctx, path, build_id), release)
     if not confirm(
-        f"Delete release {release_id}?",
+        f"Delete release {release}?",
         yes=yes,
         error_code="build_release_delete_needs_confirm",
-        details={"releaseId": release_id},
+        details={"releaseId": release},
         ctx=ctx,
     ):
         # Declining needs a prompt, and a prompt needs pretty mode, where `emit`
@@ -2974,10 +2988,10 @@ def release_delete(
         # `build_release_delete_needs_confirm` rather than reaching this branch.
         renderer.info("Aborted.")
         return
-    _builder_call(renderer, lambda: client.delete_release(release_id), {"releaseId": release_id})
+    _builder_call(renderer, lambda: client.delete_release(release), {"releaseId": release})
     if renderer.is_pretty():
-        renderer.success(f"Deleted release {release_id}")
-    renderer.emit({"releaseId": release_id, "deleted": True}, command="build release delete", changed=True)
+        renderer.success(f"Deleted release {release}")
+    renderer.emit({"releaseId": release, "deleted": True}, command="build release delete", changed=True)
 
 
 @blob_app.command("ls", help="List the workspace's private blobs.")

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -44,6 +44,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy build release show": "build_release_show",
     "comfy build release logs": "build_release_logs",
     "comfy build release manifest": "build_release_manifest",
+    "comfy build release delete": "build_release_delete",
     "comfy build validate": "build_validate",
     "comfy build delete": "build_delete",
     "comfy build update": "build_update",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1195,7 +1195,7 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "build_release_limit",
         "The builder refused `comfy build release create` because the workspace already holds as many "
-        "releases as its limit allows (20 today), counting every status. `message` is the builder's own "
+        "releases as its limit allows, counting every status. `message` is the builder's own "
         "wording and `details.buildId` names the Build the cut was for. Nothing was created and retrying "
         "unchanged is refused again.",
         "delete a release with `comfy build release delete`, or delete a whole build to give up every "

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1194,10 +1194,13 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ),
     ErrorCode(
         "build_release_limit",
-        "The builder refused `comfy build release create` because the workspace already holds as many "
-        "releases as its limit allows, counting every status. `message` is the builder's own "
-        "wording and `details.buildId` names the Build the cut was for. Nothing was created and retrying "
-        "unchanged is refused again.",
+        "The builder refused the release cut because the workspace already holds as many releases as its "
+        "limit allows, counting every status. `message` is the builder's own wording. `comfy build release "
+        "create` and `comfy build push --release` both post to this route and both answer this code, and "
+        "each attaches `details.buildId` naming the Build the cut was for. No release was cut and retrying "
+        "unchanged is refused again -- but only the cut was refused: under `comfy build push --release` the "
+        "push already landed, so the build was created or updated, its blobs were stored, and its id was "
+        "written into the spec on disk before the refusal.",
         "delete a release with `comfy build release delete`, or delete a whole build to give up every "
         "release it holds, then cut again",
     ),

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1204,7 +1204,9 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "build_release_in_use",
         "The builder refused `comfy build release delete` because a deployment still references the "
-        "release. `message` names every blocking deployment and `details.releaseId` names the release. A "
+        "release. `message` is the builder's own wording and names the blocking deployments, though on a "
+        "long list it may name only the first several and say so. `comfy build release delete` is the "
+        "route that answers this code, and it attaches `details.releaseId` naming the release. A "
         "deployment blocks whatever its state -- serving, stopped or failed -- and stops blocking only "
         "once it has been deleted and its teardown has released its compute.",
         "delete each deployment the message names (stopping one is not enough), wait for its teardown, then retry",
@@ -1212,9 +1214,11 @@ REGISTRY: tuple[ErrorCode, ...] = (
     ErrorCode(
         "build_in_use",
         "The builder refused `comfy build delete` because a deployment still references one of the "
-        "build's releases. `message` names every blocking deployment and `details.buildId` names the "
-        "build. A deployment blocks whatever its state -- serving, stopped or failed -- and stops "
-        "blocking only once it has been deleted and its teardown has released its compute.",
+        "build's releases. `message` is the builder's own wording and names the blocking deployments, "
+        "though on a long list it may name only the first several and say so. `comfy build delete` is "
+        "the route that answers this code, and it attaches `details.buildId` naming the build. A "
+        "deployment blocks whatever its state -- serving, stopped or failed -- and stops blocking only "
+        "once it has been deleted and its teardown has released its compute.",
         "delete each deployment the message names (stopping one is not enough), wait for its teardown, then retry",
     ),
     ErrorCode(

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -1193,6 +1193,39 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "edit the spec to name a published registry version or normalized repository, or remove the node",
     ),
     ErrorCode(
+        "build_release_limit",
+        "The builder refused `comfy build release create` because the workspace already holds as many "
+        "releases as its limit allows (20 today), counting every status. `message` is the builder's own "
+        "wording and `details.buildId` names the Build the cut was for. Nothing was created and retrying "
+        "unchanged is refused again.",
+        "delete a release with `comfy build release delete`, or delete a whole build to give up every "
+        "release it holds, then cut again",
+    ),
+    ErrorCode(
+        "build_release_in_use",
+        "The builder refused `comfy build release delete` because a deployment still references the "
+        "release. `message` names every blocking deployment and `details.releaseId` names the release. A "
+        "deployment blocks whatever its state -- serving, stopped or failed -- and stops blocking only "
+        "once it has been deleted and its teardown has released its compute.",
+        "delete each deployment the message names (stopping one is not enough), wait for its teardown, then retry",
+    ),
+    ErrorCode(
+        "build_in_use",
+        "The builder refused `comfy build delete` because a deployment still references one of the "
+        "build's releases. `message` names every blocking deployment and `details.buildId` names the "
+        "build. A deployment blocks whatever its state -- serving, stopped or failed -- and stops "
+        "blocking only once it has been deleted and its teardown has released its compute.",
+        "delete each deployment the message names (stopping one is not enough), wait for its teardown, then retry",
+    ),
+    ErrorCode(
+        "build_release_delete_needs_confirm",
+        "`comfy build release delete` was run without `--yes` in a non-interactive context (JSON output, "
+        "an agent, or a pipe) where nothing can answer a confirmation. Delete is refused rather than "
+        "blocking on a prompt. `details.releaseId` names the release, and `details.question` carries the "
+        "confirmation.",
+        "pass `--yes` to confirm the delete when running non-interactively",
+    ),
+    ErrorCode(
         "build_delete_needs_confirm",
         "`comfy build delete` was run without `--yes` in a non-interactive context (JSON output, an agent, "
         "or a pipe) where nothing can answer a confirmation. Delete is refused rather than blocking on a "

--- a/comfy_cli/schemas/build_release_delete.json
+++ b/comfy_cli/schemas/build_release_delete.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://comfy.org/schemas/build_release_delete.json",
+  "title": "comfy build release delete --json data payload",
+  "type": "object",
+  "required": ["releaseId", "deleted"],
+  "additionalProperties": true,
+  "properties": {
+    "releaseId": {"type": "string", "description": "The deleted release's id."},
+    "deleted": {"type": "boolean"}
+  }
+}

--- a/comfy_cli/skills/comfy-build/SKILL.md
+++ b/comfy_cli/skills/comfy-build/SKILL.md
@@ -273,15 +273,19 @@ for comes back as a refusal envelope and exits 1: `build_update_needs_confirm`,
 Pass `--yes`, or the option it named, once the user has actually agreed. Do not
 pass `--yes` first and disclose after.
 
-**Three other refusals are limits, not confirmations — `--yes` does nothing for
-them.** Each names what must be deleted, and each exits 1:
+**Three other refusals block rather than ask — `--yes` does nothing for them.**
+Each is cleared by deleting something, and each exits 1:
 
 - **`build_release_limit`** — the cut was refused because the workspace already
   holds as many releases as its limit allows. Free a slot, then cut again.
 - **`build_release_in_use`** — `comfy build release delete` was refused because a
-  deployment still references that release. The `message` names every one.
+  deployment still references that release. The `message` is the builder's own
+  wording and names the blocking deployments, though on a long list it may name
+  only the first several and say so.
 - **`build_in_use`** — `comfy build delete` was refused because a deployment
-  still references one of that build's releases. The `message` names every one.
+  still references one of that build's releases. The `message` is the builder's
+  own wording and names the blocking deployments, though on a long list it may
+  name only the first several and say so.
 
 ## The two limits, and what clears each
 

--- a/comfy_cli/skills/comfy-build/SKILL.md
+++ b/comfy_cli/skills/comfy-build/SKILL.md
@@ -43,7 +43,7 @@ ls        List the workspace's builds.
 show      Show a Build and its full definition.
 validate  Validate the local spec without contacting the builder.
 delete    Delete a Build (soft-delete).
-release   create · ls · show · logs · manifest
+release   create · ls · show · logs · manifest · delete
 refs      resolve · base-images · build-targets · model-dirs
 blob      ls                                    (hidden; workspace private blobs)
 ```
@@ -267,9 +267,44 @@ Say all of this in plain words, and wait for a yes:
 
 **Under `--json`, nothing prompts.** A confirmation the command would have asked
 for comes back as a refusal envelope and exits 1: `build_update_needs_confirm`,
-`build_pull_needs_confirm`, `build_delete_needs_confirm`, `build_missing_input`,
-`build_id_unknown`. Pass `--yes`, or the option it named, once the user has
-actually agreed. Do not pass `--yes` first and disclose after.
+`build_pull_needs_confirm`, `build_delete_needs_confirm`,
+`build_release_delete_needs_confirm`, `build_missing_input`, `build_id_unknown`.
+Pass `--yes`, or the option it named, once the user has actually agreed. Do not
+pass `--yes` first and disclose after.
+
+**Three other refusals are limits, not confirmations — `--yes` does nothing for
+them.** Each names what must be deleted, and each exits 1:
+
+- **`build_release_limit`** — the cut was refused because the workspace already
+  holds as many releases as its limit allows (20 today). Free a slot, then cut
+  again.
+- **`build_release_in_use`** — `comfy build release delete` was refused because a
+  deployment still references that release. The `message` names every one.
+- **`build_in_use`** — `comfy build delete` was refused because a deployment
+  still references one of that build's releases. The `message` names every one.
+
+## The two limits, and what clears each
+
+A workspace has a ceiling on **how many releases it may hold**, counting every
+status and whether or not anything deploys them, and a separate ceiling on **how
+many builds it may keep**. Both are cleared the same way, by deleting:
+
+- **`comfy build release delete [RELEASE]`** gives up one release slot. With no
+  RELEASE it takes the current Build's newest release, which is rarely the one to
+  drop — name the id from `comfy build release ls`. It is idempotent, so a
+  release already gone answers success again.
+- **`comfy build delete`** gives up the build slot *and* every release that build
+  held, so it is how to free several release slots at once. Say that plainly
+  before running it: the releases go with it.
+
+**A deployment blocking either delete has to be deleted, not stopped.** The
+builder counts a stopped or failed deployment exactly as it counts a serving one,
+so stopping one and retrying is refused a second time. It stops blocking only
+once it has been deleted *and* its teardown has released its compute, so a delete
+still tearing down keeps refusing. **A deleted deployment never starts again** —
+that is a decision for the user to make, not one to take on their behalf to clear
+a limit. Name the deployments the refusal message lists, say what deleting them
+costs, and wait.
 
 ## Watching the release
 

--- a/comfy_cli/skills/comfy-build/SKILL.md
+++ b/comfy_cli/skills/comfy-build/SKILL.md
@@ -50,8 +50,9 @@ blob      ls                                    (hidden; workspace private blobs
 
 - **Every command that reads the spec takes the install directory or the spec
   path** as its argument, defaulting to the current directory. `ls`, `refs` and
-  `blob` are workspace-level and take none. Once the spec exists it carries the
-  Build id, so nothing after `init` needs an id from you. `--id` overrides it.
+  `blob` are workspace-level and take none, and `release delete` takes the
+  release id instead. Once the spec exists it carries the Build id, so nothing
+  after `init` needs an id from you. `--id` overrides it.
 - **`comfy which` names the install** when the user has not said where it is.
 - **Only sign in when told to.** Run `comfy cloud login` if a command answers
   `build_not_signed_in`, and not before. Everything under `refs`, both importers
@@ -276,8 +277,7 @@ pass `--yes` first and disclose after.
 them.** Each names what must be deleted, and each exits 1:
 
 - **`build_release_limit`** — the cut was refused because the workspace already
-  holds as many releases as its limit allows (20 today). Free a slot, then cut
-  again.
+  holds as many releases as its limit allows. Free a slot, then cut again.
 - **`build_release_in_use`** — `comfy build release delete` was refused because a
   deployment still references that release. The `message` names every one.
 - **`build_in_use`** — `comfy build delete` was refused because a deployment
@@ -289,10 +289,11 @@ A workspace has a ceiling on **how many releases it may hold**, counting every
 status and whether or not anything deploys them, and a separate ceiling on **how
 many builds it may keep**. Both are cleared the same way, by deleting:
 
-- **`comfy build release delete [RELEASE]`** gives up one release slot. With no
-  RELEASE it takes the current Build's newest release, which is rarely the one to
-  drop — name the id from `comfy build release ls`. It is idempotent, so a
-  release already gone answers success again.
+- **`comfy build release delete RELEASE`** gives up one release slot. RELEASE is
+  required — there is no default and no spec to fall back on, so name the id from
+  `comfy build release ls`. Repeating the same id is safe: the builder answers
+  success again for a release already deleted, so a retry after a dropped
+  connection costs nothing.
 - **`comfy build delete`** gives up the build slot *and* every release that build
   held, so it is how to free several release slots at once. Say that plainly
   before running it: the releases go with it.

--- a/tests/comfy_cli/command/build_auth_support.py
+++ b/tests/comfy_cli/command/build_auth_support.py
@@ -73,6 +73,7 @@ _ROUTES: dict[tuple[str, str], tuple[int, JsonObject]] = {
         },
     ),
     ("GET", f"/v1/releases/{RELEASE_ID}/manifest"): (200, {"models": []}),
+    ("DELETE", f"/v1/releases/{RELEASE_ID}"): (204, {}),
     ("GET", "/v1/base-images"): (200, {"baseImages": []}),
     ("GET", "/v1/build-targets"): (200, {"targets": []}),
     ("GET", "/v1/model-directories"): (200, {"directories": []}),

--- a/tests/comfy_cli/command/test_build_auth_matrix.py
+++ b/tests/comfy_cli/command/test_build_auth_matrix.py
@@ -63,6 +63,7 @@ class FixtureKind(Enum):
     RELEASE_SHOW = "release show"
     RELEASE_LOGS = "release logs"
     RELEASE_MANIFEST = "release manifest"
+    RELEASE_DELETE = "release delete"
     REFS_RESOLVE = "refs resolve"
     REFS_BASE_IMAGES = "refs base-images"
     REFS_BUILD_TARGETS = "refs build-targets"
@@ -103,6 +104,7 @@ BUILD_AUTH_CASES = (
     BuildAuthCase(FixtureKind.RELEASE_SHOW, "release show", True, _ONE_PLUS),
     BuildAuthCase(FixtureKind.RELEASE_LOGS, "release logs", True, _ONE_PLUS),
     BuildAuthCase(FixtureKind.RELEASE_MANIFEST, "release manifest", True, _ONE_PLUS),
+    BuildAuthCase(FixtureKind.RELEASE_DELETE, "release delete", True, _ONE_PLUS),
     BuildAuthCase(FixtureKind.REFS_RESOLVE, "refs resolve", True, _ONE_PLUS),
     BuildAuthCase(FixtureKind.REFS_BASE_IMAGES, "refs base-images", True, _ONE_PLUS),
     BuildAuthCase(FixtureKind.REFS_BUILD_TARGETS, "refs build-targets", True, _ONE_PLUS),
@@ -183,6 +185,8 @@ def _prepare(kind: FixtureKind, root: Path) -> list[str]:
             return ["build", "release", "logs", "--id", BUILD_ID, "--target", "linux/nvidia"]
         case FixtureKind.RELEASE_MANIFEST:
             return ["build", "release", "manifest", "--id", BUILD_ID]
+        case FixtureKind.RELEASE_DELETE:
+            return ["build", "release", "delete", "-y", "--id", BUILD_ID]
         case FixtureKind.REFS_RESOLVE:
             return ["build", "refs", "resolve", "base.safetensors"]
         case FixtureKind.REFS_BASE_IMAGES:

--- a/tests/comfy_cli/command/test_build_auth_matrix.py
+++ b/tests/comfy_cli/command/test_build_auth_matrix.py
@@ -17,7 +17,7 @@ from enum import Enum
 from pathlib import Path
 
 import pytest
-from build_auth_support import BUILD_ID, RecordingTransport, write_snapshot
+from build_auth_support import BUILD_ID, RELEASE_ID, RecordingTransport, write_snapshot
 from build_push_support import make_workspace, write_spec
 from build_tree_support import leaf_commands
 from deploy_auth_support import (
@@ -186,7 +186,7 @@ def _prepare(kind: FixtureKind, root: Path) -> list[str]:
         case FixtureKind.RELEASE_MANIFEST:
             return ["build", "release", "manifest", "--id", BUILD_ID]
         case FixtureKind.RELEASE_DELETE:
-            return ["build", "release", "delete", "-y", "--id", BUILD_ID]
+            return ["build", "release", "delete", RELEASE_ID, "-y"]
         case FixtureKind.REFS_RESOLVE:
             return ["build", "refs", "resolve", "base.safetensors"]
         case FixtureKind.REFS_BASE_IMAGES:

--- a/tests/comfy_cli/command/test_build_push.py
+++ b/tests/comfy_cli/command/test_build_push.py
@@ -425,8 +425,59 @@ def test_a_failed_upload_keeps_the_signature_out_of_the_envelope(
     assert (
         "X-Goog-Signature" in result.output,
         "X-Goog-Credential" in result.output,
+        "?" in message,
         kept in message,
-    ) == (False, False, True)
+    ) == (False, False, False, True)
+
+
+@pytest.mark.parametrize(
+    "error, code, kept",
+    [
+        pytest.param(
+            requests.exceptions.SSLError(
+                f"HTTPSConnectionPool(host='storage.googleapis.com', port=443): Max retries exceeded with url: "
+                f"{SIGNED_URL} (Caused by SSLError(SSLCertVerificationError(1, "
+                "'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate')))"
+            ),
+            "tls_verify_failed",
+            "Max retries exceeded with url: https://storage.googleapis.com/comfy-blobs/blob-1 (Caused by",
+            id="tls-branch-redacts-too",
+        ),
+        pytest.param(
+            requests.exceptions.InvalidURL(f"Invalid URL {SIGNED_URL!r}: No host supplied."),
+            "build_builder_error",
+            "Invalid URL 'https://storage.googleapis.com/comfy-blobs/blob-1",
+            id="malformed-url-is-the-builders-failure-and-redacted",
+        ),
+    ],
+)
+def test_the_other_two_failure_paths_keep_the_signature_out_too(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, error: Exception, code: str, kept: str
+) -> None:
+    """Two paths skipped the redaction above. A certificate failure exits
+    `_report_builder_error` before the transport branch, and used to interpolate
+    the exception raw. And `requests.exceptions.InvalidURL` (with `MissingSchema`
+    and `InvalidSchema`) subclasses `ValueError` as well as `RequestException`, so
+    with the `ValueError` clause first a malformed builder-supplied upload URL was
+    relabelled `build_missing_input` -- the caller's fault -- and printed whole."""
+    # Given
+    write_spec(workspace, build_id="build-1", revision="revision-0")
+    failing = _SignedUrlBuilder(error)
+    failing.remote_revisions["build-1"] = "revision-0"
+    _install_client(monkeypatch, failing)
+
+    # When
+    result = invoke_push(workspace)
+
+    # Then
+    err = envelope(result)["error"]
+    assert (
+        err["code"],
+        "X-Goog-Signature" in result.output,
+        "X-Goog-Credential" in result.output,
+        "?" in err["message"],
+        kept in err["message"],
+    ) == (code, False, False, False, True)
 
 
 def test_resuming_an_interrupted_push_uploads_only_what_is_missing(

--- a/tests/comfy_cli/command/test_build_push.py
+++ b/tests/comfy_cli/command/test_build_push.py
@@ -361,6 +361,74 @@ def test_an_interrupted_push_keeps_the_blobs_it_already_uploaded(
     assert [(upload.kind, upload.index) for upload in pending_uploads(resumed)] == [("node_zip", 0)]
 
 
+#: A presigned GCS PUT URL: everything after the `?` IS the credential, and it
+#: stays valid for as long as `X-Goog-Expires` says.
+SIGNED_URL = (
+    "https://storage.googleapis.com/comfy-blobs/blob-1"
+    "?X-Goog-Algorithm=GOOG4-RSA-SHA256"
+    "&X-Goog-Credential=builder%40comfy.iam.gserviceaccount.com%2F20260906%2Fauto%2Fstorage%2Fgoog4_request"
+    "&X-Goog-Date=20260906T090000Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host"
+    "&X-Goog-Signature=6d1f3c9ab0e5147a2d8f"
+)
+
+
+class _SignedUrlBuilder(RecordingBuilder):
+    """Fails the first upload with an exception quoting the presigned URL."""
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__()
+        self.error = error
+
+    def upload_blob(self, upload_url: str, path: Path) -> None:
+        raise self.error
+
+
+@pytest.mark.parametrize(
+    "error, kept",
+    [
+        pytest.param(
+            requests.HTTPError(f"403 Client Error: Forbidden for url: {SIGNED_URL}"),
+            "403 Client Error: Forbidden for url: https://storage.googleapis.com/comfy-blobs/blob-1",
+            id="raise_for_status-quotes-the-whole-url",
+        ),
+        pytest.param(
+            requests.ConnectionError(
+                "HTTPSConnectionPool(host='storage.googleapis.com', port=443): Max retries exceeded with url: "
+                "/comfy-blobs/blob-1?X-Goog-Signature=6d1f3c9ab0e5147a2d8f (Caused by NewConnectionError('boom'))"
+            ),
+            "Max retries exceeded with url: /comfy-blobs/blob-1 (Caused by NewConnectionError('boom'))",
+            id="connection-error-quotes-the-path",
+        ),
+    ],
+)
+def test_a_failed_upload_keeps_the_signature_out_of_the_envelope(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, error: Exception, kept: str
+) -> None:
+    """`upload_assets` runs inside `_builder_call`, so an upload that fails hands
+    its exception to the transport branch of `_report_builder_error`, which
+    interpolates it whole. Both shapes `requests` produces quote what they were
+    talking to -- and for a presigned PUT the query string IS the credential, so
+    an ordinary failed upload writes a still-valid `X-Goog-Signature` to stdout,
+    into the JSON envelope and into any CI log that captured it. The host and the
+    path are what make the failure diagnosable, so only the query comes off."""
+    # Given
+    write_spec(workspace, build_id="build-1", revision="revision-0")
+    failing = _SignedUrlBuilder(error)
+    failing.remote_revisions["build-1"] = "revision-0"
+    _install_client(monkeypatch, failing)
+
+    # When
+    result = invoke_push(workspace)
+
+    # Then
+    message = envelope(result)["error"]["message"]
+    assert (
+        "X-Goog-Signature" in result.output,
+        "X-Goog-Credential" in result.output,
+        kept in message,
+    ) == (False, False, True)
+
+
 def test_resuming_an_interrupted_push_uploads_only_what_is_missing(
     workspace: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/comfy_cli/command/test_build_release.py
+++ b/tests/comfy_cli/command/test_build_release.py
@@ -25,9 +25,13 @@ AT_THE_LIMIT = (
 )
 
 
-def refusal(status: int, body: dict, url: str) -> urllib.error.HTTPError:
-    """The builder's `{error, message}` body, raised the way the HTTP layer raises it."""
-    return urllib.error.HTTPError(url, status, "Conflict", {}, io.BytesIO(json.dumps(body).encode()))
+def refusal(status: int, body: dict | bytes, url: str) -> urllib.error.HTTPError:
+    """The builder's `{error, message}` body, raised the way the HTTP layer raises it.
+
+    Bytes are sent through untouched, for the bodies a hostile endpoint can send
+    that `json.dumps` cannot produce."""
+    raw = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return urllib.error.HTTPError(url, status, "Conflict", {}, io.BytesIO(raw))
 
 
 class ReleaseBuilder:
@@ -654,6 +658,95 @@ def test_delete_without_yes_refuses_an_agent_before_the_builder(
     )
 
 
+def _refusing_builder(monkeypatch: pytest.MonkeyPatch, status: int, refused_body: dict | bytes) -> None:
+    """A live `BuilderClient` whose transport answers every call with one refusal."""
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(status, refused_body, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+
+def test_a_deeply_nested_error_body_still_reaches_the_agent_as_an_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`json.loads` answers a nest this deep with `RecursionError`, a `RuntimeError`
+    rather than a `ValueError`, so it escapes every clause between here and the CLI
+    and leaves exit 1 with nothing on stdout -- on every builder HTTP error path,
+    not just this one, so an agent cannot even tell whether the delete happened.
+    20 000 is deterministic on this interpreter; 5 000 parses fine."""
+    # Given
+    _refusing_builder(monkeypatch, 409, b"[" * 20_000)
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (error["code"], error["details"]["status"]) == ("build_builder_error", 409)
+
+
+def test_a_lone_surrogate_in_the_builder_message_still_reaches_the_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A lone surrogate is legal in a JSON string and legal in a Python `str`, but
+    encoding it raises `UnicodeEncodeError` -- a `ValueError`, which the JSON
+    writer's own except swallows, so the whole envelope silently never lands."""
+    # Given
+    _refusing_builder(
+        monkeypatch, 409, json.dumps({"error": "RELEASE_IN_USE", "message": "\ud800"}).encode("utf-8", "surrogatepass")
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (error["code"], error["details"]["releaseId"]) == ("build_release_in_use", "release-9")
+
+
+def test_the_carried_message_cannot_forge_a_line_of_its_own(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The carried message is now the envelope's authoritative `message`, and the
+    skill page sends an agent to act on the deployments it names. `json.dumps`
+    escapes C0 but emits C1 raw, and the pretty path prints the message, so an
+    erase-line plus a carriage return would let the builder's prose overwrite what
+    the CLI already printed with a success that never happened."""
+    # Given
+    _refusing_builder(
+        monkeypatch,
+        409,
+        {
+            "error": "RELEASE_IN_USE",
+            "message": "these deployments still reference this release: dep-01a4f7c1e9b3, dep-02a4f7c1e9b3"
+            "\x1b[2K\rDeleted release release-9",
+        },
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    assert envelope(result)["error"]["message"] == (
+        "these deployments still reference this release: dep-01a4f7c1e9b3, dep-02a4f7c1e9b3Deleted release release-9"
+    )
+
+
+def test_a_long_message_under_an_unmapped_status_obeys_the_message_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The block comment beside the caps says nothing an endpoint sends reaches the
+    envelope unbounded, but only the refusal branch three lines below it applied
+    the message cap: a 400 carrying a 60 000-character message produced an
+    `error.message` detail of 60 006 beside a `details.body` of exactly 1 000."""
+    # Given
+    _refusing_builder(monkeypatch, 400, {"error": "NOPE", "message": "x" * 60_000})
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    message = envelope(result)["error"]["message"]
+    assert len(message.removeprefix("builder call failed (400): ")) == build._BUILDER_MESSAGE_CAP
+
+
 def _recording_builder(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """A live `BuilderClient` whose transport records the URLs it is handed."""
     from comfy_cli.builder_api import BuilderClient
@@ -684,14 +777,52 @@ def test_delete_keeps_a_traversing_release_id_inside_one_path_segment(monkeypatc
     assert calls == ["https://builder.test/v1/releases/..%2Fbuilds%2Fabc"]
 
 
-def test_delete_refuses_a_blank_release_id_before_it_reaches_the_builder(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An empty part drops out of the path entirely, which would aim the DELETE at
-    the whole collection."""
+@pytest.mark.parametrize(
+    "release_id",
+    [
+        pytest.param("   ", id="blank"),
+        pytest.param(".", id="dot"),
+        pytest.param("..", id="dot-dot"),
+    ],
+)
+def test_delete_refuses_an_id_that_names_no_release_before_it_reaches_the_builder(
+    monkeypatch: pytest.MonkeyPatch, release_id: str
+) -> None:
+    """An empty part drops out of the path entirely, and `quote(safe="")` leaves a
+    dot segment alone because RFC 3986 calls it unreserved -- so all three aim the
+    DELETE at the collection or at its parent rather than at a release. `.` is a
+    plausible argument because every other `comfy build` verb takes a path
+    defaulting to it. The empty `calls` is the load-bearing half: nothing reached
+    the wire, rather than something reaching it encoded."""
     # Given
     calls = _recording_builder(monkeypatch)
 
     # When
-    result = invoke_release("delete", "   ", "--yes")
+    result = invoke_release("delete", release_id, "--yes")
 
     # Then
     assert (result.exit_code, envelope(result)["error"]["code"], calls) == (1, "build_missing_input", [])
+
+
+def test_delete_uses_one_stripped_release_id_for_the_prompt_the_url_and_the_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A padded id otherwise splits into three different strings: the prompt echoes
+    the padding, the client strips it for the URL, and the payload reports the
+    padding back -- so the id confirmed is not the id deleted is not the id
+    reported."""
+    # Given
+    calls = _recording_builder(monkeypatch)
+
+    # When
+    refused = invoke_release("delete", "  release-9  ")
+    deleted = invoke_release("delete", "  release-9  ", "--yes")
+
+    # Then
+    refusal_details = envelope(refused)["error"]["details"]
+    assert (refusal_details["question"], refusal_details["releaseId"], calls, envelope(deleted)["data"]) == (
+        "Delete release release-9?",
+        "release-9",
+        ["https://builder.test/v1/releases/release-9"],
+        {"releaseId": "release-9", "deleted": True},
+    )

--- a/tests/comfy_cli/command/test_build_release.py
+++ b/tests/comfy_cli/command/test_build_release.py
@@ -705,32 +705,6 @@ def test_a_lone_surrogate_in_the_builder_message_still_reaches_the_agent(monkeyp
     assert (error["code"], error["details"]["releaseId"]) == ("build_release_in_use", "release-9")
 
 
-def test_the_carried_message_cannot_forge_a_line_of_its_own(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The carried message is now the envelope's authoritative `message`, and the
-    skill page sends an agent to act on the deployments it names. `json.dumps`
-    escapes C0 but emits C1 raw, and the pretty path prints the message, so an
-    erase-line plus a carriage return would let the builder's prose overwrite what
-    the CLI already printed with a success that never happened."""
-    # Given
-    _refusing_builder(
-        monkeypatch,
-        409,
-        {
-            "error": "RELEASE_IN_USE",
-            "message": "these deployments still reference this release: dep-01a4f7c1e9b3, dep-02a4f7c1e9b3"
-            "\x1b[2K\rDeleted release release-9",
-        },
-    )
-
-    # When
-    result = invoke_release("delete", "release-9", "--yes")
-
-    # Then
-    assert envelope(result)["error"]["message"] == (
-        "these deployments still reference this release: dep-01a4f7c1e9b3, dep-02a4f7c1e9b3Deleted release release-9"
-    )
-
-
 def test_a_long_message_under_an_unmapped_status_obeys_the_message_cap(monkeypatch: pytest.MonkeyPatch) -> None:
     """The block comment beside the caps says nothing an endpoint sends reaches the
     envelope unbounded, but only the refusal branch three lines below it applied
@@ -745,6 +719,72 @@ def test_a_long_message_under_an_unmapped_status_obeys_the_message_cap(monkeypat
     # Then
     message = envelope(result)["error"]["message"]
     assert len(message.removeprefix("builder call failed (400): ")) == build._BUILDER_MESSAGE_CAP
+
+
+#: One four-byte character. Sent `_BUILDER_MESSAGE_CAP // 2` times, so the
+#: message passes a cap counting characters and doubles the cap counting bytes,
+#: while its JSON-escaped body (12 bytes per character) still fits the 64 KiB
+#: `_BUILDER_ERROR_READ` and so still parses as the builder's `{error, message}`.
+WIDE = "\N{GRINNING FACE}"
+
+
+@pytest.mark.parametrize(
+    "status, builder_error, prefix",
+    [
+        pytest.param(409, "RELEASE_IN_USE", "", id="carried-refusal"),
+        pytest.param(400, "NOPE", "builder call failed (400): ", id="generic-branch"),
+    ],
+)
+def test_a_multibyte_message_is_capped_in_bytes_not_characters(
+    monkeypatch: pytest.MonkeyPatch, status: int, builder_error: str, prefix: str
+) -> None:
+    """Both slices cap Python characters, so the block comment's promise that
+    nothing an endpoint sends reaches the envelope unbounded holds only for
+    ASCII: a message of four-byte characters passes the cap and emits four times
+    it. Capping the encoded form must not split a character either -- a
+    truncated envelope carrying half a character is not one an agent can
+    decode."""
+    # Given
+    _refusing_builder(
+        monkeypatch, status, {"error": builder_error, "message": WIDE * (build._BUILDER_MESSAGE_CAP // 2)}
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    message = envelope(result)["error"]["message"]
+    carried = message.removeprefix(prefix)
+    assert (
+        len(message.encode("utf-8")) <= build._BUILDER_MESSAGE_CAP + len(prefix),
+        # Every surviving character is whole: a byte slice through the middle of
+        # one would leave a replacement character or a mojibake tail here.
+        set(carried.removeprefix(f"{builder_error}: ")),
+    ) == (True, {WIDE})
+
+
+def test_a_blank_id_is_refused_before_a_signed_out_caller_is_sent_to_log_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructing the client can exit with `build_not_signed_in` after an OAuth
+    round trip, so validating the id afterwards tells a signed-out caller with a
+    blank id to sign in -- and only once they have does it say the id was never
+    usable. The first envelope has to be the actionable one."""
+    # Given
+    constructed: list[str] = []
+
+    def signed_out(renderer, builder_url):
+        constructed.append("client")
+        renderer.error(code="build_not_signed_in", message="run `comfy cloud login` first")
+        raise typer.Exit(code=1)
+
+    monkeypatch.setattr(build, "_builder_client", signed_out)
+
+    # When
+    result = invoke_release("delete", "   ", "--yes")
+
+    # Then
+    assert (envelope(result)["error"]["code"], constructed) == ("build_missing_input", [])
 
 
 def _recording_builder(monkeypatch: pytest.MonkeyPatch) -> list[str]:

--- a/tests/comfy_cli/command/test_build_release.py
+++ b/tests/comfy_cli/command/test_build_release.py
@@ -98,6 +98,16 @@ def invoke_release(*args: str, agentic: bool = True):
     )
 
 
+def invoke_build(*args: str):
+    """`comfy build ...` — the refusal table below is shared with `build delete`,
+    which is not a release verb."""
+    return CliRunner().invoke(
+        cli_app,
+        ["build", *args],
+        env={"AI_AGENT": "1", "COMFY_OUTPUT": "json", "NO_COLOR": "1", "COMFY_BUILDER_TOKEN": None},
+    )
+
+
 def test_release_surface_replaces_version_and_uses_one_target_spelling() -> None:
     # Given
     command = typer.main.get_command(build.app)
@@ -379,7 +389,9 @@ def test_release_limit_refusal_gets_its_own_code(workspace: Path, monkeypatch: p
     assert result.exit_code != 0
     error = envelope(result)["error"]
     assert isinstance(error, dict)
-    assert error["code"] == "build_release_limit"
+    # `details.buildId` is what the registered remediation sends the agent back
+    # to, so it is part of the code's contract and not decoration.
+    assert (error["code"], error["details"]["buildId"]) == ("build_release_limit", "build-1")
 
 
 #: Every deployment the builder found blocking, named in one sentence. Long on
@@ -435,16 +447,18 @@ def test_each_mapped_refusal_reaches_the_agent_under_its_own_code(
     "status",
     [pytest.param(400, id="bad-request"), pytest.param(500, id="server-error")],
 )
-def test_a_status_outside_the_table_keeps_the_generic_envelope(
+def test_a_mapped_code_under_another_status_keeps_the_generic_envelope(
     workspace: Path, monkeypatch: pytest.MonkeyPatch, status: int
 ) -> None:
-    """The table is keyed on the builder's `error`, not on 409, so a code it does
-    carry under another status must not be relabelled either."""
+    """All three refusals are 409 in the builder's contract, so a mapped code
+    arriving under any other status came from something that is not the builder
+    -- a proxy, a WAF page, a service that changed -- and must not hand an agent
+    remediation for a limit that may not exist."""
     # Given
     from comfy_cli.builder_api import BuilderClient
 
     def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
-        raise refusal(status, {"error": "INVALID_DEFINITION", "message": "no target is buildable"}, url)
+        raise refusal(status, {"error": "RELEASE_IN_USE", "message": BLOCKED_BY}, url)
 
     monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
     monkeypatch.setattr(
@@ -483,6 +497,40 @@ def test_the_blocking_deployment_ids_survive_the_body_cap(monkeypatch: pytest.Mo
         LAST_BLOCKER in error["details"]["body"],
         "RELEASE_IN_USE" in error["details"]["body"],
     ) == ("build_release_in_use", BLOCKED_BY, "release-9", False, False)
+
+
+#: The builder's `BUILD_IN_USE` prose, naming what blocks a build delete.
+BLOCKS_THE_BUILD = (
+    "these deployments still reference releases of this build: dep-01a4f7c1e9b3, dep-02a4f7c1e9b3; each stops "
+    "blocking once it has been deleted and its teardown has released its compute"
+)
+
+
+def test_a_refused_build_delete_names_the_build_and_the_deployments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`comfy build delete` is the only call the builder answers `BUILD_IN_USE`
+    on, so it is the only place the code and its `details.buildId` are real."""
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(409, {"error": "BUILD_IN_USE", "message": BLOCKS_THE_BUILD}, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_build("delete", "--id", "build-1", "--yes")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (result.exit_code, error["code"], error["message"], error["details"]["buildId"]) == (
+        1,
+        "build_in_use",
+        BLOCKS_THE_BUILD,
+        "build-1",
+    )
 
 
 def test_delete_exits_non_zero_when_a_deployment_still_references_the_release(
@@ -586,17 +634,16 @@ def test_delete_reaches_the_release_route_as_a_DELETE(monkeypatch: pytest.Monkey
 
 
 def test_delete_without_yes_refuses_an_agent_before_the_builder(
-    workspace: Path, client: ReleaseBuilder, monkeypatch: pytest.MonkeyPatch
+    client: ReleaseBuilder, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Delete is the one release verb that destroys something, so an agent that
     cannot answer a prompt is refused rather than having the prompt skipped."""
     # Given
     deleted: list[str] = []
-    client.releases = [{"id": "release-9", "version": 9}]
     monkeypatch.setattr(client, "delete_release", deleted.append, raising=False)
 
     # When
-    result = invoke_release("delete")
+    result = invoke_release("delete", "release-9")
 
     # Then
     error = envelope(result)["error"]
@@ -607,19 +654,44 @@ def test_delete_without_yes_refuses_an_agent_before_the_builder(
     )
 
 
-def test_delete_takes_the_newest_release_when_none_is_named(
-    workspace: Path, client: ReleaseBuilder, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Resolution is the neighbouring release commands' own, so an omitted id
-    means the current Build's newest release and not a refusal."""
+def _recording_builder(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """A live `BuilderClient` whose transport records the URLs it is handed."""
+    from comfy_cli.builder_api import BuilderClient
+
+    calls: list[str] = []
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        calls.append(url)
+        return 204, None
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+    return calls
+
+
+def test_delete_keeps_a_traversing_release_id_inside_one_path_segment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`Target.url` only strips slashes, so an unencoded id would send this DELETE
+    -- through any normalizing proxy -- at a resource the prompt never named."""
     # Given
-    deleted: list[str] = []
-    client.releases = [{"id": "release-1", "version": 1}, {"id": "release-9", "version": 9}]
-    monkeypatch.setattr(client, "delete_release", deleted.append, raising=False)
+    calls = _recording_builder(monkeypatch)
 
     # When
-    result = invoke_release("delete", "--yes")
+    invoke_release("delete", "../builds/abc", "--yes")
 
     # Then
-    assert result.exit_code == 0, result.stderr
-    assert deleted == ["release-9"]
+    assert calls == ["https://builder.test/v1/releases/..%2Fbuilds%2Fabc"]
+
+
+def test_delete_refuses_a_blank_release_id_before_it_reaches_the_builder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty part drops out of the path entirely, which would aim the DELETE at
+    the whole collection."""
+    # Given
+    calls = _recording_builder(monkeypatch)
+
+    # When
+    result = invoke_release("delete", "   ", "--yes")
+
+    # Then
+    assert (result.exit_code, envelope(result)["error"]["code"], calls) == (1, "build_missing_input", [])

--- a/tests/comfy_cli/command/test_build_release.py
+++ b/tests/comfy_cli/command/test_build_release.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import io
+import json
+import urllib.error
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -12,6 +15,19 @@ from comfy_cli.caller import Caller
 from comfy_cli.cmdline import app as cli_app
 from comfy_cli.command import build
 from comfy_cli.command.build_spec import JsonObject
+
+#: The builder's own refusal prose for a workspace holding every release its
+#: limit allows. Carried verbatim so the envelope's message is the one a user
+#: would be shown.
+AT_THE_LIMIT = (
+    "this workspace already holds 20 releases, which is its limit; delete a release, or delete a build to "
+    "give up every release it holds, and cut again"
+)
+
+
+def refusal(status: int, body: dict, url: str) -> urllib.error.HTTPError:
+    """The builder's `{error, message}` body, raised the way the HTTP layer raises it."""
+    return urllib.error.HTTPError(url, status, "Conflict", {}, io.BytesIO(json.dumps(body).encode()))
 
 
 class ReleaseBuilder:
@@ -93,7 +109,7 @@ def test_release_surface_replaces_version_and_uses_one_target_spelling() -> None
 
     # Then
     assert "version" not in command.commands
-    assert set(release.commands) == {"create", "ls", "show", "logs", "manifest"}
+    assert set(release.commands) == {"create", "ls", "show", "logs", "manifest", "delete"}
     assert {"--target", "--follow", "-f"} <= options
     assert options.isdisjoint({"--os", "--gpu"})
 
@@ -339,3 +355,271 @@ def test_a_release_order_key_stays_comparable_for_every_created_at(created_at: o
 
     # Then
     assert newest["id"] == "release-dated"
+
+
+def test_release_limit_refusal_gets_its_own_code(workspace: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A workspace at its release limit is a state the caller can clear itself, so
+    it reaches an agent as a code it can branch on rather than folded into the one
+    envelope every builder failure shared."""
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(409, {"error": "RELEASE_LIMIT", "message": AT_THE_LIMIT}, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("create", "--target", "linux/nvidia")
+
+    # Then
+    assert result.exit_code != 0
+    error = envelope(result)["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "build_release_limit"
+
+
+#: Every deployment the builder found blocking, named in one sentence. Long on
+#: purpose: this is the shape that made the old envelope useless, because the ids
+#: sat in a body truncated at 1000 bytes.
+BLOCKED_BY = (
+    "these deployments still reference this release: "
+    + ", ".join(f"dep-{index:02d}a4f7c1e9b3" for index in range(80))
+    + "; each stops blocking once it has been deleted and its teardown has released its compute"
+)
+
+#: The last id the builder named, and the first thing a capped body loses.
+LAST_BLOCKER = "dep-79a4f7c1e9b3"
+
+
+def delete_refused(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+    """A `RELEASE_IN_USE` body whose long `message` precedes its `error`, so the
+    capped copy in `details.body` no longer contains the code at all."""
+    raise refusal(409, {"message": BLOCKED_BY, "error": "RELEASE_IN_USE"}, url)
+
+
+@pytest.mark.parametrize(
+    "builder_error, expected_code",
+    [
+        pytest.param("RELEASE_LIMIT", "build_release_limit", id="release-limit"),
+        pytest.param("RELEASE_IN_USE", "build_release_in_use", id="release-in-use"),
+        pytest.param("BUILD_IN_USE", "build_in_use", id="build-in-use"),
+        pytest.param("STALE", "build_builder_error", id="unmapped-409-is-unchanged"),
+    ],
+)
+def test_each_mapped_refusal_reaches_the_agent_under_its_own_code(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, builder_error: str, expected_code: str
+) -> None:
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(409, {"error": builder_error, "message": AT_THE_LIMIT}, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("create", "--target", "linux/nvidia")
+
+    # Then
+    assert envelope(result)["error"]["code"] == expected_code
+
+
+@pytest.mark.parametrize(
+    "status",
+    [pytest.param(400, id="bad-request"), pytest.param(500, id="server-error")],
+)
+def test_a_status_outside_the_table_keeps_the_generic_envelope(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """The table is keyed on the builder's `error`, not on 409, so a code it does
+    carry under another status must not be relabelled either."""
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(status, {"error": "INVALID_DEFINITION", "message": "no target is buildable"}, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("create", "--target", "linux/nvidia")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (error["code"], error["details"]["status"]) == ("build_builder_error", status)
+
+
+def test_the_blocking_deployment_ids_survive_the_body_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ids are the whole reason an agent reads this refusal, and the builder
+    puts them in prose. Matching a substring of `details.body` would have found
+    nothing here, and reading the ids back out of it would have found only some."""
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", delete_refused)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (
+        error["code"],
+        error["message"],
+        error["details"]["releaseId"],
+        LAST_BLOCKER in error["details"]["body"],
+        "RELEASE_IN_USE" in error["details"]["body"],
+    ) == ("build_release_in_use", BLOCKED_BY, "release-9", False, False)
+
+
+def test_delete_exits_non_zero_when_a_deployment_still_references_the_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", delete_refused)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "already_deleted",
+    [pytest.param(False, id="deleted-now"), pytest.param(True, id="deleted-before")],
+)
+def test_delete_reports_the_same_payload_whether_or_not_the_release_was_already_gone(
+    monkeypatch: pytest.MonkeyPatch, already_deleted: bool
+) -> None:
+    """The builder answers 204 both times -- delete is idempotent -- so a retry
+    after a dropped connection must not read as a different outcome."""
+    # Given
+    import jsonschema
+
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        return 204, None
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    if already_deleted:
+        invoke_release("delete", "release-9", "--yes")
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    assert result.exit_code == 0, result.stderr
+    data = envelope(result)["data"]
+    assert data == {"releaseId": "release-9", "deleted": True}
+    schemas_dir = Path(__file__).parent.parent.parent.parent / "comfy_cli" / "schemas"
+    schema = json.loads((schemas_dir / "build_release_delete.json").read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator(schema).validate(data)
+
+
+def test_deleting_a_release_the_workspace_does_not_have_stays_a_builder_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 404 is not a refusal the caller clears by deleting something, so it keeps
+    the generic code rather than joining the table."""
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        raise refusal(404, {"error": "NOT_FOUND", "message": "release not found"}, url)
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    result = invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (error["code"], error["details"]["status"]) == ("build_builder_error", 404)
+
+
+def test_delete_reaches_the_release_route_as_a_DELETE(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given
+    from comfy_cli.builder_api import BuilderClient
+
+    calls: list[tuple[str, str]] = []
+
+    def request_json(url, target, *, method="GET", body=None, timeout=30.0, max_bytes):
+        calls.append((method, url))
+        return 204, None
+
+    monkeypatch.setattr("comfy_cli.builder_api.request_json", request_json)
+    monkeypatch.setattr(
+        build, "_builder_client", lambda renderer, builder_url: BuilderClient("https://builder.test", "token")
+    )
+
+    # When
+    invoke_release("delete", "release-9", "--yes")
+
+    # Then
+    assert calls == [("DELETE", "https://builder.test/v1/releases/release-9")]
+
+
+def test_delete_without_yes_refuses_an_agent_before_the_builder(
+    workspace: Path, client: ReleaseBuilder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Delete is the one release verb that destroys something, so an agent that
+    cannot answer a prompt is refused rather than having the prompt skipped."""
+    # Given
+    deleted: list[str] = []
+    client.releases = [{"id": "release-9", "version": 9}]
+    monkeypatch.setattr(client, "delete_release", deleted.append, raising=False)
+
+    # When
+    result = invoke_release("delete")
+
+    # Then
+    error = envelope(result)["error"]
+    assert (error["code"], error["details"]["releaseId"], deleted) == (
+        "build_release_delete_needs_confirm",
+        "release-9",
+        [],
+    )
+
+
+def test_delete_takes_the_newest_release_when_none_is_named(
+    workspace: Path, client: ReleaseBuilder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolution is the neighbouring release commands' own, so an omitted id
+    means the current Build's newest release and not a refusal."""
+    # Given
+    deleted: list[str] = []
+    client.releases = [{"id": "release-1", "version": 1}, {"id": "release-9", "version": 9}]
+    monkeypatch.setattr(client, "delete_release", deleted.append, raising=False)
+
+    # When
+    result = invoke_release("delete", "--yes")
+
+    # Then
+    assert result.exit_code == 0, result.stderr
+    assert deleted == ["release-9"]

--- a/tests/comfy_cli/test_builder_api.py
+++ b/tests/comfy_cli/test_builder_api.py
@@ -302,6 +302,31 @@ def test_create_release_refuses_a_missing_or_empty_target_list(recorder, targets
     assert recorder.calls == []
 
 
+@pytest.mark.parametrize(
+    "release_id",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="blank"),
+        pytest.param(".", id="dot"),
+        pytest.param("..", id="dot-dot"),
+        pytest.param("...", id="three-dots"),
+    ],
+)
+def test_delete_release_refuses_an_id_that_is_not_one_path_segment(recorder, release_id):
+    """The method's own comment promises the id stays a single terminal path
+    segment, and `quote(safe="")` keeps that promise for everything except the
+    two segments that are not one: RFC 3986 calls `.` and `..` unreserved, so
+    they pass through untouched and aim the DELETE at the collection or at its
+    parent. `release_delete` refuses them above its prompt, but this method is
+    public, so the guarantee has to hold for a second caller too."""
+    client = BuilderClient(_BASE_URL, "jwt-token")
+
+    with pytest.raises(ValueError, match="empty or dot-only"):
+        client.delete_release(release_id)
+
+    assert recorder.calls == []
+
+
 def test_create_release_refuses_when_targets_is_omitted_entirely(recorder):
     client = BuilderClient(_BASE_URL, "jwt-token")
 


### PR DESCRIPTION
**TL;DR:** A workspace at its release limit can now free one slot from the command line with `comfy build release delete`, instead of giving up a whole build. A refused cut, a refused release delete and a refused build delete each arrive under an error code of their own, carrying the deployments the builder named.

Closes [BE-12349](https://linear.app/comfyorg/issue/BE-12349), part of [BE-11331](https://linear.app/comfyorg/issue/BE-11331).

## Why

An agent iterating on an environment reaches the release limit first and had nothing smaller than a whole build to give up. Every builder failure also came back as one envelope, so a limit the agent could clear itself read the same as a transport error, and the blocking deployment ids sat inside a body cut off at 1000 bytes.

## What changed

```mermaid
%%{init: {"flowchart": {"wrappingWidth": 480}}}%%
flowchart LR
    subgraph cli["service: comfy-cli"]
        subgraph bv["component: the build verb"]
            D["command: build release delete"]
            X["command: build delete"]
            E["the builder-error envelope"]
        end
        subgraph sk["component: the build skill page"]
            P["comfy-build"]
        end
    end
    subgraph builder["service: comfy-builder"]
        subgraph api["component: apiserver"]
            R["endpoint: DELETE /v1/releases/{id}"]
            B["endpoint: DELETE /v1/builds/{id}"]
        end
    end

    D -- "the release id" --> R
    X -- "the build id" --> B
    R -- "RELEASE_IN_USE, and every deployment still on it" --> E
    B -- "BUILD_IN_USE, and every deployment still on one of its releases" --> E
    P -. "which delete clears which limit" .-> D

    classDef changed fill:#ffe08a,stroke:#b8860b,color:#000;
    classDef elsewhere fill:#f6f6f6,stroke:#999,color:#444;
    class D,X,E,P changed
    class R,B elsewhere
```

- **the build verb · release delete**: a new command deletes one release and frees the slot it held. It confirms first, and `--yes` skips that.
- **the build verb · the builder-error envelope**: three refusals get codes of their own, and the builder's message rides through whole so its ids survive.
- **the build verb · the error-code registry**: gains four codes, each saying what clears it. It repurposes none of the codes already there.
- **the build skill page · the two limits**: names both limits, which delete clears each, and that a blocking deployment must be deleted rather than stopped.

## Landing it

- **Depends-On:** https://github.com/Comfy-Org/cloud/pull/8574, which has to merge first
- **Depends-On:** https://github.com/Comfy-Org/cloud/pull/8580, which has to merge first as well
- **Rollback:** a revert suffices. The command writes nothing locally, and the codes are additive: `build_builder_error` still covers every refusal outside the table.
- **Rule bent:** none.
- **Now depends on:** comfy-builder answering a release delete, and refusing a build delete over a stopped or failed deployment. Neither is on main yet.
- **Left for later:** nothing. This closes the ticket.
- **Deliberately not handled:** parsing the blocking ids into a list. The builder's error body carries no array, and it may reword the prose at any time.

## Validation

- **Unit and integration**: 7408 pass. Fifteen of the new cases fail on `origin/main`, and two failures there are unchanged by this branch.
- **Local stack, end to end**: the real CLI against a double of comfy-builder's release delete, whose refusal bodies are ported from its handler. A delete succeeds, the same command repeated answers success again, and a refusal names ten deployments and exits 1. A workspace at the limit deletes one release and the next cut is accepted.
- **Development environment**: staging comfy-builder, workspace w-04544fb6. The delete authenticates, reaches the service and reports the route's absence with the release id in its details, and the release survived. The confirmation refuses an agent with the same flag the build delete uses. The run then deleted the build it had created and read the listing back empty.

**Not run:** The release delete's success path against a real builder, since the route ships with cloud#8574 and nobody can drive it yet. A genuine in-use refusal from the deployed builder, which needs a live deployment: staging refused every build for both ComfyUI pins tried, so no release became deployable. Two staging release slots stay held, since a build delete retains them until cloud#8580..