### PR TITLE
feat(generate): name the node class each `generate list` row would mint (BE-13301)

### DIFF
--- a/comfy_cli/command/generate/app.py
+++ b/comfy_cli/command/generate/app.py
@@ -923,6 +923,11 @@ def _model_record(e: spec.Endpoint) -> dict[str, object]:
         # Most of the catalog is proxy-only; an agent that could not see this
         # asked for a workflow it could never get (`emit_workflow_failed`).
         "emit_supported": emit.is_supported(e.id),
+        # The class the row above would mint, or None when unmapped. Paired with
+        # `emit_supported` so a consumer outside this repo can check the
+        # hand-written mapping against a live catalog instead of taking the
+        # boolean on trust (BE-13301).
+        "node_class": emit.node_class_for(e.id),
     }
 
 

--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -270,6 +270,21 @@ def is_supported(model: str) -> bool:
     return _lookup_model(model) is not None
 
 
+def node_class_for(model: str) -> str | None:
+    """The ComfyUI class ``--emit-workflow`` would mint for ``model``, or None
+    when nothing maps to a node. The per-row ``node_class`` of ``generate list``.
+
+    Exposed because :data:`MODEL_NODE_MAP` is hand-written and nothing outside
+    this repo could see what it points at. Cloud's partner-catalog gate reads
+    this row to check the mapping against the catalog its deployed ComfyUI
+    actually serves, which is how a class ComfyUI has since deprecated gets
+    caught before a user meets it (BE-13301). ``deprecated_ok`` covers the same
+    ground against a snapshot recorded HERE; this covers it against a live one.
+    """
+    found = _lookup_model(model)
+    return found[1].node_class if found else None
+
+
 def _resolve_model(model: str) -> tuple[str, NodeSpec]:
     found = _lookup_model(model)
     if found is None:

--- a/comfy_cli/schemas/generate_list.json
+++ b/comfy_cli/schemas/generate_list.json
@@ -4,14 +4,26 @@
   "title": "comfy generate list",
   "description": "The partner-model catalog `comfy generate list` exposes. This is the only source of the alias list — `comfy discover` does not carry it. Under --json the summary is the FULL text, not the '…'-truncated form the human table cuts to fit its column.",
   "type": "object",
-  "required": ["models", "count"],
+  "required": [
+    "models",
+    "count"
+  ],
   "properties": {
     "models": {
       "type": "array",
       "description": "One record per model, ordered by (partner, id) — the same order the human table renders.",
       "items": {
         "type": "object",
-        "required": ["alias", "id", "partner", "category", "mode", "summary", "emit_supported"],
+        "required": [
+          "alias",
+          "id",
+          "partner",
+          "category",
+          "mode",
+          "summary",
+          "emit_supported",
+          "node_class"
+        ],
         "properties": {
           "alias": {
             "type": "string",
@@ -31,7 +43,10 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["sync", "async"],
+            "enum": [
+              "sync",
+              "async"
+            ],
             "description": "'async' when the partner returns a job to poll (resumable via `comfy generate resume`); 'sync' when the result comes back on the create call."
           },
           "summary": {
@@ -41,6 +56,13 @@
           "emit_supported": {
             "type": "boolean",
             "description": "Whether `comfy generate <alias> --emit-workflow <path>` can render this model as a ComfyUI partner node (a runnable workflow) instead of calling the proxy. False for most of the catalog: asking for --emit-workflow on such a model fails with `emit_workflow_unsupported_model`, whose `details.supported` lists the aliases that can."
+          },
+          "node_class": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The ComfyUI node class `--emit-workflow` would mint for this model, or null when `emit_supported` is false. The mapping behind it is hand-written, so a consumer can check this against the catalog its own ComfyUI serves rather than trusting the boolean."
           }
         }
       }
@@ -53,11 +75,29 @@
       "type": "object",
       "description": "The filters that produced this result, echoed back. Null where the flag was not passed.",
       "properties": {
-        "partner": { "type": ["string", "null"] },
-        "category": { "type": ["string", "null"] },
-        "query": { "type": ["string", "null"] }
+        "partner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "query": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
       }
     },
-    "knowledge": { "$ref": "knowledge_block.json", "description": "Curated model knowledge matching this call; absent when no bundle is loaded or the call named no subject. A query term nothing curated answers attaches a rowless block carrying hit_ids: [] and zero_hit, unless the terms alone overrun the byte ceiling." }
+    "knowledge": {
+      "$ref": "knowledge_block.json",
+      "description": "Curated model knowledge matching this call; absent when no bundle is loaded or the call named no subject. A query term nothing curated answers attaches a rowless block carrying hit_ids: [] and zero_hit, unless the terms alone overrun the byte ceiling."
+    }
   }
 }

