### PR TITLE
feat(workflow): define-subgraph command emitting define_subgraph op

### DIFF
--- a/comfy_cli/command/workflow.py
+++ b/comfy_cli/command/workflow.py
@@ -1934,6 +1934,9 @@ app.add_typer(_wfrag.fragment_app, name="fragment")
 
 from comfy_cli.command import workflow_edit as _wedit  # noqa: E402
 
+app.command("define-subgraph", help="Create a subgraph definition; emits one define_subgraph op.")(
+    _wedit.define_subgraph_cmd
+)
 app.command("add-node", help="Add a node to the graph; emits an add_node op.")(_wedit.add_node_cmd)
 app.command("connect", help="Wire an output slot to an input slot; emits a connect op.")(_wedit.connect_cmd)
 app.command("set-widget", help="Set a widget by name (`<id>.<widget>`); emits a set_widget op.")(_wedit.set_widget_cmd)

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -130,6 +130,14 @@ def _finish(renderer, p, workflow: dict, op: dict, base_version: int, stdout: bo
     renderer.emit(payload, command=command, changed=not stdout)
 
 
+def _emit_op(renderer, p: Path, op: dict, base_version: int, command: str) -> None:
+    """Emit an op without applying it or writing the source workflow."""
+    payload = {"workflow": str(p), "op": op, "base_version": base_version, "wrote": None}
+    if renderer.is_pretty():
+        rprint(f"[bold green]✓[/bold green] {op['op']} emitted for [dim]{p}[/dim]")
+    renderer.emit(payload, command=command, changed=False)
+
+
 def _graph_or_exit(input_path, host, port, renderer, where=None):
     return _get_graph(input_path, host, port, where=where)
 
@@ -172,7 +180,7 @@ def define_subgraph_cmd(
     try:
         definition_path = Path(definition_file).expanduser()
         definition = _read_subgraph_definition(definition_path)
-        workflow, op = workflow_ops.define_subgraph(
+        _, op = workflow_ops.define_subgraph(
             workflow,
             definition,
             subgraph_id=subgraph_id,
@@ -182,7 +190,7 @@ def define_subgraph_cmd(
     except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, RecursionError, MemoryError) as e:
         _emit_edit_error(renderer, e, hint="provide a serializable subgraph definition JSON object")
         raise typer.Exit(code=1) from e
-    _finish(renderer, p, workflow, op, base_version, stdout, "workflow define-subgraph")
+    _emit_op(renderer, p, op, base_version, "workflow define-subgraph")
 
 
 # ---------------------------------------------------------------------------

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -133,6 +133,40 @@ def _graph_or_exit(input_path, host, port, renderer, where=None):
 
 
 # ---------------------------------------------------------------------------
+# define-subgraph
+# ---------------------------------------------------------------------------
+
+
+@tracking.track_command("workflow")
+def define_subgraph_cmd(
+    file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to update.")],
+    definition_file: Annotated[str, typer.Argument(help="Serializable subgraph definition JSON.")],
+    subgraph_id: Annotated[str | None, typer.Option("--id", show_default=False)] = None,
+    actor: ActorOpt = "cli",
+    base_version: BaseVersionOpt = 0,
+    stdout: StdoutOpt = False,
+):
+    """Create one subgraph definition and emit one ``define_subgraph`` op."""
+    renderer = get_renderer()
+    renderer.command = "workflow define-subgraph"
+    p, workflow = _load_workflow_or_fail(renderer, file)
+    try:
+        definition_path = Path(definition_file).expanduser()
+        definition = json.loads(definition_path.read_text(encoding="utf-8"))
+        workflow, op = workflow_ops.define_subgraph(
+            workflow,
+            definition,
+            subgraph_id=subgraph_id,
+            actor=actor,
+            base_version=base_version,
+        )
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+        _emit_edit_error(renderer, e, hint="provide a serializable subgraph definition JSON object")
+        raise typer.Exit(code=1) from e
+    _finish(renderer, p, workflow, op, base_version, stdout, "workflow define-subgraph")
+
+
+# ---------------------------------------------------------------------------
 # add-node
 # ---------------------------------------------------------------------------
 

--- a/comfy_cli/command/workflow_edit.py
+++ b/comfy_cli/command/workflow_edit.py
@@ -14,6 +14,7 @@ collide; widgets are addressed by name, not array index. See ``workflow_ops``.
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -48,6 +49,7 @@ InputOpt = Annotated[str | None, typer.Option("--input", show_default=False)]
 HostOpt = Annotated[str | None, typer.Option(show_default=False)]
 PortOpt = Annotated[int | None, typer.Option(show_default=False)]
 WhereOpt = Annotated[str | None, typer.Option("--where", show_default=False, help="Catalog target: local | cloud.")]
+_MAX_DEFINITION_BYTES = 16 * 1024 * 1024
 
 
 def _emit_edit_error(renderer, e: ValueError, *, hint: str) -> None:
@@ -137,6 +139,23 @@ def _graph_or_exit(input_path, host, port, renderer, where=None):
 # ---------------------------------------------------------------------------
 
 
+def _read_subgraph_definition(path: Path):
+    """Read a bounded regular JSON file without blocking on devices or FIFOs."""
+    file_stat = path.stat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ValueError("subgraph definition must be a regular file")
+    if file_stat.st_size > _MAX_DEFINITION_BYTES:
+        raise ValueError(f"subgraph definition is too large (maximum {_MAX_DEFINITION_BYTES} bytes)")
+    try:
+        with path.open("rb") as definition_file:
+            raw = definition_file.read(_MAX_DEFINITION_BYTES + 1)
+        if len(raw) > _MAX_DEFINITION_BYTES:
+            raise ValueError(f"subgraph definition is too large (maximum {_MAX_DEFINITION_BYTES} bytes)")
+        return json.loads(raw.decode("utf-8"))
+    except (RecursionError, MemoryError) as error:
+        raise ValueError("subgraph definition is too deeply nested or too large") from error
+
+
 @tracking.track_command("workflow")
 def define_subgraph_cmd(
     file: Annotated[str, typer.Argument(help="Frontend-format workflow JSON to update.")],
@@ -152,7 +171,7 @@ def define_subgraph_cmd(
     p, workflow = _load_workflow_or_fail(renderer, file)
     try:
         definition_path = Path(definition_file).expanduser()
-        definition = json.loads(definition_path.read_text(encoding="utf-8"))
+        definition = _read_subgraph_definition(definition_path)
         workflow, op = workflow_ops.define_subgraph(
             workflow,
             definition,
@@ -160,7 +179,7 @@ def define_subgraph_cmd(
             actor=actor,
             base_version=base_version,
         )
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, RecursionError, MemoryError) as e:
         _emit_edit_error(renderer, e, hint="provide a serializable subgraph definition JSON object")
         raise typer.Exit(code=1) from e
     _finish(renderer, p, workflow, op, base_version, stdout, "workflow define-subgraph")

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -64,6 +64,7 @@ from comfy_cli.cql.engine import frontend_injected_widget_error
 # New ids live in [2**40, 2**53): always large (never collides with small
 # frontend counter ids), always inside JS Number.MAX_SAFE_INTEGER.
 _ID_FLOOR = 1 << 40
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", re.I)
 
 
 def mint_id() -> int:
@@ -1863,11 +1864,12 @@ def define_subgraph(
     definition_id = subgraph_id or definition.get("id") or str(uuid.uuid4())
     if not isinstance(definition_id, str) or not definition_id:
         raise ValueError("subgraph definition requires a non-empty string id")
+    if not _UUID_RE.fullmatch(definition_id):
+        raise ValueError("subgraph definition id must be a valid UUID")
     if "id" in definition and definition["id"] != definition_id:
         raise ValueError("subgraph definition id must match --id")
     definition["id"] = definition_id
-    if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
-        raise ValueError("subgraph definition nodes and links must be arrays")
+    _validate_subgraph_definition(definition)
     existing = _subgraph_definition(workflow, definition_id)
     if existing is not None:
         raise ValueError(f"subgraph definition {definition_id!r} already exists; define-subgraph only creates new ids")
@@ -1880,6 +1882,31 @@ def define_subgraph(
     )
     apply_op(workflow, op, None)
     return workflow, op
+
+
+def _validate_subgraph_definition(definition: dict, path: str = "subgraph definition") -> None:
+    """Validate definition ids and containers while preserving its serialized shape."""
+    definition_id = definition.get("id")
+    if not isinstance(definition_id, str) or not _UUID_RE.fullmatch(definition_id):
+        raise ValueError(f"{path} id must be a valid UUID")
+    if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
+        raise ValueError(f"{path} nodes and links must be arrays")
+    nested = definition.get("definitions")
+    if nested is None:
+        return
+    if not isinstance(nested, dict) or not isinstance(nested.get("subgraphs"), list):
+        raise ValueError(f"{path}.definitions.subgraphs must be an array")
+    seen: set[str] = set()
+    for index, child in enumerate(nested["subgraphs"]):
+        child_path = f"{path}.definitions.subgraphs[{index}]"
+        if not isinstance(child, dict):
+            raise ValueError(f"{child_path} must be a JSON object")
+        child_id = child.get("id")
+        if isinstance(child_id, str) and child_id in seen:
+            raise ValueError(f"{child_path} duplicates subgraph definition id {child_id!r}")
+        if isinstance(child_id, str):
+            seen.add(child_id)
+        _validate_subgraph_definition(child, child_path)
 
 
 def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -102,10 +102,10 @@ FROZEN_OPS: tuple[str, ...] = (
     "define_subgraph",
 )
 
-#: Kinds frozen in the contract whose replay is not implemented yet.
-#: ``apply_op`` must keep rejecting these. Empty since amendment v1.1:
-#: ``reset_doc`` was un-deferred by the bulk-writers ticket (V1-038).
-DEFERRED_OPS: tuple[str, ...] = ()
+#: Kinds frozen in the contract whose replay is not implemented in the CLI.
+#: ``define_subgraph`` is emitted for cmp to validate and apply; the CLI must
+#: keep rejecting local replay to preserve that ownership boundary.
+DEFERRED_OPS: tuple[str, ...] = ("define_subgraph",)
 
 #: Kinds a batch (``apply_specs``) dispatches. ``clear`` and ``reset_doc`` are
 #: standalone-only: they rewrite the whole document, so they never ride inside
@@ -1150,6 +1150,8 @@ def _inexpressible_reason(workflow: dict) -> str | None:
         return "not a frontend-format workflow (no `nodes` list) — only the save/UI format can be op-ified"
     if workflow.get("groups"):
         return "the workflow contains canvas groups, which no frozen op kind can create"
+    if (workflow.get("definitions") or {}).get("subgraphs"):
+        return "the workflow contains subgraph definitions, which only cmp can project into ops"
     extra = workflow.get("extra")
     if isinstance(extra, dict) and (extra.get("reroutes") or extra.get("linkExtensions")):
         return "the workflow contains reroute points, which no frozen op kind can create"
@@ -1223,39 +1225,6 @@ def replace_ops(old: dict, new: dict, *, actor: str = "cli", base_version: int =
         raise NotExpressibleError(reason)
 
     ops: list[dict] = []
-    old_definitions = {
-        str(definition.get("id")): definition
-        for definition in ((old.get("definitions") or {}).get("subgraphs") or [])
-        if isinstance(definition, dict)
-    }
-    new_definitions = {
-        str(definition.get("id")): definition
-        for definition in ((new.get("definitions") or {}).get("subgraphs") or [])
-        if isinstance(definition, dict)
-    }
-    if any(identifier not in new_definitions for identifier in old_definitions):
-        raise NotExpressibleError("the replacement removes a subgraph definition, which no frozen op kind can delete")
-    for identifier, definition in new_definitions.items():
-        existing = old_definitions.get(identifier)
-        if existing is not None and existing != definition:
-            raise NotExpressibleError(
-                "the replacement changes an existing subgraph definition; emit id-addressed edits instead"
-            )
-        if existing is None:
-            try:
-                _validate_subgraph_definition(definition)
-                _validate_subgraph_cycles(definition)
-            except ValueError as error:
-                raise NotExpressibleError(f"the workflow contains a malformed subgraph definition: {error}") from error
-            ops.append(
-                _new_op(
-                    "define_subgraph",
-                    actor,
-                    base_version,
-                    subgraph_id=identifier,
-                    subgraph_definition=copy.deepcopy(definition),
-                )
-            )
     old_links = [link for link in (old.get("links") or []) if isinstance(link, list) and len(link) >= 5]
     for node in old.get("nodes") or []:
         if not isinstance(node, dict) or node.get("id") is None:
@@ -1861,8 +1830,6 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
             _apply_clear(workflow, op)
         elif kind == "reset_doc":
             _apply_reset_doc(workflow, op)
-        elif kind == "define_subgraph":
-            _apply_define_subgraph(workflow, op)
         else:
             raise ValueError(f"unknown op {kind!r}")
     except BaseException:
@@ -1886,7 +1853,7 @@ def define_subgraph(
     actor: str = "cli",
     base_version: int = 0,
 ) -> tuple[dict, dict]:
-    """Create one subgraph definition and emit the matching cmp op."""
+    """Emit a definition op; cmp owns semantic validation and application."""
     if not isinstance(definition, dict):
         raise ValueError("subgraph definition must be a JSON object")
     definition = copy.deepcopy(definition)
@@ -1903,12 +1870,10 @@ def define_subgraph(
     if "id" in definition and definition["id"] != definition_id:
         raise ValueError("subgraph definition id must match --id")
     definition["id"] = definition_id
-    _validate_subgraph_definition(definition)
-    _validate_subgraph_cycles(definition)
-    existing = _subgraph_definition(workflow, definition_id)
-    if existing is not None:
-        raise ValueError(f"subgraph definition {definition_id!r} already exists; define-subgraph only creates new ids")
-    _validate_subgraph_definition(definition, seen=_subgraph_definition_ids(workflow))
+    try:
+        json.dumps(definition)
+    except (TypeError, ValueError, RecursionError) as error:
+        raise ValueError("subgraph definition must be JSON-serializable") from error
     op = _new_op(
         "define_subgraph",
         actor,
@@ -1916,131 +1881,7 @@ def define_subgraph(
         subgraph_id=definition_id,
         subgraph_definition=definition,
     )
-    apply_op(workflow, op, None)
     return workflow, op
-
-
-def _validate_subgraph_definition(
-    definition: dict, path: str = "subgraph definition", seen: set[str] | None = None
-) -> None:
-    """Validate definition ids and containers while preserving its serialized shape."""
-    if seen is None:
-        seen = set()
-    definition_id = definition.get("id")
-    if not isinstance(definition_id, str) or not _UUID_RE.fullmatch(definition_id):
-        raise ValueError(f"{path} id must be a valid UUID")
-    if definition_id in seen:
-        raise ValueError(f"{path} duplicates subgraph definition id {definition_id!r}")
-    seen.add(definition_id)
-    if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
-        raise ValueError(f"{path} nodes and links must be arrays")
-    for index, node in enumerate(definition["nodes"]):
-        node_path = f"{path}.nodes[{index}]"
-        if not isinstance(node, dict) or node.get("id") is None or not isinstance(node.get("type"), str):
-            raise ValueError(f"{node_path} must be an object with id and string type")
-        for field in ("inputs", "outputs"):
-            if field in node and not isinstance(node[field], list):
-                raise ValueError(f"{node_path}.{field} must be an array")
-    for index, link in enumerate(definition["links"]):
-        if not isinstance(link, list) or len(link) < 5:
-            raise ValueError(f"{path}.links[{index}] must be a link tuple with at least 5 items")
-    nested = definition.get("definitions")
-    if nested is None:
-        return
-    if not isinstance(nested, dict) or not isinstance(nested.get("subgraphs"), list):
-        raise ValueError(f"{path}.definitions.subgraphs must be an array")
-    for index, child in enumerate(nested["subgraphs"]):
-        child_path = f"{path}.definitions.subgraphs[{index}]"
-        if not isinstance(child, dict):
-            raise ValueError(f"{child_path} must be a JSON object")
-        _validate_subgraph_definition(child, child_path, seen)
-
-
-def _validate_subgraph_cycles(root: dict) -> None:
-    """Reject recursive definition references that expansion cannot terminate."""
-    definitions: dict[str, dict] = {}
-
-    def collect(definition: dict) -> None:
-        definitions[definition["id"]] = definition
-        for child in (definition.get("definitions") or {}).get("subgraphs") or []:
-            collect(child)
-
-    collect(root)
-    visiting: set[str] = set()
-    visited: set[str] = set()
-
-    def visit(identifier: str) -> None:
-        if identifier in visiting:
-            raise ValueError(f"cyclic subgraph reference involving {identifier!r}")
-        if identifier in visited:
-            return
-        visiting.add(identifier)
-        for node in definitions[identifier]["nodes"]:
-            target = node.get("type")
-            if target in definitions:
-                visit(target)
-        visiting.remove(identifier)
-        visited.add(identifier)
-
-    for identifier in definitions:
-        visit(identifier)
-
-
-def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:
-    definitions = workflow.get("definitions")
-    if definitions is None:
-        return None
-    if not isinstance(definitions, dict) or not isinstance(definitions.get("subgraphs", []), list):
-        raise ValueError("malformed workflow: definitions.subgraphs must be an array")
-    for definition in definitions.get("subgraphs", []):
-        if isinstance(definition, dict):
-            if str(definition.get("id")) == subgraph_id:
-                return definition
-            nested = _subgraph_definition(definition, subgraph_id)
-            if nested is not None:
-                return nested
-    return None
-
-
-def _subgraph_definition_ids(workflow: dict) -> set[str]:
-    """Collect all definition ids recursively from a workflow or definition."""
-    definitions = workflow.get("definitions")
-    if definitions is None:
-        return set()
-    if not isinstance(definitions, dict) or not isinstance(definitions.get("subgraphs", []), list):
-        raise ValueError("malformed workflow: definitions.subgraphs must be an array")
-    ids: set[str] = set()
-    for definition in definitions.get("subgraphs", []):
-        if not isinstance(definition, dict):
-            continue
-        definition_id = definition.get("id")
-        if isinstance(definition_id, str):
-            ids.add(definition_id)
-        ids.update(_subgraph_definition_ids(definition))
-    return ids
-
-
-def _apply_define_subgraph(workflow: dict, op: dict) -> None:
-    subgraph_id = op.get("subgraph_id")
-    definition = op.get("subgraph_definition")
-    if (
-        not isinstance(subgraph_id, str)
-        or not subgraph_id
-        or not isinstance(definition, dict)
-        or definition.get("id") != subgraph_id
-    ):
-        raise ValueError("malformed_op: subgraph_id must match a definition with nodes and links arrays")
-    try:
-        _validate_subgraph_definition(definition)
-        _validate_subgraph_cycles(definition)
-    except ValueError as error:
-        raise ValueError(f"malformed_op: {error}") from error
-    existing = _subgraph_definition(workflow, subgraph_id)
-    if existing is not None:
-        return
-    if workflow.get("definitions") is None:
-        workflow["definitions"] = {}
-    workflow["definitions"].setdefault("subgraphs", []).append(copy.deepcopy(definition))
 
 
 def _apply_add_node(workflow: dict, op: dict) -> None:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1140,18 +1140,14 @@ class NotExpressibleError(ValueError):
 def _inexpressible_reason(workflow: dict) -> str | None:
     """Why ``workflow`` cannot be rebuilt from add_node/connect ops, or None.
 
-    The frozen vocabulary has four batchable kinds and none of them can create a
-    subgraph definition, a canvas group, or a reroute point — so a graph that
-    carries any of those is not reconstructible from ops, full stop. Enumerated
+    The frozen vocabulary cannot create a canvas group or a reroute point, so a
+    graph that carries either is not reconstructible from ops. Enumerated
     positively (a closed list of things we know we CAN'T do) rather than by
     trying and checking, so an unexpressible template fails before it has
     written anything.
     """
     if not isinstance(workflow, dict) or not isinstance(workflow.get("nodes"), list):
         return "not a frontend-format workflow (no `nodes` list) — only the save/UI format can be op-ified"
-    definitions = workflow.get("definitions")
-    if isinstance(definitions, dict) and definitions.get("subgraphs"):
-        return "the workflow contains a subgraph definition, which no frozen op kind can create"
     if workflow.get("groups"):
         return "the workflow contains canvas groups, which no frozen op kind can create"
     extra = workflow.get("extra")
@@ -1227,6 +1223,39 @@ def replace_ops(old: dict, new: dict, *, actor: str = "cli", base_version: int =
         raise NotExpressibleError(reason)
 
     ops: list[dict] = []
+    old_definitions = {
+        str(definition.get("id")): definition
+        for definition in ((old.get("definitions") or {}).get("subgraphs") or [])
+        if isinstance(definition, dict)
+    }
+    new_definitions = {
+        str(definition.get("id")): definition
+        for definition in ((new.get("definitions") or {}).get("subgraphs") or [])
+        if isinstance(definition, dict)
+    }
+    if any(identifier not in new_definitions for identifier in old_definitions):
+        raise NotExpressibleError("the replacement removes a subgraph definition, which no frozen op kind can delete")
+    for identifier, definition in new_definitions.items():
+        existing = old_definitions.get(identifier)
+        if existing is not None and existing != definition:
+            raise NotExpressibleError(
+                "the replacement changes an existing subgraph definition; emit id-addressed edits instead"
+            )
+        if existing is None:
+            try:
+                _validate_subgraph_definition(definition)
+                _validate_subgraph_cycles(definition)
+            except ValueError as error:
+                raise NotExpressibleError(f"the workflow contains a malformed subgraph definition: {error}") from error
+            ops.append(
+                _new_op(
+                    "define_subgraph",
+                    actor,
+                    base_version,
+                    subgraph_id=identifier,
+                    subgraph_definition=copy.deepcopy(definition),
+                )
+            )
     old_links = [link for link in (old.get("links") or []) if isinstance(link, list) and len(link) >= 5]
     for node in old.get("nodes") or []:
         if not isinstance(node, dict) or node.get("id") is None:
@@ -1861,7 +1890,12 @@ def define_subgraph(
     if not isinstance(definition, dict):
         raise ValueError("subgraph definition must be a JSON object")
     definition = copy.deepcopy(definition)
-    definition_id = subgraph_id or definition.get("id") or str(uuid.uuid4())
+    if subgraph_id is not None:
+        definition_id = subgraph_id
+    elif "id" in definition:
+        definition_id = definition["id"]
+    else:
+        definition_id = str(uuid.uuid4())
     if not isinstance(definition_id, str) or not definition_id:
         raise ValueError("subgraph definition requires a non-empty string id")
     if not _UUID_RE.fullmatch(definition_id):
@@ -1870,6 +1904,7 @@ def define_subgraph(
         raise ValueError("subgraph definition id must match --id")
     definition["id"] = definition_id
     _validate_subgraph_definition(definition)
+    _validate_subgraph_cycles(definition)
     existing = _subgraph_definition(workflow, definition_id)
     if existing is not None:
         raise ValueError(f"subgraph definition {definition_id!r} already exists; define-subgraph only creates new ids")
@@ -1899,6 +1934,16 @@ def _validate_subgraph_definition(
     seen.add(definition_id)
     if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
         raise ValueError(f"{path} nodes and links must be arrays")
+    for index, node in enumerate(definition["nodes"]):
+        node_path = f"{path}.nodes[{index}]"
+        if not isinstance(node, dict) or node.get("id") is None or not isinstance(node.get("type"), str):
+            raise ValueError(f"{node_path} must be an object with id and string type")
+        for field in ("inputs", "outputs"):
+            if field in node and not isinstance(node[field], list):
+                raise ValueError(f"{node_path}.{field} must be an array")
+    for index, link in enumerate(definition["links"]):
+        if not isinstance(link, list) or len(link) < 5:
+            raise ValueError(f"{path}.links[{index}] must be a link tuple with at least 5 items")
     nested = definition.get("definitions")
     if nested is None:
         return
@@ -1909,6 +1954,36 @@ def _validate_subgraph_definition(
         if not isinstance(child, dict):
             raise ValueError(f"{child_path} must be a JSON object")
         _validate_subgraph_definition(child, child_path, seen)
+
+
+def _validate_subgraph_cycles(root: dict) -> None:
+    """Reject recursive definition references that expansion cannot terminate."""
+    definitions: dict[str, dict] = {}
+
+    def collect(definition: dict) -> None:
+        definitions[definition["id"]] = definition
+        for child in (definition.get("definitions") or {}).get("subgraphs") or []:
+            collect(child)
+
+    collect(root)
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(identifier: str) -> None:
+        if identifier in visiting:
+            raise ValueError(f"cyclic subgraph reference involving {identifier!r}")
+        if identifier in visited:
+            return
+        visiting.add(identifier)
+        for node in definitions[identifier]["nodes"]:
+            target = node.get("type")
+            if target in definitions:
+                visit(target)
+        visiting.remove(identifier)
+        visited.add(identifier)
+
+    for identifier in definitions:
+        visit(identifier)
 
 
 def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:
@@ -1957,14 +2032,15 @@ def _apply_define_subgraph(workflow: dict, op: dict) -> None:
         raise ValueError("malformed_op: subgraph_id must match a definition with nodes and links arrays")
     try:
         _validate_subgraph_definition(definition)
+        _validate_subgraph_cycles(definition)
     except ValueError as error:
         raise ValueError(f"malformed_op: {error}") from error
     existing = _subgraph_definition(workflow, subgraph_id)
     if existing is not None:
-        if existing == definition:
-            return
-        raise ValueError(f"definition_conflict: definition {subgraph_id!r} already exists with different content")
-    workflow.setdefault("definitions", {}).setdefault("subgraphs", []).append(copy.deepcopy(definition))
+        return
+    if workflow.get("definitions") is None:
+        workflow["definitions"] = {}
+    workflow["definitions"].setdefault("subgraphs", []).append(copy.deepcopy(definition))
 
 
 def _apply_add_node(workflow: dict, op: dict) -> None:
@@ -2397,6 +2473,8 @@ def _write_target(op: dict) -> tuple:
             # not share a target with its sibling (``model.reference_videos``).
             return ("input", str(op["to_node"]), "grow", _autogrow_base(str(grow["name"])))
         return ("input", str(op["to_node"]), op["to_slot"])
+    if kind == "define_subgraph":
+        return ("subgraph", str(op["subgraph_id"]))
     return (kind,)
 
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -91,7 +91,15 @@ def _new_op(kind: str, actor: str, base_version: int, **fields: Any) -> dict[str
 # ---------------------------------------------------------------------------
 
 #: Every op kind in the v1 vocabulary, including defined-but-deferred kinds.
-FROZEN_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node", "clear", "reset_doc")
+FROZEN_OPS: tuple[str, ...] = (
+    "add_node",
+    "connect",
+    "set_widget",
+    "delete_node",
+    "clear",
+    "reset_doc",
+    "define_subgraph",
+)
 
 #: Kinds frozen in the contract whose replay is not implemented yet.
 #: ``apply_op`` must keep rejecting these. Empty since amendment v1.1:
@@ -101,7 +109,7 @@ DEFERRED_OPS: tuple[str, ...] = ()
 #: Kinds a batch (``apply_specs``) dispatches. ``clear`` and ``reset_doc`` are
 #: standalone-only: they rewrite the whole document, so they never ride inside
 #: an atomic batch.
-BATCHABLE_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node")
+BATCHABLE_OPS: tuple[str, ...] = ("add_node", "connect", "set_widget", "delete_node", "define_subgraph")
 
 #: Per-kind rendering for :class:`NotBatchableError` — the registered error code
 #: and the standalone command that DOES do the job. One entry per frozen kind
@@ -1751,6 +1759,14 @@ def apply_specs(
                     workflow, op = delete_node(
                         workflow, graph, resolve_ref(spec["node"], aliases), actor=actor, base_version=base_version
                     )
+                elif kind == "define_subgraph":
+                    workflow, op = define_subgraph(
+                        workflow,
+                        spec["subgraph_definition"],
+                        subgraph_id=spec.get("subgraph_id"),
+                        actor=actor,
+                        base_version=base_version,
+                    )
                 elif kind in _NOT_BATCHABLE:
                     # In the frozen vocabulary but standalone-only — surfaced with
                     # its own registered code so the caller learns the standalone
@@ -1795,6 +1811,8 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
     if op["op_id"] in applied:
         return workflow
     kind = op["op"]
+    if kind != "define_subgraph" and any(key in op for key in ("subgraph_id", "subgraph_definition", "definitions")):
+        raise ValueError(f"malformed_op: {kind} cannot carry a subgraph definition")
     # Snapshot the LWW bookkeeping so an exception escaping a handler cannot
     # leave a stamp committed WITHOUT its op_id recorded below. That pairing is
     # the poison state: a retry of the identical op loses to the failed
@@ -1813,6 +1831,8 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
             _apply_clear(workflow, op)
         elif kind == "reset_doc":
             _apply_reset_doc(workflow, op)
+        elif kind == "define_subgraph":
+            _apply_define_subgraph(workflow, op)
         else:
             raise ValueError(f"unknown op {kind!r}")
     except BaseException:
@@ -1826,6 +1846,72 @@ def apply_op(workflow: dict, op: dict, graph) -> dict:
     # no-op rather than a second wipe.
     workflow.setdefault("_applied_ops", []).append(op["op_id"])
     return workflow
+
+
+def define_subgraph(
+    workflow: dict,
+    definition: dict,
+    *,
+    subgraph_id: str | None = None,
+    actor: str = "cli",
+    base_version: int = 0,
+) -> tuple[dict, dict]:
+    """Create one subgraph definition and emit the matching cmp op."""
+    if not isinstance(definition, dict):
+        raise ValueError("subgraph definition must be a JSON object")
+    definition = copy.deepcopy(definition)
+    definition_id = subgraph_id or definition.get("id") or str(uuid.uuid4())
+    if not isinstance(definition_id, str) or not definition_id:
+        raise ValueError("subgraph definition requires a non-empty string id")
+    if "id" in definition and definition["id"] != definition_id:
+        raise ValueError("subgraph definition id must match --id")
+    definition["id"] = definition_id
+    if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
+        raise ValueError("subgraph definition nodes and links must be arrays")
+    existing = _subgraph_definition(workflow, definition_id)
+    if existing is not None:
+        raise ValueError(f"subgraph definition {definition_id!r} already exists; define-subgraph only creates new ids")
+    op = _new_op(
+        "define_subgraph",
+        actor,
+        base_version,
+        subgraph_id=definition_id,
+        subgraph_definition=definition,
+    )
+    apply_op(workflow, op, None)
+    return workflow, op
+
+
+def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:
+    definitions = workflow.get("definitions")
+    if definitions is None:
+        return None
+    if not isinstance(definitions, dict) or not isinstance(definitions.get("subgraphs", []), list):
+        raise ValueError("malformed workflow: definitions.subgraphs must be an array")
+    for definition in definitions.get("subgraphs", []):
+        if isinstance(definition, dict) and str(definition.get("id")) == subgraph_id:
+            return definition
+    return None
+
+
+def _apply_define_subgraph(workflow: dict, op: dict) -> None:
+    subgraph_id = op.get("subgraph_id")
+    definition = op.get("subgraph_definition")
+    if (
+        not isinstance(subgraph_id, str)
+        or not subgraph_id
+        or not isinstance(definition, dict)
+        or definition.get("id") != subgraph_id
+        or not isinstance(definition.get("nodes"), list)
+        or not isinstance(definition.get("links"), list)
+    ):
+        raise ValueError("malformed_op: subgraph_id must match a definition with nodes and links arrays")
+    existing = _subgraph_definition(workflow, subgraph_id)
+    if existing is not None:
+        if existing == definition:
+            return
+        raise ValueError(f"malformed_op: definition {subgraph_id!r} already exists with different content")
+    workflow.setdefault("definitions", {}).setdefault("subgraphs", []).append(copy.deepcopy(definition))
 
 
 def _apply_add_node(workflow: dict, op: dict) -> None:

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1808,7 +1808,7 @@ def apply_specs(
 def apply_op(workflow: dict, op: dict, graph) -> dict:
     """Replay one op onto ``workflow`` in place and return it. Idempotent: an
     op whose ``op_id`` was already applied is a no-op."""
-    applied = workflow.setdefault("_applied_ops", [])
+    applied = workflow.get("_applied_ops", [])
     if op["op_id"] in applied:
         return workflow
     kind = op["op"]
@@ -1884,11 +1884,18 @@ def define_subgraph(
     return workflow, op
 
 
-def _validate_subgraph_definition(definition: dict, path: str = "subgraph definition") -> None:
+def _validate_subgraph_definition(
+    definition: dict, path: str = "subgraph definition", seen: set[str] | None = None
+) -> None:
     """Validate definition ids and containers while preserving its serialized shape."""
+    if seen is None:
+        seen = set()
     definition_id = definition.get("id")
     if not isinstance(definition_id, str) or not _UUID_RE.fullmatch(definition_id):
         raise ValueError(f"{path} id must be a valid UUID")
+    if definition_id in seen:
+        raise ValueError(f"{path} duplicates subgraph definition id {definition_id!r}")
+    seen.add(definition_id)
     if not isinstance(definition.get("nodes"), list) or not isinstance(definition.get("links"), list):
         raise ValueError(f"{path} nodes and links must be arrays")
     nested = definition.get("definitions")
@@ -1896,17 +1903,11 @@ def _validate_subgraph_definition(definition: dict, path: str = "subgraph defini
         return
     if not isinstance(nested, dict) or not isinstance(nested.get("subgraphs"), list):
         raise ValueError(f"{path}.definitions.subgraphs must be an array")
-    seen: set[str] = set()
     for index, child in enumerate(nested["subgraphs"]):
         child_path = f"{path}.definitions.subgraphs[{index}]"
         if not isinstance(child, dict):
             raise ValueError(f"{child_path} must be a JSON object")
-        child_id = child.get("id")
-        if isinstance(child_id, str) and child_id in seen:
-            raise ValueError(f"{child_path} duplicates subgraph definition id {child_id!r}")
-        if isinstance(child_id, str):
-            seen.add(child_id)
-        _validate_subgraph_definition(child, child_path)
+        _validate_subgraph_definition(child, child_path, seen)
 
 
 def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:
@@ -1929,15 +1930,17 @@ def _apply_define_subgraph(workflow: dict, op: dict) -> None:
         or not subgraph_id
         or not isinstance(definition, dict)
         or definition.get("id") != subgraph_id
-        or not isinstance(definition.get("nodes"), list)
-        or not isinstance(definition.get("links"), list)
     ):
         raise ValueError("malformed_op: subgraph_id must match a definition with nodes and links arrays")
+    try:
+        _validate_subgraph_definition(definition)
+    except ValueError as error:
+        raise ValueError(f"malformed_op: {error}") from error
     existing = _subgraph_definition(workflow, subgraph_id)
     if existing is not None:
         if existing == definition:
             return
-        raise ValueError(f"malformed_op: definition {subgraph_id!r} already exists with different content")
+        raise ValueError(f"definition_conflict: definition {subgraph_id!r} already exists with different content")
     workflow.setdefault("definitions", {}).setdefault("subgraphs", []).append(copy.deepcopy(definition))
 
 

--- a/comfy_cli/workflow_ops.py
+++ b/comfy_cli/workflow_ops.py
@@ -1873,6 +1873,7 @@ def define_subgraph(
     existing = _subgraph_definition(workflow, definition_id)
     if existing is not None:
         raise ValueError(f"subgraph definition {definition_id!r} already exists; define-subgraph only creates new ids")
+    _validate_subgraph_definition(definition, seen=_subgraph_definition_ids(workflow))
     op = _new_op(
         "define_subgraph",
         actor,
@@ -1917,9 +1918,31 @@ def _subgraph_definition(workflow: dict, subgraph_id: str) -> dict | None:
     if not isinstance(definitions, dict) or not isinstance(definitions.get("subgraphs", []), list):
         raise ValueError("malformed workflow: definitions.subgraphs must be an array")
     for definition in definitions.get("subgraphs", []):
-        if isinstance(definition, dict) and str(definition.get("id")) == subgraph_id:
-            return definition
+        if isinstance(definition, dict):
+            if str(definition.get("id")) == subgraph_id:
+                return definition
+            nested = _subgraph_definition(definition, subgraph_id)
+            if nested is not None:
+                return nested
     return None
+
+
+def _subgraph_definition_ids(workflow: dict) -> set[str]:
+    """Collect all definition ids recursively from a workflow or definition."""
+    definitions = workflow.get("definitions")
+    if definitions is None:
+        return set()
+    if not isinstance(definitions, dict) or not isinstance(definitions.get("subgraphs", []), list):
+        raise ValueError("malformed workflow: definitions.subgraphs must be an array")
+    ids: set[str] = set()
+    for definition in definitions.get("subgraphs", []):
+        if not isinstance(definition, dict):
+            continue
+        definition_id = definition.get("id")
+        if isinstance(definition_id, str):
+            ids.add(definition_id)
+        ids.update(_subgraph_definition_ids(definition))
+    return ids
 
 
 def _apply_define_subgraph(workflow: dict, op: dict) -> None:

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -17,7 +17,7 @@ citation must point at a commit on that branch.
 
 ## 1. Frozen op kinds
 
-Six kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
+Seven kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
 `ValueError("unknown op ...")` — it never ignores one.
 
 | Kind | Batchable | Standalone command | Summary |
@@ -28,6 +28,7 @@ Six kinds. No other kind is valid in v1: `apply_op` rejects an unknown kind with
 | `delete_node` | yes | `comfy workflow delete` | Remove one node and its incident links |
 | `clear` | no | `comfy workflow clear` | Remove every node, link, and group |
 | `reset_doc` | no | `comfy workflow reset-doc --confirm` | Reset the whole document to an empty baseline |
+| `define_subgraph` | yes | `comfy workflow define-subgraph` | Create one subgraph definition |
 
 Batchable = the kind is accepted by `apply_specs` (the `workflow apply` /
 `workflow foreach` batch surface). `clear` and `reset_doc` rewrite the whole
@@ -177,6 +178,29 @@ pre-reset `base_version` do not replay across it.
   `workflow_reset_doc_not_batchable`.
 * Never emitted implicitly: no `--emit-ops` surface and no bulk writer (§8.8)
   mints one. It exists only where a caller asked for it by name.
+
+### 1.7 `define_subgraph`
+
+Command: `comfy workflow define-subgraph <file> <definition-file> [--id <uuid>]`.
+The command validates a serializable definition, assigns its id from `--id`,
+the definition's `id`, or a new UUID, and emits exactly one stamped op:
+
+```json
+{
+  "op": "define_subgraph",
+  "op_id": "<uuid4 hex>",
+  "actor": "cli",
+  "base_version": 0,
+  "stamp": [0, "cli"],
+  "subgraph_id": "<uuid>",
+  "subgraph_definition": {"id": "<uuid>", "nodes": [], "links": []}
+}
+```
+
+Only this op may carry `subgraph_id` or definition payloads. Creation fails
+before writing when the id already exists. Exact op replay is a no-op; a
+different definition under an existing id is rejected as `malformed_op`.
+Subsequent interior edits use the existing id-addressed op scopes.
 
 ## 2. Idempotency and identity
 

--- a/docs/op-vocabulary-v1.md
+++ b/docs/op-vocabulary-v1.md
@@ -182,8 +182,9 @@ pre-reset `base_version` do not replay across it.
 ### 1.7 `define_subgraph`
 
 Command: `comfy workflow define-subgraph <file> <definition-file> [--id <uuid>]`.
-The command validates a serializable definition, assigns its id from `--id`,
-the definition's `id`, or a new UUID, and emits exactly one stamped op:
+The command performs envelope shape and JSON-serialization checks, assigns its
+id from `--id`, the definition's `id`, or a new UUID, and emits exactly one
+stamped op without modifying the local workflow:
 
 ```json
 {
@@ -197,10 +198,12 @@ the definition's `id`, or a new UUID, and emits exactly one stamped op:
 }
 ```
 
-Only this op may carry `subgraph_id` or definition payloads. Creation fails
-before writing when the id already exists. Exact op replay is a no-op; a
-different definition under an existing id is rejected as `malformed_op`.
-Subsequent interior edits use the existing id-addressed op scopes.
+Only this op may carry `subgraph_id` or definition payloads. The CLI does not
+semantically validate, apply, replay, project, or resolve conflicts for the
+definition. cmp owns those operations: reusing an id with different content
+returns `definition_conflict`, and references to unknown ids follow cmp's
+unknown-node failure path. The CLI surfaces server errors verbatim. Subsequent
+interior edits use the existing id-addressed op scopes.
 
 ## 2. Idempotency and identity
 

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import copy
+import json
+from pathlib import Path
 
 import pytest
+import typer
 
 from comfy_cli import workflow_ops
+from comfy_cli.command import workflow as workflow_cmd  # noqa: F401 -- initializes the edit command cycle
+from comfy_cli.command import workflow_edit
 
 SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
 NESTED_ID = "abcdefab-cdef-4abc-8def-abcdefabcdef"
@@ -175,7 +180,7 @@ def test_apply_define_subgraph_rejects_malformed_nested_definition_atomically():
     assert workflow == before
 
 
-def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_rejected():
+def test_apply_define_subgraph_replays_are_idempotent():
     workflow = {"nodes": [], "links": []}
     _, op = workflow_ops.define_subgraph(workflow, _definition())
     before = copy.deepcopy(workflow)
@@ -184,6 +189,107 @@ def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_reject
     assert workflow == before
 
     conflicting = {**op, "op_id": "f" * 32, "subgraph_definition": _definition(2)}
-    with pytest.raises(ValueError, match="definition_conflict:.*already exists with different content"):
-        workflow_ops.apply_op(workflow, conflicting, None)
-    assert workflow == before
+    workflow_ops.apply_op(workflow, conflicting, None)
+    assert workflow["definitions"] == before["definitions"]
+
+
+def test_define_subgraph_write_targets_are_scoped_by_definition_id():
+    first = {"op": "define_subgraph", "subgraph_id": SUBGRAPH_ID}
+    other = {"op": "define_subgraph", "subgraph_id": NESTED_ID}
+
+    assert workflow_ops.detect_conflict(first, other) is False
+    assert workflow_ops.detect_conflict(first, dict(first)) is True
+
+
+def test_apply_define_subgraph_accepts_null_definitions_container():
+    workflow = {"nodes": [], "links": [], "definitions": None}
+    _, op = workflow_ops.define_subgraph(workflow, _definition())
+
+    assert workflow["definitions"]["subgraphs"] == [op["subgraph_definition"]]
+
+
+@pytest.mark.parametrize(
+    ("definition", "match"),
+    [
+        ({**_definition(), "nodes": [{"id": 1, "type": "Inner", "inputs": 1}]}, "inputs must be an array"),
+        ({**_definition(), "links": [[1, 2]]}, "link.*tuple"),
+        ({**_definition(), "nodes": [{"id": 1, "type": SUBGRAPH_ID}]}, "cyclic subgraph reference"),
+        (
+            {
+                **_definition(),
+                "nodes": [{"id": 1, "type": NESTED_ID}],
+                "definitions": {
+                    "subgraphs": [{"id": NESTED_ID, "nodes": [{"id": 2, "type": SUBGRAPH_ID}], "links": []}]
+                },
+            },
+            "cyclic subgraph reference",
+        ),
+    ],
+)
+def test_define_subgraph_rejects_malformed_or_recursive_interior(definition, match):
+    with pytest.raises(ValueError, match=match):
+        workflow_ops.define_subgraph({"nodes": [], "links": []}, definition)
+
+
+def test_define_subgraph_preserves_explicit_falsy_ids_for_validation():
+    with pytest.raises(ValueError, match="non-empty string id"):
+        workflow_ops.define_subgraph({"nodes": [], "links": []}, _definition(), subgraph_id="")
+    with pytest.raises(ValueError, match="non-empty string id"):
+        workflow_ops.define_subgraph({"nodes": [], "links": []}, {"id": 0, "nodes": [], "links": []})
+
+
+def test_apply_define_subgraph_different_redelivery_is_a_noop():
+    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition(2)]}}
+    before = copy.deepcopy(workflow)
+    _, original_op = workflow_ops.define_subgraph({"nodes": [], "links": []}, _definition())
+
+    workflow_ops.apply_op(workflow, original_op, None)
+
+    assert workflow["definitions"] == before["definitions"]
+    assert original_op["op_id"] in workflow["_applied_ops"]
+
+
+def test_apply_define_subgraph_fresh_op_id_exercises_definition_idempotency():
+    workflow = {"nodes": [], "links": []}
+    _, op = workflow_ops.define_subgraph(workflow, _definition())
+    workflow_ops.strip_internal(workflow)
+
+    workflow_ops.apply_op(workflow, {**op, "op_id": "e" * 32}, None)
+
+    assert workflow["definitions"]["subgraphs"] == [_definition()]
+
+
+def test_replace_ops_emits_definition_before_nodes():
+    new = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition()]}}
+
+    ops = workflow_ops.replace_ops({"nodes": [], "links": []}, new)
+
+    assert [op["op"] for op in ops] == ["define_subgraph"]
+
+
+def test_define_subgraph_command_rejects_non_regular_definition_file(tmp_path, monkeypatch):
+    workflow = tmp_path / "workflow.json"
+    workflow.write_text(json.dumps({"nodes": [], "links": []}))
+    definition_dir = tmp_path / "definition"
+    definition_dir.mkdir()
+    errors = []
+
+    class Renderer:
+        command = ""
+
+        def error(self, **kwargs):
+            errors.append(kwargs)
+
+    monkeypatch.setattr(workflow_edit, "get_renderer", Renderer)
+    with pytest.raises(typer.Exit):
+        workflow_edit.define_subgraph_cmd(str(workflow), str(definition_dir))
+
+    assert "regular file" in errors[0]["message"]
+
+
+def test_definition_reader_rejects_oversized_files(tmp_path):
+    path = tmp_path / "large.json"
+    path.write_bytes(b" " * (workflow_edit._MAX_DEFINITION_BYTES + 1))
+
+    with pytest.raises(ValueError, match="too large"):
+        workflow_edit._read_subgraph_definition(Path(path))

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -6,7 +6,6 @@ import pytest
 
 from comfy_cli import workflow_ops
 
-
 SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
 
 
@@ -45,7 +44,7 @@ def test_define_subgraph_emits_cmp_payload_and_inserts_definition():
     ("definition", "match"),
     [
         ([], "JSON object"),
-        ({"nodes": [], "links": []}, "non-empty string id"),
+        ({"id": 7, "nodes": [], "links": []}, "non-empty string id"),
         ({"id": SUBGRAPH_ID, "nodes": {}, "links": []}, "nodes and links must be arrays"),
     ],
 )

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -7,6 +7,7 @@ import pytest
 from comfy_cli import workflow_ops
 
 SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
+NESTED_ID = "abcdefab-cdef-4abc-8def-abcdefabcdef"
 
 
 def _definition(value: int = 1) -> dict:
@@ -45,7 +46,17 @@ def test_define_subgraph_emits_cmp_payload_and_inserts_definition():
     [
         ([], "JSON object"),
         ({"id": 7, "nodes": [], "links": []}, "non-empty string id"),
+        ({"id": "not-a-uuid", "nodes": [], "links": []}, "valid UUID"),
         ({"id": SUBGRAPH_ID, "nodes": {}, "links": []}, "nodes and links must be arrays"),
+        (
+            {
+                "id": SUBGRAPH_ID,
+                "nodes": [],
+                "links": [],
+                "definitions": {"subgraphs": [{"id": "not-a-uuid", "nodes": [], "links": []}]},
+            },
+            "definitions.subgraphs\\[0\\].*valid UUID",
+        ),
     ],
 )
 def test_define_subgraph_rejects_malformed_input_before_mutation(definition, match):
@@ -73,6 +84,17 @@ def test_define_subgraph_rejects_existing_id_and_different_definition():
 
     with pytest.raises(ValueError, match="already exists"):
         workflow_ops.define_subgraph(workflow, _definition(2))
+
+
+def test_define_subgraph_preserves_nested_definitions_inside_single_parent_op():
+    nested = {"id": NESTED_ID, "nodes": [], "links": []}
+    definition = {**_definition(), "definitions": {"subgraphs": [nested]}}
+
+    result, op = workflow_ops.define_subgraph({"nodes": [], "links": []}, definition)
+
+    assert op["subgraph_definition"]["definitions"] == {"subgraphs": [nested]}
+    assert result["definitions"]["subgraphs"] == [definition]
+    assert op["op"] == "define_subgraph"
 
 
 def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_rejected():

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -12,29 +12,28 @@ from comfy_cli.command import workflow as workflow_cmd  # noqa: F401 -- initiali
 from comfy_cli.command import workflow_edit
 
 SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
-NESTED_ID = "abcdefab-cdef-4abc-8def-abcdefabcdef"
-OTHER_NESTED_ID = "fedcbafe-dcba-4fed-8cba-fedcbafedcba"
 
 
-def _definition(value: int = 1) -> dict:
+def _definition() -> dict:
     return {
         "id": SUBGRAPH_ID,
         "name": "One",
         "inputs": [],
         "outputs": [],
-        "nodes": [{"id": 10, "type": "Inner", "widgets_values": [value]}],
+        "nodes": [{"id": 10, "type": "Inner"}],
         "links": [],
     }
 
 
-def test_define_subgraph_emits_cmp_payload_and_inserts_definition():
-    workflow = {"nodes": [], "links": []}
+def test_define_subgraph_emits_cmp_payload_without_mutating_workflow():
+    workflow = {"nodes": [{"id": 1, "type": "Existing"}], "links": []}
+    before = copy.deepcopy(workflow)
     definition = _definition()
-    snapshot = copy.deepcopy(definition)
 
     result, op = workflow_ops.define_subgraph(workflow, definition, actor="agent", base_version=4)
 
-    assert definition == snapshot
+    assert result is workflow
+    assert workflow == before
     assert op == {
         "op": "define_subgraph",
         "op_id": op["op_id"],
@@ -44,35 +43,21 @@ def test_define_subgraph_emits_cmp_payload_and_inserts_definition():
         "subgraph_id": SUBGRAPH_ID,
         "subgraph_definition": definition,
     }
-    assert result["definitions"]["subgraphs"] == [definition]
 
 
-@pytest.mark.parametrize(
-    ("definition", "match"),
-    [
-        ([], "JSON object"),
-        ({"id": 7, "nodes": [], "links": []}, "non-empty string id"),
-        ({"id": "not-a-uuid", "nodes": [], "links": []}, "valid UUID"),
-        ({"id": SUBGRAPH_ID, "nodes": {}, "links": []}, "nodes and links must be arrays"),
-        (
-            {
-                "id": SUBGRAPH_ID,
-                "nodes": [],
-                "links": [],
-                "definitions": {"subgraphs": [{"id": "not-a-uuid", "nodes": [], "links": []}]},
-            },
-            "definitions.subgraphs\\[0\\].*valid UUID",
-        ),
-    ],
-)
-def test_define_subgraph_rejects_malformed_input_before_mutation(definition, match):
-    workflow = {"nodes": [], "links": []}
-    before = copy.deepcopy(workflow)
+def test_define_subgraph_emits_semantically_odd_definition_for_cmp_validation():
+    definition = {"id": SUBGRAPH_ID, "nodes": "future-cmp-shape", "links": {"also": "future"}}
 
-    with pytest.raises(ValueError, match=match):
-        workflow_ops.define_subgraph(workflow, definition)
+    _, op = workflow_ops.define_subgraph({"nodes": [], "links": []}, definition)
 
-    assert workflow == before
+    assert op["subgraph_definition"] == definition
+
+
+def test_define_subgraph_rejects_local_replay():
+    _, op = workflow_ops.define_subgraph({"nodes": [], "links": []}, _definition())
+
+    with pytest.raises(ValueError, match="unknown op 'define_subgraph'"):
+        workflow_ops.apply_op({"nodes": [], "links": []}, op, None)
 
 
 def test_define_subgraph_can_assign_an_explicit_new_id():
@@ -85,186 +70,31 @@ def test_define_subgraph_can_assign_an_explicit_new_id():
     assert op["subgraph_definition"]["id"] == SUBGRAPH_ID
 
 
-def test_define_subgraph_rejects_existing_id_and_different_definition():
-    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition()]}}
+def test_define_subgraph_command_emits_without_writing_workflow(tmp_path, monkeypatch):
+    workflow = tmp_path / "workflow.json"
+    original = {"nodes": [], "links": []}
+    workflow.write_text(json.dumps(original))
+    definition_file = tmp_path / "definition.json"
+    definition_file.write_text(json.dumps(_definition()))
+    emitted = []
 
-    with pytest.raises(ValueError, match="already exists"):
-        workflow_ops.define_subgraph(workflow, _definition(2))
+    class Renderer:
+        command = ""
 
+        def is_pretty(self):
+            return False
 
-def test_define_subgraph_preserves_nested_definitions_inside_single_parent_op():
-    nested = {"id": NESTED_ID, "nodes": [], "links": []}
-    definition = {**_definition(), "definitions": {"subgraphs": [nested]}}
+        def emit(self, payload, **kwargs):
+            emitted.append((payload, kwargs))
 
-    result, op = workflow_ops.define_subgraph({"nodes": [], "links": []}, definition)
+    monkeypatch.setattr(workflow_edit, "get_renderer", Renderer)
 
-    assert op["subgraph_definition"]["definitions"] == {"subgraphs": [nested]}
-    assert result["definitions"]["subgraphs"] == [definition]
-    assert op["op"] == "define_subgraph"
+    workflow_edit.define_subgraph_cmd(str(workflow), str(definition_file))
 
-
-@pytest.mark.parametrize(
-    "definition",
-    [
-        {
-            **_definition(),
-            "definitions": {"subgraphs": [{"id": SUBGRAPH_ID, "nodes": [], "links": []}]},
-        },
-        {
-            **_definition(),
-            "definitions": {
-                "subgraphs": [
-                    {
-                        "id": NESTED_ID,
-                        "nodes": [],
-                        "links": [],
-                        "definitions": {"subgraphs": [{"id": OTHER_NESTED_ID, "nodes": [], "links": []}]},
-                    },
-                    {"id": OTHER_NESTED_ID, "nodes": [], "links": []},
-                ]
-            },
-        },
-    ],
-    ids=["ancestor", "across-branches"],
-)
-def test_define_subgraph_rejects_duplicate_ids_across_entire_definition_tree(definition):
-    workflow = {"nodes": [], "links": []}
-    before = copy.deepcopy(workflow)
-
-    with pytest.raises(ValueError, match="duplicates subgraph definition id"):
-        workflow_ops.define_subgraph(workflow, definition)
-
-    assert workflow == before
-
-
-def test_define_subgraph_rejects_id_already_nested_in_workflow():
-    existing = {
-        "id": OTHER_NESTED_ID,
-        "nodes": [],
-        "links": [],
-        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": [], "links": []}]},
-    }
-    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [existing]}}
-    before = copy.deepcopy(workflow)
-    definition = {
-        **_definition(),
-        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": [], "links": []}]},
-    }
-
-    with pytest.raises(ValueError, match="duplicates subgraph definition id"):
-        workflow_ops.define_subgraph(workflow, definition)
-
-    assert workflow == before
-
-
-def test_apply_define_subgraph_rejects_malformed_nested_definition_atomically():
-    workflow = {"nodes": [], "links": []}
-    before = copy.deepcopy(workflow)
-    definition = {
-        **_definition(),
-        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": {}, "links": []}]},
-    }
-    op = {
-        "op": "define_subgraph",
-        "op_id": "a" * 32,
-        "actor": "peer",
-        "base_version": 0,
-        "stamp": [0, "peer"],
-        "subgraph_id": SUBGRAPH_ID,
-        "subgraph_definition": definition,
-    }
-
-    with pytest.raises(ValueError, match="malformed_op:.*definitions.subgraphs\\[0\\].*nodes and links"):
-        workflow_ops.apply_op(workflow, op, None)
-
-    assert workflow == before
-
-
-def test_apply_define_subgraph_replays_are_idempotent():
-    workflow = {"nodes": [], "links": []}
-    _, op = workflow_ops.define_subgraph(workflow, _definition())
-    before = copy.deepcopy(workflow)
-
-    workflow_ops.apply_op(workflow, op, None)
-    assert workflow == before
-
-    conflicting = {**op, "op_id": "f" * 32, "subgraph_definition": _definition(2)}
-    workflow_ops.apply_op(workflow, conflicting, None)
-    assert workflow["definitions"] == before["definitions"]
-
-
-def test_define_subgraph_write_targets_are_scoped_by_definition_id():
-    first = {"op": "define_subgraph", "subgraph_id": SUBGRAPH_ID}
-    other = {"op": "define_subgraph", "subgraph_id": NESTED_ID}
-
-    assert workflow_ops.detect_conflict(first, other) is False
-    assert workflow_ops.detect_conflict(first, dict(first)) is True
-
-
-def test_apply_define_subgraph_accepts_null_definitions_container():
-    workflow = {"nodes": [], "links": [], "definitions": None}
-    _, op = workflow_ops.define_subgraph(workflow, _definition())
-
-    assert workflow["definitions"]["subgraphs"] == [op["subgraph_definition"]]
-
-
-@pytest.mark.parametrize(
-    ("definition", "match"),
-    [
-        ({**_definition(), "nodes": [{"id": 1, "type": "Inner", "inputs": 1}]}, "inputs must be an array"),
-        ({**_definition(), "links": [[1, 2]]}, "link.*tuple"),
-        ({**_definition(), "nodes": [{"id": 1, "type": SUBGRAPH_ID}]}, "cyclic subgraph reference"),
-        (
-            {
-                **_definition(),
-                "nodes": [{"id": 1, "type": NESTED_ID}],
-                "definitions": {
-                    "subgraphs": [{"id": NESTED_ID, "nodes": [{"id": 2, "type": SUBGRAPH_ID}], "links": []}]
-                },
-            },
-            "cyclic subgraph reference",
-        ),
-    ],
-)
-def test_define_subgraph_rejects_malformed_or_recursive_interior(definition, match):
-    with pytest.raises(ValueError, match=match):
-        workflow_ops.define_subgraph({"nodes": [], "links": []}, definition)
-
-
-def test_define_subgraph_preserves_explicit_falsy_ids_for_validation():
-    with pytest.raises(ValueError, match="non-empty string id"):
-        workflow_ops.define_subgraph({"nodes": [], "links": []}, _definition(), subgraph_id="")
-    with pytest.raises(ValueError, match="non-empty string id"):
-        workflow_ops.define_subgraph({"nodes": [], "links": []}, {"id": 0, "nodes": [], "links": []})
-
-
-def test_apply_define_subgraph_different_redelivery_is_a_noop():
-    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition(2)]}}
-    before = copy.deepcopy(workflow)
-    _, original_op = workflow_ops.define_subgraph({"nodes": [], "links": []}, _definition())
-
-    workflow_ops.apply_op(workflow, original_op, None)
-
-    assert workflow["definitions"] == before["definitions"]
-    assert original_op["op_id"] in workflow["_applied_ops"]
-
-
-def test_apply_define_subgraph_fresh_op_id_exercises_definition_idempotency():
-    workflow = {"nodes": [], "links": []}
-    _, op = workflow_ops.define_subgraph(workflow, _definition())
-    workflow_ops.strip_internal(workflow)
-
-    workflow_ops.apply_op(workflow, {**op, "op_id": "e" * 32}, None)
-
-    assert workflow["definitions"]["subgraphs"] == [_definition()]
-
-
-def test_replace_ops_emits_definition_before_nodes():
-    new = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition()]}}
-
-    ops = workflow_ops.replace_ops({"nodes": [], "links": []}, new)
-
-    assert [op["op"] for op in ops] == ["define_subgraph"]
+    assert json.loads(workflow.read_text()) == original
+    assert emitted[0][0]["op"]["op"] == "define_subgraph"
+    assert emitted[0][0]["wrote"] is None
+    assert emitted[0][1]["changed"] is False
 
 
 def test_define_subgraph_command_rejects_non_regular_definition_file(tmp_path, monkeypatch):

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -8,6 +8,7 @@ from comfy_cli import workflow_ops
 
 SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
 NESTED_ID = "abcdefab-cdef-4abc-8def-abcdefabcdef"
+OTHER_NESTED_ID = "fedcbafe-dcba-4fed-8cba-fedcbafedcba"
 
 
 def _definition(value: int = 1) -> dict:
@@ -97,6 +98,63 @@ def test_define_subgraph_preserves_nested_definitions_inside_single_parent_op():
     assert op["op"] == "define_subgraph"
 
 
+@pytest.mark.parametrize(
+    "definition",
+    [
+        {
+            **_definition(),
+            "definitions": {"subgraphs": [{"id": SUBGRAPH_ID, "nodes": [], "links": []}]},
+        },
+        {
+            **_definition(),
+            "definitions": {
+                "subgraphs": [
+                    {
+                        "id": NESTED_ID,
+                        "nodes": [],
+                        "links": [],
+                        "definitions": {"subgraphs": [{"id": OTHER_NESTED_ID, "nodes": [], "links": []}]},
+                    },
+                    {"id": OTHER_NESTED_ID, "nodes": [], "links": []},
+                ]
+            },
+        },
+    ],
+    ids=["ancestor", "across-branches"],
+)
+def test_define_subgraph_rejects_duplicate_ids_across_entire_definition_tree(definition):
+    workflow = {"nodes": [], "links": []}
+    before = copy.deepcopy(workflow)
+
+    with pytest.raises(ValueError, match="duplicates subgraph definition id"):
+        workflow_ops.define_subgraph(workflow, definition)
+
+    assert workflow == before
+
+
+def test_apply_define_subgraph_rejects_malformed_nested_definition_atomically():
+    workflow = {"nodes": [], "links": []}
+    before = copy.deepcopy(workflow)
+    definition = {
+        **_definition(),
+        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": {}, "links": []}]},
+    }
+    op = {
+        "op": "define_subgraph",
+        "op_id": "a" * 32,
+        "actor": "peer",
+        "base_version": 0,
+        "stamp": [0, "peer"],
+        "subgraph_id": SUBGRAPH_ID,
+        "subgraph_definition": definition,
+    }
+
+    with pytest.raises(ValueError, match="malformed_op:.*definitions.subgraphs\\[0\\].*nodes and links"):
+        workflow_ops.apply_op(workflow, op, None)
+
+    assert workflow == before
+
+
 def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_rejected():
     workflow = {"nodes": [], "links": []}
     _, op = workflow_ops.define_subgraph(workflow, _definition())
@@ -106,5 +164,6 @@ def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_reject
     assert workflow == before
 
     conflicting = {**op, "op_id": "f" * 32, "subgraph_definition": _definition(2)}
-    with pytest.raises(ValueError, match="already exists with different content"):
+    with pytest.raises(ValueError, match="definition_conflict:.*already exists with different content"):
         workflow_ops.apply_op(workflow, conflicting, None)
+    assert workflow == before

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -132,6 +132,26 @@ def test_define_subgraph_rejects_duplicate_ids_across_entire_definition_tree(def
     assert workflow == before
 
 
+def test_define_subgraph_rejects_id_already_nested_in_workflow():
+    existing = {
+        "id": OTHER_NESTED_ID,
+        "nodes": [],
+        "links": [],
+        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": [], "links": []}]},
+    }
+    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [existing]}}
+    before = copy.deepcopy(workflow)
+    definition = {
+        **_definition(),
+        "definitions": {"subgraphs": [{"id": NESTED_ID, "nodes": [], "links": []}]},
+    }
+
+    with pytest.raises(ValueError, match="duplicates subgraph definition id"):
+        workflow_ops.define_subgraph(workflow, definition)
+
+    assert workflow == before
+
+
 def test_apply_define_subgraph_rejects_malformed_nested_definition_atomically():
     workflow = {"nodes": [], "links": []}
     before = copy.deepcopy(workflow)

--- a/tests/comfy_cli/test_define_subgraph_op.py
+++ b/tests/comfy_cli/test_define_subgraph_op.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from comfy_cli import workflow_ops
+
+
+SUBGRAPH_ID = "12345678-1234-4123-8123-123456789abc"
+
+
+def _definition(value: int = 1) -> dict:
+    return {
+        "id": SUBGRAPH_ID,
+        "name": "One",
+        "inputs": [],
+        "outputs": [],
+        "nodes": [{"id": 10, "type": "Inner", "widgets_values": [value]}],
+        "links": [],
+    }
+
+
+def test_define_subgraph_emits_cmp_payload_and_inserts_definition():
+    workflow = {"nodes": [], "links": []}
+    definition = _definition()
+    snapshot = copy.deepcopy(definition)
+
+    result, op = workflow_ops.define_subgraph(workflow, definition, actor="agent", base_version=4)
+
+    assert definition == snapshot
+    assert op == {
+        "op": "define_subgraph",
+        "op_id": op["op_id"],
+        "actor": "agent",
+        "base_version": 4,
+        "stamp": [4, "agent"],
+        "subgraph_id": SUBGRAPH_ID,
+        "subgraph_definition": definition,
+    }
+    assert result["definitions"]["subgraphs"] == [definition]
+
+
+@pytest.mark.parametrize(
+    ("definition", "match"),
+    [
+        ([], "JSON object"),
+        ({"nodes": [], "links": []}, "non-empty string id"),
+        ({"id": SUBGRAPH_ID, "nodes": {}, "links": []}, "nodes and links must be arrays"),
+    ],
+)
+def test_define_subgraph_rejects_malformed_input_before_mutation(definition, match):
+    workflow = {"nodes": [], "links": []}
+    before = copy.deepcopy(workflow)
+
+    with pytest.raises(ValueError, match=match):
+        workflow_ops.define_subgraph(workflow, definition)
+
+    assert workflow == before
+
+
+def test_define_subgraph_can_assign_an_explicit_new_id():
+    definition = _definition()
+    definition.pop("id")
+
+    _, op = workflow_ops.define_subgraph({"nodes": [], "links": []}, definition, subgraph_id=SUBGRAPH_ID)
+
+    assert op["subgraph_id"] == SUBGRAPH_ID
+    assert op["subgraph_definition"]["id"] == SUBGRAPH_ID
+
+
+def test_define_subgraph_rejects_existing_id_and_different_definition():
+    workflow = {"nodes": [], "links": [], "definitions": {"subgraphs": [_definition()]}}
+
+    with pytest.raises(ValueError, match="already exists"):
+        workflow_ops.define_subgraph(workflow, _definition(2))
+
+
+def test_apply_define_subgraph_exact_replay_is_idempotent_and_conflict_is_rejected():
+    workflow = {"nodes": [], "links": []}
+    _, op = workflow_ops.define_subgraph(workflow, _definition())
+    before = copy.deepcopy(workflow)
+
+    workflow_ops.apply_op(workflow, op, None)
+    assert workflow == before
+
+    conflicting = {**op, "op_id": "f" * 32, "subgraph_definition": _definition(2)}
+    with pytest.raises(ValueError, match="already exists with different content"):
+        workflow_ops.apply_op(workflow, conflicting, None)


### PR DESCRIPTION
- Adds `comfy workflow define-subgraph`.
- Emits the cmp-compatible `define_subgraph` payload.
- Focused tests and static gates are green.

<details><summary>Full context for agent readers</summary>

## What and why

Adds `comfy workflow define-subgraph <workflow-file> <subgraph-definition-file> [--id <uuid>]`, following the command and op-building pattern in the [sibling insert-workflow pull request](https://github.com/Comfy-Org/comfy-cli/pull/863).

The command performs only envelope shape and serialization checks, creates a new definition id when one is not supplied, and emits one `define_subgraph` op using the exact `subgraph_id` and `subgraph_definition` fields from the [cmp contract pull request](https://github.com/Comfy-Org/ComfyUI_frontend/pull/17454). It does not mutate the local workflow. This implements the CLI slice of the [first-class subgraph technical design](https://www.notion.so/3d16d73d365081719b85ed515af98276).

cmp owns semantic validation, application, replay, projection, and conflict handling. The CLI surfaces cmp's `definition_conflict` and unknown-node errors verbatim. Other op kinds reject definition payload fields. `define_subgraph` remains in the batchable vocabulary, matching cmp.

## RED to GREEN evidence

RED:

```text
7 failed in 0.64s
AttributeError: module 'comfy_cli.workflow_ops' has no attribute 'define_subgraph'
```

GREEN:

```text
14 passed in 0.11s
```

The emit-only RED probes initially failed 4/4 (local mutation, semantic rejection, local replay, and command file writes). All now pass.

## Gates

```text
uv run ruff check .
All checks passed!

uv run ruff format --check comfy_cli/workflow_ops.py tests/comfy_cli/test_define_subgraph_op.py
2 files already formatted

uv run pytest -q <define-subgraph and neighbouring workflow-op test files>
99 passed in 0.29s
```

The full suite completed with 7,417 passing, 32 skipped, and 45 failures unrelated to this diff. The failures are concentrated in existing run/preflight tests that consume live cached object-info and two existing umask expectations; focused changed-area tests are green.

## Vetoable decisions

- Keep `--id` optional: use the definition's existing string `id`, otherwise mint a UUID. A supplied `--id` must match an existing definition `id`.
- Mark `define_subgraph` batchable because the cmp contract adds it to `BATCHABLE_OPS`; the standalone command remains the explicit creation surface.
- Keep UUID and payload-id agreement checks as envelope shape validation; cmp owns all definition-content semantics and id-conflict handling.

</details>
