### PR TITLE
fix(generate): unwrap single-branch anyOf so partner flags keep their type

### DIFF
--- a/comfy_cli/command/generate/schema.py
+++ b/comfy_cli/command/generate/schema.py
@@ -34,6 +34,48 @@ class SchemaError(ValueError):
     pass
 
 
+# Spec-authored nesting is one level deep in practice; the bound just keeps a
+# pathological or self-referential schema from spinning here.
+_MAX_VARIANT_DEPTH = 4
+
+
+def _unwrap_single_variant(prop: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a one-real-branch ``anyOf``/``oneOf``/``allOf`` into its parent.
+
+    Several partner specs wrap every optional field in a single-branch
+    ``anyOf`` (BFL's Fill / Expand / Canny / Depth inputs all do): ``prompt``
+    arrives as ``{"anyOf": [{"type": "string"}], "description": ...}`` rather
+    than the ``{"type": "string", ...}`` it plainly means. Left alone,
+    :func:`_classify` sees the ``anyOf`` and calls the field an ``object``, so
+    a plain ``--prompt "a fox"`` is rejected for not being JSON, ``--steps 50``
+    lands as parsed JSON rather than a coerced int, and ``--mask path.png``
+    never reaches
+    :func:`_detect_upload_mode` (which only inspects ``string`` props), leaving
+    the caller to base64 the file by hand.
+
+    The parent's own keys are kept unless the branch restates them, so an outer
+    ``description`` still drives upload-mode detection and an outer ``default``
+    survives. Only the unambiguous shape is flattened: exactly one branch once
+    ``null`` branches are dropped. A genuine multi-branch union stays an
+    ``object``, which is what it is.
+    """
+    for _ in range(_MAX_VARIANT_DEPTH):
+        for key in ("anyOf", "oneOf", "allOf"):
+            variants = prop.get(key)
+            if not isinstance(variants, list):
+                continue
+            branches = [v for v in variants if isinstance(v, dict) and v.get("type") != "null"]
+            if len(branches) != 1:
+                continue
+            merged = {k: v for k, v in prop.items() if k not in ("anyOf", "oneOf", "allOf")}
+            merged.update(branches[0])
+            prop = merged
+            break
+        else:
+            break
+    return prop
+
+
 def _classify(prop: dict[str, Any]) -> tuple[str, str | None]:
     """Return (kind, item_kind). item_kind only set when kind == 'array'."""
     if "enum" in prop and prop.get("type", "string") == "string":
@@ -100,6 +142,7 @@ def flags_for(endpoint: Endpoint) -> list[FlagDef]:
     for name, prop in props.items():
         if not isinstance(prop, dict):
             continue
+        prop = _unwrap_single_variant(prop)
         kind, item_kind = _classify(prop)
         upload_mode = _detect_upload_mode(name, prop) if kind == "string" else None
         out.append(

--- a/tests/comfy_cli/command/generate/test_schema.py
+++ b/tests/comfy_cli/command/generate/test_schema.py
@@ -141,3 +141,52 @@ def test_coerce_string_array_commas_only_raises():
     # Commas and whitespace split/strip to no items; should raise SchemaError, not return [].
     with pytest.raises(schema.SchemaError, match="expected at least one value"):
         schema._coerce(_string_array_flag(), ", ,")
+
+
+def test_flags_for_unwraps_single_branch_anyof():
+    # BFL's Fill inputs wrap every optional field in a one-branch anyOf; the
+    # wrapper is spec noise, not a real union, so the declared type must win.
+    ep = spec.get_endpoint("bfl/flux-pro-1.0-fill/generate")
+    flags = {f.name: f for f in schema.flags_for(ep)}
+    assert flags["prompt"].kind == "string"
+    assert flags["steps"].kind == "integer"
+    assert flags["guidance"].kind == "number"
+    assert flags["output_format"].kind == "enum"
+    assert flags["output_format"].enum == ["jpeg", "png"]
+    # The parent's own default survives the unwrap.
+    assert flags["output_format"].default == "jpeg"
+
+
+def test_flags_for_single_branch_anyof_keeps_base64_upload():
+    # upload-mode detection only inspects `string` props, so a mis-classified
+    # `object` silently loses it and forces the caller to base64 by hand.
+    ep = spec.get_endpoint("bfl/flux-pro-1.0-fill/generate")
+    flags = {f.name: f for f in schema.flags_for(ep)}
+    assert flags["mask"].upload_mode == "base64"
+    assert flags["image"].upload_mode == "base64"
+
+
+def test_unwrap_single_variant_drops_null_branch():
+    prop = {"anyOf": [{"type": "string"}, {"type": "null"}], "description": "d"}
+    assert schema._unwrap_single_variant(prop) == {"type": "string", "description": "d"}
+
+
+def test_unwrap_single_variant_keeps_real_union_as_object():
+    prop = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+    assert schema._unwrap_single_variant(prop) == prop
+    assert schema._classify(prop) == ("object", None)
+
+
+def test_unwrap_single_variant_branch_overrides_parent_type():
+    prop = {"anyOf": [{"type": "integer"}], "title": "outer", "default": 3}
+    assert schema._unwrap_single_variant(prop) == {"type": "integer", "title": "outer", "default": 3}
+
+
+def test_parse_args_accepts_plain_text_for_wrapped_prompt():
+    # The regression this guards: `--prompt "a fox"` used to fail with
+    # "expected JSON object" because the one-branch anyOf read as an object.
+    ep = spec.get_endpoint("bfl/flux-pro-1.0-expand/generate")
+    flags = schema.flags_for(ep)
+    values = schema.parse_args(flags, ["--image", "in.png", "--prompt", "a fox", "--left", "236"])
+    assert values["prompt"] == "a fox"
+    assert values["left"] == 236


### PR DESCRIPTION
## Summary

BFL's Fill / Expand / Canny / Depth request schemas wrap every optional field in a **single-branch `anyOf`**: `prompt` arrives as `{"anyOf": [{"type": "string"}], "description": ...}` rather than the `{"type": "string", ...}` it plainly means. `_classify` sees the `anyOf` and returns `object`, so one misread produces three separate user-visible failures:

- `--prompt "a fox"` is rejected with `expected JSON object`, forcing callers to write `--prompt '"a fox"'`
- `--steps 50` lands as parsed JSON instead of a coerced int, and `output_format` loses its `['jpeg','png']` enum and its default
- `--mask path.png` silently loses base64 auto-upload, because `_detect_upload_mode` only inspects `string` props — so the caller has to base64 the file by hand, even though its plainly-typed sibling `--image` on the same endpoint accepts a path

None of this is visible until the paid call runs, so the first thing a user learns is a hard argument error on a request they have already been billed for.

## Details

`flags_for` now normalizes each property through `_unwrap_single_variant` before classification. It flattens `anyOf` / `oneOf` / `allOf` only in the unambiguous case — exactly one branch remains once `null` branches are dropped — merging the branch over the parent so an outer `description` still drives upload-mode detection and an outer `default` survives. A genuine multi-branch union is left as an `object`, which is what it is. Iteration is bounded so a self-referential schema cannot spin.

Before and after on `bfl/flux-pro-1.0-fill/generate`:

| flag | before | after |
| --- | --- | --- |
| `prompt` | `object` | `string` |
| `mask` | `object`, `upload_mode=None` | `string`, `upload_mode=base64` |
| `steps` | `object` | `integer` |
| `output_format` | `object`, `enum=[]` | `enum`, `['jpeg','png']`, default `jpeg` |

`bfl/flux-pro-1.1/generate`, whose spec declares types plainly, is unchanged — covered by the existing `test_flags_for_bfl_classifies_types`.

## Testing

- 6 new tests in `tests/comfy_cli/command/generate/test_schema.py`: the wrapped-endpoint classification, base64 upload survival, null-branch dropping, real-union preservation, branch-overrides-parent, and an end-to-end `parse_args` accepting plain prompt text
- Full `tests/comfy_cli/command/generate/` suite: 332 passed
- `ruff format` / `ruff check` clean

One pre-existing failure is unrelated and untouched: `test_list_schema_envelope.py::test_json_mode_leaves_stderr_clean` fails identically on a clean `origin/main` checkout, where a `POSTHOG_API_KEY` warning is written to stderr.

## ELI5

Every partner model describes its own inputs in a spec, and the CLI reads that spec to work out what each flag should accept: text, a number, a file, a fixed set of choices.

Some of those specs have a quirk. Instead of saying "prompt is text", they say "prompt is one of the following: text" — a list with a single item in it. Same meaning, more words. The CLI wasn't unwrapping that list, so it gave up and labelled the field "some complex structure I don't understand", then demanded you hand it raw JSON.

That mislabelling had a knock-on effect. The step that offers to read a local file and encode it for you only looks at fields it knows are text. A field stuck under the "complex structure" label got skipped, so `--mask` quietly stopped accepting a filename on an endpoint where `--image`, described without the quirk, still did.

This change unwraps those single-item lists before anything else looks at them, but only when there is genuinely one option to unwrap. A field that really does accept several different shapes is left exactly as it was.
