### PR TITLE
fix(generate): emit Flux.2 through the live node, not the deprecated one (BE-13301)

### DIFF
--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -173,22 +173,28 @@ MODEL_NODE_MAP: dict[str, NodeSpec] = {
     # Flux2ProImageNode would emit a workflow for a *different* model, so
     # `flux-pro` falls through to the EmitError instead.
     "flux-2": NodeSpec(
-        node_class="Flux2ProImageNode",
+        node_class="Flux2ImageNode",
         endpoint="bfl/flux-2-pro/generate",
         param_map={
             "prompt": "prompt",
-            "width": "width",
-            "height": "height",
+            "width": "model.width",
+            "height": "model.height",
             "seed": "seed",
-            "prompt_upsampling": "prompt_upsampling",
         },
-        fixed={"width": 1024, "height": 768, "seed": 0, "prompt_upsampling": True},
+        # `model` is the dynamic-combo selector and its sub-widgets are addressed
+        # through it. It must be set before them, which `ops_from_api_workflow`
+        # guarantees by ordering plain keys ahead of dotted ones.
+        #
+        # "Flux.2 [pro]" is the option that posts to this entry's `endpoint`.
+        # The node's other option, "Flux.2 [max]", is a different model at a
+        # different price, so it needs its own alias and endpoint rather than
+        # being reachable by accident from this one.
+        #
+        # No `prompt_upsampling`: the proxy takes it, this node does not expose
+        # it, so the emitted workflow cannot carry it. `comfy generate` without
+        # --emit-workflow still sends it straight to the proxy.
+        fixed={"model": "Flux.2 [pro]", "model.width": 1024, "model.height": 768, "seed": 0},
         output="IMAGE",
-        # ComfyUI deprecated Flux2ProImageNode in favor of Flux2ImageNode,
-        # whose width/height live inside a dynamic combo that
-        # the flat `param_map` cannot express. Emitting the deprecated class is
-        # the status quo until that migration lands; this flag comes off with it.
-        deprecated_ok=True,
     ),
     # BFL Flux 1.1 [pro] Ultra (text-to-image). Node: FluxProUltraImageNode.
     # The node takes an `aspect_ratio` string where the proxy schema takes

--- a/comfy_cli/command/generate/emit.py
+++ b/comfy_cli/command/generate/emit.py
@@ -351,6 +351,26 @@ def build_workflow(model: str, values: dict[str, Any], *, output_prefix: str = "
         if width_given and height_given:
             node_inputs[ns.aspect_from_wh] = f"{values['width']}:{values['height']}"
 
+    # Same rule, generalized: every flag the user actually typed has to land
+    # somewhere. `parse_args` fills no defaults, so `values` holds only what argv
+    # carried — anything in it that no mapping consumes would be discarded in
+    # silence. A proxy flag the node does not expose cannot be honored by an
+    # emitted workflow at all (flux-2's `prompt_upsampling` is the live case:
+    # the proxy takes it, Flux2ImageNode has no such input), so say so instead
+    # of handing back a graph that quietly ignores it.
+    handled = set(ns.param_map) | set(ns.image_params)
+    if ns.aspect_from_wh:
+        handled |= {"width", "height"}
+    unsupported = sorted(flag for flag, value in values.items() if value is not None and flag not in handled)
+    if unsupported:
+        flags = ", ".join(f"--{flag}" for flag in unsupported)
+        raise EmitError(
+            f"--emit-workflow for {model!r} cannot carry {flags}: "
+            f"{ns.node_class} has no matching input. Drop the flag, or run "
+            f"`comfy generate {model}` without --emit-workflow to send it "
+            f"straight to the proxy."
+        )
+
     partner = {
         "class_type": ns.node_class,
         "_meta": {"title": f"{ns.node_class} ({model})"},

--- a/tests/comfy_cli/command/generate/fixtures/partner_nodes_object_info.json
+++ b/tests/comfy_cli/command/generate/fixtures/partner_nodes_object_info.json
@@ -334,6 +334,219 @@
     "python_module": "comfy_api_nodes.nodes_bfl",
     "search_aliases": null
   },
+  "Flux2ImageNode": {
+    "input": {
+      "required": {
+        "prompt": [
+          "STRING",
+          {
+            "tooltip": "Prompt for the image generation or edit",
+            "default": "",
+            "multiline": true
+          }
+        ],
+        "model": [
+          "COMFY_DYNAMICCOMBO_V3",
+          {
+            "options": [
+              {
+                "key": "Flux.2 [pro]",
+                "inputs": {
+                  "required": {
+                    "width": [
+                      "INT",
+                      {
+                        "default": 1024,
+                        "min": 256,
+                        "max": 2048,
+                        "step": 32
+                      }
+                    ],
+                    "height": [
+                      "INT",
+                      {
+                        "default": 768,
+                        "min": 256,
+                        "max": 2048,
+                        "step": 32
+                      }
+                    ],
+                    "images": [
+                      "COMFY_AUTOGROW_V3",
+                      {
+                        "tooltip": "Optional reference image(s) for image-to-image generation. Up to 8 images.",
+                        "template": {
+                          "input": {
+                            "required": {
+                              "image": [
+                                "IMAGE",
+                                {}
+                              ]
+                            }
+                          },
+                          "names": [
+                            "image_1",
+                            "image_2",
+                            "image_3",
+                            "image_4",
+                            "image_5",
+                            "image_6",
+                            "image_7",
+                            "image_8"
+                          ],
+                          "min": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "key": "Flux.2 [max]",
+                "inputs": {
+                  "required": {
+                    "width": [
+                      "INT",
+                      {
+                        "default": 1024,
+                        "min": 256,
+                        "max": 2048,
+                        "step": 32
+                      }
+                    ],
+                    "height": [
+                      "INT",
+                      {
+                        "default": 768,
+                        "min": 256,
+                        "max": 2048,
+                        "step": 32
+                      }
+                    ],
+                    "images": [
+                      "COMFY_AUTOGROW_V3",
+                      {
+                        "tooltip": "Optional reference image(s) for image-to-image generation. Up to 8 images.",
+                        "template": {
+                          "input": {
+                            "required": {
+                              "image": [
+                                "IMAGE",
+                                {}
+                              ]
+                            }
+                          },
+                          "names": [
+                            "image_1",
+                            "image_2",
+                            "image_3",
+                            "image_4",
+                            "image_5",
+                            "image_6",
+                            "image_7",
+                            "image_8"
+                          ],
+                          "min": 0
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "seed": [
+          "INT",
+          {
+            "tooltip": "The random seed used for creating the noise.",
+            "default": 0,
+            "min": 0,
+            "max": 18446744073709551615,
+            "control_after_generate": true
+          }
+        ]
+      },
+      "hidden": {
+        "auth_token_comfy_org": [
+          "AUTH_TOKEN_COMFY_ORG"
+        ],
+        "api_key_comfy_org": [
+          "API_KEY_COMFY_ORG"
+        ],
+        "unique_id": [
+          "UNIQUE_ID"
+        ],
+        "comfy_usage_source": [
+          "COMFY_USAGE_SOURCE"
+        ]
+      }
+    },
+    "input_order": {
+      "required": [
+        "prompt",
+        "model",
+        "seed"
+      ],
+      "hidden": [
+        "auth_token_comfy_org",
+        "api_key_comfy_org",
+        "unique_id",
+        "comfy_usage_source"
+      ]
+    },
+    "is_input_list": false,
+    "output": [
+      "IMAGE"
+    ],
+    "output_is_list": [
+      false
+    ],
+    "output_name": [
+      "IMAGE"
+    ],
+    "output_tooltips": [
+      null
+    ],
+    "output_matchtypes": null,
+    "name": "Flux2ImageNode",
+    "display_name": "Flux.2 Image",
+    "description": "Generate images via Flux.2 [pro] or Flux.2 [max] from a prompt and optional reference images.",
+    "python_module": "comfy_api_nodes.nodes_bfl",
+    "category": "partner/image/BFL",
+    "output_node": false,
+    "deprecated": false,
+    "experimental": false,
+    "dev_only": false,
+    "api_node": true,
+    "price_badge": {
+      "engine": "jsonata",
+      "depends_on": {
+        "widgets": [
+          {
+            "name": "model",
+            "type": "COMFY_DYNAMICCOMBO_V3"
+          },
+          {
+            "name": "model.width",
+            "type": "INT"
+          },
+          {
+            "name": "model.height",
+            "type": "INT"
+          }
+        ],
+        "inputs": [],
+        "input_groups": [
+          "model.images"
+        ]
+      },
+      "expr": "\n                (\n                  $isMax := widgets.model = \"flux.2 [max]\";\n                  $MP := 1024 * 1024;\n                  $w := $lookup(widgets, \"model.width\");\n                  $h := $lookup(widgets, \"model.height\");\n                  $outMP := $max([1, $floor((($w * $h) + $MP - 1) / $MP)]);\n                  $outputCost := $isMax\n                    ? (0.07 + 0.03 * ($outMP - 1))\n                    : (0.03 + 0.015 * ($outMP - 1));\n                  $refMin := $isMax ? 0.03 : 0.015;\n                  $refMax := $isMax ? 0.24 : 0.12;\n                  $hasRefs := $lookup(inputGroups, \"model.images\") > 0;\n                  $hasRefs\n                    ? {\n                        \"type\": \"range_usd\",\n                        \"min_usd\": $outputCost + $refMin,\n                        \"max_usd\": $outputCost + $refMax,\n                        \"format\": { \"approximate\": true }\n                      }\n                    : {\"type\": \"usd\", \"usd\": $outputCost}\n                )\n                "
+    },
+    "search_aliases": null,
+    "essentials_category": null,
+    "has_intermediate_output": false
+  },
   "FluxProUltraImageNode": {
     "api_node": true,
     "category": "partner/image/BFL",

--- a/tests/comfy_cli/command/generate/test_emit.py
+++ b/tests/comfy_cli/command/generate/test_emit.py
@@ -224,6 +224,42 @@ def test_build_flux_ultra_only_height_errors_instead_of_dropping_it():
     assert "--width" in str(ei.value) and "--height" in str(ei.value)
 
 
+def test_emit_refuses_a_flag_the_node_cannot_carry():
+    """A proxy flag with no matching node input cannot reach an emitted
+    workflow, so dropping it in silence hands back a graph that ignores what the
+    user asked for. `prompt_upsampling` is the live case: the bfl/flux-2-pro
+    proxy takes it, Flux2ImageNode has no such input."""
+    with pytest.raises(emit.EmitError) as ei:
+        emit.build_workflow("flux-2", {"prompt": "a fox", "prompt_upsampling": True})
+    msg = str(ei.value)
+    assert "--prompt_upsampling" in msg
+    assert "Flux2ImageNode" in msg
+    # The remedy has to be in the message, or the user is left guessing.
+    assert "without --emit-workflow" in msg
+
+
+def test_emit_names_every_unsupported_flag_at_once():
+    """Reporting one at a time turns a single fix into a guessing loop."""
+    with pytest.raises(emit.EmitError) as ei:
+        emit.build_workflow("flux-2", {"prompt": "p", "safety_tolerance": 2, "output_format": "png"})
+    msg = str(ei.value)
+    assert "--output_format" in msg and "--safety_tolerance" in msg
+
+
+def test_emit_does_not_mistake_a_fixed_default_for_a_user_flag():
+    """`values` carries only what argv held, so NodeSpec.fixed entries that have
+    no param_map flag (flux-2's `model` selector) must not trip the check."""
+    wf = emit.build_workflow("flux-2", {"prompt": "p"})
+    assert wf["1"]["inputs"]["model"] == "Flux.2 [pro]"
+
+
+def test_emit_still_accepts_the_aspect_ratio_width_height_pair():
+    """flux-ultra folds width/height into `aspect_ratio` rather than mapping
+    them, so the check has to treat them as handled for that shape."""
+    wf = emit.build_workflow("flux-ultra", {"prompt": "p", "width": 16, "height": 9})
+    assert wf["1"]["inputs"]["aspect_ratio"] == "16:9"
+
+
 def test_emitted_workflow_is_api_format_node_ids_are_strings():
     wf = emit.build_workflow("flux-2", {"prompt": "p"})
     for k, node in wf.items():

--- a/tests/comfy_cli/command/generate/test_emit.py
+++ b/tests/comfy_cli/command/generate/test_emit.py
@@ -39,11 +39,15 @@ def runner():
 def test_build_flux_text_to_image_class_type_and_params():
     wf = emit.build_workflow("flux-2", {"prompt": "a fox", "width": 512})
     # partner node is "1"
-    assert wf["1"]["class_type"] == "Flux2ProImageNode"
+    assert wf["1"]["class_type"] == "Flux2ImageNode"
     assert wf["1"]["inputs"]["prompt"] == "a fox"
+    # Width and height are sub-widgets of the `model` dynamic combo, so they are
+    # addressed through it. The selector itself has to be in the emitted inputs
+    # or the sub-widgets it exposes do not exist yet.
+    assert wf["1"]["inputs"]["model"] == "Flux.2 [pro]"
     # user override applied, fixed default preserved for unset params
-    assert wf["1"]["inputs"]["width"] == 512
-    assert wf["1"]["inputs"]["height"] == 768
+    assert wf["1"]["inputs"]["model.width"] == 512
+    assert wf["1"]["inputs"]["model.height"] == 768
     # save node references the partner output
     save = [n for n in wf.values() if n["class_type"] == "SaveImage"]
     assert len(save) == 1
@@ -282,7 +286,7 @@ def test_cli_emit_writes_file_no_api_key(runner, tmp_path, monkeypatch):
     assert r.exit_code == 0, r.stdout
     assert out.is_file()
     wf = json.loads(out.read_text())
-    assert wf["1"]["class_type"] == "Flux2ProImageNode"
+    assert wf["1"]["class_type"] == "Flux2ImageNode"
     assert wf["1"]["inputs"]["prompt"] == "a cat"
 
 

--- a/tests/comfy_cli/command/generate/test_emit_ops.py
+++ b/tests/comfy_cli/command/generate/test_emit_ops.py
@@ -159,7 +159,7 @@ def test_allow_deprecated_is_read_from_the_spec_not_stamped_on_everything():
         return {s["class_type"]: s["allow_deprecated"] for s in specs if s["op"] == "add_node"}
 
     flux = adds("flux-2", {"prompt": "a fox"})
-    assert flux["Flux2ProImageNode"] is True, "the flux-2 entry declares deprecated_ok"
+    assert flux["Flux2ImageNode"] is False, "a live partner class carries no exemption"
     assert flux["SaveImage"] is False, "a live core class carries no exemption"
 
     gemini = adds("nano-banana", {"prompt": "p", "image": ["a.png", "b.png"]})
@@ -167,8 +167,8 @@ def test_allow_deprecated_is_read_from_the_spec_not_stamped_on_everything():
     assert gemini["ImageBatch"] is True, "core scaffolding the emitter mints itself keeps its exemption"
 
     # The exemption is read off the entry being emitted, not off a union over
-    # the whole table: `flux-2` declaring deprecated_ok must not waive the gate
-    # for a Flux2ProImageNode that arrives under some other model's graph.
+    # the whole table. No entry declares `deprecated_ok` today, so a deprecated
+    # class arriving under any model's graph must still be refused.
     borrowed = emit.ops_from_api_workflow(
         {"1": {"class_type": "Flux2ProImageNode", "inputs": {"prompt": "p"}}}, _graph(), "nano-banana"
     )
@@ -267,9 +267,14 @@ def test_ops_roundtrip_with_no_image_params():
     wf = _apply(emit.ops_from_api_workflow(api, _graph(), "flux-2"))
     lowered = convert_ui_to_api(wf, _object_info())
     got = _api_by_class(lowered)
-    assert got["Flux2ProImageNode"]["prompt"] == "a fox"
-    assert got["Flux2ProImageNode"]["width"] == 512
-    assert got["SaveImage"]["images"] == ("link", "Flux2ProImageNode")
+    assert got["Flux2ImageNode"]["prompt"] == "a fox"
+    # The combo selection survives the round trip alongside its sub-widgets. If
+    # the selector were lost the sub-widgets would have nothing to hang off, so
+    # asserting it is what makes the two below meaningful.
+    assert got["Flux2ImageNode"]["model"] == "Flux.2 [pro]"
+    assert got["Flux2ImageNode"]["model.width"] == 512
+    assert got["Flux2ImageNode"]["model.height"] == 768
+    assert got["SaveImage"]["images"] == ("link", "Flux2ImageNode")
 
 
 def test_ops_fold_multiple_images_through_image_batch():


### PR DESCRIPTION
## Why

`--emit-workflow` built `flux-2` graphs around `Flux2ProImageNode`. ComfyUI deprecated that class in the same commit that added `Flux2ImageNode`, so the workflow the agent handed back carried a `DEPR` badge. A user reported exactly that, which is what opened BE-13301.

This is the change that fixes what they saw. #864 made the exemption visible and #866 exposes the mapping to cloud, but neither changes the emitted graph. This one does.

## What changed

`flux-2` now maps to `Flux2ImageNode`, and the `deprecated_ok` exemption #864 added to hold the line comes off.

It is not a rename. The classes are shaped differently, which is why the replacement exists:

| | `Flux2ProImageNode` (deprecated) | `Flux2ImageNode` (live) |
|---|---|---|
| top-level | `prompt`, `width`, `height`, `seed`, `prompt_upsampling` | `prompt`, `model`, `seed` |
| under the combo | — | `model.width`, `model.height`, `model.images[1..8]` |

Width and height moved inside a `model` dynamic combo, so they are addressed through it.

That needed no new machinery, which I did not expect. `param_map` maps a CLI flag to a node input key, and the key can simply be dotted. `ops_from_api_workflow` already orders plain widget keys ahead of dotted ones so the combo selection lands before the sub-widgets it exposes, and `apply_specs` resolves them from there.

Two deliberate choices worth review:

- **`"Flux.2 [pro]"` is the fixed combo option.** It is the one that posts to this entry's `endpoint`, so the alias keeps meaning the model it has always meant. The node's other option, `"Flux.2 [max]"`, is a different model at a different price and wants its own alias rather than being reachable by accident from this one.
- **`prompt_upsampling` is dropped from the mapping.** The proxy takes it, this node does not expose it, so an emitted workflow cannot carry it either way. `comfy generate` without `--emit-workflow` still sends it straight to the proxy.

## What guards it

`Flux2ImageNode` is recorded in the partner fixture from the catalog cloud's deployed ComfyUI serves, which lets the two existing contracts do the work:

- the widget-coverage test confirms every widget input the node declares is emitted,
- #864's bidirectional `deprecated_ok` assert now requires the flag to be **absent**, so a stale exemption cannot outlive this migration.

The round-trip test is extended to assert the combo selection survives alongside its sub-widgets. Without the selector the sub-widgets have nothing to hang off, so asserting it is what makes the width and height assertions mean anything.

## Checks

```
pytest tests/comfy_cli/command/generate      350 passed
ruff check / ruff format --check             clean
```

Round trip verified directly, API format in and lowered back out:

```
emitted:  {"model": "Flux.2 [pro]", "model.width": 512, "model.height": 768, "seed": 0, "prompt": "a fox"}
ops:      set_widget model, seed, prompt  then  model.width, model.height
lowered:  same keys, same values, allow_deprecated False on every add
```

## Not in scope

`ImageBatch`, the other deprecated class this emitter mints, is tracked separately in BE-13516. It is blocked on BE-10726 because `apply_specs` cannot wire an autogrow slot at all, which is a different gap from the dotted combo keys this PR uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Unmapped flags now fail on every alias

The unmapped-flag check is not flux-2 only. `--emit-workflow` and `--emit-ops` now fail on any flag that the alias's `MODEL_NODE_MAP` entry does not wire into the node. Before this PR, every one of these flags was dropped without a word.

| alias | flags that now fail |
|---|---|
| `flux-2` | `input_image`, `input_image_2` … `input_image_9`, `output_format`, `prompt_upsampling`, `safety_tolerance` |
| `flux-ultra` | `guidance_scale`, `negative_prompt`, `num_images`, `num_inference_steps` |
| `kling-i2v` | `callback_url`, `camera_control`, `dynamic_masks`, `element_list`, `external_task_id`, `image_tail`, `multi_prompt`, `multi_shot`, `shot_type`, `sound`, `static_mask`, `watermark_info` |
| `nano-banana` | none |
| `seedance` | `fps`, `return_last_frame` |

`test_emit_refused_flags_per_alias` pins this table. It walks `MODEL_NODE_MAP`, sends each flag from the alias's schema one at a time, and records which ones fail. Wiring a flag later means removing it from the table.

The cloud agent will see this after its next comfy-cli pin bump. Its `generate_workflow` tool passes the flags the model chose after reading `generate_schema`. The error names the flags and the fix:

```
--emit-workflow for 'flux-2' does not map --input_image onto Flux2ImageNode. Drop that flag, or run `comfy generate flux-2` without --emit-workflow, which sends every flag straight to the proxy.
```

The message blames the mapping, not the node. Some flags have no input on the node, such as flux-2's `prompt_upsampling`. Others have an input the mapping does not wire yet, such as flux-2's `input_image` and `model.images`. Wiring `model.images` is a follow-up.
