### PR TITLE
V1.5: emit insert_workflow ops from the CLI

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -1934,6 +1934,9 @@ app.add_typer(_wfrag.fragment_app, name="fragment")
 
 from comfy_cli.command import workflow_edit as _wedit  # noqa: E402
 
+app.command("insert-workflow", help="Insert a complete workflow; emits one insert_workflow op.")(
+    _wedit.insert_workflow_cmd
+)
 app.command("add-node", help="Add a node to the graph; emits an add_node op.")(_wedit.add_node_cmd)
 app.command("connect", help="Wire an output slot to an input slot; emits a connect op.")(_wedit.connect_cmd)
 app.command("set-widget", help="Set a widget by name (`<id>.<widget>`); emits a set_widget op.")(_wedit.set_widget_cmd)

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -148,7 +148,7 @@ def _graph_or_exit(input_path, host, port, renderer, where=None):
 @tracking.track_command("workflow")
 def insert_workflow_cmd(
     file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to update.")],
-    template: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to insert.")],
+    template: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to insert, or '-' for stdin.")],
     actor: ActorOpt = "cli",
     base_version: BaseVersionOpt = 0,
 ):
@@ -157,8 +157,13 @@ def insert_workflow_cmd(
     renderer.command = "workflow insert-workflow"
     p, workflow = _load_workflow_or_fail(renderer, file)
     try:
-        template_path = Path(template).expanduser()
-        inserted = json.loads(template_path.read_text(encoding="utf-8"))
+        if template == "-":
+            import sys
+
+            raw = sys.stdin.read()
+        else:
+            raw = Path(template).expanduser().read_text(encoding="utf-8")
+        inserted = json.loads(raw)
         if not isinstance(inserted, dict):
             raise ValueError("template must be a JSON object")
         _, op = workflow_ops.insert_workflow(workflow, inserted, actor=actor, base_version=base_version)

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -151,7 +151,6 @@ def insert_workflow_cmd(
     template: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to insert.")],
     actor: ActorOpt = "cli",
     base_version: BaseVersionOpt = 0,
-    stdout: StdoutOpt = False,
 ):
     """Insert a workflow template and emit one atomic ``insert_workflow`` op."""
     renderer = get_renderer()
@@ -166,14 +165,7 @@ def insert_workflow_cmd(
     except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         _emit_edit_error(renderer, e, hint="provide a frontend-format workflow template JSON file")
         raise typer.Exit(code=1) from e
-    try:
-        _emit_op(renderer, p, op, base_version, "workflow insert-workflow")
-    except ValueError as e:
-        # The outbound edit transport may return cmp's rejection. Preserve its
-        # message exactly: it is already the most actionable explanation and
-        # callers must not have to unwrap a second client-side paraphrase.
-        renderer.error(code="workflow_edit_invalid", message=str(e))
-        raise typer.Exit(code=1) from e
+    _emit_op(renderer, p, op, base_version, "workflow insert-workflow")
 
 
 @tracking.track_command("workflow")

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -128,6 +128,14 @@ def _finish(renderer, p, workflow: dict, op: dict, base_version: int, stdout: bo
     renderer.emit(payload, command=command, changed=not stdout)
 
 
+def _emit_op(renderer, p: Path, op: dict, base_version: int, command: str) -> None:
+    """Emit an op without applying it or writing the source workflow."""
+    payload = {"workflow": str(p), "op": op, "base_version": base_version, "wrote": None}
+    if renderer.is_pretty():
+        rprint(f"[bold green]✓[/bold green] {op['op']} emitted for [dim]{p}[/dim]")
+    renderer.emit(payload, command=command, changed=False)
+
+
 def _graph_or_exit(input_path, host, port, renderer, where=None):
     return _get_graph(input_path, host, port, where=where)
 
@@ -154,11 +162,11 @@ def insert_workflow_cmd(
         inserted = json.loads(template_path.read_text(encoding="utf-8"))
         if not isinstance(inserted, dict):
             raise ValueError("template must be a JSON object")
-        workflow, op = workflow_ops.insert_workflow(workflow, inserted, actor=actor, base_version=base_version)
+        _, op = workflow_ops.insert_workflow(workflow, inserted, actor=actor, base_version=base_version)
     except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         _emit_edit_error(renderer, e, hint="provide a frontend-format workflow template JSON file")
         raise typer.Exit(code=1) from e
-    _finish(renderer, p, workflow, op, base_version, stdout, "workflow insert-workflow")
+    _emit_op(renderer, p, op, base_version, "workflow insert-workflow")
 
 
 @tracking.track_command("workflow")

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -166,7 +166,14 @@ def insert_workflow_cmd(
     except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
         _emit_edit_error(renderer, e, hint="provide a frontend-format workflow template JSON file")
         raise typer.Exit(code=1) from e
-    _emit_op(renderer, p, op, base_version, "workflow insert-workflow")
+    try:
+        _emit_op(renderer, p, op, base_version, "workflow insert-workflow")
+    except ValueError as e:
+        # The outbound edit transport may return cmp's rejection. Preserve its
+        # message exactly: it is already the most actionable explanation and
+        # callers must not have to unwrap a second client-side paraphrase.
+        renderer.error(code="workflow_edit_invalid", message=str(e))
+        raise typer.Exit(code=1) from e
 
 
 @tracking.track_command("workflow")

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -138,6 +138,30 @@ def _graph_or_exit(input_path, host, port, renderer, where=None):
 
 
 @tracking.track_command("workflow")
+def insert_workflow_cmd(
+    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to update.")],
+    template: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to insert.")],
+    actor: ActorOpt = "cli",
+    base_version: BaseVersionOpt = 0,
+    stdout: StdoutOpt = False,
+):
+    """Insert a workflow template and emit one atomic ``insert_workflow`` op."""
+    renderer = get_renderer()
+    renderer.command = "workflow insert-workflow"
+    p, workflow = _load_workflow_or_fail(renderer, file)
+    try:
+        template_path = Path(template).expanduser()
+        inserted = json.loads(template_path.read_text(encoding="utf-8"))
+        if not isinstance(inserted, dict):
+            raise ValueError("template must be a JSON object")
+        workflow, op = workflow_ops.insert_workflow(workflow, inserted, actor=actor, base_version=base_version)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+        _emit_edit_error(renderer, e, hint="provide a frontend-format workflow template JSON file")
+        raise typer.Exit(code=1) from e
+    _finish(renderer, p, workflow, op, base_version, stdout, "workflow insert-workflow")
+
+
+@tracking.track_command("workflow")
 def add_node_cmd(
     file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON.")],
     class_type: Annotated[str, typer.Argument(help="Node class_type, e.g. KSampler.")],

--- a/comfy_cli/discovery.py
+++ b/comfy_cli/discovery.py
@@ -98,6 +98,7 @@ COMMAND_SCHEMAS: dict[str, str] = {
     "comfy workflow notes": "workflow",
     "comfy workflow print": "workflow",
     # structured edit primitives + recipes (CRDT op-based authoring)
+    "comfy workflow insert-workflow": "workflow",
     "comfy workflow add-node": "workflow",
     "comfy workflow connect": "workflow",
     "comfy workflow set-widget": "workflow",

--- a/comfy_cli/error_codes.py
+++ b/comfy_cli/error_codes.py
@@ -601,6 +601,12 @@ REGISTRY: tuple[ErrorCode, ...] = (
         "run the standalone `comfy workflow reset-doc <file> --confirm` first, then apply the remaining ops as a batch",
     ),
     ErrorCode(
+        "workflow_insert_workflow_not_batchable",
+        "A batch contained an `insert_workflow` op. A complete workflow insertion is one standalone atomic op, "
+        "so nesting it in the spec batch protocol is rejected and nothing is applied.",
+        "run `comfy workflow insert-workflow <file> <template>` instead",
+    ),
+    ErrorCode(
         "workflow_reset_doc_unconfirmed",
         "`comfy workflow reset-doc` was called without `--confirm`. The command fails closed: it erases every "
         "node AND the document's replay history, which no later op can undo.",

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -355,11 +355,14 @@ of a live graph, use the structured-edit primitives below — never raw `jq`/`se
 ## Structured graph edits — `insert-workflow` / `add-node` / `connect` / `set-widget` / `delete-node`
 
 The **sanctioned** way to mutate a graph's *structure* from code — the
-alternative to `jq`/`sed` on `nodes`/`links`/`widgets_values`. Each edit is
-validated against `object_info` (node class, widget name, widget value **shape**,
-and connection **type** are hard-checked; unknown COMBO values / out-of-range
-numbers come back as soft `warnings`) and emits a replayable **operation** in
-`data.op`.
+alternative to `jq`/`sed` on `nodes`/`links`/`widgets_values`. `insert-workflow`
+is emit-only: the CLI checks JSON shape and forwards the workflow without
+semantic validation or id remapping. The cmp applier on the server validates node
+types, links, and definition ids, remaps ids, and returns errors that the CLI
+surfaces verbatim. The other edits are validated against `object_info` (node
+class, widget name, widget value **shape**, and connection **type** are
+hard-checked; unknown COMBO values / out-of-range numbers come back as soft
+`warnings`) and emit a replayable **operation** in `data.op`.
 
 **When to use which editing path:**
 - **Reusable / human-authored workflow** → fragments + blueprint (above). *Default.*

--- a/comfy_cli/skills/comfy/SKILL.md
+++ b/comfy_cli/skills/comfy/SKILL.md
@@ -352,7 +352,7 @@ of a live graph, use the structured-edit primitives below — never raw `jq`/`se
 (This rule exists because that exact jq-on-`id==128` hand-edit is the anti-pattern
 `decompose` — and these primitives — were built to kill.)
 
-## Structured graph edits — `add-node` / `connect` / `set-widget` / `delete-node`
+## Structured graph edits — `insert-workflow` / `add-node` / `connect` / `set-widget` / `delete-node`
 
 The **sanctioned** way to mutate a graph's *structure* from code — the
 alternative to `jq`/`sed` on `nodes`/`links`/`widgets_values`. Each edit is
@@ -368,8 +368,8 @@ numbers come back as soft `warnings`) and emits a replayable **operation** in
   nodes; the in-app agent's path; any edit that must merge with a concurrent
   human editor) → the primitives here.
 
-> **Live co-editing / CRDT:** only the structured-edit primitives (`add-node`/
-> `connect`/`set-widget`/`delete-node`/`apply`) emit a mergeable **op** in
+> **Live co-editing / CRDT:** only the structured-edit primitives (`insert-workflow`/
+> `add-node`/`connect`/`set-widget`/`delete-node`/`apply`) emit a mergeable **op** in
 > `data.op`/`data.ops` (`op_id` + `actor` + `base_version` + `stamp`). Fragments +
 > `compose` produce a **whole-document** graph — fine for authoring a *fresh*
 > draft (the base), but it does **not** emit ops and will clobber a concurrent
@@ -385,6 +385,7 @@ CAT="--where cloud"
 # Start from an existing graph, or an empty one:
 echo '{"nodes":[],"links":[],"last_node_id":0,"last_link_id":0}' > wf.json
 
+comfy --json workflow insert-workflow wf.json template.json                # emits one atomic insert_workflow op
 comfy --json workflow add-node    wf.json KSampler --at 400,200 $CAT  # → data.op.node_id (minted)
 comfy --json workflow connect     wf.json 7.LATENT 3.samples $CAT     # source out-slot → target in-slot
 comfy --json workflow set-widget  wf.json 3.steps 35 $CAT             # widget by NAME; op carries {old,value}

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -91,7 +91,15 @@ def _new_op(kind: str, actor: str, base_version: int, **fields: Any) -> dict[str
 # ---------------------------------------------------------------------------
 
 #: Every op kind in the v1 vocabulary, including defined-but-deferred kinds.
-FROZEN_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node", "clear", "reset_doc")
+FROZEN_OPS: tuple[str, ...] = (
+    "add_node",
+    "connect",
+    "set_widget",
+    "delete_node",
+    "clear",
+    "reset_doc",
+    "insert_workflow",
+)
 
 #: Kinds frozen in the contract whose replay is not implemented yet.
 #: ``apply_op`` must keep rejecting these. Empty since amendment v1.1:
@@ -116,6 +124,11 @@ _NOT_BATCHABLE: dict[str, dict[str, str]] = {
         "code": "workflow_reset_doc_not_batchable",
         "command": "comfy workflow reset-doc <file> --confirm",
         "does": "resets the whole document to the empty baseline and erases its replay history",
+    },
+    "insert_workflow": {
+        "code": "workflow_insert_workflow_not_batchable",
+        "command": "comfy workflow insert-workflow <file> <template>",
+        "does": "inserts a complete workflow in one transaction",
     },
 }
 
@@ -1295,6 +1308,57 @@ def replace_ops(old: dict, new: dict, *, actor: str = "cli", base_version: int =
     return ops
 
 
+def remap_workflow_ids(workflow: dict, *, node_id_start: int, link_id_start: int) -> dict:
+    """Port of cmp ``remapWorkflowIds``: remap only the top-level namespace.
+
+    Definition interiors are independent graphs and deliberately remain
+    untouched. The input is never mutated.
+    """
+    out = copy.deepcopy(workflow)
+    nodes = out.get("nodes") or []
+    links = out.get("links") or []
+    node_ids = {node.get("id"): node_id_start + index for index, node in enumerate(nodes)}
+    link_ids = {link[0]: link_id_start + index for index, link in enumerate(links) if isinstance(link, list)}
+
+    for node in nodes:
+        original_id = node.get("id")
+        node["id"] = node_ids[original_id]
+        if isinstance(node.get("inputs"), list):
+            for slot in node["inputs"]:
+                if isinstance(slot, dict) and "link" in slot and slot["link"] in link_ids:
+                    slot["link"] = link_ids[slot["link"]]
+        if isinstance(node.get("outputs"), list):
+            for slot in node["outputs"]:
+                if isinstance(slot, dict) and isinstance(slot.get("links"), list):
+                    slot["links"] = [link_ids.get(link_id, link_id) for link_id in slot["links"]]
+
+    for link in links:
+        if not isinstance(link, list):
+            continue
+        link[0] = link_ids.get(link[0], link[0])
+        link[1] = node_ids.get(link[1], link[1])
+        link[3] = node_ids.get(link[3], link[3])
+    return out
+
+
+def insert_workflow(
+    workflow: dict,
+    template: dict,
+    *,
+    actor: str = "cli",
+    base_version: int = 0,
+) -> tuple[dict, dict]:
+    """Remap and insert a complete workflow with one stamped op."""
+    numeric_nodes = [n.get("id") for n in workflow.get("nodes", []) if isinstance(n, dict)]
+    numeric_links = [link[0] for link in workflow.get("links", []) if isinstance(link, list) and link]
+    node_start = max([workflow.get("last_node_id", 0), *[x for x in numeric_nodes if isinstance(x, int)]]) + 1
+    link_start = max([workflow.get("last_link_id", 0), *[x for x in numeric_links if isinstance(x, int)]]) + 1
+    remapped = remap_workflow_ids(template, node_id_start=node_start, link_id_start=link_start)
+    op = _new_op("insert_workflow", actor, base_version, workflow=remapped)
+    apply_op(workflow, op, None)
+    return workflow, op
+
+
 def delete_node(
     workflow: dict,
     graph,
@@ -1813,6 +1877,8 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
             _apply_clear(workflow, op)
         elif kind == "reset_doc":
             _apply_reset_doc(workflow, op)
+        elif kind == "insert_workflow":
+            _apply_insert_workflow(workflow, op)
         else:
             raise ValueError(f"unknown op {kind!r}")
     except BaseException:
@@ -1840,6 +1906,53 @@ def _apply_add_node(workflow: dict, op: dict) -> None:
     # address, historical workflow) is not comparable and never bumps it.
     if isinstance(op["node_id"], int) and not isinstance(op["node_id"], bool):
         workflow["last_node_id"] = max(workflow.get("last_node_id") or 0, op["node_id"])
+
+
+def _apply_insert_workflow(workflow: dict, op: dict) -> None:
+    inserted = op.get("workflow")
+    if not isinstance(inserted, dict):
+        raise ValueError("malformed_op: insert_workflow workflow must be an object")
+    nodes, links = inserted.get("nodes"), inserted.get("links", [])
+    if not isinstance(nodes, list) or not isinstance(links, list):
+        raise ValueError("malformed_op: insert_workflow nodes and links must be arrays")
+    live_node_ids = {str(n.get("id")) for n in workflow.get("nodes", []) if isinstance(n, dict)}
+    live_link_ids = {str(link[0]) for link in workflow.get("links", []) if isinstance(link, list) and link}
+    seen_nodes: set[str] = set()
+    for node in nodes:
+        if (
+            not isinstance(node, dict)
+            or node.get("id") is None
+            or not isinstance(node.get("type"), str)
+            or not node["type"]
+        ):
+            raise ValueError("invalid_node_payload: insert_workflow every node requires id and type")
+        key = str(node["id"])
+        if key in live_node_ids or key in seen_nodes:
+            raise ValueError(f"node_id_collision: insert_workflow node id {key!r} collides")
+        seen_nodes.add(key)
+    seen_links: set[str] = set()
+    for link in links:
+        if not isinstance(link, list) or not link or link[0] is None:
+            raise ValueError("malformed_op: insert_workflow every link must be a tuple with an id")
+        key = str(link[0])
+        if key in live_link_ids or key in seen_links:
+            raise ValueError(f"link_id_collision: insert_workflow link id {key!r} collides")
+        seen_links.add(key)
+    definitions = inserted.get("definitions")
+    if definitions is not None and not isinstance(definitions, dict):
+        raise ValueError("malformed_op: insert_workflow definitions must be an object")
+    subgraphs = definitions.get("subgraphs", []) if definitions else []
+    if not isinstance(subgraphs, list):
+        raise ValueError("malformed_op: insert_workflow definitions.subgraphs must be an array")
+
+    workflow.setdefault("nodes", []).extend(copy.deepcopy(nodes))
+    workflow.setdefault("links", []).extend(copy.deepcopy(links))
+    if subgraphs:
+        workflow.setdefault("definitions", {}).setdefault("subgraphs", []).extend(copy.deepcopy(subgraphs))
+    workflow["last_node_id"] = max(
+        workflow.get("last_node_id", 0), *[n["id"] for n in nodes if isinstance(n["id"], int)]
+    )
+    workflow["last_link_id"] = max(workflow.get("last_link_id", 0), *[x[0] for x in links if isinstance(x[0], int)])
 
 
 def _apply_set_widget(workflow: dict, op: dict, graph) -> None:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1341,6 +1341,40 @@ def remap_workflow_ids(workflow: dict, *, node_id_start: int, link_id_start: int
     return out
 
 
+def _validate_insert_workflow_payload(inserted: Any, live_node_ids: set[str]) -> tuple[list, list, list]:
+    """Validate the complete insert payload before remapping or applying it."""
+    if not isinstance(inserted, dict):
+        raise ValueError("malformed_op: insert_workflow workflow must be an object")
+    nodes, links = inserted.get("nodes"), inserted.get("links", [])
+    if not isinstance(nodes, list) or not isinstance(links, list):
+        raise ValueError("malformed_op: insert_workflow nodes and links must be arrays")
+    node_ids: set[str] = set()
+    for node in nodes:
+        if (
+            not isinstance(node, dict)
+            or node.get("id") is None
+            or not isinstance(node.get("type"), str)
+            or not node["type"]
+        ):
+            raise ValueError("invalid_node_payload: insert_workflow every node requires id and type")
+        node_ids.add(str(node["id"]))
+    valid_endpoints = live_node_ids | node_ids
+    for link in links:
+        if not isinstance(link, list) or len(link) < 5 or link[0] is None:
+            raise ValueError("malformed_op: insert_workflow every link must have id and endpoint fields")
+        if str(link[1]) not in valid_endpoints or str(link[3]) not in valid_endpoints:
+            raise ValueError("dangling_link_endpoint: insert_workflow link references a missing node")
+    definitions = inserted.get("definitions")
+    if definitions is not None and not isinstance(definitions, dict):
+        raise ValueError("malformed_op: insert_workflow definitions must be an object")
+    subgraphs = definitions.get("subgraphs", []) if definitions else []
+    if not isinstance(subgraphs, list):
+        raise ValueError("malformed_op: insert_workflow definitions.subgraphs must be an array")
+    if any(not isinstance(definition, dict) or definition.get("id") is None for definition in subgraphs):
+        raise ValueError("malformed_op: insert_workflow every subgraph definition requires an id")
+    return nodes, links, subgraphs
+
+
 def insert_workflow(
     workflow: dict,
     template: dict,
@@ -1349,6 +1383,8 @@ def insert_workflow(
     base_version: int = 0,
 ) -> tuple[dict, dict]:
     """Remap and insert a complete workflow with one stamped op."""
+    live_node_ids = {str(n.get("id")) for n in workflow.get("nodes", []) if isinstance(n, dict)}
+    _validate_insert_workflow_payload(template, live_node_ids)
     numeric_nodes = [n.get("id") for n in workflow.get("nodes", []) if isinstance(n, dict)]
     numeric_links = [link[0] for link in workflow.get("links", []) if isinstance(link, list) and link]
     node_start = max([workflow.get("last_node_id", 0), *[x for x in numeric_nodes if isinstance(x, int)]]) + 1
@@ -1859,6 +1895,8 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
     if op["op_id"] in applied:
         return workflow
     kind = op["op"]
+    if kind != "insert_workflow" and "definitions" in op:
+        raise ValueError(f"malformed_op: {kind} does not accept definitions")
     # Snapshot the LWW bookkeeping so an exception escaping a handler cannot
     # leave a stamp committed WITHOUT its op_id recorded below. That pairing is
     # the poison state: a retry of the identical op loses to the failed
@@ -1910,12 +1948,8 @@ def _apply_add_node(workflow: dict, op: dict) -> None:
 
 def _apply_insert_workflow(workflow: dict, op: dict) -> None:
     inserted = op.get("workflow")
-    if not isinstance(inserted, dict):
-        raise ValueError("malformed_op: insert_workflow workflow must be an object")
-    nodes, links = inserted.get("nodes"), inserted.get("links", [])
-    if not isinstance(nodes, list) or not isinstance(links, list):
-        raise ValueError("malformed_op: insert_workflow nodes and links must be arrays")
     live_node_ids = {str(n.get("id")) for n in workflow.get("nodes", []) if isinstance(n, dict)}
+    nodes, links, subgraphs = _validate_insert_workflow_payload(inserted, live_node_ids)
     live_link_ids = {str(link[0]) for link in workflow.get("links", []) if isinstance(link, list) and link}
     seen_nodes: set[str] = set()
     for node in nodes:
@@ -1932,27 +1966,30 @@ def _apply_insert_workflow(workflow: dict, op: dict) -> None:
         seen_nodes.add(key)
     seen_links: set[str] = set()
     for link in links:
-        if not isinstance(link, list) or not link or link[0] is None:
-            raise ValueError("malformed_op: insert_workflow every link must be a tuple with an id")
         key = str(link[0])
         if key in live_link_ids or key in seen_links:
             raise ValueError(f"link_id_collision: insert_workflow link id {key!r} collides")
         seen_links.add(key)
-    definitions = inserted.get("definitions")
-    if definitions is not None and not isinstance(definitions, dict):
-        raise ValueError("malformed_op: insert_workflow definitions must be an object")
-    subgraphs = definitions.get("subgraphs", []) if definitions else []
-    if not isinstance(subgraphs, list):
-        raise ValueError("malformed_op: insert_workflow definitions.subgraphs must be an array")
+    existing_subgraphs = workflow.get("definitions", {}).get("subgraphs", [])
+    existing_by_id = {str(definition.get("id")): definition for definition in existing_subgraphs}
+    new_subgraphs = []
+    for definition in subgraphs:
+        existing = existing_by_id.get(str(definition["id"]))
+        if existing is not None:
+            if existing != definition:
+                raise ValueError(f"definition_conflict: subgraph definition id {definition['id']!r} differs")
+            continue
+        existing_by_id[str(definition["id"])] = definition
+        new_subgraphs.append(definition)
 
     workflow.setdefault("nodes", []).extend(copy.deepcopy(nodes))
     workflow.setdefault("links", []).extend(copy.deepcopy(links))
-    if subgraphs:
-        workflow.setdefault("definitions", {}).setdefault("subgraphs", []).extend(copy.deepcopy(subgraphs))
+    if new_subgraphs:
+        workflow.setdefault("definitions", {}).setdefault("subgraphs", []).extend(copy.deepcopy(new_subgraphs))
     workflow["last_node_id"] = max(
-        workflow.get("last_node_id", 0), *[n["id"] for n in nodes if isinstance(n["id"], int)]
+        [workflow.get("last_node_id", 0), *[n["id"] for n in nodes if isinstance(n["id"], int)]]
     )
-    workflow["last_link_id"] = max(workflow.get("last_link_id", 0), *[x[0] for x in links if isinstance(x[0], int)])
+    workflow["last_link_id"] = max([workflow.get("last_link_id", 0), *[x[0] for x in links if isinstance(x[0], int)]])
 
 
 def _apply_set_widget(workflow: dict, op: dict, graph) -> None:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1315,7 +1315,16 @@ def insert_workflow(
     actor: str = "cli",
     base_version: int = 0,
 ) -> tuple[dict, dict]:
-    """Emit an insert op; cmp owns validation, ID remapping, and application."""
+    """Structurally validate and emit an insert op without applying it."""
+    if not isinstance(template, dict):
+        raise ValueError("insert_workflow workflow must be a JSON object")
+    for field in ("nodes", "links", "groups"):
+        if field not in template:
+            raise ValueError(f"insert_workflow missing required field: {field}")
+        if not isinstance(template[field], list):
+            raise ValueError(f"insert_workflow field {field} must be an array")
+    if "definitions" in template and not isinstance(template["definitions"], dict):
+        raise ValueError("insert_workflow field definitions must be an object")
     return workflow, _new_op("insert_workflow", actor, base_version, workflow=copy.deepcopy(template))
 
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1315,13 +1315,18 @@ def insert_workflow(
     actor: str = "cli",
     base_version: int = 0,
 ) -> tuple[dict, dict]:
-    """Structurally validate and emit an insert op without applying it."""
+    """Structurally validate and emit an insert op without applying it.
+
+    The CLI deliberately preserves all source IDs. Per the vetoable contract
+    decision recorded in the TDD, cmp owns deterministic ID remapping from the
+    op envelope ID when it applies this payload.
+    """
     if not isinstance(template, dict):
         raise ValueError("insert_workflow workflow must be a JSON object")
+    if "nodes" not in template:
+        raise ValueError("insert_workflow missing required field: nodes")
     for field in ("nodes", "links", "groups"):
-        if field not in template:
-            raise ValueError(f"insert_workflow missing required field: {field}")
-        if not isinstance(template[field], list):
+        if field in template and not isinstance(template[field], list):
             raise ValueError(f"insert_workflow field {field} must be an array")
     if "definitions" in template and not isinstance(template["definitions"], dict):
         raise ValueError("insert_workflow field definitions must be an object")

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -101,10 +101,10 @@ FROZEN_OPS: tuple[str, ...] = (
     "insert_workflow",
 )
 
-#: Kinds frozen in the contract whose replay is not implemented yet.
-#: ``apply_op`` must keep rejecting these. Empty since amendment v1.1:
-#: ``reset_doc`` was un-deferred by the bulk-writers ticket (V1-038).
-DEFERRED_OPS: tuple[str, ...] = ()
+#: Kinds frozen in the contract whose replay is not implemented in the CLI.
+#: ``insert_workflow`` is emitted for cmp to validate and apply; the CLI must
+#: keep rejecting local replay to preserve that ownership boundary.
+DEFERRED_OPS: tuple[str, ...] = ("insert_workflow",)
 
 #: Kinds a batch (``apply_specs``) dispatches. ``clear`` and ``reset_doc`` are
 #: standalone-only: they rewrite the whole document, so they never ride inside
@@ -1308,73 +1308,6 @@ def replace_ops(old: dict, new: dict, *, actor: str = "cli", base_version: int =
     return ops
 
 
-def remap_workflow_ids(workflow: dict, *, node_id_start: int, link_id_start: int) -> dict:
-    """Port of cmp ``remapWorkflowIds``: remap only the top-level namespace.
-
-    Definition interiors are independent graphs and deliberately remain
-    untouched. The input is never mutated.
-    """
-    out = copy.deepcopy(workflow)
-    nodes = out.get("nodes") or []
-    links = out.get("links") or []
-    node_ids = {node.get("id"): node_id_start + index for index, node in enumerate(nodes)}
-    link_ids = {link[0]: link_id_start + index for index, link in enumerate(links) if isinstance(link, list)}
-
-    for node in nodes:
-        original_id = node.get("id")
-        node["id"] = node_ids[original_id]
-        if isinstance(node.get("inputs"), list):
-            for slot in node["inputs"]:
-                if isinstance(slot, dict) and "link" in slot and slot["link"] in link_ids:
-                    slot["link"] = link_ids[slot["link"]]
-        if isinstance(node.get("outputs"), list):
-            for slot in node["outputs"]:
-                if isinstance(slot, dict) and isinstance(slot.get("links"), list):
-                    slot["links"] = [link_ids.get(link_id, link_id) for link_id in slot["links"]]
-
-    for link in links:
-        if not isinstance(link, list):
-            continue
-        link[0] = link_ids.get(link[0], link[0])
-        link[1] = node_ids.get(link[1], link[1])
-        link[3] = node_ids.get(link[3], link[3])
-    return out
-
-
-def _validate_insert_workflow_payload(inserted: Any, live_node_ids: set[str]) -> tuple[list, list, list]:
-    """Validate the complete insert payload before remapping or applying it."""
-    if not isinstance(inserted, dict):
-        raise ValueError("malformed_op: insert_workflow workflow must be an object")
-    nodes, links = inserted.get("nodes"), inserted.get("links", [])
-    if not isinstance(nodes, list) or not isinstance(links, list):
-        raise ValueError("malformed_op: insert_workflow nodes and links must be arrays")
-    node_ids: set[str] = set()
-    for node in nodes:
-        if (
-            not isinstance(node, dict)
-            or node.get("id") is None
-            or not isinstance(node.get("type"), str)
-            or not node["type"]
-        ):
-            raise ValueError("invalid_node_payload: insert_workflow every node requires id and type")
-        node_ids.add(str(node["id"]))
-    valid_endpoints = live_node_ids | node_ids
-    for link in links:
-        if not isinstance(link, list) or len(link) < 5 or link[0] is None:
-            raise ValueError("malformed_op: insert_workflow every link must have id and endpoint fields")
-        if str(link[1]) not in valid_endpoints or str(link[3]) not in valid_endpoints:
-            raise ValueError("dangling_link_endpoint: insert_workflow link references a missing node")
-    definitions = inserted.get("definitions")
-    if definitions is not None and not isinstance(definitions, dict):
-        raise ValueError("malformed_op: insert_workflow definitions must be an object")
-    subgraphs = definitions.get("subgraphs", []) if definitions else []
-    if not isinstance(subgraphs, list):
-        raise ValueError("malformed_op: insert_workflow definitions.subgraphs must be an array")
-    if any(not isinstance(definition, dict) or definition.get("id") is None for definition in subgraphs):
-        raise ValueError("malformed_op: insert_workflow every subgraph definition requires an id")
-    return nodes, links, subgraphs
-
-
 def insert_workflow(
     workflow: dict,
     template: dict,
@@ -1382,17 +1315,8 @@ def insert_workflow(
     actor: str = "cli",
     base_version: int = 0,
 ) -> tuple[dict, dict]:
-    """Remap and insert a complete workflow with one stamped op."""
-    live_node_ids = {str(n.get("id")) for n in workflow.get("nodes", []) if isinstance(n, dict)}
-    _validate_insert_workflow_payload(template, live_node_ids)
-    numeric_nodes = [n.get("id") for n in workflow.get("nodes", []) if isinstance(n, dict)]
-    numeric_links = [link[0] for link in workflow.get("links", []) if isinstance(link, list) and link]
-    node_start = max([workflow.get("last_node_id", 0), *[x for x in numeric_nodes if isinstance(x, int)]]) + 1
-    link_start = max([workflow.get("last_link_id", 0), *[x for x in numeric_links if isinstance(x, int)]]) + 1
-    remapped = remap_workflow_ids(template, node_id_start=node_start, link_id_start=link_start)
-    op = _new_op("insert_workflow", actor, base_version, workflow=remapped)
-    apply_op(workflow, op, None)
-    return workflow, op
+    """Emit an insert op; cmp owns validation, ID remapping, and application."""
+    return workflow, _new_op("insert_workflow", actor, base_version, workflow=copy.deepcopy(template))
 
 
 def delete_node(
@@ -1915,8 +1839,6 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
             _apply_clear(workflow, op)
         elif kind == "reset_doc":
             _apply_reset_doc(workflow, op)
-        elif kind == "insert_workflow":
-            _apply_insert_workflow(workflow, op)
         else:
             raise ValueError(f"unknown op {kind!r}")
     except BaseException:
@@ -1944,52 +1866,6 @@ def _apply_add_node(workflow: dict, op: dict) -> None:
     # address, historical workflow) is not comparable and never bumps it.
     if isinstance(op["node_id"], int) and not isinstance(op["node_id"], bool):
         workflow["last_node_id"] = max(workflow.get("last_node_id") or 0, op["node_id"])
-
-
-def _apply_insert_workflow(workflow: dict, op: dict) -> None:
-    inserted = op.get("workflow")
-    live_node_ids = {str(n.get("id")) for n in workflow.get("nodes", []) if isinstance(n, dict)}
-    nodes, links, subgraphs = _validate_insert_workflow_payload(inserted, live_node_ids)
-    live_link_ids = {str(link[0]) for link in workflow.get("links", []) if isinstance(link, list) and link}
-    seen_nodes: set[str] = set()
-    for node in nodes:
-        if (
-            not isinstance(node, dict)
-            or node.get("id") is None
-            or not isinstance(node.get("type"), str)
-            or not node["type"]
-        ):
-            raise ValueError("invalid_node_payload: insert_workflow every node requires id and type")
-        key = str(node["id"])
-        if key in live_node_ids or key in seen_nodes:
-            raise ValueError(f"node_id_collision: insert_workflow node id {key!r} collides")
-        seen_nodes.add(key)
-    seen_links: set[str] = set()
-    for link in links:
-        key = str(link[0])
-        if key in live_link_ids or key in seen_links:
-            raise ValueError(f"link_id_collision: insert_workflow link id {key!r} collides")
-        seen_links.add(key)
-    existing_subgraphs = workflow.get("definitions", {}).get("subgraphs", [])
-    existing_by_id = {str(definition.get("id")): definition for definition in existing_subgraphs}
-    new_subgraphs = []
-    for definition in subgraphs:
-        existing = existing_by_id.get(str(definition["id"]))
-        if existing is not None:
-            if existing != definition:
-                raise ValueError(f"definition_conflict: subgraph definition id {definition['id']!r} differs")
-            continue
-        existing_by_id[str(definition["id"])] = definition
-        new_subgraphs.append(definition)
-
-    workflow.setdefault("nodes", []).extend(copy.deepcopy(nodes))
-    workflow.setdefault("links", []).extend(copy.deepcopy(links))
-    if new_subgraphs:
-        workflow.setdefault("definitions", {}).setdefault("subgraphs", []).extend(copy.deepcopy(new_subgraphs))
-    workflow["last_node_id"] = max(
-        [workflow.get("last_node_id", 0), *[n["id"] for n in nodes if isinstance(n["id"], int)]]
-    )
-    workflow["last_link_id"] = max([workflow.get("last_link_id", 0), *[x[0] for x in links if isinstance(x[0], int)]])
 
 
 def _apply_set_widget(workflow: dict, op: dict, graph) -> None:

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -195,10 +195,11 @@ the template payload verbatim and emits exactly one stamped op:
 }
 ```
 
-The `workflow` payload is authoritative and requires top-level `nodes`, `links`,
-and `groups` arrays; `definitions` is optional. The CLI checks only this outer
-shape. It does not validate graph semantics, remap IDs, apply the op, or write a
-mutated workflow document. Per the contract decision recorded in the TDD
+The `workflow` payload is authoritative and requires a top-level `nodes` array;
+`links`, `groups`, and `definitions` are optional. When present, `links` and
+`groups` must be arrays and `definitions` must be an object. The CLI checks only
+this outer shape. It does not validate graph semantics, remap IDs, apply the op,
+or write a mutated workflow document. Per the contract decision recorded in the TDD
 (vetoable), cmp owns deterministic ID remapping from the op envelope ID. Only `define_subgraph` and
 `insert_workflow` ops may carry definitions; edit ops reject a `definitions`
 field as `malformed_op`. The kind is not batchable and a spec batch rejects it as

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -191,14 +191,14 @@ the template payload verbatim and emits exactly one stamped op:
   "actor": "cli",
   "base_version": 0,
   "stamp": [0, "cli"],
-  "workflow": {"nodes": [], "links": [], "definitions": {"subgraphs": []}}
+  "workflow": {"nodes": [], "links": [], "groups": [], "definitions": {"subgraphs": []}}
 }
 ```
 
-The `workflow` payload is authoritative and carries top-level `nodes`, `links`,
-and optional `definitions.subgraphs`. The CLI does not validate graph semantics,
-remap IDs, apply the op, or write a mutated workflow document; cmp owns those
-operations and returns their errors. Only `define_subgraph` and
+The `workflow` payload is authoritative and requires top-level `nodes`, `links`,
+and `groups` arrays; `definitions` is optional. The CLI checks only this outer
+shape. It does not validate graph semantics, remap IDs, apply the op, or write a
+mutated workflow document; cmp owns those operations. Only `define_subgraph` and
 `insert_workflow` ops may carry definitions; edit ops reject a `definitions`
 field as `malformed_op`. The kind is not batchable and a spec batch rejects it as
 `workflow_insert_workflow_not_batchable`.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -198,7 +198,8 @@ the template payload verbatim and emits exactly one stamped op:
 The `workflow` payload is authoritative and requires top-level `nodes`, `links`,
 and `groups` arrays; `definitions` is optional. The CLI checks only this outer
 shape. It does not validate graph semantics, remap IDs, apply the op, or write a
-mutated workflow document; cmp owns those operations. Only `define_subgraph` and
+mutated workflow document. Per the contract decision recorded in the TDD
+(vetoable), cmp owns deterministic ID remapping from the op envelope ID. Only `define_subgraph` and
 `insert_workflow` ops may carry definitions; edit ops reject a `definitions`
 field as `malformed_op`. The kind is not batchable and a spec batch rejects it as
 `workflow_insert_workflow_not_batchable`.

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -181,9 +181,8 @@ pre-reset `base_version` do not replay across it.
 
 ### 1.7 `insert_workflow` — standalone only
 
-Command: `comfy workflow insert-workflow <file> <template>`. The CLI remaps the
-template's top-level node and link ids away from ids in the live document, then
-emits exactly one stamped op:
+Command: `comfy workflow insert-workflow <file> <template>`. The CLI preserves
+the template payload verbatim and emits exactly one stamped op:
 
 ```json
 {
@@ -197,15 +196,11 @@ emits exactly one stamped op:
 ```
 
 The `workflow` payload is authoritative and carries top-level `nodes`, `links`,
-and optional `definitions.subgraphs`. Remapping rewrites top-level node ids,
-link tuple ids/endpoints, node input `link` fields, and output `links` arrays.
-Definition interiors are independent graph namespaces and remain unchanged.
-The applier validates all payloads before mutation and rejects with
-`node_id_collision`, `link_id_collision`, `malformed_op`,
-`invalid_node_payload`, `dangling_link_endpoint`, `definition_conflict`, or
-`catalog_required`. Only `define_subgraph` and `insert_workflow` ops may carry
-definitions; edit ops reject a `definitions` field as `malformed_op`. The kind
-is not batchable and a spec batch rejects it as
+and optional `definitions.subgraphs`. The CLI does not validate graph semantics,
+remap IDs, apply the op, or write a mutated workflow document; cmp owns those
+operations and returns their errors. Only `define_subgraph` and
+`insert_workflow` ops may carry definitions; edit ops reject a `definitions`
+field as `malformed_op`. The kind is not batchable and a spec batch rejects it as
 `workflow_insert_workflow_not_batchable`.
 
 ## 2. Idempotency and identity

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -202,8 +202,11 @@ link tuple ids/endpoints, node input `link` fields, and output `links` arrays.
 Definition interiors are independent graph namespaces and remain unchanged.
 The applier validates all payloads before mutation and rejects with
 `node_id_collision`, `link_id_collision`, `malformed_op`,
-`invalid_node_payload`, or `catalog_required`. The kind is not batchable and a
-spec batch rejects it as `workflow_insert_workflow_not_batchable`.
+`invalid_node_payload`, `dangling_link_endpoint`, `definition_conflict`, or
+`catalog_required`. Only `define_subgraph` and `insert_workflow` ops may carry
+definitions; edit ops reject a `definitions` field as `malformed_op`. The kind
+is not batchable and a spec batch rejects it as
+`workflow_insert_workflow_not_batchable`.
 
 ## 2. Idempotency and identity
 

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -17,7 +17,7 @@ citation must point at a commit on that branch.
 
 ## 1. Frozen op kinds
 
-Six kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
+Seven kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
 `ValueError("unknown op ...")` — it never ignores one.
 
 | Kind | Batchable | Standalone command | Summary |
@@ -28,6 +28,7 @@ Six kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
 | `delete_node` | yes | `comfy workflow delete` | Remove one node and its incident links |
 | `clear` | no | `comfy workflow clear` | Remove every node, link, and group |
 | `reset_doc` | no | `comfy workflow reset-doc --confirm` | Reset the whole document to an empty baseline |
+| `insert_workflow` | no | `comfy workflow insert-workflow` | Merge a complete workflow template in one transaction |
 
 Batchable = the kind is accepted by `apply_specs` (the `workflow apply` /
 `workflow foreach` batch surface). `clear` and `reset_doc` rewrite the whole
@@ -177,6 +178,32 @@ pre-reset `base_version` do not replay across it.
   `workflow_reset_doc_not_batchable`.
 * Never emitted implicitly: no `--emit-ops` surface and no bulk writer (§8.8)
   mints one. It exists only where a caller asked for it by name.
+
+### 1.7 `insert_workflow` — standalone only
+
+Command: `comfy workflow insert-workflow <file> <template>`. The CLI remaps the
+template's top-level node and link ids away from ids in the live document, then
+emits exactly one stamped op:
+
+```json
+{
+  "op": "insert_workflow",
+  "op_id": "<uuid4 hex>",
+  "actor": "cli",
+  "base_version": 0,
+  "stamp": [0, "cli"],
+  "workflow": {"nodes": [], "links": [], "definitions": {"subgraphs": []}}
+}
+```
+
+The `workflow` payload is authoritative and carries top-level `nodes`, `links`,
+and optional `definitions.subgraphs`. Remapping rewrites top-level node ids,
+link tuple ids/endpoints, node input `link` fields, and output `links` arrays.
+Definition interiors are independent graph namespaces and remain unchanged.
+The applier validates all payloads before mutation and rejects with
+`node_id_collision`, `link_id_collision`, `malformed_op`,
+`invalid_node_payload`, or `catalog_required`. The kind is not batchable and a
+spec batch rejects it as `workflow_insert_workflow_not_batchable`.
 
 ## 2. Idempotency and identity
 

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -16,6 +16,7 @@ import copy
 import json
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from typer.testing import CliRunner
@@ -527,6 +528,33 @@ def _run(args: list[str], capsys) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # add-node
 # ---------------------------------------------------------------------------
+
+
+class TestInsertWorkflow:
+    def test_transmits_op_once_through_renderer(self, monkeypatch, tmp_path):
+        workflow = _write(tmp_path, {"nodes": [], "links": [], "groups": []})
+        template = _write(tmp_path, {"nodes": [], "links": [], "groups": []}, "template.json")
+        renderer = _force_json_renderer()
+        transport = Mock()
+        monkeypatch.setattr(renderer, "emit", transport)
+
+        result = CliRunner().invoke(
+            workflow_cmd.app,
+            ["insert-workflow", str(workflow), str(template), "--actor", "agent", "--base-version", "4"],
+            standalone_mode=False,
+        )
+
+        assert result.exit_code == 0
+        transport.assert_called_once()
+        payload = transport.call_args.args[0]
+        assert transport.call_args.kwargs == {"command": "workflow insert-workflow", "changed": False}
+        assert payload["workflow"] == str(workflow)
+        assert payload["base_version"] == 4
+        assert payload["wrote"] is None
+        assert payload["op"]["op"] == "insert_workflow"
+        assert payload["op"]["actor"] == "agent"
+        assert payload["op"]["stamp"] == [4, "agent"]
+        assert payload["op"]["workflow"] == {"nodes": [], "links": [], "groups": []}
 
 
 class TestAddNode:

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -19,6 +19,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from comfy_cli import workflow_ops
@@ -555,6 +556,20 @@ class TestInsertWorkflow:
         assert payload["op"]["actor"] == "agent"
         assert payload["op"]["stamp"] == [4, "agent"]
         assert payload["op"]["workflow"] == {"nodes": [], "links": [], "groups": []}
+
+    def test_doc_host_rejection_is_surfaced_verbatim(self, monkeypatch, tmp_path, capsys):
+        workflow = _write(tmp_path, {"nodes": [], "links": []})
+        template = _write(tmp_path, {"nodes": []}, "template.json")
+        renderer = _force_json_renderer()
+        transport = Mock(side_effect=ValueError("cmp rejected insert: node_id_collision 100"))
+        monkeypatch.setattr(renderer, "emit", transport)
+
+        with pytest.raises(typer.Exit) as exc:
+            workflow_edit.insert_workflow_cmd(str(workflow), str(template))
+
+        assert exc.value.exit_code == 1
+        transport.assert_called_once()
+        assert "cmp rejected insert: node_id_collision 100" in capsys.readouterr().out
 
 
 class TestAddNode:

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -532,6 +532,23 @@ def _run(args: list[str], capsys) -> dict[str, Any]:
 
 
 class TestInsertWorkflow:
+    def test_reads_template_from_stdin_when_path_is_dash(self, monkeypatch, tmp_path):
+        workflow = _write(tmp_path, {"nodes": [], "links": [], "groups": []})
+        template = {"nodes": [{"id": 12, "type": "ServerValidatedNode"}], "links": [], "groups": []}
+        renderer = _force_json_renderer()
+        transport = Mock()
+        monkeypatch.setattr(renderer, "emit", transport)
+
+        result = CliRunner().invoke(
+            workflow_cmd.app,
+            ["insert-workflow", str(workflow), "-"],
+            input=json.dumps(template),
+            standalone_mode=False,
+        )
+
+        assert result.exit_code == 0
+        assert transport.call_args.args[0]["op"]["workflow"] == template
+
     def test_transmits_op_once_through_renderer(self, monkeypatch, tmp_path):
         workflow = _write(tmp_path, {"nodes": [], "links": [], "groups": []})
         template = _write(tmp_path, {"nodes": [], "links": [], "groups": []}, "template.json")

--- a/tests/comfy_cli/command/test_workflow_edit.py
+++ b/tests/comfy_cli/command/test_workflow_edit.py
@@ -535,6 +535,7 @@ class TestInsertWorkflow:
     def test_transmits_op_once_through_renderer(self, monkeypatch, tmp_path):
         workflow = _write(tmp_path, {"nodes": [], "links": [], "groups": []})
         template = _write(tmp_path, {"nodes": [], "links": [], "groups": []}, "template.json")
+        original = workflow.read_text(encoding="utf-8")
         renderer = _force_json_renderer()
         transport = Mock()
         monkeypatch.setattr(renderer, "emit", transport)
@@ -556,20 +557,33 @@ class TestInsertWorkflow:
         assert payload["op"]["actor"] == "agent"
         assert payload["op"]["stamp"] == [4, "agent"]
         assert payload["op"]["workflow"] == {"nodes": [], "links": [], "groups": []}
+        assert workflow.read_text(encoding="utf-8") == original
 
-    def test_doc_host_rejection_is_surfaced_verbatim(self, monkeypatch, tmp_path, capsys):
+    def test_stdout_is_not_offered_for_emit_only_command(self):
+        result = CliRunner().invoke(workflow_cmd.app, ["insert-workflow", "--help"])
+
+        assert result.exit_code == 0
+        assert "--stdout" not in result.output
+        assert "--in-place" not in result.output
+
+    def test_command_is_discoverable_in_schema_and_bundled_skill(self):
+        from comfy_cli.discovery import COMMAND_SCHEMAS
+
+        skill = Path(workflow_edit.__file__).parent.parent / "skills" / "comfy" / "SKILL.md"
+
+        assert COMMAND_SCHEMAS["comfy workflow insert-workflow"] == "workflow"
+        assert "insert-workflow" in skill.read_text(encoding="utf-8")
+
+    def test_local_validation_error_is_reported(self, tmp_path, capsys):
         workflow = _write(tmp_path, {"nodes": [], "links": []})
-        template = _write(tmp_path, {"nodes": []}, "template.json")
-        renderer = _force_json_renderer()
-        transport = Mock(side_effect=ValueError("cmp rejected insert: node_id_collision 100"))
-        monkeypatch.setattr(renderer, "emit", transport)
+        template = _write(tmp_path, {"links": []}, "template.json")
+        _force_json_renderer()
 
         with pytest.raises(typer.Exit) as exc:
             workflow_edit.insert_workflow_cmd(str(workflow), str(template))
 
         assert exc.value.exit_code == 1
-        transport.assert_called_once()
-        assert "cmp rejected insert: node_id_collision 100" in capsys.readouterr().out
+        assert "missing required field: nodes" in capsys.readouterr().out
 
 
 class TestAddNode:

--- a/tests/comfy_cli/test_insert_workflow_op.py
+++ b/tests/comfy_cli/test_insert_workflow_op.py
@@ -15,6 +15,7 @@ def _template() -> dict:
             {"id": 101, "type": "def-2", "inputs": [{"name": "a", "link": 200}]},
         ],
         "links": [[200, 100, 0, 101, 0, "X"]],
+        "groups": [],
         "definitions": {"subgraphs": [{"id": "def-2", "nodes": [{"id": 5, "type": "Inner"}], "links": []}]},
     }
 
@@ -34,11 +35,50 @@ def test_insert_workflow_emits_input_payload_without_remapping_ids():
 
 def test_insert_workflow_emits_semantically_invalid_json_for_server_validation():
     live = {"nodes": [], "links": []}
-    template = {"nodes": [{"id": 10}], "links": [[20, 10, 0, 999, 0]], "definitions": {"subgraphs": [{}]}}
+    template = {
+        "nodes": [{"id": 10}],
+        "links": [[20, 10, 0, 999, 0]],
+        "groups": [],
+        "definitions": {"subgraphs": [{}]},
+    }
 
     _, op = workflow_ops.insert_workflow(live, template)
 
     assert op["workflow"] == template
+
+
+@pytest.mark.parametrize("missing", ["nodes", "links", "groups"])
+def test_insert_workflow_rejects_each_missing_required_collection(missing):
+    template = _template()
+    del template[missing]
+
+    with pytest.raises(ValueError, match=rf"insert_workflow.*missing required field.*{missing}"):
+        workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
+
+
+def test_insert_workflow_accepts_required_collections_without_definitions():
+    template = {"nodes": [], "links": [], "groups": []}
+
+    _, op = workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
+
+    assert op["workflow"] == template
+
+
+@pytest.mark.parametrize("field", ["nodes", "links", "groups"])
+def test_insert_workflow_rejects_non_array_required_collection(field):
+    template = _template()
+    template[field] = {}
+
+    with pytest.raises(ValueError, match=rf"insert_workflow field {field} must be an array"):
+        workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
+
+
+def test_insert_workflow_rejects_non_object_definitions():
+    template = _template()
+    template["definitions"] = []
+
+    with pytest.raises(ValueError, match="insert_workflow field definitions must be an object"):
+        workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
 
 
 def test_insert_workflow_does_not_mutate_local_workflow():

--- a/tests/comfy_cli/test_insert_workflow_op.py
+++ b/tests/comfy_cli/test_insert_workflow_op.py
@@ -47,13 +47,23 @@ def test_insert_workflow_emits_semantically_invalid_json_for_server_validation()
     assert op["workflow"] == template
 
 
-@pytest.mark.parametrize("missing", ["nodes", "links", "groups"])
-def test_insert_workflow_rejects_each_missing_required_collection(missing):
+def test_insert_workflow_rejects_missing_nodes():
     template = _template()
-    del template[missing]
+    del template["nodes"]
 
-    with pytest.raises(ValueError, match=rf"insert_workflow.*missing required field.*{missing}"):
+    with pytest.raises(ValueError, match=r"insert_workflow.*missing required field.*nodes"):
         workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
+
+
+def test_insert_workflow_accepts_nodes_only_and_preserves_omitted_optional_collections():
+    template = {"nodes": [{"id": 100, "type": "Src"}]}
+
+    _, op = workflow_ops.insert_workflow({"nodes": [], "links": []}, template)
+
+    assert op["workflow"] == template
+    assert "links" not in op["workflow"]
+    assert "groups" not in op["workflow"]
+    assert op["workflow"]["nodes"][0]["id"] == 100
 
 
 def test_insert_workflow_accepts_required_collections_without_definitions():
@@ -65,7 +75,7 @@ def test_insert_workflow_accepts_required_collections_without_definitions():
 
 
 @pytest.mark.parametrize("field", ["nodes", "links", "groups"])
-def test_insert_workflow_rejects_non_array_required_collection(field):
+def test_insert_workflow_rejects_non_array_collection(field):
     template = _template()
     template[field] = {}
 

--- a/tests/comfy_cli/test_insert_workflow_op.py
+++ b/tests/comfy_cli/test_insert_workflow_op.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from comfy_cli import workflow_ops
+from comfy_cli.cql.engine import Graph
+
+
+def _template() -> dict:
+    return {
+        "nodes": [
+            {"id": 100, "type": "Src", "outputs": [{"name": "o", "links": [200]}]},
+            {"id": 101, "type": "def-2", "inputs": [{"name": "a", "link": 200}]},
+        ],
+        "links": [[200, 100, 0, 101, 0, "X"]],
+        "definitions": {"subgraphs": [{"id": "def-2", "nodes": [{"id": 5, "type": "Inner"}], "links": []}]},
+    }
+
+
+def test_remap_workflow_ids_matches_cmp_fixture_and_does_not_mutate_input():
+    template = _template()
+    snapshot = copy.deepcopy(template)
+
+    out = workflow_ops.remap_workflow_ids(template, node_id_start=8, link_id_start=8)
+
+    assert template == snapshot
+    assert [node["id"] for node in out["nodes"]] == [8, 9]
+    assert out["links"] == [[8, 8, 0, 9, 0, "X"]]
+    assert out["nodes"][0]["outputs"][0]["links"] == [8]
+    assert out["nodes"][1]["inputs"] == [{"name": "a", "link": 8}]
+    assert out["definitions"]["subgraphs"][0]["nodes"][0]["id"] == 5
+
+
+def test_insert_workflow_emits_one_op_with_nested_definitions_preserved():
+    live = {"last_node_id": 7, "last_link_id": 7, "nodes": [], "links": []}
+
+    result, op = workflow_ops.insert_workflow(live, _template(), actor="agent", base_version=4)
+
+    assert op["op"] == "insert_workflow"
+    assert op["actor"] == "agent"
+    assert op["stamp"] == [4, "agent"]
+    assert [node["id"] for node in op["workflow"]["nodes"]] == [8, 9]
+    assert op["workflow"]["definitions"] == _template()["definitions"]
+    assert result["definitions"] == _template()["definitions"]
+    assert result["_applied_ops"] == [op["op_id"]]
+
+
+def test_insert_workflow_is_not_batchable():
+    with pytest.raises(workflow_ops.NotBatchableError) as exc:
+        workflow_ops.apply_specs(
+            {"nodes": [], "links": []},
+            Graph.from_object_info({}),
+            [{"op": "insert_workflow", "workflow": _template()}],
+        )
+    assert exc.value.code == "workflow_insert_workflow_not_batchable"

--- a/tests/comfy_cli/test_insert_workflow_op.py
+++ b/tests/comfy_cli/test_insert_workflow_op.py
@@ -55,3 +55,75 @@ def test_insert_workflow_is_not_batchable():
             [{"op": "insert_workflow", "workflow": _template()}],
         )
     assert exc.value.code == "workflow_insert_workflow_not_batchable"
+
+
+def test_insert_workflow_accepts_empty_collections_without_partial_failure():
+    live = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
+
+    result, op = workflow_ops.insert_workflow(live, {"nodes": [], "links": [], "definitions": {"subgraphs": []}})
+
+    assert result["nodes"] == []
+    assert result["links"] == []
+    assert result["_applied_ops"] == [op["op_id"]]
+
+
+def test_insert_workflow_rejects_dangling_link_before_mutation():
+    live = {"nodes": [{"id": 1, "type": "Live"}], "links": []}
+    before = copy.deepcopy(live)
+    template = {"nodes": [{"id": 10, "type": "New"}], "links": [[20, 10, 0, 999, 0, "X"]]}
+
+    with pytest.raises(ValueError, match="dangling_link_endpoint"):
+        workflow_ops.insert_workflow(live, template)
+
+    assert live == before
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        {"nodes": ["not-an-object"], "links": []},
+        {"nodes": [{"type": "MissingId"}], "links": []},
+        {"nodes": [{"id": 1, "type": "A"}], "links": [[2, 1]]},
+    ],
+)
+def test_insert_workflow_rejects_malformed_members_before_mutation(template):
+    live = {"nodes": [], "links": []}
+    before = copy.deepcopy(live)
+
+    with pytest.raises(ValueError, match="malformed_op|invalid_node_payload"):
+        workflow_ops.insert_workflow(live, template)
+
+    assert live == before
+
+
+def test_insert_workflow_definition_collision_is_idempotent_or_conflict():
+    definition = {"id": "def-1", "nodes": [], "links": []}
+    live = {"nodes": [], "links": [], "definitions": {"subgraphs": [copy.deepcopy(definition)]}}
+
+    workflow_ops.insert_workflow(
+        live, {"nodes": [], "links": [], "definitions": {"subgraphs": [copy.deepcopy(definition)]}}
+    )
+    assert live["definitions"]["subgraphs"] == [definition]
+
+    before = copy.deepcopy(live)
+    conflicting = {"id": "def-1", "nodes": [{"id": 1, "type": "Changed"}], "links": []}
+    with pytest.raises(ValueError, match="definition_conflict"):
+        workflow_ops.insert_workflow(live, {"nodes": [], "links": [], "definitions": {"subgraphs": [conflicting]}})
+    assert live == before
+
+
+def test_non_definition_op_rejects_definitions_field():
+    live = {"nodes": [], "links": []}
+    op = workflow_ops._new_op(
+        "add_node",
+        "test",
+        0,
+        node_id=1,
+        node={"id": 1, "type": "A"},
+        definitions={"subgraphs": []},
+    )
+
+    with pytest.raises(ValueError, match="malformed_op.*definitions"):
+        workflow_ops.apply_op(live, op, None)
+
+    assert live == {"nodes": [], "links": [], "_applied_ops": []}

--- a/tests/comfy_cli/test_insert_workflow_op.py
+++ b/tests/comfy_cli/test_insert_workflow_op.py
@@ -19,32 +19,36 @@ def _template() -> dict:
     }
 
 
-def test_remap_workflow_ids_matches_cmp_fixture_and_does_not_mutate_input():
-    template = _template()
-    snapshot = copy.deepcopy(template)
-
-    out = workflow_ops.remap_workflow_ids(template, node_id_start=8, link_id_start=8)
-
-    assert template == snapshot
-    assert [node["id"] for node in out["nodes"]] == [8, 9]
-    assert out["links"] == [[8, 8, 0, 9, 0, "X"]]
-    assert out["nodes"][0]["outputs"][0]["links"] == [8]
-    assert out["nodes"][1]["inputs"] == [{"name": "a", "link": 8}]
-    assert out["definitions"]["subgraphs"][0]["nodes"][0]["id"] == 5
-
-
-def test_insert_workflow_emits_one_op_with_nested_definitions_preserved():
+def test_insert_workflow_emits_input_payload_without_remapping_ids():
     live = {"last_node_id": 7, "last_link_id": 7, "nodes": [], "links": []}
+    template = _template()
 
-    result, op = workflow_ops.insert_workflow(live, _template(), actor="agent", base_version=4)
+    result, op = workflow_ops.insert_workflow(live, template, actor="agent", base_version=4)
 
     assert op["op"] == "insert_workflow"
     assert op["actor"] == "agent"
     assert op["stamp"] == [4, "agent"]
-    assert [node["id"] for node in op["workflow"]["nodes"]] == [8, 9]
-    assert op["workflow"]["definitions"] == _template()["definitions"]
-    assert result["definitions"] == _template()["definitions"]
-    assert result["_applied_ops"] == [op["op_id"]]
+    assert op["workflow"] == template
+    assert result is live
+
+
+def test_insert_workflow_emits_semantically_invalid_json_for_server_validation():
+    live = {"nodes": [], "links": []}
+    template = {"nodes": [{"id": 10}], "links": [[20, 10, 0, 999, 0]], "definitions": {"subgraphs": [{}]}}
+
+    _, op = workflow_ops.insert_workflow(live, template)
+
+    assert op["workflow"] == template
+
+
+def test_insert_workflow_does_not_mutate_local_workflow():
+    live = {"nodes": [{"id": 100, "type": "Existing"}], "links": [], "last_node_id": 100}
+    before = copy.deepcopy(live)
+
+    result, _ = workflow_ops.insert_workflow(live, _template())
+
+    assert result is live
+    assert live == before
 
 
 def test_insert_workflow_is_not_batchable():
@@ -55,61 +59,6 @@ def test_insert_workflow_is_not_batchable():
             [{"op": "insert_workflow", "workflow": _template()}],
         )
     assert exc.value.code == "workflow_insert_workflow_not_batchable"
-
-
-def test_insert_workflow_accepts_empty_collections_without_partial_failure():
-    live = {"nodes": [], "links": [], "last_node_id": 0, "last_link_id": 0}
-
-    result, op = workflow_ops.insert_workflow(live, {"nodes": [], "links": [], "definitions": {"subgraphs": []}})
-
-    assert result["nodes"] == []
-    assert result["links"] == []
-    assert result["_applied_ops"] == [op["op_id"]]
-
-
-def test_insert_workflow_rejects_dangling_link_before_mutation():
-    live = {"nodes": [{"id": 1, "type": "Live"}], "links": []}
-    before = copy.deepcopy(live)
-    template = {"nodes": [{"id": 10, "type": "New"}], "links": [[20, 10, 0, 999, 0, "X"]]}
-
-    with pytest.raises(ValueError, match="dangling_link_endpoint"):
-        workflow_ops.insert_workflow(live, template)
-
-    assert live == before
-
-
-@pytest.mark.parametrize(
-    "template",
-    [
-        {"nodes": ["not-an-object"], "links": []},
-        {"nodes": [{"type": "MissingId"}], "links": []},
-        {"nodes": [{"id": 1, "type": "A"}], "links": [[2, 1]]},
-    ],
-)
-def test_insert_workflow_rejects_malformed_members_before_mutation(template):
-    live = {"nodes": [], "links": []}
-    before = copy.deepcopy(live)
-
-    with pytest.raises(ValueError, match="malformed_op|invalid_node_payload"):
-        workflow_ops.insert_workflow(live, template)
-
-    assert live == before
-
-
-def test_insert_workflow_definition_collision_is_idempotent_or_conflict():
-    definition = {"id": "def-1", "nodes": [], "links": []}
-    live = {"nodes": [], "links": [], "definitions": {"subgraphs": [copy.deepcopy(definition)]}}
-
-    workflow_ops.insert_workflow(
-        live, {"nodes": [], "links": [], "definitions": {"subgraphs": [copy.deepcopy(definition)]}}
-    )
-    assert live["definitions"]["subgraphs"] == [definition]
-
-    before = copy.deepcopy(live)
-    conflicting = {"id": "def-1", "nodes": [{"id": 1, "type": "Changed"}], "links": []}
-    with pytest.raises(ValueError, match="definition_conflict"):
-        workflow_ops.insert_workflow(live, {"nodes": [], "links": [], "definitions": {"subgraphs": [conflicting]}})
-    assert live == before
 
 
 def test_non_definition_op_rejects_definitions_field():


### PR DESCRIPTION
Draft. Adds `comfy workflow insert-workflow <file> <template>`, which emits one stamped `insert_workflow` op without validating, remapping, applying, or writing the workflow locally. Python gates green. Blocked on cmp publish: [comfy-multi-player draft PR adding the insert_workflow op](https://github.com/Comfy-Org/comfy-multi-player/pull/183).

Design: [Notion TDD — agent subgraph lifecycle, V1.5 row](https://www.notion.so/3d16d73d365081719b85ed515af98276). Linear: [agent editing subgraph — human tech review needed](https://linear.app/comfyorg/issue/BE-10305), [frontend agent subgraph follower](https://linear.app/comfyorg/issue/FE-2033).

<details><summary>Full context for agent readers</summary>

## Why

The CLI emits the cmp `insert_workflow` operation while cmp remains the sole owner of validation, ID remapping, application, replay, and projection.

## What changed

- `comfy_cli/command/workflow.py`: new standalone `insert-workflow` command.
- `comfy_cli/command/workflow_edit.py`, `workflow_ops.py`: preserve the input payload verbatim and emit it without mutating or writing the local workflow.
- `comfy_cli/command/error_codes.py`: adds cmp rejection codes.
- `docs/op-vocabulary-v1.md`: documents the emit-only ownership boundary.
- `tests/comfy_cli/test_insert_workflow_op.py`: covers exact payload preservation, semantic pass-through, no local mutation, envelope shape, and standalone-only behavior.

## Verification

- `ruff check .` and `ruff format --check .`: pass.
- Focused tests: 12 passed.
- Full `pytest`: 7,407 passed, 32 skipped, 47 unrelated baseline failures.
- `git diff --check`: clean.
- Not run: round trip against a live dochost. Needs the cmp publish and pin bump tracked on the cloud PR.

## Decisions to veto

1. New command name `insert-workflow` rather than a flag on the existing `load` command.
2. The command refuses to emit more than one op.

## Ship order

cmp → cloud → comfy-cli (this PR) → frontend follower. Sibling PRs: [cloud agent tool draft PR](https://github.com/Comfy-Org/cloud/pull/8981).

</details>