--- a/tests/comfy_cli/command/generate/test_list_schema_envelope.py
+++ b/tests/comfy_cli/command/generate/test_list_schema_envelope.py
@@ -155,6 +155,31 @@ def test_list_rows_say_whether_emit_workflow_supports_them():
     assert by_alias["flux-2"]["emit_supported"] is True
 
 
+def test_list_rows_name_the_node_class_they_would_mint():
+    """`emit_supported` says a mapping exists; `node_class` says what it points
+    at. MODEL_NODE_MAP is hand-written, so without this a consumer outside this
+    repo cannot tell that an entry has gone stale against the catalog its own
+    ComfyUI serves — which is how `flux-2` kept emitting a class ComfyUI had
+    deprecated until a user reported the workflow (BE-13301)."""
+    from comfy_cli.command.generate import emit
+
+    data = _envelope(["--json", "generate", "list"])["data"]
+    by_alias = {row["alias"]: row for row in data["models"]}
+
+    for row in data["models"]:
+        assert "node_class" in row, row
+        if row["emit_supported"]:
+            assert isinstance(row["node_class"], str) and row["node_class"], row
+        else:
+            assert row["node_class"] is None, row
+
+    # Every mapped row names the class its NodeSpec holds, not a guess.
+    for alias, ns in emit.MODEL_NODE_MAP.items():
+        assert by_alias[alias]["node_class"] == ns.node_class
+
+    assert by_alias["flux-pro"]["node_class"] is None
+
+
 def test_list_with_no_matches_is_an_empty_success_not_an_error():
     result = _run(["--json", "generate", "list", "--partner", "no-such-partner"])
     envelope = json.loads(result.stdout.splitlines()[-1])


### PR DESCRIPTION
## Why

`emit_supported` tells a caller that a partner-node mapping exists. It never tells them what it points at.

`MODEL_NODE_MAP` is hand-written, so nothing outside this repo could tell that an entry had gone stale. That is how `flux-2` kept emitting `Flux2ProImageNode` after ComfyUI deprecated it, until a user reported the workflow.

#864 catches that here, against a snapshot recorded in this repo. This is the other half. Cloud's partner-catalog gate already runs `comfy generate list` and already reads the `object_info` its deployed ComfyUI serves, but it could not see which class an alias maps to, so it had no way to check one against the other.

## What changed

- `generate list` rows carry `node_class`: the class `--emit-workflow` would mint, or `null` when the model has no mapping.
- `emit.node_class_for()` mirrors the existing `is_supported()`.
- `comfy_cli/schemas/generate_list.json` documents the field and lists it as required.

Nothing else changes. `emit_supported` keeps its meaning and its callers.

## Checks

```
pytest tests/comfy_cli/command/generate      351 passed
ruff check / ruff format --check             clean
```

`test_list_payload_validates` runs the real payload against `generate_list.json`, so `node_class` being required is enforced rather than documented. The new test also asserts every mapped row names the class its own `NodeSpec` holds, and that unmapped rows are `null`.

## Follow-up

Cloud can now add a rule comparing each row's `node_class` against its synced `object_info`, which catches a stale mapping against a live catalog rather than a recorded one. That needs this merged plus a comfy-cli SHA bump in `services/agent/Dockerfile` first. Tracked in BE-13301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
